### PR TITLE
Design the storage disclosure and the persistence request

### DIFF
--- a/docs/storage-disclosure.md
+++ b/docs/storage-disclosure.md
@@ -1,0 +1,349 @@
+# The storage disclosure and the persistence request
+
+This design document covers the two things Iron Arachne does at the moment a user first makes a
+project: it **tells them their work lives in this browser and nowhere else**, and it **asks the
+browser not to throw that work away**.
+
+It is one section of [the workshop](workshop.md) — [Eviction and
+persistence](workshop.md#eviction-and-persistence) and
+[What the user is told about storage](workshop.md#what-the-user-is-told-about-storage) — worked out
+far enough to build. `src/lib/storage_status` already _reports_ whether the origin is protected;
+nothing yet _asks_ for it, and nothing yet tells the user anything.
+
+**Status:** proposal. The [domain model](#domain-model) has not been reviewed. Per `CLAUDE.md`,
+implementation does not start until a human has approved it, and there are three
+[questions for review](#questions-for-review) that change what gets built.
+
+Designs [#26](https://github.com/ironarachne/ironarachne/issues/26). The storage panel
+([#27](https://github.com/ironarachne/ironarachne/issues/27)) is the neighbouring piece of the same
+surface and is designed separately; this document produces the state that panel will read, and says
+where the boundary is.
+
+## The problem
+
+Under [Local only](workshop.md#local-only) the browser holds the only copy of everything a user has
+made. That turns storage eviction from a tidiness concern into **silent total loss that arrives
+without the user doing anything**:
+
+- Safari's ITP discards script-writable storage for an origin with no user interaction for seven
+  days. A campaign built in March and left alone until April is gone, and nothing announced it.
+- Every browser may evict an origin it considers "best effort" under storage pressure.
+
+Two separate gaps follow, and they are the two halves of this document:
+
+1. **Nothing asks the browser not to.** `navigator.storage.persist()` exists, is cheap, and is never
+   called anywhere in the codebase today.
+2. **Nothing tells the user.** There is no account, no server, and no copy anywhere else, and the
+   product has never said so. Someone cannot take the one action that protects them — export —
+   against a risk nobody described.
+
+`src/lib/storage_status` (#177) reads `persisted()` and reports `persisted | notPersisted |
+unknown`. It is a display of a fact nothing in the product has ever tried to change.
+
+## The shape
+
+One moment, two halves, in this order:
+
+```
+/projects ─ user types a name, presses Create
+             │
+             ├─ 1. the project is written                    (createProject)
+             │
+             ├─ 2. the disclosure is rendered and painted    ┌──────────────────────────────┐
+             │                                               │ Your work is saved in this   │
+             │                                               │ browser only. There is no    │
+             │                                               │ account and no server.       │
+             │                                               │ Export is how it leaves.     │
+             │                                               │           [Got it] [Export]  │
+             │                                               └──────────────────────────────┘
+             │
+             └─ 3. persistence is requested                   navigator.storage.persist()
+                    (Firefox prompts here; Chromium decides silently)
+```
+
+The order is the design. Firefox raises a permission prompt on `persist()`, and a prompt is answered
+with whatever is on screen behind it. If the sentence has not painted yet, the user is answering a
+question they have not been given a reason for — and **a declined permission is much harder to
+recover than one not yet asked**, because Firefox remembers a denial per origin and stops prompting.
+
+This is also why the moment is first project creation rather than first page load. At first load
+there is nothing worth protecting and the prompt is noise to dismiss. At first project creation
+there is something to lose, and the reason is on screen one line above the prompt.
+
+### Where it appears
+
+Projects are created in exactly one place a user can see. `src/components/layout/ProjectsPage.svelte`
+is the only caller of `createProject` a user drives; the workshop's project bar links here rather
+than creating one itself, and `/projects` already carries `VaultTransferControls`, so the
+disclosure's _Export vault_ action is a scroll away rather than a navigation.
+
+The notice follows the pattern the legacy-adoption notice already established in
+`ProjectContextBar` — inline, dismissible, a **Got it** button, no dialog. It is not a modal: a modal
+on the first thing a user ever makes is a toll gate, and this is a sentence.
+
+## What triggers what
+
+Three code paths create projects, and they are not equivalent.
+
+| Path                                     | Disclosure | Persistence request | Why                                                                                    |
+| ---------------------------------------- | ---------- | ------------------- | -------------------------------------------------------------------------------------- |
+| `ProjectsPage` — the user presses Create | Yes, once  | Yes                 | The moment the issue names: a user gesture, with something newly worth protecting.     |
+| `legacy_adoption` — a run on page load   | No         | No                  | Page load with no gesture — exactly the prompt-before-anything-exists case. See below. |
+| `vault_file` import — restoring a backup | No         | Yes                 | Not a first project, and an importer already knows about files. But it is real work.   |
+
+**Legacy adoption is the gap in the narrow reading**, and it is worth naming here rather than
+discovering later. A user who arrives with pre-workshop saves gets a project created for them on
+load and may never press Create, so under the rule above they are never told and never protected.
+The proposal is the cheapest thing that closes it: **one sentence added to the adoption notice
+copy**, in a notice that is already on screen and already dismissible, saying the same thing. No new
+trigger, no new state, no cross-library coupling. Their persistence request then arrives at the next
+qualifying moment through the rule below. See [question 2](#questions-for-review).
+
+## Asking at most once per session
+
+The retry rule the issue sets — re-request at most once per session, and only after the user has
+done more work — needs no counters. It falls out of restricting **who may call**:
+
+```typescript
+requestPersistenceIfWarranted('projectCreated'); // ProjectsPage, after a successful create
+requestPersistenceIfWarranted('vaultExported'); // after a successful vault export
+requestPersistenceIfWarranted('projectExported'); // after a successful project export
+```
+
+Those three call sites _are_ "the user has done more work". Nothing else calls it, so no page load,
+no route change, and no idle timer can ask. The function then applies three gates in order:
+
+1. **Already protected?** `persisted()` first. A persisted origin is never asked again — calling
+   `persist()` on one is a prompt with nothing behind it.
+2. **Asked already this session?** One request per page lifetime, refused or not.
+3. Otherwise call `persist()`, record the outcome, and on a grant `invalidateStorageMeasurement()` —
+   a granted request changes what the browser will give, which is a case `storage_status`'s README
+   already reserves.
+
+**A session is the page's lifetime**, held in module state rather than `sessionStorage`. A reload
+therefore permits one more request — but only paired with fresh work, and in the browser where the
+distinction matters, Firefox remembers an explicit denial and answers `false` without prompting
+again. The gate that actually protects the user from nagging is the call-site restriction, not the
+storage the flag lives in. See [question 3](#questions-for-review).
+
+Nothing about this is modal, nothing blocks, and no outcome stops the project from being created.
+`persist()` is fire-and-observe: a refusal is recorded and the work carries on.
+
+## What the copy may not say
+
+Two rules, both about not selling a guarantee the product cannot honour.
+
+**Persistence is not a backup.** It resists automatic eviction under storage pressure. It does
+nothing about the user clearing site data, a lost laptop, a different browser, or a different profile
+on the same laptop. A "Protected" badge presented as safety would be the most expensive lie in the
+product, because it would talk someone out of the export that is their actual protection.
+
+**No browser sniffing, and Safari needs none.** `docs/workshop.md` treats Safari as a separate case —
+inconsistent `persist()` support, and ITP evicting regardless. The answer here is not to detect it. A
+user agent string is a guess, and the honest position it would lead to is one this design takes in
+_every_ branch: **export is the protection, whatever the browser said.** So the disclosure's closing
+line — export is how your work leaves this browser — is unconditional, and no branch of the UI ever
+reads "you are safe". `PersistenceState` keeps reporting the fact, and #27 decides how to phrase a
+fact that is true and not reassuring.
+
+## Domain model
+
+Two diagrams. The first is the new state; the second is how it meets what `storage_status` already
+has.
+
+### The disclosure and the request
+
+```mermaid
+classDiagram
+    class StorageDisclosure {
+        +number shownAt
+    }
+    class PersistenceRequest {
+        +PersistenceTrigger trigger
+        +number requestedAt
+        +PersistenceRequestOutcome outcome
+    }
+    class PersistenceRequestSession {
+        +boolean askedThisSession
+        +PersistenceRequest lastRequest
+    }
+    class PersistenceTrigger {
+        <<enumeration>>
+        projectCreated
+        vaultExported
+        projectExported
+    }
+    class PersistenceRequestOutcome {
+        <<enumeration>>
+        granted
+        refused
+        unavailable
+        alreadyPersisted
+        notAsked
+    }
+
+    PersistenceRequestSession "1" o-- "0..1" PersistenceRequest : lastRequest
+    PersistenceRequest "1" --> "1" PersistenceTrigger : trigger
+    PersistenceRequest "1" --> "1" PersistenceRequestOutcome : outcome
+```
+
+Reading it:
+
+- **`StorageDisclosure` is the only stored thing here**, and it is one timestamp: `shownAt`, in the
+  vault's `meta` store under a new `storageDisclosureShownAt` key, beside `localStorageAdoptedAt` —
+  the once-ever stamp it most resembles. `meta` is not carried by the export envelope, so the stamp
+  cannot travel in a backup and silence a disclosure in a browser that was never told. It is a
+  timestamp rather than a boolean because "when were they told" is answerable for free, and #27 may
+  want it.
+- **A failed stamp write shows the disclosure again next time**, and that is the right failure. The
+  alternative — remembering it in memory and stamping optimistically — is a user who was told once,
+  during a run where the database was refusing writes, and never again.
+- **Everything else is session state and dies with the page.** `askedThisSession` is the whole retry
+  policy. Nothing about a refusal is persisted: a stored "they said no" would outlive the reason and
+  turn a browser-level decision the user can revisit into a product-level one they cannot.
+- **`outcome` is five-valued because the answers are genuinely different.** `refused` is the browser
+  saying no; `unavailable` is no `persist()` at all, or one that threw; `alreadyPersisted` means
+  nothing was asked because nothing needed to be; `notAsked` is this session's gate declining to ask
+  again. Collapsing any pair produces a display or a log that is confidently wrong — the same
+  argument that made `PersistenceState` three-valued.
+- **`trigger` is recorded, not just consumed.** It is what makes "we only ask after real work"
+  checkable in a test rather than a claim in a comment.
+
+### Meeting the existing storage status
+
+```mermaid
+classDiagram
+    class StorageStatus {
+        +number usageBytes?
+        +number quotaBytes?
+        +PersistenceState persistence
+        +number lastVaultExportAt?
+        +number measuredAt
+        +ProjectUsage[] projects
+    }
+    class PersistenceState {
+        <<enumeration>>
+        persisted
+        notPersisted
+        unknown
+    }
+    class PersistenceRequest {
+        +PersistenceTrigger trigger
+        +number requestedAt
+        +PersistenceRequestOutcome outcome
+    }
+    class StorageDisclosure {
+        +number shownAt
+    }
+
+    StorageStatus "1" --> "1" PersistenceState : reports
+    PersistenceRequest ..> PersistenceState : may change
+    StorageDisclosure ..> StorageStatus : neither reads nor changes
+```
+
+- **`StorageStatus` gains no fields.** The request is an action against `navigator.storage`, and its
+  effect reaches the status the only way it should: the next `readPersistenceState()` says
+  `persisted`. A `lastRequestOutcome` on `StorageStatus` would be a second, staler source of truth
+  for a fact the browser answers directly.
+- **The disclosure touches neither.** It is about what the user has been told, not about what the
+  browser is doing.
+
+## Where the code goes
+
+```
+src/lib/storage_status/
+  persistence_request.ts     requestPersistenceIfWarranted, the session gate, the outcomes
+  storage_disclosure.ts      hasSeenStorageDisclosure, recordStorageDisclosureShown
+  storage_status_types.ts    + PersistenceTrigger, PersistenceRequestOutcome, PersistenceRequest
+src/lib/vault_db/
+  vault_db_types.ts          + VAULT_META_KEYS.storageDisclosureShownAt
+src/components/common/
+  StorageDisclosureNotice.svelte   the sentence, Got it, and the way to the export controls
+src/components/layout/
+  ProjectsPage.svelte        shows the notice, then requests, in that order
+```
+
+**In `storage_status` rather than a new library.** That library already owns every call into
+`navigator.storage`, and already owns the vault-meta stamps that record what the user did
+(`recordVaultExport`). A `storage_protection` library would be a second door onto the same two
+surfaces, and its README's first job would be explaining why it is not the other one. What that
+README claims — "nothing here renders anything" — stays true.
+
+The README's **Not here** list loses its "#178" line and gains a paragraph on the request policy.
+
+## The plan
+
+| Step | Work                                                                                                               | Depends on |
+| ---- | ------------------------------------------------------------------------------------------------------------------ | ---------- |
+| 1    | `storageDisclosureShownAt` meta key; `storage_disclosure.ts` with its read and its stamp, and tests                | —          |
+| 2    | `persistence_request.ts`: outcomes, the session gate, `requestPersistenceIfWarranted`, tests on a fake `navigator` | —          |
+| 3    | `StorageDisclosureNotice.svelte`, and `ProjectsPage` showing it once and requesting after it paints                | 1, 2       |
+| 4    | The two export paths call `requestPersistenceIfWarranted` on success                                               | 2          |
+| 5    | One sentence in the adoption notice copy (subject to [question 2](#questions-for-review))                          | —          |
+| 6    | `storage_status/README.md` and the two `docs/workshop.md` sections updated to point here                           | 1–4        |
+
+Steps 1 and 2 are independent and are where the coverage lives. Step 3 is the one that needs
+`npm run verify:all`, per `CLAUDE.md` — it touches a component and a route.
+
+### Testing
+
+- **Unit** — the gate: not asked twice in a session, never asked when already persisted, each of the
+  five outcomes reachable, and a `persist()` that throws reported as `unavailable` rather than
+  rejecting. The stamp: written once, and a refused write leaving no stamp behind.
+- **E2e** — the notice appears on a first project creation at `/projects` and does not appear on the
+  second. **The test must not assert what the browser decided.** Headless Chromium's answer to
+  `persist()` is not ours to pin, and a suite that depends on it fails on a browser upgrade for a
+  reason that has nothing to do with this feature.
+- **Coverage** — both new files land in `storage_status`, which is not in
+  `scripts/library_coverage_baseline.json` and stays out of it.
+
+## Decisions taken here
+
+**1. The disclosure is stamped in the vault's `meta` store, not `localStorage`.** It joins
+`localStorageAdoptedAt` as a once-ever fact about this vault. The export envelope does not carry
+`meta`, so the stamp cannot ride a backup into a browser that was never told.
+
+**2. Only a user-driven creation triggers it.** Adoption and import create projects without anyone
+asking for one at that instant, and adoption in particular happens at page load — the case the whole
+"not on first load" argument is about.
+
+**3. The retry policy is enforced by the call sites, not by a counter.** Three functions call
+`requestPersistenceIfWarranted`, all three are completions of real work, and one flag stops a second
+ask in a session. There is no "qualifying work" tally to keep correct.
+
+**4. Nothing about a refusal is persisted.** A browser-level decision the user can revisit must not
+become a product-level one they cannot.
+
+**5. `persisted()` is checked before `persist()` is called.** A protected origin is never
+re-prompted.
+
+**6. No user-agent detection.** Safari's ITP is met by the copy rule that already applies everywhere
+— export is the protection — rather than by guessing the browser and writing a special case for it.
+
+**7. `StorageStatus` gains no fields.** The request's effect is observable through `persisted()`, and
+a cached copy of it would be a second source of truth that can be stale.
+
+## Questions for review
+
+1. **Does the notice carry an Export vault button, or only a way down to the controls already on the
+   page?** A button means the first thing a new user is offered is exporting a nearly empty project,
+   which is a strange first act and also teaches the habit at the cheapest possible moment. A link
+   means one fewer thing to build. The sketch above shows the button.
+2. **Is the adoption sentence in scope for #26?** It is one string in a notice that already exists,
+   and it closes the only path by which a user can hold work and never be told. It is also, strictly,
+   not what the issue asked for.
+3. **Is "a session" the page's lifetime or the tab's?** The proposal is module state — a reload
+   allows one more request, paired with fresh work. `sessionStorage` would make it the tab, at the
+   cost of a mechanism `persistent_save` does not have today. It matters only in Firefox, and only
+   before the user gives the explicit answer that Firefox then remembers.
+
+## Acceptance, against the issue
+
+| #26 asks                                                   | Where it is settled                                                        |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Disclosure appears exactly once, at first project creation | [What triggers what](#what-triggers-what), and the `meta` stamp            |
+| Dismissible                                                | [Where it appears](#where-it-appears) — inline, **Got it**, never a modal  |
+| `persist()` requested then, never on first page load       | [The shape](#the-shape); no page-load caller exists, decision 3            |
+| A refusal does not repeat in a session, never blocks       | [Asking at most once per session](#asking-at-most-once-per-session)        |
+| No copy describes persistence as a backup                  | [What the copy may not say](#what-the-copy-may-not-say), decisions 6 and 7 |
+| `npm run verify:all` green                                 | [Testing](#testing) — step 3 is the one that needs it                      |

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -321,6 +321,11 @@ artifact to reconcile.
 Under [Local only](#local-only) the browser holds the only copy, so eviction is not a tidiness
 concern — it is silent total loss, arriving without the user doing anything.
 
+This section and the one after it are designed for implementation in
+[The storage disclosure and the persistence request](storage-disclosure.md), which settles which
+creation paths trigger a request, what "once per session" means, and where the "told once" stamp
+lives.
+
 `navigator.storage.persist()` asks the browser not to evict. The workshop requests it **at first
 project creation**, not on first page load. Firefox prompts for it and Chromium decides silently on
 engagement heuristics; a prompt shown before the user has made anything is a prompt they dismiss,


### PR DESCRIPTION
Designs #26 — the disclosure and `navigator.storage.persist()` request at first project creation.

`docs/workshop.md` already states the policy in *Eviction and persistence* and *What the user is
told about storage*. `docs/storage-disclosure.md` works it out far enough to build, with the
domain model `CLAUDE.md` requires before implementation starts. **Status is proposal** — nothing
is implemented, and the model has not been reviewed.

## What it settles beyond what the issue said

- **Which creation path triggers it.** Three code paths create projects and they are not
  equivalent. Only the user-driven one on `/projects` shows the disclosure; `legacy_adoption` runs
  at page load with no gesture (exactly the case the "not on first load" argument is about), and a
  vault import is not a first project. Adoption is therefore a real gap — a returning user can hold
  work and never be told — and the proposal closes it with one sentence in the adoption notice that
  is already on screen and already dismissible.
- **Once per session needs no counter.** Only three functions may call
  `requestPersistenceIfWarranted`, and all three are completions of real work (project created,
  vault exported, project exported). "Only after the user has done more work" is then structural
  rather than a tally to keep correct; one flag stops a second ask in a session.
- **Safari needs no detection.** The honest line a UA sniff would lead to — export is the
  protection — already applies in every branch, so the copy is unconditional and nothing ever reads
  "you are safe".
- **The "told once" stamp lives in the vault's `meta` store**, beside `localStorageAdoptedAt`. The
  export envelope does not carry `meta`, so the stamp cannot ride a backup into a browser that was
  never told.
- **`StorageStatus` gains no fields.** The request's effect is observable through `persisted()`;
  a cached copy would be a second source of truth that can go stale.

## Review

The three [questions for review](https://github.com/ironarachne/ironarachne/blob/worktree-issue-26-storage-disclosure/docs/storage-disclosure.md#questions-for-review)
change what gets built: whether the notice carries an *Export vault* button, whether the adoption
sentence is in scope for #26, and whether "a session" is the page's lifetime or the tab's.

Approving the domain model is the gate on implementation, so #26 stays `needs-design` until that
happens.

Docs only — no code, no behaviour change. `npm run lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
