### PR TITLE
Keep release-ready to ourselves

### DIFF
--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -1359,13 +1359,20 @@ Beta, and **culture (#40), religion (#41), and settlement (#20), which are Relea
 not a criticism of the tools; it is the size of the gap between what exists and what the workshop
 needs, and it is better stated plainly than discovered one generator at a time.
 
-**The catalog records this (#43).** `maturity` is a required field on `ToolDefinition` and `Tool`,
+**The catalog records this.** `maturity` is a required field on `ToolDefinition` and `Tool`,
 with no default — a default would let a tool claim a level nobody assessed, which is the one thing
 the levels exist to prevent — and it is expanded into a `maturity:` tag beside `genre:` and
 `system:`, so "tools that will keep my work" is the same filtering operation as a genre. The level
 appears beside the heading on the tool's own page, with the sentence saying what it promises, and
 beside every entry in the workshop's tool browser. `GeneratorPage` takes the catalog path for that
 reason and requires it: a page cannot render a tool without stating where the tool stands.
+
+**Release-ready is recorded but not shown (#43).** Experimental and Beta each qualify what will
+happen to the user's work; Release-ready qualifies nothing, and a badge that promises everything is
+fine is a decoration rather than a warning. So it stays a classifier — the field, the tag, and
+`toolsWithMaturity` are unchanged, and every surface that would have displayed it shows nothing.
+`showsMaturityBadge` in `$lib/tools` is the single place that decides, because the badge and the
+elements callers wrap it in have to make the same call.
 
 Heraldry's Beta was assessed rather than inherited from "approaching Beta": it clears sections 1–3,
 6, and 7.1–7.2, and what holds it short of Release-ready is 4.1 — `ARTIFACT_EDITORS` gives it a

--- a/e2e/preview_goldens.spec.ts
+++ b/e2e/preview_goldens.spec.ts
@@ -26,8 +26,13 @@ import { PREVIEW_CASES, openPinnedPreview } from './preview_fixtures';
  * captured half a pixel lower is a slightly different 385×129 PNG — enough to cross the tolerance
  * below, though nothing about the render changed. **Anything added above a preview on its route
  * therefore needs the baselines regenerated**, and a plain paragraph is enough to do it: adding the
- * maturity badge (#43) is what turned this up, and an empty `<p>` in its place moved the failure to
+ * maturity badge is what turned this up, and an empty `<p>` in its place moved the failure to
  * a different case. Which cases fail is luck; that some will is not.
+ *
+ * (Removing that badge again for release-ready tools, in #43, did *not* need a regeneration: both
+ * preview routes are `experimental` and keep theirs. The `#43` this paragraph used to cite was a
+ * pre-migration number belonging to the change that added the badge, not to the issue that number
+ * now names.)
  *
  * Regenerate with the goldens workflow on your branch, before merging, never with
  * `--update-snapshots` locally — see below.

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -8,6 +8,10 @@ import { visitRoute } from './helpers';
  * level reaches a screen. That is the whole point of the field — a promise about durability that
  * lives only in a TypeScript type is the paragraph in a document it replaced.
  *
+ * Release-ready is the exception, and the other half of what this file pins: it is an internal
+ * classifier, so it must reach no screen at all (#43). The absence is asserted rather than assumed,
+ * because a badge that quietly comes back is exactly the regression nothing else here would catch.
+ *
  * The expected levels are written out rather than imported from `$lib/tools`, in keeping with the
  * rest of `e2e/`: a spec that read the catalog would pass whatever the catalog happened to say.
  */
@@ -17,12 +21,6 @@ const maturityBadge = (page: Page) => page.locator('.maturity__level');
 const TOOL_PAGES = [
   { path: '/planet', title: 'Planet Generator | Iron Arachne', level: 'Experimental' },
   { path: '/heraldry', title: 'Heraldry Generator | Iron Arachne', level: 'Beta' },
-  { path: '/culture', title: 'Culture Generator | Iron Arachne', level: 'Release-ready' },
-  {
-    path: '/fantasy/settlement',
-    title: 'Settlement Generator | Iron Arachne',
-    level: 'Release-ready',
-  },
   {
     // Its own header rather than `GeneratorPage`, so it states its maturity itself and is worth
     // checking separately.
@@ -33,11 +31,29 @@ const TOOL_PAGES = [
   { path: '/workshop', title: 'Workshop | Iron Arachne', level: 'Experimental' },
 ] as const;
 
+/** The release-ready tools, which must say nothing at all. */
+const SILENT_TOOL_PAGES = [
+  { path: '/culture', title: 'Culture Generator | Iron Arachne' },
+  { path: '/fantasy/settlement', title: 'Settlement Generator | Iron Arachne' },
+  { path: '/fantasy/religion', title: 'Religion Generator | Iron Arachne' },
+] as const;
+
 for (const { path, title, level } of TOOL_PAGES) {
   test(`maturity: ${path} shows ${level}`, async ({ page }) => {
     await visitRoute(page, path, { title, webgl: path === '/planet' });
 
     await expect(maturityBadge(page).first()).toHaveText(level);
+  });
+}
+
+for (const { path, title } of SILENT_TOOL_PAGES) {
+  test(`maturity: ${path} shows no badge`, async ({ page }) => {
+    await visitRoute(page, path, { title });
+
+    await expect(maturityBadge(page)).toHaveCount(0);
+    // The paragraph that wrapped it goes too, not just its contents: an empty `<p>` keeps its
+    // margin and pushes the tool down the page for no reason a reader could see.
+    await expect(page.locator('.generator-page__maturity')).toHaveCount(0);
   });
 }
 
@@ -49,18 +65,38 @@ test('maturity: a tool page says what its level promises', async ({ page }) => {
   await expect(page.locator('.maturity__detail').first()).toContainText('may change or disappear');
 });
 
-test('maturity: the tool browser marks every tool it lists', async ({ page }) => {
+test('maturity: the home page does not advertise release-ready either', async ({ page }) => {
+  await visitRoute(page, '/');
+
+  // Culture is featured *and* release-ready, which is the one place outside the workshop the level
+  // used to reach. Planet is featured and experimental, so the list still marks what it should.
+  const featured = page.locator('.home__featured');
+  await expect(featured.getByRole('link', { name: 'Culture' })).toBeVisible();
+  await expect(featured).not.toContainText('Release-ready');
+  await expect(featured).toContainText('Experimental');
+});
+
+test('maturity: the tool browser marks every tool that has something to warn about', async ({
+  page,
+}) => {
   await visitRoute(page, '/workshop', { title: 'Workshop | Iron Arachne' });
 
   const browser = page.locator('section.tool-browser');
   const tools = browser.locator('.tool-browser__tool');
   await expect(tools.first()).toBeVisible();
 
-  const toolCount = await tools.count();
-  await expect(browser.locator('.maturity__level')).toHaveCount(toolCount);
+  // Exactly the release-ready tools are unmarked, and all three of them are mountable so all
+  // three are listed here. Counted rather than spot-checked: a tool that quietly lost its badge
+  // would otherwise pass every assertion below it.
+  const unmarked = tools.filter({ hasNot: page.locator('.maturity__level') });
+  await expect(unmarked).toHaveCount(SILENT_TOOL_PAGES.length);
 
-  await expect(browser.getByRole('button', { name: /^Culture/ })).toContainText('Release-ready');
-  await expect(browser.getByRole('button', { name: /^Settlement/ })).toContainText('Release-ready');
+  await expect(browser.getByRole('button', { name: /^Culture/ })).not.toContainText(
+    'Release-ready',
+  );
+  await expect(browser.getByRole('button', { name: /^Settlement/ })).not.toContainText(
+    'Release-ready',
+  );
   await expect(browser.getByRole('button', { name: /^Heraldry/ })).toContainText('Beta');
   await expect(browser.getByRole('button', { name: /^Planet/ })).toContainText('Experimental');
 });

--- a/src/components/characters/AdndCharacterBuilder.svelte
+++ b/src/components/characters/AdndCharacterBuilder.svelte
@@ -34,7 +34,7 @@
   } from '$lib/adnd';
   import type { ADNDClass, ADNDRace } from '$lib/adnd';
   import { Currency } from '$lib/currency';
-  import { toolMaturityForPath } from '$lib/tools';
+  import { showsMaturityBadge, toolMaturityForPath } from '$lib/tools';
   import { showAlertModal } from '$lib/ui';
   import {
     buildCharacterNameSource,
@@ -585,9 +585,11 @@
     <button type="button" onclick={resetBuilderForm}>Reset</button>
   </header>
 
-  <p class="builder-maturity">
-    <ToolMaturityBadge {maturity} detailed />
-  </p>
+  {#if showsMaturityBadge(maturity)}
+    <p class="builder-maturity">
+      <ToolMaturityBadge {maturity} detailed />
+    </p>
+  {/if}
 
   <p>
     Roll attributes, then choose race, class, and alignment. Caster level 1 spells, thief

--- a/src/components/common/ToolBrowser.svelte
+++ b/src/components/common/ToolBrowser.svelte
@@ -120,9 +120,13 @@
               onclick={() => selectTool(tool)}
             >
               <span class="tool-browser__name">{tool.label}</span>
-              <!-- The maturity rides along with every entry, unfiltered and unhidden: a list that
-                   only marked the unfinished tools would leave the user reading absence, which is
-                   not something you can read. -->
+              <!-- The maturity rides along with every entry that has one to state. This list
+                   used to mark all of them, on the grounds that marking only the unfinished tools
+                   leaves the user reading absence; #43 settled it the other way, because
+                   release-ready is an internal classifier and a promise the user never asked to
+                   read. So an unmarked row is a finished tool, and the levels that remain are the
+                   ones that qualify what will happen to their work — which is the only reason a
+                   level was ever put in front of them. -->
               <span class="tool-browser__badges">
                 {#if isActive}
                   <span class="tool-browser__badge">Loaded</span>

--- a/src/components/common/ToolMaturityBadge.svelte
+++ b/src/components/common/ToolMaturityBadge.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { maturityDescription, maturityDisplayName } from '$lib/tools';
+  import { maturityDescription, maturityDisplayName, showsMaturityBadge } from '$lib/tools';
   import type { ToolMaturity } from '$lib/tools';
 
   type Props = {
@@ -21,14 +21,20 @@
   const { maturity, detailed = false, plain = false }: Props = $props();
 </script>
 
-<!-- The level is carried by the text, never by the colour alone: the colours say the same thing a
-     second time for people who can see them, and nothing is lost if they cannot. -->
-<span class="maturity maturity--{maturity}" class:maturity--plain={plain}>
-  <span class="maturity__level">{maturityDisplayName(maturity)}</span>
-  {#if detailed}
-    <span class="maturity__detail">{maturityDescription(maturity)}</span>
-  {/if}
-</span>
+<!-- Nothing at all for a release-ready tool: `showsMaturityBadge` explains why, and rendering no
+     element rather than an empty one matters, because every caller that lists these puts them in a
+     flex container with a `gap` that an empty span would still open.
+
+     Otherwise: the level is carried by the text, never by the colour alone: the colours say the
+     same thing a second time for people who can see them, and nothing is lost if they cannot. -->
+{#if showsMaturityBadge(maturity)}
+  <span class="maturity maturity--{maturity}" class:maturity--plain={plain}>
+    <span class="maturity__level">{maturityDisplayName(maturity)}</span>
+    {#if detailed}
+      <span class="maturity__detail">{maturityDescription(maturity)}</span>
+    {/if}
+  </span>
+{/if}
 
 <style>
   .maturity {
@@ -73,16 +79,12 @@
   }
 
   /* Gold for a tool that may change under you, cyan for one that keeps your work but is not
-     finished, brand green for one that is. */
+     finished. There is no third colour, because a finished tool says nothing. */
   .maturity--experimental {
     --maturity-color: var(--gold);
   }
 
   .maturity--beta {
     --maturity-color: var(--cyan);
-  }
-
-  .maturity--release-ready {
-    --maturity-color: var(--acid-green);
   }
 </style>

--- a/src/components/layout/GeneratorPage.svelte
+++ b/src/components/layout/GeneratorPage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import type { RouteId } from '$app/types';
-  import { toolMaturityForPath } from '$lib/tools';
+  import { showsMaturityBadge, toolMaturityForPath } from '$lib/tools';
   import ToolMaturityBadge from '$components/common/ToolMaturityBadge.svelte';
 
   type Props = {
@@ -25,10 +25,17 @@
 <section class="{theme} main">
   <h1>{title}</h1>
   <!-- Directly under the title, above anything the tool renders: the point of the level is that a
-       user reads it before they start, not after they have generated something they wanted to keep. -->
-  <p class="generator-page__maturity">
-    <ToolMaturityBadge {maturity} detailed />
-  </p>
+       user reads it before they start, not after they have generated something they wanted to keep.
+
+       A release-ready tool has nothing to warn about and loses the paragraph as well as the badge.
+       The wrapper has to go with it: the badge rendering nothing would still leave an empty `<p>`
+       and its margin pushing the tool down the page, which is exactly the shift
+       `e2e/preview_goldens.spec.ts` warns about. -->
+  {#if showsMaturityBadge(maturity)}
+    <p class="generator-page__maturity">
+      <ToolMaturityBadge {maturity} detailed />
+    </p>
+  {/if}
   {#if description}
     {@render description()}
   {/if}

--- a/src/components/layout/WorkshopPage.svelte
+++ b/src/components/layout/WorkshopPage.svelte
@@ -10,7 +10,13 @@
   import WorkshopPanel from '$components/common/WorkshopPanel.svelte';
   import { getArtifactSummary, hydrateArtifacts, onArtifactsChanged } from '$lib/artifacts';
   import type { Project } from '$lib/projects';
-  import { allTools, findToolByPath, toolMaturityForPath, type Tool } from '$lib/tools';
+  import {
+    allTools,
+    findToolByPath,
+    showsMaturityBadge,
+    toolMaturityForPath,
+    type Tool,
+  } from '$lib/tools';
   import { showConfirmModal } from '$lib/ui';
   import { hasToolPanel, hasUnsavedEdits } from '$lib/workshop';
   import {
@@ -30,6 +36,7 @@
   // The browser offers what the workshop can actually mount, which is also what keeps the
   // workshop's own catalog entry from listing itself inside itself.
   const mountableTools = allTools().filter((tool) => hasToolPanel(tool.path));
+  const workshopMaturity = toolMaturityForPath('/workshop');
 
   let project = $state<Project | undefined>(undefined);
   let bench: ProjectWorkspace = $state(emptyWorkspace(''));
@@ -201,9 +208,11 @@
        is true of a generator and false here — the workshop is what does the saving. What a user
        needs to know about the durability of their work is the Backup section, which says it
        accurately; that now lives on /projects, one click away in the sidebar. -->
-  <p class="workshop__maturity">
-    <ToolMaturityBadge maturity={toolMaturityForPath('/workshop')} />
-  </p>
+  {#if showsMaturityBadge(workshopMaturity)}
+    <p class="workshop__maturity">
+      <ToolMaturityBadge maturity={workshopMaturity} />
+    </p>
+  {/if}
 
   <ProjectContextBar onProjectChange={(next) => void openProject(next)} />
 

--- a/src/lib/tools/README.md
+++ b/src/lib/tools/README.md
@@ -52,14 +52,21 @@ Two consequences follow from it being a promise:
   `applyTagFilter` call rather than a filter plus a second pass. The authoring site sets one value,
   so the two cannot disagree.
 
-`maturityDisplayName` and `maturityDescription` give the badge its text; `toolsWithMaturity` and
-`toolMaturityForPath` are the readers. Raising a tool's level belongs in the change that earns it —
-`tool_catalog.test.ts` pins the tools currently assessed above `experimental` so a level cannot
-rise as a side effect of an unrelated edit.
+`maturityDisplayName` and `maturityDescription` give the badge its text; `showsMaturityBadge` says
+whether it is shown at all; `toolsWithMaturity` and `toolMaturityForPath` are the readers. Raising a
+tool's level belongs in the change that earns it — `tool_catalog.test.ts` pins the tools currently
+assessed above `experimental` so a level cannot rise as a side effect of an unrelated edit.
 
 The UI shows it in two places: `ToolMaturityBadge` beside the heading on the tool's own page
 (via `GeneratorPage`, which requires the catalog path for exactly this reason), and beside every
 entry in `ToolBrowser`.
+
+**`release-ready` is shown in neither.** It is an internal classifier: `experimental` and `beta`
+each qualify what will happen to a user's work, and `release-ready` is the ordinary case with
+nothing to qualify, so announcing it makes a warning into a decoration (#43). The field and the
+`maturity:release-ready` tag are unaffected — filtering, `toolsWithMaturity`, and the catalog tests
+all still see it. A caller that wraps the badge in an element of its own asks `showsMaturityBadge`
+too, because a component that renders nothing still leaves the wrapper and its margin behind.
 
 ## Usage
 

--- a/src/lib/tools/tools.test.ts
+++ b/src/lib/tools/tools.test.ts
@@ -11,6 +11,7 @@ import {
   maturityDescription,
   maturityDisplayName,
   maturityTag,
+  showsMaturityBadge,
   systemDisplayName,
   systemTag,
   systemsOf,
@@ -253,6 +254,26 @@ describe('maturityDisplayName', () => {
     const unnamed = MATURITIES.filter((maturity) => maturityDisplayName(maturity) === undefined);
 
     expect(unnamed).toEqual([]);
+  });
+});
+
+describe('showsMaturityBadge', () => {
+  it('shows the levels that carry a warning', () => {
+    expect(showsMaturityBadge('experimental')).toBe(true);
+    expect(showsMaturityBadge('beta')).toBe(true);
+  });
+
+  it('keeps release-ready to itself', () => {
+    expect(showsMaturityBadge('release-ready')).toBe(false);
+  });
+
+  it('shows every level that describes a limitation, and only those', () => {
+    // The rule is not "hide the top level" but "show what qualifies the user's work". If a level
+    // is ever added between beta and release-ready, it announces itself unless someone decides
+    // otherwise here, which is the right default for a warning.
+    const shown = MATURITIES.filter(showsMaturityBadge);
+
+    expect(shown).toEqual(['experimental', 'beta']);
   });
 });
 

--- a/src/lib/tools/tools.ts
+++ b/src/lib/tools/tools.ts
@@ -140,6 +140,27 @@ export function maturityDescription(maturity: ToolTypes.ToolMaturity): string {
   return MATURITY_DESCRIPTIONS[maturity];
 }
 
+/**
+ * Whether a level is worth putting in front of a user, as opposed to being kept as the internal
+ * classifier it also is.
+ *
+ * Only the levels that carry a warning are: `experimental` and `beta` each qualify what will
+ * happen to the user's work, which is something they have to know before they invest any.
+ * `release-ready` qualifies nothing — it is the ordinary case — so showing it turns a warning into
+ * a decoration, and a badge on every tool is a badge nobody reads, including the two that matter.
+ *
+ * The trade is that a finished tool is now recognised by an absence, which is harder to read than
+ * a label. That was the argument for marking every row in the tool browser, and #43 settled it the
+ * other way: release-ready is our classification of a tool, not a promise the user asked for.
+ *
+ * The level itself stays on the catalog entry and in the `maturity:` tag either way; this governs
+ * display only. Callers that wrap the badge in an element of their own must ask this too, because
+ * a component rendering nothing still leaves that wrapper behind.
+ */
+export function showsMaturityBadge(maturity: ToolTypes.ToolMaturity): boolean {
+  return maturity !== 'release-ready';
+}
+
 const DOMAIN_NAMES: Record<ToolTypes.ToolDomain, string> = {
   characters: 'Characters & People',
   factions: 'Factions & Groups',


### PR DESCRIPTION
Closes #43.

Release-ready no longer reaches a screen. The field, the `maturity:release-ready` tag,
`toolsWithMaturity` and both display helpers are unchanged — this is display only.

## What changed

- **`showsMaturityBadge` (`$lib/tools`)** is the single place that decides. Not a
  `!== 'release-ready'` at each call site, because the badge and the elements callers wrap it in
  have to make the same call.
- **`ToolMaturityBadge`** renders no element at all for a release-ready tool. That matters rather
  than being tidiness: both list call sites are flex containers with a `gap`, which an empty span
  would still open.
- **`GeneratorPage`, `WorkshopPage`, `AdndCharacterBuilder`** drop their wrapper `<p>` too. A
  paragraph that renders nothing still keeps its margin, and `e2e/preview_goldens.spec.ts` already
  records what a stray paragraph above a preview does.
- **The home page's featured list** loses it as well. Not named in the issue, but Culture is
  `featured: true` *and* release-ready, so leaving it would have made the front page the last
  surface advertising an internal classification. Called out in triage; say the word and it is one
  call site to put back.
- **`ToolBrowser`'s comment** carried the argument this reverses ("a list that only marked the
  unfinished tools would leave the user reading absence"). It now records what replaced it instead
  of vanishing.
- **Two stale `#43` references** — in `e2e/preview_goldens.spec.ts` and `docs/workshop.md` — were
  pre-migration numbers belonging to the change that *added* the badge, and now point at the issue
  asking for its removal. Corrected, and the goldens note says explicitly that this change does
  **not** need baselines regenerated: both preview routes are `experimental` and keep their badges.

Three tools are affected today: `/culture`, `/fantasy/religion`, `/fantasy/settlement` — on their
own routes and in their workshop panels alike, since a panel mounts the same component the route
does.

## Verification

- `npm run verify` — 0 errors, 4123 tests, coverage gate passed (96 libraries, no baselined debt).
- `npm run verify:all` — **386 Playwright tests passed**, exit 0. Required here, since every
  assertion about this is e2e-only and no PR check runs the browser suite.
- `e2e/tool_maturity.spec.ts` asserts the absence rather than assuming it — a badge that quietly
  comes back is the one regression nothing else would catch. New cases: the three release-ready
  routes show neither `.maturity__level` nor the wrapper paragraph, the home page's featured list
  says "Experimental" but not "Release-ready", and the tool browser has exactly three unmarked
  rows.

## Design process

No design document: no new library, no new concept, no persisted-data change. Per CLAUDE.md this
is implementation-first work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
