### PR TITLE
Give every tool a unique, descriptive name

### DIFF
--- a/src/lib/tools/README.md
+++ b/src/lib/tools/README.md
@@ -25,7 +25,7 @@ Storing them as tags rather than as fields means `applyTagFilter` works on tools
 a genre filter, a system filter, and a free-form tag filter are all the same operation and
 compose with each other.
 
-A tool may have more than one genre (the Spooky Starship generator is both `scifi` and
+A tool may have more than one genre (the Spooky Ship generator is both `scifi` and
 `horror`), and a tool that is genre- or system-agnostic simply has no such tag. The environment
 generator carries no genre because its biomes suit any setting; the culture generator carries no
 system because its output is not written to any ruleset.

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -37,6 +37,24 @@ describe('TOOL_CATALOG', () => {
     expect(unlabelled).toEqual([]);
   });
 
+  // A label is the only thing identifying a tool in the places it is shown: the browser row, the
+  // bench panel title, and the switch-tools confirmation all render it with no path and no kind
+  // beside it. Two entries sharing one gives the user a choice they cannot make. This asserts on
+  // the duplicated labels rather than on a count, so a failure names the collision instead of
+  // reporting that 35 is not 34.
+  it('has a unique label for every tool', () => {
+    const seen = new Set<string>();
+    const duplicated = new Set<string>();
+    for (const { label } of TOOL_CATALOG) {
+      if (seen.has(label)) {
+        duplicated.add(label);
+      }
+      seen.add(label);
+    }
+
+    expect([...duplicated]).toEqual([]);
+  });
+
   it('uses only known genres', () => {
     const unknown = TOOL_CATALOG.flatMap(toolGenres).filter(
       (genre) => !GENRES.includes(genre as (typeof GENRES)[number]),

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -22,7 +22,7 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
   // Characters & People
   defineTool({
     path: '/fantasy/adnd/character/build',
-    label: 'AD&D 2E Character',
+    label: 'AD&D 2E Character Builder',
     kind: 'editor',
     domain: 'characters',
     maturity: 'experimental',
@@ -32,7 +32,7 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
   }),
   defineTool({
     path: '/character',
-    label: 'Character',
+    label: 'Fantasy Character',
     kind: 'generator',
     domain: 'characters',
     maturity: 'experimental',
@@ -249,7 +249,7 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
   }),
   defineTool({
     path: '/fantasy/equipment',
-    label: 'Fantasy Equipment Lists',
+    label: 'Fantasy Equipment Price Lists',
     kind: 'reference',
     domain: 'objects',
     maturity: 'experimental',
@@ -276,7 +276,7 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
   }),
   defineTool({
     path: '/fantasy/potion-generator',
-    label: 'Fantasy Potion Generator',
+    label: 'Fantasy Potion',
     kind: 'generator',
     domain: 'objects',
     maturity: 'experimental',
@@ -285,7 +285,7 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
   }),
   defineTool({
     path: '/fantasy/weapon',
-    label: 'Fantasy Weapon',
+    label: 'Fantasy Magic Weapon',
     kind: 'generator',
     domain: 'objects',
     maturity: 'experimental',
@@ -303,7 +303,7 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
   }),
   defineTool({
     path: '/spooky-ship',
-    label: 'Spooky Starship',
+    label: 'Spooky Ship',
     kind: 'generator',
     domain: 'objects',
     maturity: 'experimental',


### PR DESCRIPTION
Closes #33, implementing the decisions taken in [triage](https://github.com/ironarachne/ironarachne/issues/33#issuecomment-5395246990): include the near-misses (A), leave page headings alone (B), keep `AD&D 2E` casing (C), rename rather than add a `kind` badge (D), and take `/character` to `Fantasy Character` (E).

## The collision

`/fantasy/adnd/character/build` and `/fantasy/adnd/character` both carried the label `AD&D 2E Character` — the only duplicate among 35 entries.

Catalog labels deliberately drop the trailing "Generator" that page headings carry; 27 of the 31 label/heading differences are exactly that and nothing more. The builder is an `editor`, so that rule never applied to it, and applying it anyway removed the only word distinguishing the two tools.

Nothing renders `kind` anywhere, and both entries are `experimental`, so the two were indistinguishable in every place a label appears: the browser row (`ToolBrowser.svelte:122`), the bench panel title (`WorkshopPage.svelte:187`), the switch-tools confirmation (`:141`), and search, which matches on label alone (`tool_search.ts:30`).

## Renames

| path                            | before                     | after                           |
| ------------------------------- | -------------------------- | ------------------------------- |
| `/fantasy/adnd/character/build` | `AD&D 2E Character`        | `AD&D 2E Character Builder`     |
| `/character`                    | `Character`                | `Fantasy Character`             |
| `/fantasy/weapon`               | `Fantasy Weapon`           | `Fantasy Magic Weapon`          |
| `/spooky-ship`                  | `Spooky Starship`          | `Spooky Ship`                   |
| `/fantasy/equipment`            | `Fantasy Equipment Lists`  | `Fantasy Equipment Price Lists` |
| `/fantasy/potion-generator`     | `Fantasy Potion Generator` | `Fantasy Potion`                |

`/fantasy/adnd/character` keeps its label — under the suffix convention it was already correct.

## The test

`tool_catalog.test.ts` asserted unique _paths_ but not unique _labels_, which is why this shipped. The new `has a unique label for every tool` closes that gap, and asserts on the duplicated labels rather than a count so a failure names the collision instead of reporting that 35 is not 34.

## Notes for review

- **No persisted data changes.** `ArtifactProvenance` stores `toolPath`, not the label (`artifact_types.ts:14–20`), so no saved artifact is touched and no migration is needed.
- **Page headings are untouched**, per decision B. This leaves `/fantasy/equipment` with catalog `Fantasy Equipment Price Lists` against heading "Fantasy Equipment Lists" — a new instance of the drift that 31 of 35 entries already have, and the catalog is what the workshop displays. Worth a look if you'd rather I aligned the heading, which would mean editing `e2e/page_manifest.ts` and a `verify:all` run.
- `src/lib/tools/README.md` referred to the tool as "Spooky Starship"; updated to follow the rename.
- `/species-stats` was left alone deliberately: its catalog label is the descriptive one and the page's "Species Stats Tool" is the vague half.

## Verification

`npm run verify` green — 313 test files, 4120 tests, coverage gate passed (96 libraries, 0 carrying baselined debt). `verify:all` is not required: no route, component, or rendering changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
