### PR TITLE
Remove the paid-off persistent_save coverage baseline entry

### DIFF
--- a/scripts/library_coverage_baseline.json
+++ b/scripts/library_coverage_baseline.json
@@ -1,10 +1,5 @@
 {
-  "$comment": "Debt register for the per-library coverage gate (scripts/check_library_coverage.ts). Each entry is a library that was below the threshold when the gate was introduced, recorded at the coverage it had. A library here may not get worse, and this list is meant to shrink: when one reaches the threshold, delete its entry. Do NOT add entries \u2014 a new library below the threshold needs tests, not an exemption.",
+  "$comment": "Debt register for the per-library coverage gate (scripts/check_library_coverage.ts). Each entry is a library that was below the threshold when the gate was introduced, recorded at the coverage it had. A library here may not get worse, and this list is meant to shrink: when one reaches the threshold, delete its entry. Do NOT add entries — a new library below the threshold needs tests, not an exemption.",
   "threshold": 80,
-  "libraries": {
-    "persistent_save": {
-      "lines": 52,
-      "functions": 37
-    }
-  }
+  "libraries": {}
 }


### PR DESCRIPTION
`persistent_save` has paid off its coverage debt, so its baseline entry comes out.

| | Recorded floor | Now | Bar |
| --- | ---: | ---: | ---: |
| Lines | 52% | **80.20%** | 80% |
| Functions | 37% | **87.50%** | 80% |

The gate has been printing this on every run for a while:

```
These libraries now meet 80% and should be removed from scripts/library_coverage_baseline.json:
  - persistent_save
The baseline is a debt register. Leaving a paid-off entry in it lets the library slip back unnoticed.
```

That warning is the whole argument. While the entry stays, the library is measured against a 52% floor rather than the 80% bar, so it could lose twenty-eight points of line coverage and still pass — which is exactly the silent regression the register exists to prevent.

**This empties the register.** All 95 libraries under `src/lib` now meet the bar on their own:

```
Coverage gate passed: 95 libraries checked, 95 at or above 80%, 0 carrying baselined debt.
```

## Worth knowing before merging

**The margin is one line.** 81 of 101 lines are covered; 80 would be 79.21% and would fail the gate. That is the correct behaviour — the library is now held to the same standard as every other one, and coverage is deterministic rather than flaky, so this cannot fail on its own. But the next change to `persistent_save` that adds an uncovered line will fail CI, and that is worth knowing in advance rather than discovering in a PR.

**The gap is one file.** `legacy_load_cue.ts` is 0/10 lines — untested in its entirety. The rest of the library is well covered:

```
 0/10   legacy_load_cue.ts
31/35   save_file_export.ts
39/44   scoped_local_storage.ts
11/12   strip_function_values_deep.ts
 0/0    index.ts
```

Testing that one file is what would give the library real headroom. I have deliberately not done it here — this PR is the baseline cleanup and nothing else, and mixing new tests into it would make the register change harder to see. Happy to open that as a follow-up.

## Testing

`npm run verify` green: 303 test files, 3938 tests, `svelte-check` 0 errors, coverage gate passed with an empty register.

No browser run: this changes one JSON data file read by a build script, touching no route, component, or rendering path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
