### PR TITLE
Take the settlement generator to Release-ready

### DIFF
--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -8,9 +8,9 @@ becomes in [Domain model](#domain-model), and — in
 [Tool release readiness](#tool-release-readiness) — the specification a tool must meet before it
 is considered finished.
 
-**Status:** accepted; being built. The foundation and durability phases are largely in place, and
-the shell is live at `/workshop` — linked from navigation, with a project always open, several
-panels on a bench at once, and a project view listing what the project holds. The work is broken
+**Status:** accepted; being built. The foundation and durability phases are in place, the shell is
+live at `/workshop` — with a project always open, several panels on a bench at once, and a project
+view listing what the project holds — and all three of the first release's tools are Release-ready. The work is broken
 down in [The plan](#the-plan) and tracked on GitHub under the `workshop` label; what is built and
 what is not is in [What exists today](#what-exists-today).
 
@@ -1219,27 +1219,27 @@ This answers the remainder of #45.
 Worth being precise about what is already built, since more of the substrate exists than the
 absence of a workshop suggests.
 
-| Piece                      | State                                                                                                                                                                                                                                                                                                                                                      |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Tool catalog with metadata | **Built.** `src/lib/tools`, 35 tools, genre/system/maturity tags, search and grouping. Maturity (#43) is required on every entry and shown to the user.                                                                                                                                                                                                    |
-| Panel registry             | **Built.** `src/lib/workshop/tool_panels.ts`, lazy loaders, parity-tested against the catalog.                                                                                                                                                                                                                                                             |
-| Workshop shell             | **Built (#36).** `/workshop`, linked from navigation and in the tool catalog: project context, a bench of panels, and the project view.                                                                                                                                                                                                                    |
-| Snapshot pattern           | **Built for three kinds.** Heraldry, culture, religion.                                                                                                                                                                                                                                                                                                    |
-| Scoped storage             | **Built, wrong scope.** `src/lib/persistent_save` is per-generator rather than per-project, and still on `localStorage`, which is now where the small pointers live and nothing else.                                                                                                                                                                      |
-| Saved data page            | **Removed (#44).** `/saved-data` redirects to the workshop. The legacy storage scopes it browsed are untouched and still read; the page, its catalog, its per-kind downloads, and its deep-link builders are gone.                                                                                                                                         |
-| Save file export/import    | **Superseded, still present.** `save_file_export.ts` exports storage scopes and rejects any `formatVersion` but its own. `src/lib/vault_file` replaces it and **reads its files** (#47), so retiring it is now #44's to do.                                                                                                                                |
-| The file format            | **Built (#35, #47).** `src/lib/vault_file` — the envelope, the canonical body, the checksum, the parser, and the migration chain, at all three scopes. Restore and merge, the pre-restore backup, quarantine, the capacity check, gzip sniffing, and legacy save files.                                                                                    |
-| Quarantine                 | **Built (#47).** `src/lib/quarantine` and the `quarantine` object store — records this build cannot interpret, kept verbatim, listed, and carried in every subsequent export until a build that understands them arrives.                                                                                                                                  |
-| Projects                   | **Built (#31, #176).** `src/lib/projects` — the type, create/rename/edit/delete/list, and the active project. Deleting one cascades to its artifacts in a single transaction.                                                                                                                                                                              |
-| Generic artifact store     | **Built (#33, #176).** `src/lib/artifacts` — any registered kind, scoped to a project, migrating payloads on read. One record per summary, one per payload.                                                                                                                                                                                                |
-| Vault database             | **Built (#176).** `src/lib/vault_db` — the five IndexedDB stores of [the storage layer](#the-storage-layer), hydrated summaries, transactional writes that return a result.                                                                                                                                                                                |
-| Legacy save adoption       | **Built (#34).** `src/lib/legacy_adoption` — the three `generator.*` scopes become artifacts in a project on page load, idempotently, leaving the originals in place.                                                                                                                                                                                      |
-| Quota handling             | **Built (#180).** A write refused for want of room blocks, says nothing already saved was harmed, and offers a download built from the value in hand — `buildUnsavedArtifactExportFile`, which reads no storage because storage is what failed. That file imports back as an ordinary artifact.                                                            |
-| Storage status             | **Built (#177).** `src/lib/storage_status` — usage, quota, persistence, per-project attribution, and the export stamps, as `StorageStatus`. The panel that displays it is #179.                                                                                                                                                                            |
-| The bench                  | **Built (#36).** `src/lib/workspaces` — `ProjectWorkspace` and `PanelState`, persisted per project, reset rather than migrated, and dropped panel by panel when a target is gone.                                                                                                                                                                          |
-| Saving from a tool         | **Built for three kinds (#36).** `saveToolArtifact` plus `SaveArtifactButton`; heraldry, culture, and religion save into the open project, and prompt for one on their own routes.                                                                                                                                                                         |
-| Artifact editing           | **Framework built (#39); culture (#40) and religion (#41) fill it.** `openArtifactForEditing`, the dirty/save lifecycle, the destructive re-roll, and the unsaved-edits guard, with a per-kind editor slot — and a per-kind **viewer** slot beside it, for a kind that can draw itself (6.3) before it can be edited (4.1). Heraldry is the one that does. |
-| Composition                | **Built (#37).** `SavedArtifactPicker` offers any registered kind, `loadArtifactValue` rebuilds the choice, and references are recorded, resolved both ways, and shown where they break.                                                                                                                                                                   |
+| Piece                      | State                                                                                                                                                                                                                                                                                                                                                                         |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tool catalog with metadata | **Built.** `src/lib/tools`, 35 tools, genre/system/maturity tags, search and grouping. Maturity (#43) is required on every entry and shown to the user.                                                                                                                                                                                                                       |
+| Panel registry             | **Built.** `src/lib/workshop/tool_panels.ts`, lazy loaders, parity-tested against the catalog.                                                                                                                                                                                                                                                                                |
+| Workshop shell             | **Built (#36).** `/workshop`, linked from navigation and in the tool catalog: project context, a bench of panels, and the project view.                                                                                                                                                                                                                                       |
+| Snapshot pattern           | **Built for four kinds.** Heraldry, culture, religion, settlement — the last built against the contract from scratch rather than retrofitted.                                                                                                                                                                                                                                 |
+| Scoped storage             | **Built, wrong scope.** `src/lib/persistent_save` is per-generator rather than per-project, and still on `localStorage`, which is now where the small pointers live and nothing else.                                                                                                                                                                                         |
+| Saved data page            | **Removed (#44).** `/saved-data` redirects to the workshop. The legacy storage scopes it browsed are untouched and still read; the page, its catalog, its per-kind downloads, and its deep-link builders are gone.                                                                                                                                                            |
+| Save file export/import    | **Superseded, still present.** `save_file_export.ts` exports storage scopes and rejects any `formatVersion` but its own. `src/lib/vault_file` replaces it and **reads its files** (#47), so retiring it is now #44's to do.                                                                                                                                                   |
+| The file format            | **Built (#35, #47).** `src/lib/vault_file` — the envelope, the canonical body, the checksum, the parser, and the migration chain, at all three scopes. Restore and merge, the pre-restore backup, quarantine, the capacity check, gzip sniffing, and legacy save files.                                                                                                       |
+| Quarantine                 | **Built (#47).** `src/lib/quarantine` and the `quarantine` object store — records this build cannot interpret, kept verbatim, listed, and carried in every subsequent export until a build that understands them arrives.                                                                                                                                                     |
+| Projects                   | **Built (#31, #176).** `src/lib/projects` — the type, create/rename/edit/delete/list, and the active project. Deleting one cascades to its artifacts in a single transaction.                                                                                                                                                                                                 |
+| Generic artifact store     | **Built (#33, #176).** `src/lib/artifacts` — any registered kind, scoped to a project, migrating payloads on read. One record per summary, one per payload.                                                                                                                                                                                                                   |
+| Vault database             | **Built (#176).** `src/lib/vault_db` — the five IndexedDB stores of [the storage layer](#the-storage-layer), hydrated summaries, transactional writes that return a result.                                                                                                                                                                                                   |
+| Legacy save adoption       | **Built (#34).** `src/lib/legacy_adoption` — the three `generator.*` scopes become artifacts in a project on page load, idempotently, leaving the originals in place.                                                                                                                                                                                                         |
+| Quota handling             | **Built (#180).** A write refused for want of room blocks, says nothing already saved was harmed, and offers a download built from the value in hand — `buildUnsavedArtifactExportFile`, which reads no storage because storage is what failed. That file imports back as an ordinary artifact.                                                                               |
+| Storage status             | **Built (#177).** `src/lib/storage_status` — usage, quota, persistence, per-project attribution, and the export stamps, as `StorageStatus`. The panel that displays it is #179.                                                                                                                                                                                               |
+| The bench                  | **Built (#36).** `src/lib/workspaces` — `ProjectWorkspace` and `PanelState`, persisted per project, reset rather than migrated, and dropped panel by panel when a target is gone.                                                                                                                                                                                             |
+| Saving from a tool         | **Built for four kinds (#36).** `saveToolArtifact` plus `SaveArtifactButton`; heraldry, culture, religion, and settlement save into the open project, and prompt for one on their own routes.                                                                                                                                                                                 |
+| Artifact editing           | **Framework built (#39); culture (#40), religion (#41), and settlement (#20) fill it.** `openArtifactForEditing`, the dirty/save lifecycle, the destructive re-roll, and the unsaved-edits guard, with a per-kind editor slot — and a per-kind **viewer** slot beside it, for a kind that can draw itself (6.3) before it can be edited (4.1). Heraldry is the one that does. |
+| Composition                | **Built (#37).** `SavedArtifactPicker` offers any registered kind, `loadArtifactValue` rebuilds the choice, and references are recorded, resolved both ways, and shown where they break.                                                                                                                                                                                      |
 
 ## Tool release readiness
 
@@ -1344,9 +1344,9 @@ levels, so a tool's state is legible to users and to us:
 | **Release-ready** | A full citizen of the workshop.                                          | All sections.             |
 
 Measured against this, **every tool on the site today is Experimental**, except heraldry, which is
-Beta, and **culture (#40) and religion (#41), which are Release-ready**. That is not a
-criticism of the tools; it is the size of the gap between what exists and what the workshop needs,
-and it is better stated plainly than discovered one generator at a time.
+Beta, and **culture (#40), religion (#41), and settlement (#20), which are Release-ready**. That is
+not a criticism of the tools; it is the size of the gap between what exists and what the workshop
+needs, and it is better stated plainly than discovered one generator at a time.
 
 **The catalog records this (#43).** `maturity` is a required field on `ToolDefinition` and `Tool`,
 with no default — a default would let a tool claim a level nobody assessed, which is the one thing
@@ -1423,16 +1423,16 @@ the disclosure.
 
 **Phase 5 — Three tools to Release-ready.**
 
-| Issue            | Depends on | State                                                                         |
-| ---------------- | ---------- | ----------------------------------------------------------------------------- |
-| #40 — culture    | #37, #39   | **Done.** The first kind with an editor, and the first reference.             |
-| #41 — religion   | #37, #39   | **Done.** Editing inside a list of sub-objects, and both ends of a reference. |
-| #42 — settlement | #37, #39   | —                                                                             |
+| Issue            | Depends on | State                                                                                        |
+| ---------------- | ---------- | -------------------------------------------------------------------------------------------- |
+| #40 — culture    | #37, #39   | **Done.** The first kind with an editor, and the first reference.                            |
+| #41 — religion   | #37, #39   | **Done.** Editing inside a list of sub-objects, and both ends of a reference.                |
+| #20 — settlement | #37, #39   | **Done.** A payload built against the contract from scratch, and sixteen shapes of one kind. |
 
 Independent of every phase and able to land at any point: **#43 — record tool maturity in the
-catalog. Done.** It landed while #42 was still open, which was the point: the gap this document
-describes is now visible in the product while it is being closed rather than only in this file.
-Settlement's entry reads Experimental until #42 earns it something else.
+catalog. Done.** It landed while settlement was still open, which was the point: the gap this
+document describes was visible in the product while it was being closed rather than only in this
+file.
 
 ### Why those three tools
 
@@ -1443,10 +1443,45 @@ They were chosen to stress different parts of the model, not because they are th
 - **Religion** sits on both sides of a reference at once — it consumes a culture and is consumed by
   one — so it is the honest test of cycle tolerance. Its pantheon is also the best available test
   of editing one part without re-rolling the whole (requirement 4.4).
-- **Settlement** has no snapshot at all today. It is the only one of the three whose payload is
-  built against the registry contract from scratch rather than retrofitted from an existing
-  pattern, which is where an awkward contract will show up. Better discovered on the first tool
-  than the tenth.
+- **Settlement** had no snapshot at all. It is the only one of the three whose payload was built
+  against the registry contract from scratch rather than retrofitted from an existing pattern,
+  which is where an awkward contract would show up. Better discovered on the first tool than the
+  tenth.
+
+#### What settlement found
+
+The contract held. What it exposed was in the payload rather than in the registry, and it is
+recorded here because it is what the next kind will meet:
+
+- **The contract's own words earn their place.** Requirement 3.2 says non-serialisable values are
+  "stripped **or reconstructed explicitly**", and a settlement needs all of the second. Its
+  organizations carry three `Map`s each, which `JSON.stringify` empties to `{}` without
+  complaining; its coats of arms carry a render function per charge group, which `structuredClone`
+  refuses outright; and its characters carry the equipment tables they were rolled from, which are
+  66 KB apiece and are generator input rather than content. Stored naively, one enriched settlement
+  is a megabyte with its organizations silently hollowed out. Converted by name — entries, charge
+  names, archetype names — it is about forty kilobytes and round-trips exactly.
+- **A kind can have more than one legitimate shape.** `enrich_settlement.ts` is opt-in four times
+  over, so sixteen combinations are all current payloads at version 1. That is not a version
+  problem and must not be treated as one: `validate` accepts each optional layer when absent and
+  checks it when present, which is also what makes a payload written by a build with different
+  enrichment defaults readable rather than quarantined (requirement 3.3).
+- **Determinism needs a single roll path, and the page is not it.** The generator built its
+  configuration inline, drawing name sets and an environment off a shared RNG in an order nothing
+  else could reproduce, so requirement 2.2 was true only for as long as nobody edited the
+  component and a re-roll had nothing to reproduce from. `rollSettlement` in the library is what
+  both the page and `ARTIFACT_EDITORS`'s roller now call.
+- **`role` on a reference is doing real work.** A settlement holds two links of different kinds at
+  once — a culture it took its names from, and a religion recorded as the local faith — and they
+  behave differently: the culture is an input, gated on the roll that used it, while the faith
+  follows the picker because it is something the user says about the place afterwards. Without the
+  required `role` of [decision 1](#1-references-carry-a-required-role) the panel could not tell
+  them apart.
+- **A provenance `config` must be plain data.** IndexedDB serialises with `structuredClone`, which
+  refuses a Proxy, so a config held in a Svelte `$state` object fails the write with
+  `could not be cloned`. It is a loud failure and the user keeps their content, but it is a trap
+  every future tool walks past; it is written down in `$lib/workshop`'s README beside
+  `saveToolArtifact`.
 
 ### Immediately after
 

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -19,6 +19,11 @@ const TOOL_PAGES = [
   { path: '/heraldry', title: 'Heraldry Generator | Iron Arachne', level: 'Beta' },
   { path: '/culture', title: 'Culture Generator | Iron Arachne', level: 'Release-ready' },
   {
+    path: '/fantasy/settlement',
+    title: 'Settlement Generator | Iron Arachne',
+    level: 'Release-ready',
+  },
+  {
     // Its own header rather than `GeneratorPage`, so it states its maturity itself and is worth
     // checking separately.
     path: '/fantasy/adnd/character/build',
@@ -55,6 +60,7 @@ test('maturity: the tool browser marks every tool it lists', async ({ page }) =>
   await expect(browser.locator('.maturity__level')).toHaveCount(toolCount);
 
   await expect(browser.getByRole('button', { name: /^Culture/ })).toContainText('Release-ready');
+  await expect(browser.getByRole('button', { name: /^Settlement/ })).toContainText('Release-ready');
   await expect(browser.getByRole('button', { name: /^Heraldry/ })).toContainText('Beta');
   await expect(browser.getByRole('button', { name: /^Planet/ })).toContainText('Experimental');
 });

--- a/e2e/workshop.spec.ts
+++ b/e2e/workshop.spec.ts
@@ -521,6 +521,63 @@ test.describe('building one artifact from another', () => {
 
     await expect(savedCulture.filter({ hasText: 'Built from' })).toContainText('The Ashen Path');
   });
+
+  /**
+   * Two references of different kinds on one artifact (#20), and the reason `role` is required.
+   *
+   * A settlement takes a culture as an *input* — the tongue its town, organizations, and people
+   * are named in — and records a religion as the faith practised there. Both are links by id, and
+   * a picker that recorded only "a culture" and "a religion" would leave the panel unable to say
+   * which was which.
+   */
+  test('builds a settlement from a saved culture and a saved religion', async ({ page }) => {
+    await mountTool(page, /^Culture/);
+    await saveFromPanel(page, /Culture Generator/, 'The Emberfolk');
+    await mountTool(page, /^Fantasy Religion/);
+    await saveFromPanel(page, /Religion Generator/, 'The Ember');
+
+    await mountTool(page, /^Settlement/);
+    const settlementPanel = panels(page).filter({
+      has: page.getByRole('heading', { name: /Settlement Generator/ }),
+    });
+    await settlementPanel.getByLabel('Use a saved culture for all names').check();
+    await settlementPanel
+      .getByLabel('Saved culture', { exact: true })
+      .selectOption({ label: 'The Emberfolk' });
+    await settlementPanel.getByLabel('Record a saved religion as the local faith?').check();
+    await settlementPanel
+      .getByLabel('Saved religion', { exact: true })
+      .selectOption({ label: 'The Ember' });
+    await settlementPanel.getByRole('button', { name: 'Generate' }).click();
+
+    // The page says outright where the names came from and whose faith is kept here. Both name the
+    // referenced artifact's own name, which is what was handed over.
+    await expect(settlementPanel.getByText(/^Naming: /)).toBeVisible();
+    await expect(settlementPanel.getByText(/^From the saved religion /)).toBeVisible();
+    await saveFromPanel(page, /Settlement Generator/, 'White Ridge');
+
+    await artifactRow(page, 'White Ridge').click();
+    const saved = page.locator('.artifact-panel').filter({ hasText: 'Built from' });
+    await expect(saved).toContainText('Naming culture');
+    await expect(saved).toContainText('The Emberfolk');
+    await expect(saved).toContainText('Faith');
+    await expect(saved).toContainText('The Ember');
+
+    // And from the other end, which is the question a user asks of a religion they wrote.
+    await artifactRow(page, 'The Ember').click();
+    await expect(page.locator('.artifact-panel').filter({ hasText: 'Used by' })).toContainText(
+      'White Ridge',
+    );
+  });
+
+  /** Requirement 5.3: composition is opt-in, and a settlement handed nothing records nothing. */
+  test('saves a settlement with no references when it was offered none', async ({ page }) => {
+    await mountTool(page, /^Settlement/);
+    await saveFromPanel(page, /Settlement Generator/, 'Oakhollow');
+
+    await artifactRow(page, 'Oakhollow').click();
+    await expect(page.locator('.artifact-panel').filter({ hasText: 'Built from' })).toHaveCount(0);
+  });
 });
 
 /**
@@ -579,6 +636,36 @@ test.describe('editing a saved artifact', () => {
     for (const category of ['monotheism', 'animism', 'totemism', 'ancestor worship', 'shamanism']) {
       await generator.getByLabel(category, { exact: true }).uncheck();
     }
+    await generator.getByRole('button', { name: 'Generate' }).click();
+
+    const saveArtifact = generator.locator('.save-artifact');
+    await saveArtifact.getByRole('button', { name: 'Save to project' }).click();
+    await saveArtifact.getByLabel('Name', { exact: true }).fill(name);
+    await saveArtifact.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(artifactRow(page, name)).toBeVisible();
+
+    await artifactRow(page, name).click();
+    await expect(artifactPanel(page).getByLabel('Name', { exact: true })).toHaveValue(name);
+  }
+
+  /**
+   * A project with one saved settlement in it — an enriched one — open in a panel of its own.
+   *
+   * Enrichment is ticked on first because it is the half of this kind worth editing: a settlement
+   * rolled plain has a name and a description, where one with problems and notables has the lists
+   * that requirement 4.4 is about. The size filter is forced large so notables and organizations
+   * have a place big enough to appear in.
+   */
+  async function openASavedSettlement(page: Page, name: string): Promise<void> {
+    await createProject(page, 'Ashfall');
+    await mountTool(page, /^Settlement/);
+    const generator = panels(page).filter({
+      has: page.getByRole('heading', { name: /Settlement Generator/ }),
+    });
+    await generator.getByLabel('Size class filter').selectOption('large');
+    await generator.getByLabel('Trade (imports / exports / blurb)').check();
+    await generator.getByLabel('Acute and creeping problems').check();
+    await generator.getByLabel(/^Important characters/).check();
     await generator.getByRole('button', { name: 'Generate' }).click();
 
     const saveArtifact = generator.locator('.save-artifact');
@@ -896,6 +983,112 @@ test.describe('editing a saved artifact', () => {
 
     await page.getByRole('link', { name: 'Home', exact: true }).click();
     await expect(page).not.toHaveURL(/\/workshop/);
+  });
+
+  /**
+   * Requirement 6.1 for the largest editing form on the site. A settlement's editor is nested
+   * three deep — facets, trade, two problem lists, and a block per notable — which is where a
+   * 320px layout gives out if it is going to.
+   */
+  test('fits a 320px screen with a settlement open on it', async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 720 });
+    await openASavedSettlement(page, 'White Ridge');
+    await expect(artifactPanel(page).getByLabel('Settlement name')).toBeVisible();
+    await expect(
+      artifactPanel(page).getByRole('textbox', { name: 'Acute problem 1', exact: true }),
+    ).toBeVisible();
+
+    await expectNoHorizontalOverflow(page);
+    await expectInteractiveControlsReachable(page);
+  });
+
+  /**
+   * Requirement 7.4 for settlement (#20): generate, save, reopen, edit — with the edit landing on
+   * a field the settlement itself owns and on one inside a sub-object, since a settlement is both.
+   */
+  test('edits a saved settlement’s contents, and the change survives a reload', async ({
+    page,
+  }) => {
+    await openASavedSettlement(page, 'White Ridge');
+    const panel = artifactPanel(page);
+
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    await panel.getByLabel('Settlement name').fill('Saltmarch');
+    await panel.getByLabel('Description', { exact: true }).fill('A wet town on a slow river.');
+    await panel
+      .getByRole('textbox', { name: 'Notable 1 title', exact: true })
+      .fill('Harbourmaster');
+    await expect(panel.getByText('Unsaved changes.')).toBeVisible();
+
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByText('Saved.')).toBeVisible();
+
+    await expect
+      .poll(async () =>
+        (await storedPanels(page)).some((stored) => stored.artifactId !== undefined),
+      )
+      .toBe(true);
+    await page.reload({ waitUntil: 'load' });
+
+    await expect(artifactPanel(page).getByLabel('Settlement name')).toHaveValue('Saltmarch');
+    await expect(artifactPanel(page).getByLabel('Description', { exact: true })).toHaveValue(
+      'A wet town on a slow river.',
+    );
+    await expect(
+      artifactPanel(page).getByRole('textbox', { name: 'Notable 1 title', exact: true }),
+    ).toHaveValue('Harbourmaster');
+  });
+
+  /** Requirement 4.4: one problem changes and the rest of the settlement does not move. */
+  test('rewrites one problem without disturbing the settlement around it', async ({ page }) => {
+    await openASavedSettlement(page, 'White Ridge');
+    const panel = artifactPanel(page);
+
+    const creeping = panel.getByRole('textbox', { name: 'Creeping problem 1', exact: true });
+    const creepingBefore = await creeping.inputValue();
+    const notable = panel.getByRole('textbox', { name: 'Notable 1 first name', exact: true });
+    const notableBefore = await notable.inputValue();
+
+    await panel
+      .getByRole('textbox', { name: 'Acute problem 1', exact: true })
+      .fill('The mill has stopped.');
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByText('Saved.')).toBeVisible();
+
+    await expect(panel.getByRole('textbox', { name: 'Acute problem 1', exact: true })).toHaveValue(
+      'The mill has stopped.',
+    );
+    await expect(creeping).toHaveValue(creepingBefore);
+    await expect(notable).toHaveValue(notableBefore);
+  });
+
+  /**
+   * Requirement 4.3 for settlement. What makes this worth its own test rather than resting on the
+   * culture one is that a settlement's roll reads four enrichment flags out of provenance: falling
+   * back to the defaults would return a plain settlement with no problems in it at all, which
+   * would read as a successful re-roll and be a silent loss.
+   */
+  test('warns before rolling a settlement again, and brings its enrichment back', async ({
+    page,
+  }) => {
+    await openASavedSettlement(page, 'White Ridge');
+    const panel = artifactPanel(page);
+    const acute = panel.getByRole('textbox', { name: 'Acute problem 1', exact: true });
+    const before = await acute.inputValue();
+
+    await panel.getByLabel('Settlement name').fill('An edit about to be thrown away.');
+    await panel.getByRole('button', { name: 'Roll again' }).click();
+    await expect(confirmDialog(page)).toContainText('unsaved changes go too');
+    await confirmDialog(page).getByRole('button', { name: 'Roll again' }).click();
+
+    await expect(panel.getByText('Rolled again from the original seed.')).toBeVisible();
+    await expect(panel.getByLabel('Settlement name')).not.toHaveValue(
+      'An edit about to be thrown away.',
+    );
+    // The same seed and the same recorded settings give the same settlement back: what a re-roll
+    // discards is the edits, not the place.
+    await expect(acute).toHaveValue(before);
   });
 });
 

--- a/src/components/locations/SettlementArtifactEditor.svelte
+++ b/src/components/locations/SettlementArtifactEditor.svelte
@@ -1,0 +1,538 @@
+<script lang="ts">
+  import {
+    addSettlementProblem,
+    removeSettlementNotable,
+    removeSettlementProblem,
+    setSettlementCategoryName,
+    setSettlementCount,
+    setSettlementEconomicRole,
+    setSettlementEnvironmentDescription,
+    setSettlementFacet,
+    setSettlementNotableField,
+    setSettlementNotableName,
+    setSettlementOrganizationField,
+    setSettlementProblem,
+    setSettlementTags,
+    setSettlementText,
+    setSettlementTradeList,
+    validateSettlementSnapshot,
+    SETTLEMENT_ECONOMIC_ROLES,
+    type SettlementCountField,
+    type SettlementFacetField,
+    type SettlementProblemList,
+    type SettlementSnapshot,
+    type SettlementTradeList,
+  } from '$lib/settlements';
+
+  /**
+   * The editing view for a saved settlement.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it, so
+   * what is here is the settlement's own shape and the calls that change it.
+   *
+   * The shape is the interesting part. Enrichment is opt-in four times over, so this component has
+   * to render sixteen combinations of the same kind without any of them looking broken: a
+   * settlement with no notables is not a settlement missing its notables, and a fieldset of empty
+   * inputs would say otherwise. Each optional layer is therefore absent when the settlement has no
+   * such layer, with one exception — the problem lists, which can be started by hand, because a
+   * problem is prose and an empty one is a field waiting to be filled.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps a settlement editor from rendering fields
+   * over something that is not a settlement.
+   */
+  const accepted = $derived(validateSettlementSnapshot(snapshot));
+  const settlement = $derived<SettlementSnapshot | undefined>(
+    accepted.ok ? accepted.value : undefined,
+  );
+
+  const FACET_FIELDS: { field: SettlementFacetField; label: string }[] = [
+    { field: 'lawAndOrder', label: 'Law and order' },
+    { field: 'commerce', label: 'Commerce' },
+    { field: 'foodSecurity', label: 'Food security' },
+    { field: 'publicHealth', label: 'Public health' },
+  ];
+
+  const COUNT_FIELDS: { field: SettlementCountField; label: string }[] = [
+    { field: 'population', label: 'Population' },
+    { field: 'prosperity', label: 'Prosperity' },
+  ];
+
+  const TRADE_LISTS: { field: SettlementTradeList; label: string }[] = [
+    { field: 'primaryExports', label: 'Exports' },
+    { field: 'primaryImports', label: 'Imports' },
+  ];
+
+  const PROBLEM_LISTS: { field: SettlementProblemList; label: string; singular: string }[] = [
+    { field: 'acuteProblems', label: 'Acute problems', singular: 'Acute problem' },
+    { field: 'creepingProblems', label: 'Creeping problems', singular: 'Creeping problem' },
+  ];
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in exactly one place. */
+  function edit(change: (current: SettlementSnapshot) => SettlementSnapshot): void {
+    if (settlement === undefined) {
+      return;
+    }
+    onChange(change(settlement));
+  }
+
+  function notableName(index: number): string {
+    const character = settlement?.importantPeople?.[index]?.character;
+    return character === undefined ? '' : `${character.firstName} ${character.lastName}`.trim();
+  }
+</script>
+
+{#if settlement === undefined}
+  <p class="settlement-editor__problem" role="alert">
+    These contents are stored as a settlement but do not read as one, so there is nothing safe to
+    edit here. {accepted.ok ? '' : accepted.message}
+  </p>
+{:else}
+  <div class="settlement-editor">
+    <div class="input-group">
+      <label for="{uid}-settlement-name">Settlement name</label>
+      <input
+        id="{uid}-settlement-name"
+        type="text"
+        value={settlement.name}
+        oninput={(event) =>
+          edit((current) => setSettlementText(current, 'name', event.currentTarget.value))}
+        autocomplete="off"
+      />
+    </div>
+
+    <div class="input-group">
+      <label for="{uid}-category">Kind of place</label>
+      <input
+        id="{uid}-category"
+        type="text"
+        value={settlement.category.name}
+        oninput={(event) =>
+          edit((current) => setSettlementCategoryName(current, event.currentTarget.value))}
+        autocomplete="off"
+      />
+    </div>
+
+    {#each COUNT_FIELDS as entry (entry.field)}
+      <div class="input-group">
+        <label for="{uid}-{entry.field}">{entry.label}</label>
+        <input
+          id="{uid}-{entry.field}"
+          type="number"
+          min="0"
+          value={settlement[entry.field]}
+          oninput={(event) =>
+            edit((current) =>
+              setSettlementCount(current, entry.field, event.currentTarget.valueAsNumber),
+            )}
+        />
+      </div>
+    {/each}
+
+    <div class="input-group">
+      <label for="{uid}-economic-role">Economic role</label>
+      <select
+        id="{uid}-economic-role"
+        value={settlement.economicRole}
+        onchange={(event) =>
+          edit((current) => setSettlementEconomicRole(current, event.currentTarget.value))}
+      >
+        {#each SETTLEMENT_ECONOMIC_ROLES as role (role)}
+          <option value={role}>{role}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="input-group settlement-editor__stacked">
+      <label for="{uid}-description">Description</label>
+      <textarea
+        id="{uid}-description"
+        rows="4"
+        value={settlement.description}
+        oninput={(event) =>
+          edit((current) => setSettlementText(current, 'description', event.currentTarget.value))}
+      ></textarea>
+    </div>
+
+    <fieldset>
+      <legend>Facets</legend>
+      <p class="settlement-editor__note">Each runs from 0 to 10.</p>
+
+      {#each FACET_FIELDS as entry (entry.field)}
+        <div class="input-group">
+          <label for="{uid}-{entry.field}">{entry.label}</label>
+          <input
+            id="{uid}-{entry.field}"
+            type="number"
+            min="0"
+            max="10"
+            value={settlement[entry.field]}
+            oninput={(event) =>
+              edit((current) =>
+                setSettlementFacet(current, entry.field, event.currentTarget.valueAsNumber),
+              )}
+          />
+        </div>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Environment</legend>
+
+      <div class="input-group settlement-editor__stacked">
+        <label for="{uid}-environment">Surroundings</label>
+        <textarea
+          id="{uid}-environment"
+          rows="3"
+          value={settlement.environment.description}
+          oninput={(event) =>
+            edit((current) =>
+              setSettlementEnvironmentDescription(current, event.currentTarget.value),
+            )}
+        ></textarea>
+      </div>
+
+      <div class="input-group settlement-editor__stacked">
+        <label for="{uid}-tags">Hook tags</label>
+        <input
+          id="{uid}-tags"
+          type="text"
+          value={settlement.settlementTags.join(', ')}
+          oninput={(event) =>
+            edit((current) => setSettlementTags(current, event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+    </fieldset>
+
+    <!-- Trade is one of the four opt-in layers. A settlement rolled without it has no trade to
+         rewrite, and a fieldset of empty boxes would suggest it lost something. -->
+    {#if settlement.primaryExports !== undefined || settlement.primaryImports !== undefined}
+      <fieldset>
+        <legend>Trade</legend>
+
+        {#each TRADE_LISTS as entry (entry.field)}
+          {#if settlement[entry.field] !== undefined}
+            <div class="input-group settlement-editor__stacked">
+              <label for="{uid}-{entry.field}">{entry.label}</label>
+              <input
+                id="{uid}-{entry.field}"
+                type="text"
+                value={(settlement[entry.field] ?? []).join(', ')}
+                oninput={(event) =>
+                  edit((current) =>
+                    setSettlementTradeList(current, entry.field, event.currentTarget.value),
+                  )}
+                autocomplete="off"
+              />
+            </div>
+          {/if}
+        {/each}
+
+        {#if settlement.tradeBlurb !== undefined}
+          <div class="input-group settlement-editor__stacked">
+            <label for="{uid}-trade-blurb">Trade notes</label>
+            <textarea
+              id="{uid}-trade-blurb"
+              rows="3"
+              value={settlement.tradeBlurb}
+              oninput={(event) =>
+                edit((current) =>
+                  setSettlementText(current, 'tradeBlurb', event.currentTarget.value),
+                )}
+            ></textarea>
+          </div>
+        {/if}
+      </fieldset>
+    {/if}
+
+    {#each PROBLEM_LISTS as list (list.field)}
+      <fieldset>
+        <legend>{list.label}</legend>
+
+        <!-- Keyed by position rather than by value: two problems may read the same, and a key that
+             changed as the user typed would lose focus on every keystroke. -->
+        {#each settlement[list.field] ?? [] as problem, index (index)}
+          <div class="settlement-editor__row">
+            <div class="input-group settlement-editor__stacked">
+              <label for="{uid}-{list.field}-{index}">{list.singular} {index + 1}</label>
+              <input
+                id="{uid}-{list.field}-{index}"
+                type="text"
+                value={problem.summary}
+                oninput={(event) =>
+                  edit((current) =>
+                    setSettlementProblem(
+                      current,
+                      list.field,
+                      index,
+                      'summary',
+                      event.currentTarget.value,
+                    ),
+                  )}
+                autocomplete="off"
+              />
+            </div>
+            <div class="input-group settlement-editor__stacked">
+              <label for="{uid}-{list.field}-{index}-detail">
+                {list.singular}
+                {index + 1} detail
+              </label>
+              <textarea
+                id="{uid}-{list.field}-{index}-detail"
+                rows="2"
+                value={problem.detail ?? ''}
+                oninput={(event) =>
+                  edit((current) =>
+                    setSettlementProblem(
+                      current,
+                      list.field,
+                      index,
+                      'detail',
+                      event.currentTarget.value,
+                    ),
+                  )}
+              ></textarea>
+            </div>
+            <button
+              type="button"
+              aria-label="Remove {list.singular.toLowerCase()} {index + 1}"
+              onclick={() => edit((current) => removeSettlementProblem(current, list.field, index))}
+            >
+              Remove
+            </button>
+          </div>
+        {/each}
+
+        <button
+          type="button"
+          onclick={() => edit((current) => addSettlementProblem(current, list.field))}
+        >
+          Add {list.singular.toLowerCase()}
+        </button>
+      </fieldset>
+    {/each}
+
+    {#if settlement.organizations !== undefined && settlement.organizations.length > 0}
+      <fieldset>
+        <legend>Organizations</legend>
+
+        {#each settlement.organizations as organization, index (index)}
+          <div class="settlement-editor__row">
+            <div class="input-group">
+              <label for="{uid}-org-{index}">Organization {index + 1}</label>
+              <input
+                id="{uid}-org-{index}"
+                type="text"
+                value={organization.name}
+                oninput={(event) =>
+                  edit((current) =>
+                    setSettlementOrganizationField(
+                      current,
+                      index,
+                      'name',
+                      event.currentTarget.value,
+                    ),
+                  )}
+                autocomplete="off"
+              />
+            </div>
+            <div class="input-group settlement-editor__stacked">
+              <label for="{uid}-org-{index}-hook">Organization {index + 1} hook</label>
+              <textarea
+                id="{uid}-org-{index}-hook"
+                rows="2"
+                value={organization.profile.hook}
+                oninput={(event) =>
+                  edit((current) =>
+                    setSettlementOrganizationField(
+                      current,
+                      index,
+                      'hook',
+                      event.currentTarget.value,
+                    ),
+                  )}
+              ></textarea>
+            </div>
+          </div>
+        {/each}
+      </fieldset>
+    {/if}
+
+    {#if settlement.importantPeople !== undefined && settlement.importantPeople.length > 0}
+      <fieldset>
+        <legend>Important people</legend>
+
+        {#each settlement.importantPeople as person, index (index)}
+          <div class="settlement-editor__row">
+            <div class="input-group">
+              <label for="{uid}-notable-{index}-role">Notable {index + 1} title</label>
+              <input
+                id="{uid}-notable-{index}-role"
+                type="text"
+                value={person.roleDisplay}
+                oninput={(event) =>
+                  edit((current) =>
+                    setSettlementNotableField(
+                      current,
+                      index,
+                      'roleDisplay',
+                      event.currentTarget.value,
+                    ),
+                  )}
+                autocomplete="off"
+              />
+            </div>
+            <div class="input-group">
+              <label for="{uid}-notable-{index}-first">Notable {index + 1} first name</label>
+              <input
+                id="{uid}-notable-{index}-first"
+                type="text"
+                value={person.character.firstName}
+                oninput={(event) =>
+                  edit((current) =>
+                    setSettlementNotableName(
+                      current,
+                      index,
+                      'firstName',
+                      event.currentTarget.value,
+                    ),
+                  )}
+                autocomplete="off"
+              />
+            </div>
+            <div class="input-group">
+              <label for="{uid}-notable-{index}-last">Notable {index + 1} family name</label>
+              <input
+                id="{uid}-notable-{index}-last"
+                type="text"
+                value={person.character.lastName}
+                oninput={(event) =>
+                  edit((current) =>
+                    setSettlementNotableName(current, index, 'lastName', event.currentTarget.value),
+                  )}
+                autocomplete="off"
+              />
+            </div>
+            <div class="input-group settlement-editor__stacked">
+              <label for="{uid}-notable-{index}-importance">
+                Notable {index + 1} importance
+              </label>
+              <textarea
+                id="{uid}-notable-{index}-importance"
+                rows="2"
+                value={person.importance}
+                oninput={(event) =>
+                  edit((current) =>
+                    setSettlementNotableField(
+                      current,
+                      index,
+                      'importance',
+                      event.currentTarget.value,
+                    ),
+                  )}
+              ></textarea>
+            </div>
+            <!-- No way to add one, deliberately: a notable is a generated character with a
+                 species, an age, and an archetype, so an empty one would be a broken record
+                 rather than a blank field. -->
+            <button
+              type="button"
+              aria-label="Remove {notableName(index) || `notable ${index + 1}`}"
+              onclick={() => edit((current) => removeSettlementNotable(current, index))}
+            >
+              Remove
+            </button>
+          </div>
+        {/each}
+      </fieldset>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .settlement-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    min-width: 0;
+  }
+
+  .settlement-editor fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    align-items: flex-start;
+    margin: 0;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid var(--tan);
+    border-radius: 4px;
+    min-width: 0;
+  }
+
+  .settlement-editor legend {
+    padding: 0 0.3rem;
+    color: var(--gold);
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  /* One sub-object per block, so a settlement's problems and its notables read as lists of things
+     rather than one long run of fields. */
+  .settlement-editor__row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    width: 100%;
+    min-width: 0;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--tan);
+  }
+
+  .settlement-editor .input-group {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin: 0;
+    width: 100%;
+    min-width: 0;
+  }
+
+  /* Prose wants the width; a label sitting beside a three-row textarea on a 320px screen leaves
+     neither enough room to be useful. */
+  .settlement-editor .settlement-editor__stacked {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .settlement-editor input[type='text'],
+  .settlement-editor input[type='number'],
+  .settlement-editor select,
+  .settlement-editor textarea {
+    min-width: 0;
+    flex: 1 1 6rem;
+    width: 100%;
+  }
+
+  .settlement-editor__note,
+  .settlement-editor__problem {
+    margin: 0;
+    font-size: 0.9rem;
+    font-style: italic;
+    opacity: 0.9;
+  }
+</style>

--- a/src/components/locations/SettlementGenerator.svelte
+++ b/src/components/locations/SettlementGenerator.svelte
@@ -1,104 +1,203 @@
 <script lang="ts">
   import { RNG } from '@ironarachne/rng';
-  import * as Names from '$lib/names';
-  import { getCharacterGenerationConfigForNameSet } from '$lib/characters';
-  import { CULTURE_ARTIFACT_KIND, type Culture } from '$lib/culture';
-  import * as Settlements from '$lib/settlements';
-  import type { Settlement, SettlementGeneratorConfig } from '$lib/settlements';
   import { onMount } from 'svelte';
-  import GeneratorPage from '$components/layout/GeneratorPage.svelte';
-  import SeedControls from '$components/common/SeedControls.svelte';
-  import SavedArtifactPicker from '$components/common/SavedArtifactPicker.svelte';
-  import SelectField from '$components/common/SelectField.svelte';
+
+  import type { ArtifactReference } from '$lib/artifacts';
+  import { CULTURE_ARTIFACT_KIND, type Culture } from '$lib/culture';
+  import Download from '$lib/download';
+  import { getFantasyNameGeneratorSetNames } from '$lib/names';
+  import { downloadTextPdf } from '$lib/pdf';
+  import { RELIGION_ARTIFACT_KIND, type RestoredReligion } from '$lib/religion';
+  import {
+    rollSettlement,
+    settlementFileStem,
+    settlementSummaryLine,
+    settlementToMarkdown,
+    settlementToPlainText,
+    toSettlementSnapshot,
+    SETTLEMENT_ARTIFACT_KIND,
+    type Settlement,
+    type SettlementSizeFilter,
+  } from '$lib/settlements';
   import CheckboxField from '$components/common/CheckboxField.svelte';
+  import DownloadPdfButton from '$components/common/DownloadPdfButton.svelte';
+  import SavedArtifactPicker from '$components/common/SavedArtifactPicker.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
+  import SeedControls from '$components/common/SeedControls.svelte';
+  import SelectField from '$components/common/SelectField.svelte';
+  import GeneratorPage from '$components/layout/GeneratorPage.svelte';
 
-  // Filled in by the picker: the culture the user chose, rebuilt by its own kind.
-  let useSavedCulture = $state(false);
-  let culture: Culture | undefined = $state();
+  const TOOL_PATH = '/fantasy/settlement';
 
-  const rng = new RNG(Date.now().toString());
-  let seed = $state(rng.randomString(13));
-  $effect(() => {
-    rng.setSeed(seed);
-  });
+  let seed = $state(new RNG(Date.now().toString()).randomString(13));
   let lockSeed = $state(false);
 
+  const nameSetNames = getFantasyNameGeneratorSetNames();
   let nameSetName = $state('any');
-  const nameSetsInitial = Names.getAllFantasyNameGeneratorSets(rng);
-  let nameSets = $state(nameSetsInitial);
-  let nameSet = $state(rng.item(nameSetsInitial));
 
-  let sizeClass = $state<'any' | 'small' | 'medium' | 'large'>('any');
+  let sizeClass = $state<SettlementSizeFilter>('any');
   let includeTrade = $state(false);
   let includeProblems = $state(false);
   let includeOrganizations = $state(false);
   let includeNotables = $state(false);
 
+  // Filled in by the picker: the culture whose tongue names this place, rebuilt by its own kind.
+  let useSavedCulture = $state(false);
+  let cultureArtifactId: string | undefined = $state();
+  let culture: Culture | undefined = $state();
+  let cultureReference: ArtifactReference | undefined = $state();
+  let cultureProblem: string | null = $state(null);
+
+  // And the faith practised here. The religion kind's live value is the restored *record* — the
+  // religion, its seed, and its options — not a bare religion, so a consumer speaks that shape.
+  let useSavedReligion = $state(false);
+  let referencedReligion: RestoredReligion | undefined = $state();
+  let religionReference: ArtifactReference | undefined = $state();
+  let religionProblem: string | null = $state(null);
+
   let settlement = $state<Settlement | null>(null);
+  /**
+   * What the settlement on screen was actually rolled with, as opposed to what the next roll would
+   * use. The two differ the moment a control is changed and nothing has been rolled since, and
+   * provenance has to record the first: a re-roll reads it, and a config describing settings the
+   * settlement was never made with would produce a different place under the same name.
+   *
+   * `$state.raw`, and that is load-bearing rather than a preference. A plain `$state` object is a
+   * deep proxy, provenance is copied into the record by reference, and IndexedDB stores through
+   * `structuredClone`, which refuses a proxy outright — the save comes back as
+   * `storage-failed: could not be cloned`. Nothing here is ever mutated in place; a roll replaces
+   * the whole record, which is what raw state is for.
+   */
+  let rolledConfig = $state.raw<Record<string, unknown>>({});
+  /**
+   * The culture link, recorded only when the settlement on screen was actually named from it.
+   *
+   * Gated on the roll rather than on the checkbox, because a reference is a record of what the
+   * tool was handed. One written for a settlement whose names were drawn at random would claim an
+   * input that was never used.
+   */
+  let rolledCultureReference = $state<ArtifactReference | undefined>();
+  /**
+   * The name of that culture, kept beside the link rather than read back off the picker.
+   *
+   * Unticking the box clears the picker's value, and a line that read from it would vanish while
+   * the reference it describes was still there to be saved — the page would stop crediting an
+   * input the artifact still records.
+   */
+  let rolledCultureName = $state<string | undefined>();
 
-  function resolveNameSetForGeneration(): void {
-    if (useSavedCulture && culture !== undefined) {
-      nameSet = culture.nameGenerators;
-    } else {
-      if (nameSetName === 'any') {
-        nameSet = rng.item(nameSets);
-      } else {
-        const found = nameSets.find((s) => s.name === nameSetName);
-        if (found) {
-          nameSet = found;
-        }
-      }
-    }
-  }
+  /**
+   * A culture has been chosen and has not arrived yet.
+   *
+   * Rolling in that window would quietly ignore the choice and draw a pattern set at random, and
+   * the user would have no way of telling that from a settlement that took the culture they picked.
+   * A chosen artifact that cannot be read reports a problem instead of a value, and waiting on
+   * that would be waiting forever.
+   */
+  const awaitingCulture = $derived(
+    useSavedCulture &&
+      cultureArtifactId !== undefined &&
+      culture === undefined &&
+      cultureProblem === null,
+  );
 
-  function buildConfig(): SettlementGeneratorConfig {
-    resolveNameSetForGeneration();
-    const config = Settlements.getDefaultConfig(rng);
-    config.size = sizeClass;
-    config.nameGenerator = nameSet.town;
+  /**
+   * The faith practised here, as a link rather than a copy.
+   *
+   * It follows the picker rather than the roll, and that is the difference between it and the
+   * culture above: a culture is an *input*, consumed while the settlement is being made, whereas a
+   * faith is something the user says about the place afterwards. Nothing about it is stored in the
+   * payload — requirement 5.2 — so choosing one changes what the page shows and what an export
+   * carries, and the artifact records which religion by id.
+   */
+  const shownReligion = $derived(useSavedReligion ? (referencedReligion?.religion ?? null) : null);
 
-    const anyEnrichment =
-      includeTrade || includeProblems || includeOrganizations || includeNotables;
-    if (anyEnrichment) {
-      config.enrichment = {
-        seedPrefix: 'fantasy-settlement-page',
-        includeTrade: includeTrade,
-        includeProblems: includeProblems,
-        includeOrganizations: includeOrganizations,
-        genre: 'fantasy',
-        importantCharacterCount: includeNotables ? { min: 1, max: 2 } : undefined,
-        characterConfig: getCharacterGenerationConfigForNameSet(`${seed}-settlement-vip`, nameSet),
-      };
-    } else {
-      config.enrichment = undefined;
-    }
-    return config;
-  }
+  const references = $derived(
+    [rolledCultureReference, useSavedReligion ? religionReference : undefined].filter(
+      (reference): reference is ArtifactReference => reference !== undefined,
+    ),
+  );
 
-  function runGenerate() {
+  const settlementSnapshot = $derived(
+    settlement === null ? null : toSettlementSnapshot(settlement),
+  );
+
+  /**
+   * Roll a settlement, through the library's own entry point rather than by assembling a config
+   * here.
+   *
+   * That is the whole of requirement 2.2 for this tool. The page used to build its own
+   * configuration inline — drawing name sets and an environment off a shared RNG in an order
+   * nothing else could reproduce — which made "same seed, same settlement" true only for as long
+   * as nobody touched this file, and left a re-roll with no way to reproduce anything.
+   */
+  function generate() {
     if (!lockSeed) {
-      seed = rng.randomString(13);
+      seed = new RNG(Date.now().toString()).randomString(13);
     }
-    rng.setSeed(seed);
-    nameSets = Names.getAllFantasyNameGeneratorSets(rng);
-    settlement = Settlements.generate(buildConfig());
+    const requestedSet = useSavedCulture ? culture?.nameGenerators.name : sanitisedNameSetName();
+    const config = {
+      ...(requestedSet === undefined ? {} : { nameGeneratorSet: requestedSet }),
+      size: sizeClass,
+      includeTrade,
+      includeProblems,
+      includeOrganizations,
+      includeNotables,
+    };
+    const rolled = rollSettlement(seed, config);
+    settlement = rolled.settlement;
+    // The resolved set, not the requested one: "any" recorded as provenance would make a re-roll a
+    // fresh draw rather than the same settlement again.
+    rolledConfig = { ...config, nameGeneratorSet: rolled.nameGeneratorSet };
+    const namedFromCulture = useSavedCulture && culture !== undefined;
+    rolledCultureReference = namedFromCulture ? cultureReference : undefined;
+    rolledCultureName = namedFromCulture ? culture?.name : undefined;
+  }
+
+  function sanitisedNameSetName(): string | undefined {
+    return nameSetName === 'any' ? undefined : nameSetName;
   }
 
   onMount(() => {
-    runGenerate();
+    generate();
   });
+
+  let downloadingPdf = $state(false);
+
+  function exportMarkdown() {
+    if (settlement === null) {
+      return;
+    }
+    const markdown = settlementToMarkdown(settlement, { religion: shownReligion });
+    const url = URL.createObjectURL(new Blob([markdown], { type: 'text/markdown' }));
+    Download(url, `${settlementFileStem(settlement)}.md`);
+    URL.revokeObjectURL(url);
+  }
+
+  async function exportPdf() {
+    if (settlement === null || downloadingPdf) {
+      return;
+    }
+    downloadingPdf = true;
+    try {
+      await downloadTextPdf(
+        settlement.name,
+        settlementToPlainText(settlement, { religion: shownReligion }),
+        `${settlementFileStem(settlement)}.pdf`,
+      );
+    } finally {
+      downloadingPdf = false;
+    }
+  }
 </script>
 
-<GeneratorPage toolPath="/fantasy/settlement" theme="fantasy" title="Settlement Generator">
+<GeneratorPage toolPath={TOOL_PATH} theme="fantasy" title="Settlement Generator">
   {#snippet description()}
     <p>
       Generate a settlement with derived facets (law, commerce, food security, health) and economic
       role. Optionally add narrative trade, acute/creeping problems, local organizations, and
-      important people. Town name, org members, and notables can all use a <strong
-        >saved culture</strong
-      >
-      for naming (as on the region generator) instead of a random fantasy name set. Uses the same pipeline
-      as the settlements library <code>generate</code> entry point.
+      important people. A <strong>saved culture</strong> can name the town, its organizations, and
+      its people, and a <strong>saved religion</strong> can be recorded as the faith practised here.
     </p>
   {/snippet}
 
@@ -121,8 +220,8 @@
     label="Name set (town, people, and orgs when enrichment is on)"
     bind:value={nameSetName}
     options={[
-      { value: 'any', label: 'any (random per run)' },
-      ...nameSets.map((ns) => ({ value: ns.name, label: ns.name })),
+      { value: 'any', label: 'any (drawn from the seed)' },
+      ...nameSetNames.map((name) => ({ value: name, label: name })),
     ]}
     disabled={useSavedCulture}
   />
@@ -131,8 +230,23 @@
     kind={CULTURE_ARTIFACT_KIND}
     role="naming-culture"
     checkboxLabel="Use a saved culture for all names"
+    selectLabel="Saved culture"
     bind:enabled={useSavedCulture}
+    bind:artifactId={cultureArtifactId}
     bind:value={culture}
+    bind:reference={cultureReference}
+    bind:problem={cultureProblem}
+  />
+
+  <SavedArtifactPicker
+    kind={RELIGION_ARTIFACT_KIND}
+    role="faith"
+    checkboxLabel="Record a saved religion as the local faith?"
+    selectLabel="Saved religion"
+    bind:enabled={useSavedReligion}
+    bind:value={referencedReligion}
+    bind:reference={religionReference}
+    bind:problem={religionProblem}
   />
 
   <h2>Optional enrichment</h2>
@@ -143,17 +257,32 @@
   <CheckboxField id="orgs" label="Organizations" bind:checked={includeOrganizations} />
   <CheckboxField id="notables" label="Important characters (1–2)" bind:checked={includeNotables} />
 
-  <p><button type="button" onclick={runGenerate}>Generate</button></p>
+  <p>
+    <button type="button" onclick={generate} disabled={awaitingCulture}>Generate</button>
+  </p>
+
+  <SaveArtifactButton
+    kind={SETTLEMENT_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={settlementSnapshot}
+    {seed}
+    config={rolledConfig}
+    defaultName={settlement?.name ?? ''}
+    {references}
+  />
 
   {#if settlement}
-    {#if useSavedCulture && culture}
-      <p class="culture-line">Naming: <strong>{culture.name}</strong> culture</p>
+    {#if rolledCultureName !== undefined}
+      <p class="settlement-referenced">Naming: <strong>{rolledCultureName}</strong> culture</p>
     {/if}
     <h2>{settlement.name}</h2>
-    <p class="settlement-meta">
-      <strong>{settlement.category.name}</strong> · population {settlement.population.toLocaleString()}
-      · prosperity {settlement.prosperity} · <em>{settlement.economicRole}</em>
-    </p>
+    <p class="settlement-meta">{settlementSummaryLine(settlement)}</p>
+
+    <div class="settlement-exports">
+      <button type="button" onclick={exportMarkdown}>Download Markdown</button>
+      <DownloadPdfButton onclick={exportPdf} downloading={downloadingPdf} />
+    </div>
+
     <p>{settlement.description}</p>
 
     <h3>Facets</h3>
@@ -167,6 +296,18 @@
 
     <h3>Environment</h3>
     <p>{settlement.environment.description}</p>
+
+    {#if useSavedReligion}
+      <h3>Faith</h3>
+      {#if shownReligion === null}
+        <p>Choose a saved religion above to record the faith practised here.</p>
+      {:else}
+        <!-- Named as borrowed, because it is: the settlement stores a link, not a copy, so
+             editing that religion changes what is practised here. -->
+        <p class="settlement-referenced">From the saved religion {shownReligion.name}.</p>
+        <p>{shownReligion.description}</p>
+      {/if}
+    {/if}
 
     {#if settlement.primaryImports && settlement.primaryImports.length > 0}
       <h3>Trade</h3>
@@ -243,12 +384,19 @@
 </GeneratorPage>
 
 <style>
-  .culture-line {
+  .settlement-referenced {
     margin-bottom: 0.5rem;
     font-size: 0.95em;
+    font-style: italic;
+    opacity: 0.9;
   }
   .settlement-meta {
     opacity: 0.95;
+  }
+  .settlement-exports {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
   }
   .detail {
     display: block;

--- a/src/lib/heraldry/heraldry_rehydrate.ts
+++ b/src/lib/heraldry/heraldry_rehydrate.ts
@@ -9,6 +9,8 @@
 
 import { getChargeGlyphByName } from '$lib/charges';
 
+import type { Arms } from './arms.js';
+
 import * as Arrangements from './charge_group_arrangements/index.js';
 import type { ChargeGroup } from './charge_group.js';
 import type { Device } from './device.js';
@@ -17,6 +19,7 @@ import {
   normalizeHeraldryGeneratorOptions,
   type HeraldrySnapshot,
   type RestoredHeraldry,
+  type StoredArms,
   type StoredChargeGroup,
   type StoredDevice,
   type StoredVariation,
@@ -49,7 +52,11 @@ function chargeGroupFromStored(stored: StoredChargeGroup): ChargeGroup {
   };
 }
 
-function deviceFromStored(stored: StoredDevice): Device {
+/**
+ * A device rebuilt from the names it was stored under. The expensive half: every charge name is
+ * resolved against `$lib/charges`, which is why this module is separate from the writing side.
+ */
+export function deviceFromStored(stored: StoredDevice): Device {
   const fieldTemplate = Fields.byName(stored.fieldName);
   return {
     field: {
@@ -58,6 +65,11 @@ function deviceFromStored(stored: StoredDevice): Device {
     },
     chargeGroups: stored.chargeGroups.map(chargeGroupFromStored),
   };
+}
+
+/** Arms rebuilt from {@link StoredArms} — an organization's emblem, a character's own device. */
+export function armsFromStored(stored: StoredArms): Arms {
+  return { device: deviceFromStored(stored.device), blazon: stored.blazon };
 }
 
 export function heraldryFromSnapshot(snapshot: HeraldrySnapshot): RestoredHeraldry {

--- a/src/lib/heraldry/heraldry_snapshot.ts
+++ b/src/lib/heraldry/heraldry_snapshot.ts
@@ -73,6 +73,20 @@ export type StoredDevice = {
   chargeGroups: StoredChargeGroup[];
 };
 
+/**
+ * A coat of arms as plain data: the device by the names of its parts, and the blazon that
+ * describes it.
+ *
+ * Separate from {@link HeraldrySnapshot}, which is a saved *artifact* and so also carries the seed
+ * and the settings it was rolled from. Arms that belong to something else — an organization's
+ * visual identity, a character's own device — have no such history of their own, and a type that
+ * demanded one would have callers inventing seeds to satisfy it.
+ */
+export type StoredArms = {
+  device: StoredDevice;
+  blazon: string;
+};
+
 export type HeraldrySnapshot = {
   name: string;
   seed: string;
@@ -112,12 +126,18 @@ function toStoredChargeGroup(group: ChargeGroup): StoredChargeGroup {
   };
 }
 
-function toStoredDevice(device: Device): StoredDevice {
+/** A device as the names of its field, variations, and charges. The cheap half of the pair. */
+export function toStoredDevice(device: Device): StoredDevice {
   return {
     fieldName: device.field.name,
     variations: device.field.variations.map(toStoredVariation),
     chargeGroups: device.chargeGroups.map(toStoredChargeGroup),
   };
+}
+
+/** Arms as plain data, for anything that owns a coat of arms without owning its provenance. */
+export function toStoredArms(arms: Arms): StoredArms {
+  return { device: toStoredDevice(arms.device), blazon: arms.blazon };
 }
 
 export function toHeraldrySnapshot(

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -44,12 +44,15 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // from the other end.
   '$lib/swn/starship',
   // The artifact kind registry, which everything in the workshop touches. Assembled through the
-  // three libraries' entry points it costs 296 KB in the importing chunk; through these modules,
+  // four libraries' entry points it costs 296 KB in the importing chunk; through these modules,
   // 4 KB. Each kind module holds metadata and validation only — its codec is a dynamic import,
   // which is what keeps 18 MB of charge art out of the chunk that merely lists a project.
+  // `$lib/settlements` is the sharpest of the four: its entry point reaches `$lib/organizations`
+  // and from there the heraldry generator and the charge library.
   '$lib/culture/culture_artifact_kind',
   '$lib/heraldry/heraldry_artifact_kind',
   '$lib/religion/religion_artifact_kind',
+  '$lib/settlements/settlement_artifact_kind',
 ]);
 
 /** A specifier ending in something other than a TS/JS extension is an asset, not a module. */

--- a/src/lib/names/index.ts
+++ b/src/lib/names/index.ts
@@ -11,6 +11,17 @@ export type NameGeneratorSet = {
   town: MUN.NameGenerator;
 };
 
+/**
+ * The names of the fantasy pattern sets, without building a generator for any of them.
+ *
+ * {@link getAllFantasyNameGeneratorSets} answers the same question, but it needs an RNG and builds
+ * six generators per set to do it. A caller that only wants to know which sets exist — to fill a
+ * dropdown, or to draw one from a seed before rolling — should not pay for that.
+ */
+export function getFantasyNameGeneratorSetNames(): string[] {
+  return MUN.getSupportedClassicRaceNamePatternSets();
+}
+
 export function getAllFantasyNameGeneratorSets(rng: RNG): NameGeneratorSet[] {
   const sets: NameGeneratorSet[] = [];
   const availableSets = MUN.getSupportedClassicRaceNamePatternSets();

--- a/src/lib/settlements/README.md
+++ b/src/lib/settlements/README.md
@@ -14,6 +14,53 @@ This library generates **narrative settlements** (hamlets through metropolises) 
 - Full economy or resource-simulation (trade strings are **narrative**; no automatic link to [`$lib/resources`](../resources/) yet).
 - Pol map placement: optional `location` / `mapNodeId` are set by region generation, not here.
 
+## Saving a settlement
+
+A settlement is an **artifact kind** (`settlement`), which is what took this tool to Release-ready
+against the spec in [`docs/workshop.md`](../../../docs/workshop.md). The pieces:
+
+| Module                        | What it is for                                                          |
+| ----------------------------- | ----------------------------------------------------------------------- |
+| `settlement_artifact_kind.ts` | The kind entry: id, `payloadVersion`, `validate`, `migrate`.            |
+| `settlement_snapshot.ts`      | `toSettlementSnapshot` and the stored shapes. The cheap half.           |
+| `settlement_rehydrate.ts`     | `settlementFromSnapshot`. The expensive half; see below.                |
+| `settlement_roll.ts`          | `rollSettlement` — the one path both the page and a re-roll take.       |
+| `settlement_editing.ts`       | One function per field a user may rewrite; each returns a new snapshot. |
+| `settlement_presentation.ts`  | The document model behind the Markdown and PDF exports.                 |
+
+### What is not plain data, and what happens to it
+
+A settlement borrows from `$lib/characters`, `$lib/organizations`, and `$lib/heraldry`, and three
+things it borrows are not storable as they stand. Each is converted by name rather than stripped,
+so the round trip is lossless:
+
+- **An organization's hierarchy is three `Map`s.** `JSON.stringify` turns a `Map` into `{}` without
+  complaining, which would have emptied every organization's structure silently. Stored as entry
+  arrays.
+- **A coat of arms carries a render function.** `arrangement.renderSVG` sits on every charge group,
+  and `structuredClone` — what IndexedDB stores with — refuses a function outright. Stored the way
+  the heraldry kind stores arms, by the names of the parts, and rebuilt through
+  `$lib/heraldry`'s `armsFromStored`.
+- **An archetype carries its own equipment tables.** `equipmentGenerationConfigs` is 66 KB per
+  character, measured, and it is what a character was rolled _from_ rather than anything about the
+  character. Dropped and rebuilt from the archetype's name: kept, one enriched settlement is a
+  megabyte, and a campaign accumulates settlements. An archetype this build no longer has comes
+  back with no tables rather than throwing — the tables are only used to re-equip somebody, which a
+  saved settlement never does.
+
+That last pair is why reading is split out of `settlement_snapshot.ts`: rebuilding reaches
+`$lib/charges` (18 MB of glyph art) and the archetype tables, and validating or listing a
+settlement needs neither.
+
+### Sixteen shapes of one kind
+
+`enrich_settlement.ts` is opt-in four times over, so a settlement generated with enrichment and one
+generated without are different shapes of the same kind — sixteen legitimate combinations in all.
+The validator accepts every optional layer when absent and checks it when present, which is what
+makes a payload written by a build with different enrichment defaults readable rather than
+quarantined. The editor renders each layer only when the settlement has it, so a settlement with no
+notables looks like what it is rather than like one that lost them.
+
 ## Core types
 
 - **`Settlement`:** `name`, `description`, `category`, `population`, `prosperity`, `environment`, optional `location` / `mapNodeId`, always-present facets and tags, plus optional `primaryImports`, `primaryExports`, `tradeBlurb`, `acuteProblems`, `creepingProblems`, `organizations`, `importantPeople` (civic `SettlementImportantPerson` records with `importance` and salient trait lists).
@@ -59,9 +106,45 @@ const settlement = Settlements.generate({
 
 **Kind filtering for orgs:** `settlement_organizations.ts` uses minimum population gates per `kindId` (e.g. `wizard_school` needs a large town). If no kind passes the full filter, the code relaxes economic-role and size constraints but still respects the requested `genre`. When nothing fits, org generation returns an empty list.
 
+## Rolling one
+
+`rollSettlement(seed, config)` is the entry point the generator page and the artifact re-roll both
+use, and having exactly one is what makes requirement 2.2 true: a seed plus a
+`SettlementGeneratorConfigRecord` determine the settlement. It returns the resolved
+`nameGeneratorSet` alongside the settlement, because a roll may draw a pattern set itself and
+provenance has to record what was used rather than what was asked for — "any set" stored as
+provenance would make a re-roll a fresh draw rather than the same place again.
+
+A settlement built around a saved culture records that culture's **pattern set name**, not its id.
+That is what lets a re-roll produce names of the same tongue without reaching back into the store
+for an artifact it has no way to ask for, and it is the same bargain `$lib/religion` makes.
+
+```typescript
+import { rollSettlement } from '$lib/settlements';
+
+const { settlement, nameGeneratorSet } = rollSettlement('greyhaven', {
+  size: 'large',
+  includeProblems: true,
+  includeNotables: true,
+});
+```
+
+## Exporting one
+
+`settlementToDocument` arranges a settlement for reading, and the Markdown and plain-text renderers
+are written over that one model. Empty sections are dropped there, once, rather than in each
+renderer — which matters more here than anywhere else on the site, because the plainest settlement
+the generator makes would otherwise print four bare headings.
+
+A referenced religion is passed in rather than read off the settlement: the payload holds no copy
+of one, only the artifact's link, so `settlementToMarkdown(settlement, { religion })` is how a
+caller that has resolved the link gets a Faith section.
+
 ## Tests
 
 `settlements.test.ts`: facet bounds, prosperity monotonicity for commerce, default vs enriched `generate` paths.
+`settlement_snapshot.test.ts`: the round trip, enriched and unenriched, and each of the three
+conversions above.
 
 ## Adding a new size category
 

--- a/src/lib/settlements/index.ts
+++ b/src/lib/settlements/index.ts
@@ -12,3 +12,9 @@ export {
 export { generateSettlementNotables, resolveNotableCharacterConfig } from './settlement_notables';
 export * from './settlement_notable_roles';
 export * from './settlement_notable_mutators';
+export * from './settlement_artifact_kind';
+export * from './settlement_editing';
+export * from './settlement_presentation';
+export * from './settlement_rehydrate';
+export * from './settlement_roll';
+export * from './settlement_snapshot';

--- a/src/lib/settlements/settlement_artifact_kind.test.ts
+++ b/src/lib/settlements/settlement_artifact_kind.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+
+import { readArtifactPayload, type AnyArtifactKindEntry } from '$lib/artifact_kinds';
+
+import {
+  migrateSettlementSnapshot,
+  settlementArtifactKind,
+  SETTLEMENT_ARTIFACT_KIND,
+  SETTLEMENT_PAYLOAD_VERSION,
+  validateSettlementSnapshot,
+} from './settlement_artifact_kind';
+import { toSettlementSnapshot } from './settlement_snapshot';
+import { rollSettlement } from './settlement_roll';
+import type { SettlementSnapshot } from './settlement_snapshot';
+
+/** A stored payload, as anything reading one actually receives it. */
+function storedSnapshot(seed: string, config = {}): Record<string, unknown> {
+  const snapshot = toSettlementSnapshot(rollSettlement(seed, config).settlement);
+  return JSON.parse(JSON.stringify(snapshot)) as Record<string, unknown>;
+}
+
+describe('validateSettlementSnapshot', () => {
+  /**
+   * The two shapes of the same kind. `enrich_settlement.ts` is opt-in four times over, so a
+   * settlement rolled with enrichment and one rolled without are both current payloads, and a
+   * validator that demanded either would reject half the settlements the generator makes.
+   */
+  it('accepts a settlement with every enrichment layer on', () => {
+    const result = validateSettlementSnapshot(
+      storedSnapshot('greyhaven', {
+        size: 'large',
+        includeTrade: true,
+        includeProblems: true,
+        includeOrganizations: true,
+        includeNotables: true,
+      }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts a settlement with no enrichment at all', () => {
+    expect(validateSettlementSnapshot(storedSnapshot('greyhaven')).ok).toBe(true);
+  });
+
+  it('accepts each enrichment layer on its own', () => {
+    for (const layer of [
+      'includeTrade',
+      'includeProblems',
+      'includeOrganizations',
+      'includeNotables',
+    ]) {
+      expect(
+        validateSettlementSnapshot(storedSnapshot('greyhaven', { size: 'large', [layer]: true }))
+          .ok,
+      ).toBe(true);
+    }
+  });
+
+  /**
+   * Requirement 3.3, in the case that actually arrives: a payload written by a build whose
+   * enrichment defaults were not this one's. A settlement carrying a layer this build would not
+   * have rolled is still a settlement, and quarantining it would take away work nobody damaged.
+   */
+  it('accepts a settlement carrying layers a differently configured build wrote', () => {
+    const payload = {
+      ...storedSnapshot('greyhaven'),
+      primaryExports: ['salt', 'timber'],
+      acuteProblems: [{ kind: 'acute', summary: 'The mill has stopped.' }],
+      creepingProblems: [
+        { kind: 'creeping', summary: 'The river is silting.', detail: 'A season at a time.' },
+      ],
+    };
+    expect(validateSettlementSnapshot(payload).ok).toBe(true);
+  });
+
+  it.each([
+    ['a payload that is not an object', 'a settlement'],
+    ['an array', []],
+    ['null', null],
+  ])('rejects %s', (_label, payload) => {
+    const result = validateSettlementSnapshot(payload);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toBe('invalid-payload');
+  });
+
+  it.each([
+    ['name', { name: 42 }],
+    ['description', { description: null }],
+    ['economicRole', { economicRole: undefined }],
+    ['population', { population: 'many' }],
+    ['prosperity', { prosperity: Number.NaN }],
+    ['lawAndOrder', { lawAndOrder: null }],
+    ['settlementTags', { settlementTags: 'river_trade' }],
+    ['category', { category: 'city' }],
+    ['category size band', { category: { name: 'city', sizeClass: 'large' } }],
+    ['environment', { environment: {} }],
+    ['primaryImports', { primaryImports: 'salt' }],
+    ['acuteProblems', { acuteProblems: [{ kind: 'sudden', summary: 'The mill has stopped.' }] }],
+    ['creepingProblems', { creepingProblems: [{ kind: 'creeping' }] }],
+    ['organizations', { organizations: [{ name: 'The Ledger' }] }],
+    ['importantPeople', { importantPeople: [{ roleId: 'mayor' }] }],
+  ])('rejects a payload with a bad %s, saying which', (field, override) => {
+    const result = validateSettlementSnapshot({ ...storedSnapshot('greyhaven'), ...override });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.message).toContain('settlement');
+  });
+
+  it('names the field it could not read, so quarantine has something to report', () => {
+    const result = validateSettlementSnapshot({
+      ...storedSnapshot('greyhaven'),
+      settlementTags: 'river_trade',
+    });
+    expect(result.ok === false && result.message).toContain('settlementTags');
+  });
+});
+
+describe('migrateSettlementSnapshot', () => {
+  it('rejects, because version 1 is the only shape there has been', () => {
+    const result = migrateSettlementSnapshot({}, 0);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toBe('unsupported-version');
+  });
+});
+
+describe('settlementArtifactKind', () => {
+  it('is registered under a stable, system-neutral id', () => {
+    expect(settlementArtifactKind.kind).toBe(SETTLEMENT_ARTIFACT_KIND);
+    expect(settlementArtifactKind.displayName).toBe('Settlement');
+    expect(settlementArtifactKind.payloadVersion).toBe(SETTLEMENT_PAYLOAD_VERSION);
+  });
+
+  it('names an artifact after the settlement in it', () => {
+    const snapshot = storedSnapshot('greyhaven') as unknown as SettlementSnapshot;
+    expect(settlementArtifactKind.nameOf(snapshot)).toBe(snapshot.name);
+  });
+
+  it('loads a codec that round-trips through the registry', async () => {
+    const codec = await settlementArtifactKind.loadCodec();
+    const settlement = rollSettlement('greyhaven', {
+      size: 'large',
+      includeProblems: true,
+      includeNotables: true,
+    }).settlement;
+    const stored = JSON.parse(JSON.stringify(codec.toSnapshot(settlement))) as unknown;
+    expect(codec.fromSnapshot(stored as never, undefined as never)).toEqual(settlement);
+  });
+
+  it('reads a current-version payload and refuses one from a newer build', () => {
+    const payload = storedSnapshot('greyhaven');
+    // The erased form the registry hands every consumer back. `registerArtifactKind` is the one
+    // place a typed entry becomes one; this is that same step taken by hand.
+    const entry = settlementArtifactKind as unknown as AnyArtifactKindEntry;
+    expect(readArtifactPayload(entry, payload, SETTLEMENT_PAYLOAD_VERSION).ok).toBe(true);
+    const ahead = readArtifactPayload(entry, payload, SETTLEMENT_PAYLOAD_VERSION + 1);
+    expect(ahead.ok).toBe(false);
+    expect(ahead.ok === false && ahead.reason).toBe('unsupported-version');
+  });
+});

--- a/src/lib/settlements/settlement_artifact_kind.ts
+++ b/src/lib/settlements/settlement_artifact_kind.ts
@@ -1,0 +1,254 @@
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  isStringArray,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import type { SettlementSnapshot } from './settlement_snapshot';
+import type { Settlement } from './settlement_types';
+
+/**
+ * Stable artifact kind id. A settlement is system-neutral — the same populated place serves any
+ * ruleset — so there is one kind covering every use of it, per decision 4 of docs/workshop.md.
+ */
+export const SETTLEMENT_ARTIFACT_KIND = 'settlement' as const;
+
+/** Version 1. The first shape a settlement has been stored in. */
+export const SETTLEMENT_PAYLOAD_VERSION = 1 as const;
+
+const SETTLEMENT_STRING_FIELDS = ['name', 'description', 'economicRole'];
+
+const SETTLEMENT_NUMBER_FIELDS = [
+  'population',
+  'prosperity',
+  'lawAndOrder',
+  'commerce',
+  'foodSecurity',
+  'publicHealth',
+];
+
+const CATEGORY_NUMBER_FIELDS = ['minSize', 'maxSize'];
+
+function hasNumberFields(record: Record<string, unknown>, keys: string[]): boolean {
+  return keys.every((key) => Number.isFinite(record[key]));
+}
+
+function validateSettlementCategory(value: unknown): PayloadResult<unknown> {
+  const category = asRecord(value);
+  if (category === null) {
+    return rejectedPayload('invalid-payload', 'settlement category is not an object');
+  }
+  if (!hasStringFields(category, ['name', 'sizeClass'])) {
+    return rejectedPayload(
+      'invalid-payload',
+      'settlement category needs string name and sizeClass',
+    );
+  }
+  if (!hasNumberFields(category, CATEGORY_NUMBER_FIELDS)) {
+    return rejectedPayload(
+      'invalid-payload',
+      `settlement category needs numeric ${CATEGORY_NUMBER_FIELDS.join(', ')}`,
+    );
+  }
+  return acceptedPayload(category);
+}
+
+/**
+ * The environment is checked for the one field a settlement prints and nothing else.
+ *
+ * A full schema for it would be a second copy of `$lib/environment`'s types living in a library
+ * that does not own them, and the copy is the half that goes stale. What a validator owes is what
+ * reading the payload depends on, which here is a description to show.
+ */
+function validateSettlementEnvironment(value: unknown): PayloadResult<unknown> {
+  const environment = asRecord(value);
+  if (environment === null || typeof environment.description !== 'string') {
+    return rejectedPayload(
+      'invalid-payload',
+      'settlement environment is not an object with a description',
+    );
+  }
+  return acceptedPayload(environment);
+}
+
+function isStoredProblem(value: unknown): boolean {
+  const problem = asRecord(value);
+  return (
+    problem !== null &&
+    (problem.kind === 'acute' || problem.kind === 'creeping') &&
+    typeof problem.summary === 'string' &&
+    (problem.detail === undefined || typeof problem.detail === 'string')
+  );
+}
+
+/**
+ * A problem list is optional and, when it is there, is a list of problems.
+ *
+ * Both are the point. Enrichment is opt-in, so a settlement rolled without problems and one rolled
+ * with them are different shapes of the same kind, and the validator has to accept both — that is
+ * what makes an unenriched settlement readable rather than quarantined.
+ */
+function validateProblemList(value: unknown, field: string): PayloadResult<unknown> {
+  if (value === undefined) {
+    return acceptedPayload(value);
+  }
+  if (!Array.isArray(value) || !value.every(isStoredProblem)) {
+    return rejectedPayload('invalid-payload', `settlement ${field} is not a list of problems`);
+  }
+  return acceptedPayload(value);
+}
+
+function isStoredNotable(value: unknown): boolean {
+  const notable = asRecord(value);
+  if (notable === null || !hasStringFields(notable, ['roleId', 'roleDisplay', 'importance'])) {
+    return false;
+  }
+  if (!isStringArray(notable.salientPersonality) || !isStringArray(notable.salientPhysical)) {
+    return false;
+  }
+  const character = asRecord(notable.character);
+  return character !== null && hasStringFields(character, ['firstName', 'lastName']);
+}
+
+function validateNotables(value: unknown): PayloadResult<unknown> {
+  if (value === undefined) {
+    return acceptedPayload(value);
+  }
+  if (!Array.isArray(value) || !value.every(isStoredNotable)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'settlement importantPeople is not a list of notables with a named character each',
+    );
+  }
+  return acceptedPayload(value);
+}
+
+function isStoredOrganization(value: unknown): boolean {
+  const organization = asRecord(value);
+  if (organization === null || typeof organization.name !== 'string') {
+    return false;
+  }
+  const profile = asRecord(organization.profile);
+  return profile !== null && typeof profile.hook === 'string';
+}
+
+function validateOrganizations(value: unknown): PayloadResult<unknown> {
+  if (value === undefined) {
+    return acceptedPayload(value);
+  }
+  if (!Array.isArray(value) || !value.every(isStoredOrganization)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'settlement organizations is not a list of named organizations',
+    );
+  }
+  return acceptedPayload(value);
+}
+
+function validateStringListField(value: unknown, field: string): PayloadResult<unknown> {
+  if (value === undefined || isStringArray(value)) {
+    return acceptedPayload(value);
+  }
+  return rejectedPayload('invalid-payload', `settlement ${field} is not an array of strings`);
+}
+
+/**
+ * Checks what reading a settlement depends on: the fields it always has, and the shape of each
+ * enrichment layer that happens to be present.
+ *
+ * The enrichment layers are the interesting half. `enrich_settlement.ts` is opt-in four times
+ * over, so sixteen combinations of the same kind are all legitimate payloads, and a validator
+ * that demanded trade or notables would reject the plainest settlement the generator makes. Every
+ * optional field is therefore accepted when absent and checked when present — including one
+ * written by a build whose enrichment defaults differed from this one's.
+ */
+export function validateSettlementSnapshot(payload: unknown): PayloadResult<SettlementSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'settlement payload is not an object');
+  }
+  if (!hasStringFields(record, SETTLEMENT_STRING_FIELDS)) {
+    return rejectedPayload(
+      'invalid-payload',
+      `settlement payload needs string ${SETTLEMENT_STRING_FIELDS.join(', ')}`,
+    );
+  }
+  if (!hasNumberFields(record, SETTLEMENT_NUMBER_FIELDS)) {
+    return rejectedPayload(
+      'invalid-payload',
+      `settlement payload needs numeric ${SETTLEMENT_NUMBER_FIELDS.join(', ')}`,
+    );
+  }
+  if (!isStringArray(record.settlementTags)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'settlement settlementTags is not an array of strings',
+    );
+  }
+
+  const checks: PayloadResult<unknown>[] = [
+    validateSettlementCategory(record.category),
+    validateSettlementEnvironment(record.environment),
+    validateStringListField(record.primaryImports, 'primaryImports'),
+    validateStringListField(record.primaryExports, 'primaryExports'),
+    validateProblemList(record.acuteProblems, 'acuteProblems'),
+    validateProblemList(record.creepingProblems, 'creepingProblems'),
+    validateOrganizations(record.organizations),
+    validateNotables(record.importantPeople),
+  ];
+  const failed = checks.find((check) => !check.ok);
+  if (failed !== undefined) {
+    return failed as PayloadResult<SettlementSnapshot>;
+  }
+
+  return acceptedPayload(record as unknown as SettlementSnapshot);
+}
+
+/**
+ * Settlements have only ever been stored at version 1, so there is nothing older to bring forward
+ * and this rejects rather than pretending. It is here because the contract requires it, and it is
+ * where the step goes the day the shape changes — a kind without one looks complete right up
+ * until it silently drops someone's work.
+ */
+export function migrateSettlementSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<SettlementSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `settlement has no migration from payload version ${from}; version ${SETTLEMENT_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/**
+ * A settlement as an artifact.
+ *
+ * The live value is the `Settlement` the library works with, and the snapshot is that settlement
+ * with the three things in it that are not plain data written as names — see
+ * `settlement_snapshot.ts`. The codec's two halves come from two modules because reading is much
+ * the more expensive one.
+ */
+export const settlementArtifactKind = defineArtifactKind<Settlement, SettlementSnapshot>({
+  kind: SETTLEMENT_ARTIFACT_KIND,
+  displayName: 'Settlement',
+  payloadVersion: SETTLEMENT_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const [{ toSettlementSnapshot }, { settlementFromSnapshot }] = await Promise.all([
+      import('./settlement_snapshot.js'),
+      import('./settlement_rehydrate.js'),
+    ]);
+    return {
+      toSnapshot: toSettlementSnapshot,
+      // The RNG the contract hands every codec. A settlement rebuilds from names alone, so there
+      // is nothing here for it to do.
+      fromSnapshot: (snapshot: SettlementSnapshot) => settlementFromSnapshot(snapshot),
+    };
+  },
+  nameOf: (snapshot) => snapshot.name,
+  validate: validateSettlementSnapshot,
+  migrate: migrateSettlementSnapshot,
+});

--- a/src/lib/settlements/settlement_editing.test.ts
+++ b/src/lib/settlements/settlement_editing.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addSettlementProblem,
+  SETTLEMENT_ECONOMIC_ROLES,
+  setSettlementCategoryName,
+  setSettlementEconomicRole,
+  setSettlementEnvironmentDescription,
+  setSettlementTags,
+  removeSettlementNotable,
+  removeSettlementProblem,
+  setSettlementCount,
+  setSettlementFacet,
+  setSettlementNotableField,
+  setSettlementNotableName,
+  setSettlementOrganizationField,
+  setSettlementProblem,
+  setSettlementText,
+  setSettlementTradeList,
+} from './settlement_editing';
+import { rollSettlement } from './settlement_roll';
+import { toSettlementSnapshot, type SettlementSnapshot } from './settlement_snapshot';
+
+const EVERY_LAYER = {
+  size: 'large',
+  includeTrade: true,
+  includeProblems: true,
+  includeOrganizations: true,
+  includeNotables: true,
+} as const;
+
+function enriched(): SettlementSnapshot {
+  return toSettlementSnapshot(rollSettlement('greyhaven', EVERY_LAYER).settlement);
+}
+
+function plain(): SettlementSnapshot {
+  return toSettlementSnapshot(rollSettlement('greyhaven').settlement);
+}
+
+describe('setSettlementText', () => {
+  it('renames a settlement without touching anything else', () => {
+    const before = enriched();
+    const after = setSettlementText(before, 'name', 'Saltmarch');
+    expect(after.name).toBe('Saltmarch');
+    expect({ ...after, name: before.name }).toEqual(before);
+  });
+
+  it('rewrites the description', () => {
+    const after = setSettlementText(plain(), 'description', 'A wet town on a slow river.');
+    expect(after.description).toBe('A wet town on a slow river.');
+  });
+
+  it('changes nothing in place', () => {
+    const before = enriched();
+    setSettlementText(before, 'name', 'Saltmarch');
+    expect(before.name).not.toBe('Saltmarch');
+  });
+});
+
+describe('the fields a settlement leads with', () => {
+  it('renames the size band without moving the band', () => {
+    const before = plain();
+    const after = setSettlementCategoryName(before, 'port city');
+    expect(after.category.name).toBe('port city');
+    expect(after.category.minSize).toBe(before.category.minSize);
+    expect(after.category.maxSize).toBe(before.category.maxSize);
+  });
+
+  it('sets an economic role from the table', () => {
+    expect(setSettlementEconomicRole(plain(), 'extractive').economicRole).toBe('extractive');
+    expect(SETTLEMENT_ECONOMIC_ROLES).toContain('mixed');
+  });
+
+  it('refuses a role that is not one', () => {
+    const before = plain();
+    expect(setSettlementEconomicRole(before, 'piratical')).toEqual(before);
+  });
+
+  it('rewrites the environment description', () => {
+    const after = setSettlementEnvironmentDescription(plain(), 'Wet fenland under low cloud.');
+    expect(after.environment.description).toBe('Wet fenland under low cloud.');
+  });
+
+  it('reads the hook tags as a comma-separated line, dropping blanks', () => {
+    expect(setSettlementTags(plain(), 'river_trade, highland,,').settlementTags).toEqual([
+      'river_trade',
+      'highland',
+    ]);
+  });
+});
+
+describe('setSettlementFacet', () => {
+  it('sets a facet', () => {
+    expect(setSettlementFacet(plain(), 'commerce', 7).commerce).toBe(7);
+  });
+
+  it.each([
+    [-3, 0],
+    [42, 10],
+    [4.6, 5],
+  ])('clamps and rounds %s onto the scale it is displayed on', (given, expected) => {
+    expect(setSettlementFacet(plain(), 'lawAndOrder', given).lawAndOrder).toBe(expected);
+  });
+
+  it('ignores a value that is not a number', () => {
+    const before = plain();
+    expect(setSettlementFacet(before, 'publicHealth', Number.NaN)).toEqual(before);
+  });
+});
+
+describe('setSettlementCount', () => {
+  it('sets a population, rounded', () => {
+    expect(setSettlementCount(plain(), 'population', 1200.4).population).toBe(1200);
+  });
+
+  it('refuses a negative population rather than storing one', () => {
+    const before = plain();
+    expect(setSettlementCount(before, 'population', -5)).toEqual(before);
+  });
+});
+
+describe('settlement problems', () => {
+  /** Requirement 4.4: one problem is rewritten and the rest of the list does not move. */
+  it('rewrites one problem, leaving the others alone', () => {
+    const before = enriched();
+    const others = (before.creepingProblems ?? []).slice(1);
+    const after = setSettlementProblem(
+      before,
+      'creepingProblems',
+      0,
+      'summary',
+      'The well is dry.',
+    );
+    expect(after.creepingProblems?.[0]?.summary).toBe('The well is dry.');
+    expect(after.creepingProblems?.slice(1)).toEqual(others);
+    expect(after.acuteProblems).toEqual(before.acuteProblems);
+  });
+
+  it('rewrites a problem detail', () => {
+    const after = setSettlementProblem(
+      enriched(),
+      'acuteProblems',
+      0,
+      'detail',
+      'Since midwinter.',
+    );
+    expect(after.acuteProblems?.[0]?.detail).toBe('Since midwinter.');
+  });
+
+  it.each([-1, 99, 1.5])('changes nothing at index %s', (index) => {
+    const before = enriched();
+    expect(setSettlementProblem(before, 'acuteProblems', index, 'summary', 'x')).toEqual(before);
+    expect(removeSettlementProblem(before, 'acuteProblems', index)).toEqual(before);
+  });
+
+  it('adds a blank problem of the right kind', () => {
+    const after = addSettlementProblem(enriched(), 'creepingProblems');
+    const added = after.creepingProblems?.at(-1);
+    expect(added).toEqual({ kind: 'creeping', summary: '' });
+  });
+
+  /**
+   * A settlement rolled without problems is a shape of this kind, not one missing something. It is
+   * still allowed to grow a problem the user writes by hand.
+   */
+  it('adds a problem to a settlement that had no list at all', () => {
+    const before = plain();
+    expect(before.acuteProblems).toBeUndefined();
+    const after = addSettlementProblem(before, 'acuteProblems', 'The mill has stopped.');
+    expect(after.acuteProblems).toEqual([{ kind: 'acute', summary: 'The mill has stopped.' }]);
+  });
+
+  it('removes one problem and keeps the rest', () => {
+    const before = addSettlementProblem(enriched(), 'acuteProblems', 'A second thing.');
+    const after = removeSettlementProblem(before, 'acuteProblems', 0);
+    expect(after.acuteProblems).toEqual((before.acuteProblems ?? []).slice(1));
+  });
+});
+
+describe('setSettlementTradeList', () => {
+  it('reads a comma-separated line as a list of goods', () => {
+    const after = setSettlementTradeList(enriched(), 'primaryExports', 'salt, timber,  wool ');
+    expect(after.primaryExports).toEqual(['salt', 'timber', 'wool']);
+  });
+
+  it('drops the blank a trailing comma leaves behind', () => {
+    const after = setSettlementTradeList(enriched(), 'primaryImports', 'iron,,');
+    expect(after.primaryImports).toEqual(['iron']);
+  });
+
+  /** A settlement with no trade layer does not grow one from an edit to a field it never shows. */
+  it('leaves a settlement with no trade layer alone', () => {
+    const before = plain();
+    expect(setSettlementTradeList(before, 'primaryExports', 'salt')).toEqual(before);
+  });
+});
+
+describe('settlement notables', () => {
+  it('rewrites one notable’s title and importance, leaving the others alone', () => {
+    const before = enriched();
+    const others = (before.importantPeople ?? []).slice(1);
+    const titled = setSettlementNotableField(before, 0, 'roleDisplay', 'Harbourmaster');
+    const after = setSettlementNotableField(titled, 0, 'importance', 'Holds the tide charts.');
+    expect(after.importantPeople?.[0]?.roleDisplay).toBe('Harbourmaster');
+    expect(after.importantPeople?.[0]?.importance).toBe('Holds the tide charts.');
+    expect(after.importantPeople?.slice(1)).toEqual(others);
+  });
+
+  it('renames the person holding the role', () => {
+    const first = setSettlementNotableName(enriched(), 0, 'firstName', 'Maren');
+    const after = setSettlementNotableName(first, 0, 'lastName', 'Voss');
+    expect(after.importantPeople?.[0]?.character.firstName).toBe('Maren');
+    expect(after.importantPeople?.[0]?.character.lastName).toBe('Voss');
+    // The rest of the character record is untouched; a rename is a rename.
+    expect(after.importantPeople?.[0]?.character.species).toEqual(
+      enriched().importantPeople?.[0]?.character.species,
+    );
+  });
+
+  it('removes a notable', () => {
+    const before = enriched();
+    const kept = (before.importantPeople ?? []).slice(1);
+    expect(removeSettlementNotable(before, 0).importantPeople).toEqual(kept);
+  });
+
+  it.each([-1, 99])('changes nothing at index %s', (index) => {
+    const before = enriched();
+    expect(setSettlementNotableField(before, index, 'importance', 'x')).toEqual(before);
+    expect(setSettlementNotableName(before, index, 'firstName', 'x')).toEqual(before);
+    expect(removeSettlementNotable(before, index)).toEqual(before);
+  });
+
+  it('leaves a settlement with no notables alone', () => {
+    const before = plain();
+    expect(setSettlementNotableField(before, 0, 'importance', 'x')).toEqual(before);
+  });
+});
+
+describe('setSettlementOrganizationField', () => {
+  it('renames an organization', () => {
+    const after = setSettlementOrganizationField(enriched(), 0, 'name', 'The Salt Ledger');
+    expect(after.organizations?.[0]?.name).toBe('The Salt Ledger');
+  });
+
+  it('rewrites the line the settlement introduces one with', () => {
+    const before = enriched();
+    const after = setSettlementOrganizationField(before, 0, 'hook', 'They own the wharf.');
+    expect(after.organizations?.[0]?.profile.hook).toBe('They own the wharf.');
+    // The rest of the profile is generated content the hook is only one line of.
+    expect(after.organizations?.[0]?.profile.goal).toEqual(before.organizations?.[0]?.profile.goal);
+  });
+
+  it.each([-1, 99])('changes nothing at index %s', (index) => {
+    const before = enriched();
+    expect(setSettlementOrganizationField(before, index, 'name', 'x')).toEqual(before);
+  });
+
+  it('leaves a settlement with no organizations alone', () => {
+    const before = plain();
+    expect(setSettlementOrganizationField(before, 0, 'name', 'x')).toEqual(before);
+  });
+});

--- a/src/lib/settlements/settlement_editing.ts
+++ b/src/lib/settlements/settlement_editing.ts
@@ -1,0 +1,322 @@
+import type { SettlementSnapshot, StoredSettlementNotable } from './settlement_snapshot.js';
+import type { SettlementEconomicRole, SettlementProblem } from './settlement_types.js';
+
+/** Every economic role a settlement may be given, for the control that offers them. */
+export const SETTLEMENT_ECONOMIC_ROLES: SettlementEconomicRole[] = [
+  'agrarian',
+  'market',
+  'industrial',
+  'extractive',
+  'mixed',
+];
+
+/**
+ * The prose fields a settlement shows as a paragraph each, and so must let a user rewrite.
+ *
+ * Named as a set rather than given a function apiece because they behave identically: a string
+ * shown to the user that the user may replace.
+ */
+export type SettlementTextField = 'name' | 'description' | 'tradeBlurb';
+
+/** The four derived facets, each an integer the settlement displays on a 0–10 scale. */
+export type SettlementFacetField = 'lawAndOrder' | 'commerce' | 'foodSecurity' | 'publicHealth';
+
+/** The two counts a settlement shows beside its category. */
+export type SettlementCountField = 'population' | 'prosperity';
+
+/** Which of a settlement's two problem lists an edit applies to. */
+export type SettlementProblemList = 'acuteProblems' | 'creepingProblems';
+
+/** The parts of a trade layer that are lists of goods. */
+export type SettlementTradeList = 'primaryImports' | 'primaryExports';
+
+/** The fields of one notable a user would reasonably rewrite. */
+export type SettlementNotableField = 'roleDisplay' | 'importance';
+
+/**
+ * Editing a stored settlement, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 in practice — rewriting one problem must not disturb the others, and renaming
+ * the place must not touch its notables — and it is what lets the editing framework compare what
+ * is on screen against what was read to decide whether there is anything to save.
+ *
+ * They work on the **snapshot**, not a live `Settlement`, because the snapshot is what is stored
+ * and what the kind's `validate` speaks. An editor that worked on live values would run the codec
+ * both ways on every keystroke, and the codec's reading half loads the whole charge library.
+ *
+ * Enrichment is opt-in, so most of these fields are optional and most settlements do not have
+ * them. Each function below is written to leave a settlement that has no such layer exactly as it
+ * was, rather than growing an empty one: an unenriched settlement is a shape of this kind, not a
+ * settlement missing something.
+ */
+export function setSettlementText(
+  snapshot: SettlementSnapshot,
+  field: SettlementTextField,
+  value: string,
+): SettlementSnapshot {
+  return { ...snapshot, [field]: value };
+}
+
+/**
+ * Set one of the four facets, clamped to the 0–10 scale the settlement is displayed on.
+ *
+ * Clamped rather than rejected: the control is a number input, and a user who drags it past the
+ * end means the end. A facet outside the scale would print as a value the legend beside it says
+ * is impossible.
+ */
+export function setSettlementFacet(
+  snapshot: SettlementSnapshot,
+  field: SettlementFacetField,
+  value: number,
+): SettlementSnapshot {
+  if (!Number.isFinite(value)) {
+    return snapshot;
+  }
+  return { ...snapshot, [field]: Math.min(10, Math.max(0, Math.round(value))) };
+}
+
+/**
+ * Rename the size band this settlement is described as being in.
+ *
+ * The name only. `minSize` and `maxSize` are the table row the settlement was drawn from, and a
+ * user calling their city a "port city" is renaming what it is called, not asserting a new
+ * population band for every city on the site.
+ */
+export function setSettlementCategoryName(
+  snapshot: SettlementSnapshot,
+  name: string,
+): SettlementSnapshot {
+  return { ...snapshot, category: { ...snapshot.category, name } };
+}
+
+/** Set the economic posture. Anything not in the table leaves the settlement alone. */
+export function setSettlementEconomicRole(
+  snapshot: SettlementSnapshot,
+  role: string,
+): SettlementSnapshot {
+  if (!SETTLEMENT_ECONOMIC_ROLES.includes(role as SettlementEconomicRole)) {
+    return snapshot;
+  }
+  return { ...snapshot, economicRole: role as SettlementEconomicRole };
+}
+
+/** Rewrite the description of the land the settlement sits in. */
+export function setSettlementEnvironmentDescription(
+  snapshot: SettlementSnapshot,
+  description: string,
+): SettlementSnapshot {
+  return { ...snapshot, environment: { ...snapshot.environment, description } };
+}
+
+/**
+ * Replace the hook tags from a comma-separated line.
+ *
+ * A line rather than a field each, for the same reason the trade lists are one: `river_trade,
+ * highland` is one thought. Unlike trade, every settlement has this list, so there is no absent
+ * layer to leave alone.
+ */
+export function setSettlementTags(snapshot: SettlementSnapshot, value: string): SettlementSnapshot {
+  return {
+    ...snapshot,
+    settlementTags: value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter((tag) => tag !== ''),
+  };
+}
+
+/** Set population or prosperity. A non-number leaves the settlement alone. */
+export function setSettlementCount(
+  snapshot: SettlementSnapshot,
+  field: SettlementCountField,
+  value: number,
+): SettlementSnapshot {
+  if (!Number.isFinite(value) || value < 0) {
+    return snapshot;
+  }
+  return { ...snapshot, [field]: Math.round(value) };
+}
+
+function problemsAt(
+  snapshot: SettlementSnapshot,
+  list: SettlementProblemList,
+): SettlementProblem[] {
+  return snapshot[list] ?? [];
+}
+
+function hasProblemAt(
+  snapshot: SettlementSnapshot,
+  list: SettlementProblemList,
+  index: number,
+): boolean {
+  return Number.isInteger(index) && index >= 0 && index < problemsAt(snapshot, list).length;
+}
+
+/** Rewrite one problem's summary or detail, leaving every other problem alone. */
+export function setSettlementProblem(
+  snapshot: SettlementSnapshot,
+  list: SettlementProblemList,
+  index: number,
+  field: 'summary' | 'detail',
+  value: string,
+): SettlementSnapshot {
+  if (!hasProblemAt(snapshot, list, index)) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    [list]: problemsAt(snapshot, list).map((problem, position) =>
+      position === index ? { ...problem, [field]: value } : problem,
+    ),
+  };
+}
+
+/**
+ * Add a blank problem to one of the lists.
+ *
+ * A problem is a summary and an optional detail — prose, all of it — so an empty one is a field
+ * waiting to be filled rather than a broken record. That is why problems can be added and
+ * notables, further down, cannot.
+ */
+export function addSettlementProblem(
+  snapshot: SettlementSnapshot,
+  list: SettlementProblemList,
+  summary = '',
+): SettlementSnapshot {
+  const kind = list === 'acuteProblems' ? 'acute' : 'creeping';
+  return { ...snapshot, [list]: [...problemsAt(snapshot, list), { kind, summary }] };
+}
+
+export function removeSettlementProblem(
+  snapshot: SettlementSnapshot,
+  list: SettlementProblemList,
+  index: number,
+): SettlementSnapshot {
+  if (!hasProblemAt(snapshot, list, index)) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    [list]: problemsAt(snapshot, list).filter((_problem, position) => position !== index),
+  };
+}
+
+/**
+ * Replace one of the trade lists from a comma-separated line.
+ *
+ * A line rather than a field per good, because that is how the page prints them and how a user
+ * thinks of them: "salt, timber, wool" is one thought. Blank entries are dropped, so a trailing
+ * comma does not leave an empty item behind in the export (requirement 6.4).
+ */
+export function setSettlementTradeList(
+  snapshot: SettlementSnapshot,
+  list: SettlementTradeList,
+  value: string,
+): SettlementSnapshot {
+  if (snapshot[list] === undefined) {
+    return snapshot;
+  }
+  const goods = value
+    .split(',')
+    .map((good) => good.trim())
+    .filter((good) => good !== '');
+  return { ...snapshot, [list]: goods };
+}
+
+function notablesOf(snapshot: SettlementSnapshot): StoredSettlementNotable[] {
+  return snapshot.importantPeople ?? [];
+}
+
+function hasNotableAt(snapshot: SettlementSnapshot, index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < notablesOf(snapshot).length;
+}
+
+function replaceNotable(
+  snapshot: SettlementSnapshot,
+  index: number,
+  change: (notable: StoredSettlementNotable) => StoredSettlementNotable,
+): SettlementSnapshot {
+  if (!hasNotableAt(snapshot, index)) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    importantPeople: notablesOf(snapshot).map((notable, position) =>
+      position === index ? change(notable) : notable,
+    ),
+  };
+}
+
+/** Rewrite a notable's civic title or the sentence saying why they matter. */
+export function setSettlementNotableField(
+  snapshot: SettlementSnapshot,
+  index: number,
+  field: SettlementNotableField,
+  value: string,
+): SettlementSnapshot {
+  return replaceNotable(snapshot, index, (notable) => ({ ...notable, [field]: value }));
+}
+
+/**
+ * Rename one notable.
+ *
+ * The name lives on the character inside the notable, not on the notable, which is why this is not
+ * another {@link SettlementNotableField}: a settlement's notable is a role held by a person, and
+ * the person is `$lib/characters`' record.
+ */
+export function setSettlementNotableName(
+  snapshot: SettlementSnapshot,
+  index: number,
+  field: 'firstName' | 'lastName',
+  value: string,
+): SettlementSnapshot {
+  return replaceNotable(snapshot, index, (notable) => ({
+    ...notable,
+    character: { ...notable.character, [field]: value },
+  }));
+}
+
+/**
+ * Drop a notable from the settlement.
+ *
+ * There is deliberately no way to add one. A notable is a generated character with a species, an
+ * age, a set of physical traits, and an archetype; an empty one would be a broken record rather
+ * than a blank field, the same reason `$lib/religion` will remove a deity but not add one.
+ */
+export function removeSettlementNotable(
+  snapshot: SettlementSnapshot,
+  index: number,
+): SettlementSnapshot {
+  if (!hasNotableAt(snapshot, index)) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    importantPeople: notablesOf(snapshot).filter((_notable, position) => position !== index),
+  };
+}
+
+/** Rewrite an organization's name or the line the settlement introduces it with. */
+export function setSettlementOrganizationField(
+  snapshot: SettlementSnapshot,
+  index: number,
+  field: 'name' | 'hook',
+  value: string,
+): SettlementSnapshot {
+  const organizations = snapshot.organizations ?? [];
+  if (!Number.isInteger(index) || index < 0 || index >= organizations.length) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    organizations: organizations.map((organization, position) => {
+      if (position !== index) {
+        return organization;
+      }
+      return field === 'name'
+        ? { ...organization, name: value }
+        : { ...organization, profile: { ...organization.profile, hook: value } };
+    }),
+  };
+}

--- a/src/lib/settlements/settlement_presentation.test.ts
+++ b/src/lib/settlements/settlement_presentation.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Religion } from '$lib/religion';
+
+import {
+  settlementFileStem,
+  settlementSummaryLine,
+  settlementToDocument,
+  settlementToMarkdown,
+  settlementToPlainText,
+} from './settlement_presentation';
+import { rollSettlement } from './settlement_roll';
+import type { Settlement } from './settlement_types';
+
+const EVERY_LAYER = {
+  size: 'large',
+  includeTrade: true,
+  includeProblems: true,
+  includeOrganizations: true,
+  includeNotables: true,
+} as const;
+
+function enriched(): Settlement {
+  return rollSettlement('greyhaven', EVERY_LAYER).settlement;
+}
+
+function plain(): Settlement {
+  return rollSettlement('greyhaven').settlement;
+}
+
+const A_RELIGION = {
+  name: 'The Tide-Keepers',
+  description: 'They read the water and keep its calendar.',
+} as unknown as Religion;
+
+function headings(settlement: Settlement, options = {}): string[] {
+  return settlementToDocument(settlement, options).sections.map((entry) => entry.heading);
+}
+
+describe('settlementSummaryLine', () => {
+  it('says what kind of place it is, how many live there, and how it is doing', () => {
+    const settlement = plain();
+    const line = settlementSummaryLine(settlement);
+    expect(line).toContain(settlement.category.name);
+    expect(line).toContain(settlement.economicRole);
+    expect(line).toContain(String(settlement.prosperity));
+  });
+});
+
+describe('settlementToDocument', () => {
+  it('gives an enriched settlement every section it has content for', () => {
+    const settlement = enriched();
+    const person = (settlement.importantPeople ?? [])[0]!;
+    expect(headings(settlement)).toEqual(
+      expect.arrayContaining([
+        'Overview',
+        'Facets',
+        'Environment',
+        'Trade',
+        'Acute Problems',
+        'Creeping Problems',
+        'Organizations',
+        `${person.roleDisplay} ${person.character.firstName} ${person.character.lastName}`,
+      ]),
+    );
+  });
+
+  /**
+   * Requirement 6.4, and the reason this model exists at all. Enrichment is opt-in four times over,
+   * so the plainest settlement the generator makes would print four bare headings if the dropping
+   * were left to each renderer.
+   */
+  it('drops the headings an unenriched settlement has nothing under', () => {
+    expect(headings(plain())).toEqual(['Overview', 'Facets', 'Environment']);
+  });
+
+  it('prints a faith only when one was supplied', () => {
+    expect(headings(plain())).not.toContain('Faith');
+    expect(headings(plain(), { religion: null })).not.toContain('Faith');
+    expect(headings(plain(), { religion: A_RELIGION })).toContain('Faith');
+  });
+
+  it('names the settlement as the title', () => {
+    const settlement = plain();
+    expect(settlementToDocument(settlement).title).toBe(settlement.name);
+  });
+
+  it('never emits a section with nothing in it', () => {
+    for (const entry of settlementToDocument(enriched(), { religion: A_RELIGION }).sections) {
+      expect(entry.paragraphs.length + entry.items.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('folds a problem’s detail into its line, and omits it when there is none', () => {
+    const settlement = {
+      ...plain(),
+      acuteProblems: [
+        { kind: 'acute' as const, summary: 'The mill has stopped.', detail: 'Since midwinter.' },
+        { kind: 'acute' as const, summary: 'The bridge is out.' },
+      ],
+    };
+    const section = settlementToDocument(settlement).sections.find(
+      (entry) => entry.heading === 'Acute Problems',
+    );
+    expect(section?.items).toEqual([
+      'The mill has stopped. Since midwinter.',
+      'The bridge is out.',
+    ]);
+  });
+
+  it('falls back to a notable’s role id when the civic title is blank', () => {
+    const settlement = enriched();
+    const people = settlement.importantPeople ?? [];
+    expect(people.length).toBeGreaterThan(0);
+    const withoutTitle = {
+      ...settlement,
+      importantPeople: [{ ...people[0]!, roleDisplay: '  ' }],
+    };
+    expect(headings(withoutTitle)).toContain(
+      `${people[0]!.roleId} ${people[0]!.character.firstName} ${people[0]!.character.lastName}`,
+    );
+  });
+});
+
+describe('settlementToMarkdown', () => {
+  it('writes the settlement under its own name, with a heading per section', () => {
+    const settlement = enriched();
+    const markdown = settlementToMarkdown(settlement);
+    expect(markdown.startsWith(`# ${settlement.name}\n`)).toBe(true);
+    expect(markdown).toContain('## Facets');
+    expect(markdown).toContain('- Law and order:');
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('leaves no blank line where an absent section would have been', () => {
+    expect(settlementToMarkdown(plain())).not.toMatch(/\n\n\n/);
+  });
+
+  it('includes a supplied faith', () => {
+    expect(settlementToMarkdown(plain(), { religion: A_RELIGION })).toContain('The Tide-Keepers');
+  });
+});
+
+describe('settlementToPlainText', () => {
+  it('writes headings as plain capitals, with no Markdown punctuation to read past', () => {
+    const text = settlementToPlainText(enriched());
+    expect(text).toContain('FACETS');
+    expect(text).not.toContain('# ');
+    expect(text).not.toContain('- ');
+  });
+
+  it('leaves no blank line where an absent section would have been', () => {
+    expect(settlementToPlainText(plain())).not.toMatch(/\n\n\n/);
+  });
+});
+
+describe('settlementFileStem', () => {
+  it.each([
+    ['White Ridge', 'white-ridge'],
+    ["Saint Elden's Rest", 'saint-elden-s-rest'],
+    ['  Kilitia  ', 'kilitia'],
+  ])('reduces %s to something a filesystem takes', (name, expected) => {
+    expect(settlementFileStem({ ...plain(), name })).toBe(expected);
+  });
+
+  it('falls back rather than producing an empty filename', () => {
+    expect(settlementFileStem({ ...plain(), name: '—' })).toBe('settlement');
+  });
+});

--- a/src/lib/settlements/settlement_presentation.ts
+++ b/src/lib/settlements/settlement_presentation.ts
@@ -1,0 +1,211 @@
+import type { Religion } from '$lib/religion';
+
+import type { Settlement, SettlementImportantPerson, SettlementProblem } from './settlement_types';
+
+export type SettlementPresentationOptions = {
+  /**
+   * The faith practised here, when the user built the settlement around a saved religion.
+   *
+   * Passed in rather than read off the settlement, because a settlement holds no copy of it: the
+   * link is recorded on the artifact and the religion is a record of its own, which someone may
+   * edit later. Left out, an exported settlement simply has no faith section — honest, where a
+   * line about a religion the library was never given would not be.
+   */
+  religion?: Religion | null;
+};
+
+/** One heading and what sits under it. A section with neither prose nor items is not printed. */
+export type SettlementSection = {
+  heading: string;
+  paragraphs: string[];
+  items: string[];
+};
+
+/** A settlement arranged for reading, independent of the format it is finally written in. */
+export type SettlementDocument = {
+  title: string;
+  sections: SettlementSection[];
+};
+
+function section(heading: string, paragraphs: string[], items: string[] = []): SettlementSection {
+  return { heading, paragraphs: paragraphs.filter(isPrintable), items: items.filter(isPrintable) };
+}
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+function hasContent(entry: SettlementSection): boolean {
+  return entry.paragraphs.length > 0 || entry.items.length > 0;
+}
+
+function problemLine(problem: SettlementProblem): string {
+  return problem.detail === undefined || problem.detail.trim() === ''
+    ? problem.summary
+    : `${problem.summary} ${problem.detail}`;
+}
+
+/**
+ * The heading one notable is printed under: the civic role and the person holding it.
+ *
+ * The role is in the heading rather than in a line beneath it so a section reads as what it is
+ * without the paragraph under it — "Harbourmaster Maren Voss" is unmistakably a person, where a
+ * bare name sitting at the same level as Trade and Organizations is not. `roleId` stands in when a
+ * settlement has been edited to have no title, since a heading is not optional.
+ */
+function notableHeading(person: SettlementImportantPerson): string {
+  const role = isPrintable(person.roleDisplay) ? person.roleDisplay : person.roleId;
+  const name = `${person.character.firstName} ${person.character.lastName}`.trim();
+  return isPrintable(name) ? `${role} ${name}`.trim() : role;
+}
+
+function notableLines(person: SettlementImportantPerson): string[] {
+  return [
+    person.importance,
+    person.salientPersonality.length === 0
+      ? ''
+      : `Notable demeanor: ${person.salientPersonality.join(', ')}`,
+    person.salientPhysical.length === 0
+      ? ''
+      : `Striking look: ${person.salientPhysical.join(', ')}`,
+  ];
+}
+
+function tradeSection(settlement: Settlement): SettlementSection {
+  return section(
+    'Trade',
+    [settlement.tradeBlurb ?? ''],
+    [
+      (settlement.primaryExports ?? []).length === 0
+        ? ''
+        : `Exports: ${(settlement.primaryExports ?? []).join(', ')}`,
+      (settlement.primaryImports ?? []).length === 0
+        ? ''
+        : `Imports: ${(settlement.primaryImports ?? []).join(', ')}`,
+    ],
+  );
+}
+
+function faithSection(religion: Religion | null | undefined): SettlementSection[] {
+  if (religion === null || religion === undefined) {
+    return [];
+  }
+  return [section('Faith', [religion.name, religion.description])];
+}
+
+/**
+ * One section per notable, and no heading grouping them.
+ *
+ * A "Important People" heading would have nothing of its own under it — a settlement has no
+ * paragraph about its notables as a body — and an empty heading is exactly what requirement 6.4
+ * forbids. Each person carries their own role in their heading instead.
+ */
+function notableSections(settlement: Settlement): SettlementSection[] {
+  return (settlement.importantPeople ?? []).map((person) =>
+    section(notableHeading(person), notableLines(person)),
+  );
+}
+
+/**
+ * The line under the title: what kind of place this is, how many live there, and how it is doing.
+ *
+ * Assembled here rather than in each renderer so the Markdown and the PDF cannot disagree about
+ * how a settlement introduces itself.
+ */
+export function settlementSummaryLine(settlement: Settlement): string {
+  return `${settlement.category.name} · population ${settlement.population.toLocaleString()} · prosperity ${settlement.prosperity} · ${settlement.economicRole}`;
+}
+
+/**
+ * Arrange a settlement for reading.
+ *
+ * Every empty section is dropped here, once, rather than in each renderer — which is what makes
+ * requirement 6.4 (no stray blank lines from empty sections) a property of the model instead of
+ * something two formats have to remember separately. It matters more for a settlement than for
+ * anything else on the site: enrichment is opt-in four times over, so the plainest settlement the
+ * generator makes has four of these sections empty, and a renderer that printed headings anyway
+ * would hand the user a page of bare titles.
+ */
+export function settlementToDocument(
+  settlement: Settlement,
+  options: SettlementPresentationOptions = {},
+): SettlementDocument {
+  const sections = [
+    section('Overview', [settlementSummaryLine(settlement), settlement.description]),
+    section(
+      'Facets',
+      [],
+      [
+        `Law and order: ${settlement.lawAndOrder}`,
+        `Commerce: ${settlement.commerce}`,
+        `Food security: ${settlement.foodSecurity}`,
+        `Public health: ${settlement.publicHealth}`,
+      ],
+    ),
+    section('Environment', [settlement.environment.description], settlement.settlementTags),
+    ...faithSection(options.religion),
+    tradeSection(settlement),
+    section('Acute Problems', [], (settlement.acuteProblems ?? []).map(problemLine)),
+    section('Creeping Problems', [], (settlement.creepingProblems ?? []).map(problemLine)),
+    section(
+      'Organizations',
+      [],
+      (settlement.organizations ?? []).map(
+        (organization) => `${organization.name}: ${organization.profile.hook}`,
+      ),
+    ),
+    ...notableSections(settlement),
+  ];
+
+  return { title: settlement.name, sections: sections.filter(hasContent) };
+}
+
+/** A settlement as Markdown, for a user who wants it in their own notes. */
+export function settlementToMarkdown(
+  settlement: Settlement,
+  options: SettlementPresentationOptions = {},
+): string {
+  const document = settlementToDocument(settlement, options);
+  const blocks = [`# ${document.title}`];
+
+  for (const entry of document.sections) {
+    blocks.push(`## ${entry.heading}`);
+    blocks.push(...entry.paragraphs);
+    if (entry.items.length > 0) {
+      blocks.push(entry.items.map((item) => `- ${item}`).join('\n'));
+    }
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/**
+ * A settlement as plain text, for the PDF export.
+ *
+ * Separate from the Markdown because `#` and `-` are punctuation a PDF reader has to see past
+ * rather than formatting it renders — the same content, written for a page instead of an editor.
+ */
+export function settlementToPlainText(
+  settlement: Settlement,
+  options: SettlementPresentationOptions = {},
+): string {
+  const document = settlementToDocument(settlement, options);
+  const blocks: string[] = [];
+
+  for (const entry of document.sections) {
+    blocks.push(entry.heading.toUpperCase());
+    blocks.push(...entry.paragraphs);
+    blocks.push(...entry.items);
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** A filename stem for an exported settlement: its name, reduced to something a filesystem takes. */
+export function settlementFileStem(settlement: Settlement): string {
+  const stem = settlement.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' ? 'settlement' : stem;
+}

--- a/src/lib/settlements/settlement_rehydrate.ts
+++ b/src/lib/settlements/settlement_rehydrate.ts
@@ -1,0 +1,112 @@
+/**
+ * Rebuilding a settlement from a snapshot, kept apart from `settlement_snapshot.ts` because of
+ * what it costs. Restoring an organization's emblem resolves charge names against
+ * `$lib/charges` — 18 MB of glyph art, measured — and restoring a character's archetype reaches
+ * the fantasy archetype tables. Writing a snapshot needs neither, and the kind registry validates
+ * one without touching either module, so the two directions do not belong in the same file.
+ */
+
+import { getAllFantasyArchetypes, type Archetype } from '$lib/archetypes';
+import type { Character } from '$lib/characters';
+import { armsFromStored } from '$lib/heraldry';
+import type { OrganizationHierarchy, Organization } from '$lib/organizations';
+import type { VisualIdentity } from '$lib/visual_identity';
+
+import type {
+  SettlementSnapshot,
+  StoredArchetype,
+  StoredCharacter,
+  StoredOrganization,
+  StoredOrganizationHierarchy,
+  StoredSettlementNotable,
+  StoredVisualIdentity,
+} from './settlement_snapshot.js';
+import type { Settlement, SettlementImportantPerson } from './settlement_types.js';
+
+/**
+ * The equipment tables each archetype was rolled from, by archetype name.
+ *
+ * Built once. `getAllFantasyArchetypes` returns a shared array that must not be mutated, and this
+ * only ever reads from it.
+ */
+const equipmentConfigsByArchetypeName = new Map(
+  getAllFantasyArchetypes().map((archetype) => [
+    archetype.name,
+    archetype.equipmentGenerationConfigs,
+  ]),
+);
+
+/**
+ * An archetype with its equipment tables put back.
+ *
+ * An archetype this build no longer has comes back with no tables rather than throwing. That is
+ * requirement 3.3 applied one level down: the tables are what a character would be *re-equipped*
+ * from, which a saved settlement never does, so a settlement whose blacksmith archetype was
+ * renamed in some later release is still every bit the settlement the user saved.
+ */
+function archetypeFromStored(stored: StoredArchetype): Archetype {
+  return {
+    ...stored,
+    equipmentGenerationConfigs: equipmentConfigsByArchetypeName.get(stored.name) ?? [],
+  };
+}
+
+function characterFromStored(stored: StoredCharacter): Character {
+  const { archetype, heraldry, ...rest } = stored;
+  return {
+    ...rest,
+    ...(archetype === undefined ? {} : { archetype: archetypeFromStored(archetype) }),
+    ...(heraldry === undefined ? {} : { heraldry: armsFromStored(heraldry) }),
+  };
+}
+
+function notableFromStored(stored: StoredSettlementNotable): SettlementImportantPerson {
+  return { ...stored, character: characterFromStored(stored.character) };
+}
+
+function hierarchyFromStored(stored: StoredOrganizationHierarchy): OrganizationHierarchy {
+  return {
+    childToParent: new Map(stored.childToParent),
+    idToOrder: new Map(stored.idToOrder),
+    roleById: new Map(stored.roleById),
+  };
+}
+
+function visualIdentityFromStored(stored: StoredVisualIdentity): VisualIdentity {
+  const { emblem } = stored;
+  return {
+    ...stored,
+    emblem:
+      emblem.kind === 'heraldry' ? { kind: 'heraldry', arms: armsFromStored(emblem.arms) } : emblem,
+  };
+}
+
+function organizationFromStored(stored: StoredOrganization): Organization {
+  return {
+    ...stored,
+    hierarchy: hierarchyFromStored(stored.hierarchy),
+    leader: characterFromStored(stored.leader),
+    notableMembers: stored.notableMembers.map(characterFromStored),
+    visualIdentity: visualIdentityFromStored(stored.visualIdentity),
+  };
+}
+
+/**
+ * A stored settlement, live again.
+ *
+ * It takes no RNG and generates nothing: the payload is the truth (docs/workshop.md), and every
+ * value here is either what was stored or a lookup from a name that was stored. The kind's codec
+ * is handed an RNG all the same, because the contract gives every codec one; this one ignores it.
+ */
+export function settlementFromSnapshot(snapshot: SettlementSnapshot): Settlement {
+  const { importantPeople, organizations, ...rest } = snapshot;
+  return {
+    ...rest,
+    ...(importantPeople === undefined
+      ? {}
+      : { importantPeople: importantPeople.map(notableFromStored) }),
+    ...(organizations === undefined
+      ? {}
+      : { organizations: organizations.map(organizationFromStored) }),
+  };
+}

--- a/src/lib/settlements/settlement_roll.test.ts
+++ b/src/lib/settlements/settlement_roll.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  readSettlementGeneratorConfig,
+  rollSettlement,
+  rollSettlementSnapshot,
+} from './settlement_roll';
+
+describe('readSettlementGeneratorConfig', () => {
+  it('reads back what the generator records', () => {
+    expect(
+      readSettlementGeneratorConfig({
+        nameGeneratorSet: 'dwarf',
+        size: 'large',
+        includeTrade: true,
+        includeProblems: false,
+        includeOrganizations: true,
+        includeNotables: false,
+      }),
+    ).toEqual({
+      nameGeneratorSet: 'dwarf',
+      size: 'large',
+      includeTrade: true,
+      includeProblems: false,
+      includeOrganizations: true,
+      includeNotables: false,
+    });
+  });
+
+  it('drops anything it does not recognise rather than coercing it', () => {
+    expect(
+      readSettlementGeneratorConfig({
+        nameGeneratorSet: '',
+        size: 'enormous',
+        includeTrade: 'yes',
+        includeProblems: 1,
+        includeOrganizations: null,
+        includeNotables: undefined,
+      }),
+    ).toEqual({});
+  });
+
+  it('reads an empty provenance as no settings at all', () => {
+    expect(readSettlementGeneratorConfig({})).toEqual({});
+  });
+});
+
+describe('rollSettlement', () => {
+  /** Requirement 2.2: same seed, same configuration, same settlement. */
+  it('is deterministic for a seed and a configuration', () => {
+    const options = {
+      nameGeneratorSet: 'dwarf',
+      size: 'medium',
+      includeTrade: true,
+      includeProblems: true,
+      includeNotables: true,
+    } as const;
+    expect(rollSettlement('anvil-deep', options)).toEqual(rollSettlement('anvil-deep', options));
+  });
+
+  it('rolls something else for a different seed', () => {
+    const first = rollSettlement('anvil-deep', { nameGeneratorSet: 'dwarf' });
+    const second = rollSettlement('salt-reach', { nameGeneratorSet: 'dwarf' });
+    expect(first.settlement.name).not.toBe(second.settlement.name);
+  });
+
+  /**
+   * Choosing a pattern set and having one chosen must produce the same settlement, which is why
+   * the draw is taken off a seed of its own rather than the settlement's RNG. A draw on the main
+   * stream would shift everything rolled after it, and "any set" would become a different
+   * settlement rather than the same one under a named set.
+   */
+  it('resolves a set from the seed, and rolling under that name gives the same settlement', () => {
+    const drawn = rollSettlement('oakhollow', { size: 'small' });
+    expect(drawn.nameGeneratorSet).not.toBe('');
+    expect(
+      rollSettlement('oakhollow', { size: 'small', nameGeneratorSet: drawn.nameGeneratorSet }),
+    ).toEqual(drawn);
+  });
+
+  it('falls back to a drawn set when the recorded one is not one this build has', () => {
+    const rolled = rollSettlement('oakhollow', { size: 'small', nameGeneratorSet: 'sylvari' });
+    expect(rolled.nameGeneratorSet).toBe(
+      rollSettlement('oakhollow', { size: 'small' }).nameGeneratorSet,
+    );
+  });
+
+  it('honours the size filter', () => {
+    const small = rollSettlement('anvil-deep', { size: 'small' }).settlement;
+    expect(small.category.sizeClass).toBe('small');
+  });
+
+  it('leaves every enrichment layer off unless asked', () => {
+    const settlement = rollSettlement('anvil-deep').settlement;
+    expect(settlement.tradeBlurb).toBeUndefined();
+    expect(settlement.acuteProblems).toBeUndefined();
+    expect(settlement.organizations).toBeUndefined();
+    expect(settlement.importantPeople).toBeUndefined();
+  });
+
+  it('adds only the layers it is asked for', () => {
+    const settlement = rollSettlement('anvil-deep', {
+      size: 'medium',
+      includeProblems: true,
+    }).settlement;
+    expect(settlement.acuteProblems?.length).toBeGreaterThan(0);
+    expect(settlement.tradeBlurb).toBeUndefined();
+    expect(settlement.importantPeople).toBeUndefined();
+  });
+});
+
+describe('rollSettlementSnapshot', () => {
+  /**
+   * The destructive half of editing (requirement 4.3). Rolling an unedited settlement again has to
+   * give the same one back, or "re-roll" would mean "lose this settlement" even for a user who
+   * only wanted to undo an edit.
+   */
+  it('produces a payload equal to the one the same provenance first produced', () => {
+    const options = { nameGeneratorSet: 'elf', size: 'large', includeNotables: true } as const;
+    expect(rollSettlementSnapshot('greyhaven', options)).toEqual(
+      rollSettlementSnapshot('greyhaven', options),
+    );
+  });
+
+  it('produces a payload its own kind accepts', async () => {
+    const { validateSettlementSnapshot } = await import('./settlement_artifact_kind');
+    const rolled = rollSettlementSnapshot('greyhaven', {
+      size: 'large',
+      includeTrade: true,
+      includeProblems: true,
+      includeNotables: true,
+    });
+    expect(validateSettlementSnapshot(rolled).ok).toBe(true);
+  });
+});

--- a/src/lib/settlements/settlement_roll.ts
+++ b/src/lib/settlements/settlement_roll.ts
@@ -1,0 +1,160 @@
+import { RNG } from '@ironarachne/rng';
+
+import { getCharacterGenerationConfigForNameSet } from '$lib/characters';
+import { getFantasyNameGeneratorSet, getFantasyNameGeneratorSetNames } from '$lib/names';
+
+import { generate, getDefaultConfig } from './settlements.js';
+import { toSettlementSnapshot, type SettlementSnapshot } from './settlement_snapshot.js';
+import type { Settlement, SettlementSizeFilter } from './settlement_types.js';
+
+/**
+ * What the settlement generator records about how it rolled, and what a re-roll reads back.
+ *
+ * Stated as a type rather than read field by field at the call site so the two ends — what the
+ * generator writes as provenance and what a re-roll expects to find there — are in one place and
+ * drift loudly instead of quietly.
+ */
+export type SettlementGeneratorConfigRecord = {
+  /**
+   * The name pattern set the town, its notables, and its organizations were named from.
+   *
+   * A settlement built around a saved culture records the culture's own pattern set here rather
+   * than the culture's id. That is what lets a re-roll produce names of the same tongue without
+   * reaching back into the store for an artifact it has no way to ask for — the same bargain
+   * `$lib/religion` makes for a pantheon named from a borrowed culture.
+   */
+  nameGeneratorSet?: string;
+  size?: SettlementSizeFilter;
+  includeTrade?: boolean;
+  includeProblems?: boolean;
+  includeOrganizations?: boolean;
+  includeNotables?: boolean;
+};
+
+/**
+ * A rolled settlement and the pattern set its names actually came from.
+ *
+ * The resolved set travels back out because a roll may choose one itself, and provenance has to
+ * record what was used rather than what was asked for. "Any set" recorded as provenance would make
+ * a re-roll a fresh draw, which is not what re-rolling an artifact means.
+ */
+export type SettlementRoll = {
+  settlement: Settlement;
+  nameGeneratorSet: string;
+};
+
+const SIZE_FILTERS: SettlementSizeFilter[] = ['small', 'medium', 'large', 'any'];
+
+function isSizeFilter(value: unknown): value is SettlementSizeFilter {
+  return SIZE_FILTERS.includes(value as SettlementSizeFilter);
+}
+
+function readBoolean(value: unknown, key: string): Record<string, boolean> {
+  return typeof value === 'boolean' ? { [key]: value } : {};
+}
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Provenance is `Record<string, unknown>` because the store cannot know what any tool puts in it,
+ * so this is the boundary where that becomes typed. Anything unrecognisable is dropped rather than
+ * coerced: a config written by a build that spelled these differently should fall back to the
+ * defaults, not roll a settlement from a field it misread.
+ */
+export function readSettlementGeneratorConfig(
+  config: Record<string, unknown>,
+): SettlementGeneratorConfigRecord {
+  return {
+    ...(typeof config.nameGeneratorSet === 'string' && config.nameGeneratorSet !== ''
+      ? { nameGeneratorSet: config.nameGeneratorSet }
+      : {}),
+    ...(isSizeFilter(config.size) ? { size: config.size } : {}),
+    ...readBoolean(config.includeTrade, 'includeTrade'),
+    ...readBoolean(config.includeProblems, 'includeProblems'),
+    ...readBoolean(config.includeOrganizations, 'includeOrganizations'),
+    ...readBoolean(config.includeNotables, 'includeNotables'),
+  };
+}
+
+/**
+ * The pattern set a roll should use, drawn from the seed when the caller did not name one.
+ *
+ * Drawn from a seed of its own rather than from the settlement's RNG, so that choosing a set
+ * explicitly and having one chosen produce the same settlement given the same set. A draw taken
+ * off the main stream would shift everything rolled after it.
+ *
+ * A set this build does not have falls back to the drawn one rather than throwing, which is the
+ * opposite of what `$lib/culture` does with the same field, deliberately. A culture *is* its
+ * naming traditions, so substituting them silently would hand back something that is not the
+ * culture that was asked for; a settlement is a place that happens to have a name. Falling back
+ * costs the tongue and keeps the settlement, and it keeps two paths working that would otherwise
+ * fail on data nobody can fix — a re-roll of an artifact whose pattern set has since been dropped,
+ * and a Generate driven by a culture adopted from `ironarachne.save.v1.*` with a set name this
+ * build never had.
+ */
+function resolveNameGeneratorSet(seed: string, requested: string | undefined): string {
+  const available = getFantasyNameGeneratorSetNames();
+  if (requested !== undefined && available.includes(requested)) {
+    return requested;
+  }
+  return new RNG(`${seed}-settlement-nameset`).item(available);
+}
+
+/**
+ * Roll a settlement from a seed and a set of options — the one path both the generator page and a
+ * re-roll take.
+ *
+ * Having one is the whole of requirement 2.2 here. The page used to build its own configuration
+ * inline, drawing name sets and an environment off a shared RNG in an order nothing else could
+ * reproduce, which made "same seed, same settlement" true only for as long as nobody touched the
+ * page. A seed and this record now determine the output, and provenance stores exactly this
+ * record.
+ */
+export function rollSettlement(
+  seed: string,
+  config: SettlementGeneratorConfigRecord = {},
+): SettlementRoll {
+  const nameGeneratorSet = resolveNameGeneratorSet(seed, config.nameGeneratorSet);
+  const rng = new RNG(seed);
+  const nameSet = getFantasyNameGeneratorSet(nameGeneratorSet, rng);
+  const base = getDefaultConfig(rng);
+
+  const enriched =
+    config.includeTrade === true ||
+    config.includeProblems === true ||
+    config.includeOrganizations === true ||
+    config.includeNotables === true;
+
+  const settlement = generate({
+    ...base,
+    size: config.size ?? 'any',
+    nameGenerator: nameSet.town,
+    enrichment: enriched
+      ? {
+          seedPrefix: `${seed}-settlement`,
+          includeTrade: config.includeTrade === true,
+          includeProblems: config.includeProblems === true,
+          includeOrganizations: config.includeOrganizations === true,
+          ...(config.includeNotables === true
+            ? { importantCharacterCount: { min: 1, max: 2 } }
+            : {}),
+          characterConfig: getCharacterGenerationConfigForNameSet(`${seed}-notable`, nameSet),
+          genre: 'fantasy',
+        }
+      : undefined,
+  });
+
+  return { settlement, nameGeneratorSet };
+}
+
+/**
+ * Roll a fresh settlement snapshot from a seed and the settings it was first made with — the
+ * destructive half of editing (requirement 4.3), and the only path in the workshop that
+ * regenerates a stored payload.
+ */
+export function rollSettlementSnapshot(
+  seed: string,
+  config: SettlementGeneratorConfigRecord = {},
+): SettlementSnapshot {
+  return toSettlementSnapshot(rollSettlement(seed, config).settlement);
+}

--- a/src/lib/settlements/settlement_snapshot.test.ts
+++ b/src/lib/settlements/settlement_snapshot.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+
+import { settlementFromSnapshot } from './settlement_rehydrate';
+import { toSettlementSnapshot } from './settlement_snapshot';
+import { rollSettlement } from './settlement_roll';
+import type { Settlement } from './settlement_types';
+
+/**
+ * The seeds are pinned, and each was chosen for what it produces rather than at random.
+ *
+ * `greyhaven` is the fully loaded case: every enrichment layer on, an organization whose emblem is
+ * a coat of arms, and a leader carrying arms of their own — which together are all three of the
+ * things in a settlement that are not plain data. `ashfall` is the same settings with a
+ * merchant-mark emblem instead, so the emblem variants that need no rebuilding are exercised too.
+ */
+const LOADED_SEED = 'greyhaven';
+const MERCHANT_MARK_SEED = 'ashfall';
+
+const EVERY_LAYER = {
+  size: 'large',
+  includeTrade: true,
+  includeProblems: true,
+  includeOrganizations: true,
+  includeNotables: true,
+} as const;
+
+/**
+ * A snapshot as it comes back out of storage, rather than as it went in.
+ *
+ * The JSON pass is the point: it is what a stored payload has been through by the time anything
+ * reads it, and it is what would expose a `Map` quietly flattened to `{}` or a key holding
+ * `undefined`. Comparing a snapshot to itself in memory would prove nothing about either.
+ */
+function throughStorage(settlement: Settlement): Settlement {
+  return settlementFromSnapshot(JSON.parse(JSON.stringify(toSettlementSnapshot(settlement))));
+}
+
+function loadedSettlement(): Settlement {
+  return rollSettlement(LOADED_SEED, EVERY_LAYER).settlement;
+}
+
+describe('toSettlementSnapshot', () => {
+  it('produces a payload that survives JSON, which is what storage does to it', () => {
+    const snapshot = toSettlementSnapshot(loadedSettlement());
+    expect(() => JSON.parse(JSON.stringify(snapshot))).not.toThrow();
+  });
+
+  it('stores an organization hierarchy as entries, because JSON empties a Map', () => {
+    const settlement = loadedSettlement();
+    const hierarchy = settlement.organizations?.[0]?.hierarchy;
+    expect(hierarchy?.roleById.size).toBeGreaterThan(0);
+
+    const stored = toSettlementSnapshot(settlement).organizations?.[0]?.hierarchy;
+    expect(Array.isArray(stored?.roleById)).toBe(true);
+    expect(stored?.roleById).toHaveLength(hierarchy?.roleById.size ?? 0);
+    // The check that matters: this is the shape a Map takes when it is stored naively.
+    expect(JSON.parse(JSON.stringify(hierarchy?.roleById))).toEqual({});
+  });
+
+  it('leaves the equipment tables behind, which is most of a settlement by weight', () => {
+    const settlement = loadedSettlement();
+    const archetype = settlement.importantPeople?.[0]?.character.archetype;
+    expect(archetype?.equipmentGenerationConfigs).toBeDefined();
+
+    const stored = toSettlementSnapshot(settlement).importantPeople?.[0]?.character.archetype;
+    expect(stored).toBeDefined();
+    expect(stored).not.toHaveProperty('equipmentGenerationConfigs');
+    expect(stored?.name).toBe(archetype?.name);
+
+    // Not a micro-optimisation: a campaign accumulates settlements, and the tables are what makes
+    // one of them a megabyte rather than a few tens of kilobytes.
+    const stored_bytes = JSON.stringify(toSettlementSnapshot(settlement)).length;
+    expect(stored_bytes).toBeLessThan(JSON.stringify(settlement).length / 4);
+  });
+
+  it('carries no functions, which is what IndexedDB refuses outright', () => {
+    const settlement = loadedSettlement();
+    // The generator really does produce one, so the assertion below is testing something.
+    expect(
+      typeof settlement.organizations?.[0]?.leader.heraldry?.device.chargeGroups[0]?.arrangement
+        .renderSVG,
+    ).toBe('function');
+    expect(functionPaths(toSettlementSnapshot(settlement))).toEqual([]);
+  });
+});
+
+describe('settlementFromSnapshot', () => {
+  it('round-trips a settlement with every enrichment layer on', () => {
+    const settlement = loadedSettlement();
+    expect(throughStorage(settlement)).toEqual(settlement);
+  });
+
+  it('round-trips a settlement with a non-heraldic emblem', () => {
+    const settlement = rollSettlement(MERCHANT_MARK_SEED, EVERY_LAYER).settlement;
+    expect(settlement.organizations?.[0]?.visualIdentity.emblem.kind).toBe('merchant_mark');
+    expect(throughStorage(settlement)).toEqual(settlement);
+  });
+
+  /**
+   * The risk this kind was chosen to find. `enrich_settlement.ts` is opt-in four times over, so a
+   * settlement rolled with enrichment and one rolled without are different shapes of the same
+   * kind, and both have to survive the same codec.
+   */
+  it('round-trips a settlement with no enrichment at all', () => {
+    const settlement = rollSettlement(LOADED_SEED).settlement;
+    expect(settlement.importantPeople).toBeUndefined();
+    expect(settlement.organizations).toBeUndefined();
+    expect(settlement.acuteProblems).toBeUndefined();
+    expect(throughStorage(settlement)).toEqual(settlement);
+  });
+
+  it('round-trips each enrichment layer on its own', () => {
+    const layers = [
+      'includeTrade',
+      'includeProblems',
+      'includeOrganizations',
+      'includeNotables',
+    ] as const;
+    for (const layer of layers) {
+      const settlement = rollSettlement(LOADED_SEED, { size: 'large', [layer]: true }).settlement;
+      expect(throughStorage(settlement)).toEqual(settlement);
+    }
+  });
+
+  it('rebuilds an organization hierarchy as the Maps it was', () => {
+    const settlement = loadedSettlement();
+    const restored = throughStorage(settlement);
+    const hierarchy = restored.organizations?.[0]?.hierarchy;
+    expect(hierarchy?.roleById).toBeInstanceOf(Map);
+    expect(hierarchy?.childToParent).toBeInstanceOf(Map);
+    expect(hierarchy?.idToOrder).toBeInstanceOf(Map);
+    expect(hierarchy?.roleById).toEqual(settlement.organizations?.[0]?.hierarchy.roleById);
+  });
+
+  it('rebuilds arms that can draw themselves again', () => {
+    const restored = throughStorage(loadedSettlement());
+    const arrangement =
+      restored.organizations?.[0]?.leader.heraldry?.device.chargeGroups[0]?.arrangement;
+    expect(typeof arrangement?.renderSVG).toBe('function');
+  });
+
+  /**
+   * An archetype this build no longer has is not a reason to refuse a settlement. The tables are
+   * what a character would be re-equipped from, which a saved settlement never is.
+   */
+  it('gives an unknown archetype no equipment tables rather than throwing', () => {
+    const settlement = loadedSettlement();
+    const snapshot = toSettlementSnapshot(settlement);
+    const notable = snapshot.importantPeople?.[0];
+    expect(notable?.character.archetype).toBeDefined();
+    const renamed = {
+      ...snapshot,
+      importantPeople: [
+        {
+          ...notable!,
+          character: {
+            ...notable!.character,
+            archetype: { ...notable!.character.archetype!, name: 'chronomancer' },
+          },
+        },
+      ],
+    };
+
+    const restored = settlementFromSnapshot(renamed);
+    expect(restored.importantPeople?.[0]?.character.archetype?.equipmentGenerationConfigs).toEqual(
+      [],
+    );
+  });
+});
+
+/** Every path in a value that holds a function, for the "IndexedDB refuses this" assertion. */
+function functionPaths(value: unknown, path = '$'): string[] {
+  if (typeof value === 'function') {
+    return [path];
+  }
+  if (value === null || typeof value !== 'object') {
+    return [];
+  }
+  return Object.entries(value).flatMap(([key, child]) => functionPaths(child, `${path}.${key}`));
+}

--- a/src/lib/settlements/settlement_snapshot.ts
+++ b/src/lib/settlements/settlement_snapshot.ts
@@ -1,0 +1,152 @@
+/**
+ * Writing a settlement snapshot, and the shapes one is made of. Reading one back is
+ * `settlement_rehydrate.ts`, split off for the reason heraldry's is: turning stored names back
+ * into charges reaches `$lib/charges`, which is 18 MB of glyph art, and nothing that merely
+ * stores, lists, or validates a settlement needs it.
+ *
+ * A settlement is the first artifact payload on the site built against the kind contract from
+ * scratch rather than retrofitted, and three things in it are not plain data. Each is handled
+ * explicitly here rather than left to a blanket strip, because requirement 3.2 in
+ * docs/workshop.md asks for exactly that — stripped *or reconstructed*, and named either way:
+ *
+ * - **An organization's hierarchy is three `Map`s.** `JSON.stringify` turns a `Map` into `{}`
+ *   without complaining, so a settlement stored naively came back with every organization's
+ *   structure silently emptied. They are stored as entry arrays.
+ * - **A coat of arms carries a render function.** `arrangement.renderSVG` is a function on every
+ *   charge group, which `structuredClone` — what IndexedDB stores with — refuses outright. Arms
+ *   are stored the way the heraldry kind stores them, by the names of their parts.
+ * - **An archetype carries its own generator tables.** `equipmentGenerationConfigs` is 66 KB per
+ *   character, measured, and it is the input a character was rolled *from* rather than anything
+ *   about the character. Kept, one enriched settlement is a megabyte and a campaign's worth is a
+ *   storage-quota problem; dropped and rebuilt from the archetype's name, the same settlement is
+ *   about forty kilobytes. That is the trade the heraldry kind already makes with charge names.
+ */
+
+import type { Archetype } from '$lib/archetypes';
+import type { Character } from '$lib/characters';
+import { toStoredArms, type StoredArms } from '$lib/heraldry';
+import type { OrganizationHierarchy, Organization, RoleId, RoleInfo } from '$lib/organizations';
+import { stripFunctionValuesDeep } from '$lib/persistent_save';
+import type { VisualEmblem, VisualIdentity } from '$lib/visual_identity';
+
+import type { Settlement, SettlementImportantPerson } from './settlement_types.js';
+
+/**
+ * An archetype without the equipment tables it was rolled from. See the module comment: they are
+ * generator input, not content, and they are rebuilt from the archetype's name on the way back.
+ */
+export type StoredArchetype = Omit<Archetype, 'equipmentGenerationConfigs'>;
+
+/** A character with the two parts of it that are not plain data stored as names. */
+export type StoredCharacter = Omit<Character, 'archetype' | 'heraldry'> & {
+  archetype?: StoredArchetype;
+  heraldry?: StoredArms;
+};
+
+export type StoredSettlementNotable = Omit<SettlementImportantPerson, 'character'> & {
+  character: StoredCharacter;
+};
+
+/** The three `Map`s of an {@link OrganizationHierarchy} as entry arrays, in their own order. */
+export type StoredOrganizationHierarchy = {
+  childToParent: [RoleId, RoleId | null][];
+  idToOrder: [RoleId, number][];
+  roleById: [RoleId, RoleInfo][];
+};
+
+/** Every emblem variant but heraldry is already plain data and travels as it is. */
+export type StoredVisualEmblem =
+  | Exclude<VisualEmblem, { kind: 'heraldry' }>
+  | { kind: 'heraldry'; arms: StoredArms };
+
+export type StoredVisualIdentity = Omit<VisualIdentity, 'emblem'> & {
+  emblem: StoredVisualEmblem;
+};
+
+export type StoredOrganization = Omit<
+  Organization,
+  'hierarchy' | 'leader' | 'notableMembers' | 'visualIdentity'
+> & {
+  hierarchy: StoredOrganizationHierarchy;
+  leader: StoredCharacter;
+  notableMembers: StoredCharacter[];
+  visualIdentity: StoredVisualIdentity;
+};
+
+/**
+ * A settlement as it is stored. Everything the settlement itself holds travels straight through;
+ * only what it borrows from `$lib/characters`, `$lib/organizations`, and `$lib/heraldry` is
+ * rewritten, and only where those carry something JSON does not have.
+ */
+export type SettlementSnapshot = Omit<Settlement, 'importantPeople' | 'organizations'> & {
+  importantPeople?: StoredSettlementNotable[];
+  organizations?: StoredOrganization[];
+};
+
+function toStoredArchetype(archetype: Archetype): StoredArchetype {
+  const { equipmentGenerationConfigs: _configs, ...rest } = archetype;
+  return rest;
+}
+
+function toStoredCharacter(character: Character): StoredCharacter {
+  const { archetype, heraldry, ...rest } = character;
+  return {
+    ...rest,
+    ...(archetype === undefined ? {} : { archetype: toStoredArchetype(archetype) }),
+    ...(heraldry === undefined ? {} : { heraldry: toStoredArms(heraldry) }),
+  };
+}
+
+function toStoredNotable(notable: SettlementImportantPerson): StoredSettlementNotable {
+  return { ...notable, character: toStoredCharacter(notable.character) };
+}
+
+function toStoredHierarchy(hierarchy: OrganizationHierarchy): StoredOrganizationHierarchy {
+  return {
+    childToParent: [...hierarchy.childToParent],
+    idToOrder: [...hierarchy.idToOrder],
+    roleById: [...hierarchy.roleById],
+  };
+}
+
+function toStoredVisualIdentity(identity: VisualIdentity): StoredVisualIdentity {
+  const { emblem } = identity;
+  return {
+    ...identity,
+    emblem:
+      emblem.kind === 'heraldry' ? { kind: 'heraldry', arms: toStoredArms(emblem.arms) } : emblem,
+  };
+}
+
+function toStoredOrganization(organization: Organization): StoredOrganization {
+  return {
+    ...organization,
+    hierarchy: toStoredHierarchy(organization.hierarchy),
+    leader: toStoredCharacter(organization.leader),
+    notableMembers: organization.notableMembers.map(toStoredCharacter),
+    visualIdentity: toStoredVisualIdentity(organization.visualIdentity),
+  };
+}
+
+/**
+ * A settlement as an artifact payload.
+ *
+ * The final strip is a net rather than the mechanism: everything this module knows to be a
+ * function has already been converted by name above, and the strip is what keeps a function
+ * added to some borrowed type later from turning a save into a `DataCloneError` the user meets
+ * instead of a settlement. It runs after the conversions, so the `Map`s are already arrays by the
+ * time it walks them.
+ */
+export function toSettlementSnapshot(settlement: Settlement): SettlementSnapshot {
+  const { importantPeople, organizations, ...rest } = settlement;
+  const converted: SettlementSnapshot = {
+    ...rest,
+    ...(importantPeople === undefined
+      ? {}
+      : { importantPeople: importantPeople.map(toStoredNotable) }),
+    ...(organizations === undefined
+      ? {}
+      : { organizations: organizations.map(toStoredOrganization) }),
+  };
+  return stripFunctionValuesDeep(converted) as SettlementSnapshot;
+}

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -89,7 +89,7 @@ describe('TOOL_CATALOG', () => {
     // A tripwire rather than a rule: raising a tool's level means adding it here, in the same
     // change that earns it. That is the point — a level should not be able to rise as a side
     // effect of editing a catalog entry for some other reason.
-    const assessedHigher = ['/culture', '/fantasy/religion', '/heraldry'];
+    const assessedHigher = ['/culture', '/fantasy/religion', '/fantasy/settlement', '/heraldry'];
 
     const claimingMore = TOOL_CATALOG.filter(
       (tool) => !assessedHigher.includes(tool.path) && tool.maturity !== 'experimental',
@@ -181,7 +181,11 @@ describe('toolsWithMaturity', () => {
   it('returns the tools at that maturity', () => {
     const releaseReady = toolsWithMaturity('release-ready');
 
-    expect(releaseReady.map((tool) => tool.path).sort()).toEqual(['/culture', '/fantasy/religion']);
+    expect(releaseReady.map((tool) => tool.path).sort()).toEqual([
+      '/culture',
+      '/fantasy/religion',
+      '/fantasy/settlement',
+    ]);
   });
 
   it('accounts for every tool across the three levels', () => {
@@ -225,7 +229,11 @@ describe('filterTools', () => {
       includeAllTags: [genreTag('fantasy'), maturityTag('release-ready')],
     });
 
-    expect(durableFantasy.map((tool) => tool.path)).toEqual(['/culture', '/fantasy/religion']);
+    expect(durableFantasy.map((tool) => tool.path)).toEqual([
+      '/culture',
+      '/fantasy/religion',
+      '/fantasy/settlement',
+    ]);
   });
 
   it('returns the whole catalog for an empty filter', () => {

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -218,11 +218,13 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     tags: ['map', 'worldbuilding'],
   }),
   defineTool({
+    // Release-ready as of #20, the third and hardest of the first release's three tools: the only
+    // one whose payload was built against the kind contract from scratch rather than retrofitted.
     path: '/fantasy/settlement',
     label: 'Settlement',
     kind: 'generator',
     domain: 'locations',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     genres: ['fantasy'],
     tags: ['worldbuilding'],
   }),

--- a/src/lib/workshop/README.md
+++ b/src/lib/workshop/README.md
@@ -67,7 +67,8 @@ another's payloads.
 
 The imports here are deep — `$lib/culture/culture_artifact_kind`, not `$lib/culture` — and
 measured. Through the entry points this registry costs 296 KB in whatever chunk imports it;
-through the kind modules, 4 KB. Everything in the workshop touches it, and a kind module holds
+through the kind modules, 4 KB. `$lib/settlements` is the sharpest case: its entry point reaches
+`$lib/organizations`, and from there the heraldry generator and the charge library. Everything in the workshop touches it, and a kind module holds
 metadata and validation only: its codec is a dynamic import, which is what keeps 18 MB of charge
 art out of the chunk that merely lists what a project contains.
 
@@ -99,6 +100,12 @@ It is here rather than in `$lib/artifacts` because it is where a _tool_ — a ca
 build's registry of kinds — meets the store, and the store deliberately knows about neither. A seed
 that is not given records no provenance at all rather than an invented one, per the design
 document: provenance is a record of origin, and a made-up seed is a lie the re-roll button acts on.
+
+**A tool's `config` must be plain data.** The store writes through IndexedDB, which serialises with
+`structuredClone`, and `structuredClone` refuses a Proxy — so a `config` held in a Svelte `$state`
+object comes back as `storage-failed: could not be cloned`, with the generated content still on
+screen and nothing saved. Build the record inline, or hold it in `$state.raw`; a provenance config
+is replaced wholesale by every roll and never mutated in place, which is what raw state is for.
 
 The draft also carries `references` — the saved artifacts the tool was handed, as
 `SavedArtifactPicker` filled them in — so the link is recorded in the same write that stores what
@@ -175,7 +182,8 @@ artifact does not restamp contents nobody changed.
 ## Artifact editors
 
 `ARTIFACT_EDITORS` maps a kind to the component that edits it, alongside an optional roller.
-**Culture and religion are the entries**, and most kinds having none is the shipped state: #39
+**Culture, religion, and settlement are the entries**, and most kinds having none is the shipped
+state: #39
 built the frame, and an editing view for a particular kind is part of taking that tool to
 Release-ready (docs/workshop.md, section 4). A kind with no entry opens read-only — the stored
 snapshot, rendered honestly — which is a state the surface draws rather than an error it reports.
@@ -198,10 +206,12 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
 };
 ```
 
-Nothing in the framework changed to accommodate culture (#40) or religion (#41), which is the claim
-these entries exist to test: adding a kind is a line here and a component taking
-`ArtifactEditorProps`. Religion is the harder of the two — its payload is a list of sub-objects
-rather than a flat record — and it needed nothing here either.
+Nothing in the framework changed to accommodate culture (#40), religion (#41), or settlement
+(#20), which is the claim these entries exist to test: adding a kind is a line here and a component
+taking `ArtifactEditorProps`. The three were chosen to be progressively less like each other —
+culture is a flat record, religion is a list of sub-objects, and a settlement is sixteen legitimate
+shapes of one kind, since its enrichment is opt-in four times over — and none of them needed
+anything here.
 
 The specifiers are written out in full, for the reason `TOOL_PANELS` is: a bundler can only split
 a dynamic import it can see.

--- a/src/lib/workshop/artifact_editors.test.ts
+++ b/src/lib/workshop/artifact_editors.test.ts
@@ -124,4 +124,33 @@ describe('the artifact editor registry', () => {
     expect(rolled.name).not.toBe('');
     expect(rolled.religion.pantheon).not.toBeNull();
   });
+
+  /**
+   * Settlement is the third (#20), and the only one whose payload was built against the contract
+   * from scratch rather than retrofitted from an existing snapshot. Nothing here changed to take
+   * it either, which is the claim these three entries exist to keep testing.
+   */
+  it('gives settlement an editor and a roller', () => {
+    const settlement = artifactEditorEntry('settlement');
+
+    expect(settlement?.loadEditor).toBeDefined();
+    expect(settlement?.loadRoller).toBeDefined();
+  });
+
+  it('rolls a settlement from provenance through the registered roller', async () => {
+    const roll = await artifactEditorEntry('settlement')!.loadRoller!();
+    const provenance = {
+      toolPath: '/fantasy/settlement' as const,
+      seed: 'registry-roll',
+      config: { nameGeneratorSet: 'dwarf', size: 'large', includeNotables: true },
+    };
+    const rolled = roll(provenance) as { name: string; importantPeople?: unknown[] };
+
+    expect(typeof rolled.name).toBe('string');
+    expect(rolled.name).not.toBe('');
+    expect(rolled.importantPeople?.length).toBeGreaterThan(0);
+    // Requirement 2.2 through the registry rather than only in the library: the same provenance
+    // rolls the same settlement, which is what makes re-rolling an unedited artifact safe.
+    expect(roll(provenance)).toEqual(rolled);
+  });
 });

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -17,13 +17,16 @@ import type { ArtifactEditorEntry, ArtifactEditorRegistry } from './workshop_typ
  * it reports.
  *
  * Adding one is a line here and a component that takes {@link ArtifactEditorProps}. Nothing in
- * the framework changed to accommodate culture or religion, which is the claim these entries exist
- * to test: the second kind cost a registration and a component, exactly as the first did.
+ * the framework changed to accommodate culture, religion, or settlement, which is the claim these
+ * entries exist to test: the second and third kinds each cost a registration and a component,
+ * exactly as the first did — and the three are as unlike each other as the site has to offer. A
+ * culture is a flat record, a religion is a list of sub-objects, and a settlement is sixteen
+ * legitimate shapes of one kind, its enrichment being opt-in four times over.
  *
- * The rollers' specifiers reach past `$lib/culture` and `$lib/religion` on purpose: they are
- * dynamic imports, which exist to split a chunk off, and going through an entry point would pull
- * the whole library — generation tables and all — back into the chunk that opening any artifact
- * loads.
+ * The rollers' specifiers reach past `$lib/culture`, `$lib/religion`, and `$lib/settlements` on
+ * purpose: they are dynamic imports, which exist to split a chunk off, and going through an entry
+ * point would pull the whole library — generation tables and all — back into the chunk that
+ * opening any artifact loads.
  */
 export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
   /**
@@ -53,6 +56,15 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         await import('$lib/religion/religion_roll.js');
       return (provenance) =>
         rollReligionSnapshot(provenance.seed, readReligionGeneratorConfig(provenance.config));
+    },
+  },
+  settlement: {
+    loadEditor: () => import('$components/locations/SettlementArtifactEditor.svelte'),
+    loadRoller: async () => {
+      const { readSettlementGeneratorConfig, rollSettlementSnapshot } =
+        await import('$lib/settlements/settlement_roll.js');
+      return (provenance) =>
+        rollSettlementSnapshot(provenance.seed, readSettlementGeneratorConfig(provenance.config));
     },
   },
 };

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -10,7 +10,12 @@ import { artifactKindIds } from '$lib/artifact_kinds';
 
 describe('artifact kind catalog', () => {
   it('registers the kinds this build knows how to store', () => {
-    expect(artifactKindIds(ARTIFACT_KINDS)).toEqual(['heraldry', 'culture', 'religion']);
+    expect(artifactKindIds(ARTIFACT_KINDS)).toEqual([
+      'heraldry',
+      'culture',
+      'religion',
+      'settlement',
+    ]);
   });
 
   it('gives every registered kind a display name and a usable payload version', () => {
@@ -28,7 +33,9 @@ describe('artifact kind catalog', () => {
 
   it('looks a kind up by id', () => {
     expect(artifactKindEntry('culture')?.displayName).toBe('Culture');
-    expect(artifactKindEntry('settlement')).toBeUndefined();
+    // A kind this build does not have is the normal case for a file from a newer one, and the miss
+    // is what routes it to quarantine rather than an exception.
+    expect(artifactKindEntry('character.swn')).toBeUndefined();
   });
 
   it('loads a codec for every registered kind', async () => {

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -9,14 +9,16 @@ import {
   type ArtifactKindRegistry,
   type PayloadResult,
 } from '$lib/artifact_kinds';
-// Deep on purpose, and measured against the bundle: these three libraries' entry points reach a
+// Deep on purpose, and measured against the bundle: these libraries' entry points reach a
 // generator and from there the species tables. Assembling this registry through
 // them costs 296 KB in the chunk that imports it; through the kind modules it costs 4 KB.
 // Everything in the workshop touches this registry, so that difference is paid by any page that
-// so much as lists what a project contains.
+// so much as lists what a project contains. Settlement is the sharpest case of the four: its entry
+// point reaches `$lib/organizations`, and from there the heraldry generator and the charge library.
 import { cultureArtifactKind } from '$lib/culture/culture_artifact_kind';
 import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
 import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
+import { settlementArtifactKind } from '$lib/settlements/settlement_artifact_kind';
 
 /**
  * Assembled statically, in a single list, exactly like `TOOL_PANELS` beside it and the tool
@@ -32,6 +34,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, heraldryArtifactKind);
   registerArtifactKind(registry, cultureArtifactKind);
   registerArtifactKind(registry, religionArtifactKind);
+  registerArtifactKind(registry, settlementArtifactKind);
   return registry;
 }
 

--- a/src/lib/workshop/artifact_loading.test.ts
+++ b/src/lib/workshop/artifact_loading.test.ts
@@ -349,3 +349,142 @@ describe('a culture and a religion that reference each other', () => {
     expect(await loadArtifactValue('p1', religion.id)).toMatchObject({ ok: true });
   });
 });
+
+/**
+ * Requirement 5.4 for settlement (#20), which is the tool that makes a cycle reachable through
+ * three real kinds rather than two.
+ *
+ * A settlement takes its names from a saved culture and records a saved religion as the local
+ * faith; a religion takes its gods' names from a saved culture; a culture takes its faith from a
+ * saved religion. Pointed round, `settlement → culture → religion → settlement` is a cycle, and
+ * per docs/workshop.md that is an ordinary arrangement rather than a bug to detect.
+ *
+ * Built through the store for the reason the two-kind case is: a reference is recorded when an
+ * artifact is saved, and saving always makes a new artifact, so the UI cannot close a loop it is
+ * allowed to describe.
+ */
+describe('a settlement in a cycle of references', () => {
+  /**
+   * The smallest payload the registered settlement kind accepts. What is proved here is the shape
+   * of the links; `settlement_artifact_kind.test.ts` is where the shape of a settlement is argued
+   * about.
+   */
+  function settlementSnapshot(name = 'White Ridge'): Record<string, unknown> {
+    return {
+      name,
+      description: 'A city on a ridge above the salt road.',
+      category: { name: 'city', sizeClass: 'large', minSize: 8000, maxSize: 20000 },
+      population: 12000,
+      prosperity: 8,
+      environment: { description: 'Dry uplands, cut by one green valley.' },
+      lawAndOrder: 6,
+      commerce: 7,
+      foodSecurity: 5,
+      publicHealth: 4,
+      settlementTags: ['highland'],
+      economicRole: 'market',
+    };
+  }
+
+  async function saveALoop(): Promise<{
+    settlement: Artifact;
+    culture: Artifact;
+    religion: Artifact;
+  }> {
+    const culture = await saveCulture();
+    const storedReligion = await saveToolArtifact('p1', {
+      kind: 'religion',
+      payload: {
+        name: 'The Ember',
+        seed: 'ember',
+        generatorOptions: {
+          lockSeed: false,
+          selectedCategories: ['polytheism'],
+          selectedSpecies: ['human'],
+          polytheisticStanding: 'random',
+          spiritCosmologyDepth: 'random',
+          useSavedCulture: true,
+          savedCultureName: 'Ashfall',
+        },
+        religion: { name: 'The Ember', description: 'They keep the long silence.' },
+      },
+      toolPath: '/fantasy/religion',
+      references: [{ targetId: culture.id, targetKind: 'culture', role: 'naming-culture' }],
+    });
+    if (!storedReligion.ok) {
+      throw new Error(`expected a stored religion, got ${storedReligion.reason}`);
+    }
+    const storedSettlement = await saveToolArtifact('p1', {
+      kind: 'settlement',
+      payload: settlementSnapshot(),
+      toolPath: '/fantasy/settlement',
+      references: [
+        { targetId: culture.id, targetKind: 'culture', role: 'naming-culture' },
+        { targetId: storedReligion.value.id, targetKind: 'religion', role: 'faith' },
+      ],
+    });
+    if (!storedSettlement.ok) {
+      throw new Error(`expected a stored settlement, got ${storedSettlement.reason}`);
+    }
+    // The link that closes the loop: the culture's own faith is the religion above, and that
+    // religion is practised in the settlement named from the culture.
+    await setArtifactReferences('p1', culture.id, [
+      { targetId: storedReligion.value.id, targetKind: 'religion', role: 'religion' },
+    ]);
+    return { settlement: storedSettlement.value, culture, religion: storedReligion.value };
+  }
+
+  it('walks out of a settlement and stops, rather than going round', async () => {
+    const { settlement, culture, religion } = await saveALoop();
+
+    expect(
+      collectReferencedArtifacts('p1', settlement.id)
+        .map((entry) => entry.id)
+        .sort(),
+    ).toEqual([culture.id, religion.id].sort());
+  });
+
+  it('rebuilds a settlement that is part of one', async () => {
+    const { settlement } = await saveALoop();
+
+    expect(await loadArtifactValue('p1', settlement.id)).toMatchObject({ ok: true });
+  });
+
+  /** The roles are what make two links of different kinds legible from the other end. */
+  it('answers what a culture and a religion are used for, by role', async () => {
+    const { settlement, culture, religion } = await saveALoop();
+
+    expect(listArtifactBacklinks('p1', culture.id)).toMatchObject([
+      { referrer: { id: religion.id }, references: [{ role: 'naming-culture' }] },
+      { referrer: { id: settlement.id }, references: [{ role: 'naming-culture' }] },
+    ]);
+    expect(listArtifactBacklinks('p1', religion.id)).toMatchObject([
+      { referrer: { id: culture.id }, references: [{ role: 'religion' }] },
+      { referrer: { id: settlement.id }, references: [{ role: 'faith' }] },
+    ]);
+  });
+
+  /**
+   * Requirement 5.3: composition is opt-in, so a settlement that was handed nothing is a settlement
+   * with no references — not one with empty ones.
+   */
+  it('records nothing for a settlement that was handed nothing', async () => {
+    const stored = await saveToolArtifact('p1', {
+      kind: 'settlement',
+      payload: settlementSnapshot('Oakhollow'),
+      toolPath: '/fantasy/settlement',
+    });
+
+    expect(stored.ok && stored.value.references).toEqual([]);
+    expect(stored.ok && collectReferencedArtifacts('p1', stored.value.id)).toEqual([]);
+  });
+
+  it('leaves a settlement readable and visibly broken when its faith is deleted', async () => {
+    const { settlement, religion } = await saveALoop();
+
+    await deleteArtifact('p1', religion.id);
+
+    expect(hasBrokenArtifactReferences('p1', getArtifactSummary('p1', settlement.id)!)).toBe(true);
+    expect(await loadArtifactValue('p1', settlement.id)).toMatchObject({ ok: true });
+  });
+});


### PR DESCRIPTION
Settlement is the third of the first release's three tools and the only one whose payload was built against the kind contract in `docs/workshop.md` from scratch rather than retrofitted from an existing snapshot. That was the point of choosing it: if the contract were awkward, this is where it would show. It was not — the registry, the editor slot, and the picker each took settlement as a registration and a component.

Closes #20.

## The payload

`settlement_snapshot.ts` writes it, `settlement_rehydrate.ts` reads it, split for the reason heraldry's pair is split: reading resolves charge names against `$lib/charges`, and validating or listing a settlement needs none of that.

Three things a settlement borrows are not plain data, and requirement 3.2's "stripped **or reconstructed explicitly**" earns its wording on all three:

| What | Why it is not storable | What happens to it |
| --- | --- | --- |
| An organization's hierarchy | Three `Map`s; `JSON.stringify` empties one to `{}` without complaining | Stored as entry arrays |
| A coat of arms | `arrangement.renderSVG` per charge group; `structuredClone` refuses a function | Stored by the names of its parts, rebuilt via `armsFromStored` |
| An archetype | `equipmentGenerationConfigs` is 66 KB per character, and is generator input rather than content | Dropped, rebuilt from the archetype's name |

Stored naively an enriched settlement is a megabyte with its organizations silently hollowed out. Converted by name it is **57 KB and round-trips exactly** — asserted, not assumed.

`$lib/heraldry` grew `toStoredArms` / `armsFromStored` and made its device pair public, rather than settlements reaching past its entry point.

## Sixteen shapes of one kind

`enrich_settlement.ts` is opt-in four times over, so a settlement rolled plain and one rolled loaded are both current payloads at version 1. `validate` accepts each optional layer when absent and checks it when present — which is also what makes a payload written by a build with different enrichment defaults readable rather than quarantined (3.3).

## Determinism

The page built its configuration inline, drawing name sets and an environment off a shared RNG in an order nothing else could reproduce, so 2.2 held only while nobody edited the component, and a re-roll had nothing to reproduce from. `rollSettlement` is now the single path, called by both the page and the registered roller. It returns the resolved pattern set beside the settlement, because provenance must record what was *used*, not what was asked for: "any set" stored as provenance makes a re-roll a fresh draw.

## Editing and composition

`SettlementArtifactEditor.svelte` covers every field the page shows. The helpers in `settlement_editing.ts` return new snapshots, so rewriting one problem leaves the rest of the place alone (4.4). Problems can be added; notables cannot, because an empty notable would be a broken record rather than a blank field.

A settlement takes a saved culture as an **input** — the tongue its town, organizations, and people are named in, recorded as that culture's pattern set so a re-roll stays faithful without reaching into the store — and records a saved religion as the **local faith**. The two behave differently, which is why `role` is required: the culture link is gated on the roll that used it, while the faith follows the picker, being something the user says about the place afterwards. Nothing about the religion enters the payload (5.2).

> The issue asked for the religion to replace a generated faith. Settlements have never generated one, so there was nothing to replace — and copying the religion's name into the payload to invent the field would have been exactly the copy 5.2 exists to prevent.

## Output

Markdown and PDF over one document model, so both drop empty sections rather than printing bare headings. That matters more here than anywhere else on the site: the plainest settlement has four of them.

## A trap worth the note

A provenance `config` held in a Svelte `$state` object is a Proxy, and `structuredClone` refuses a Proxy, so the save comes back `storage-failed: could not be cloned`. Written down in `$lib/workshop`'s README beside `saveToolArtifact`, where the next tool will meet it.

## Verification

- `npm run verify` — green. 4,098 unit tests, coverage gate passed with no baselined debt.
- `npm run test:e2e` — green, all 380.
- New e2e coverage: 7.4 (generate, save, reopen, edit), 4.3 with enrichment surviving a re-roll, 4.4, 6.1 at 320px, and both references recorded and legible from either end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)