### PR TITLE
Accept the session log design

### DIFF
--- a/docs/session-log.md
+++ b/docs/session-log.md
@@ -13,8 +13,10 @@ workshop is a single route and a query parameter on it cannot say which panel it
 Designs [#80](https://github.com/ironarachne/ironarachne/issues/80). It sits inside
 [the workshop](workshop.md) and uses its bench, its tool catalog, and its RNG contract.
 
-**Status:** proposal. The [domain model](#domain-model) has not been reviewed, and per the design
-process in CLAUDE.md implementation does not start before a human approves it.
+**Status:** accepted; not yet built. The [domain model](#domain-model) was reviewed and approved, so
+[the plan](#the-plan) is clear to start. What it is broken into is tracked on GitHub under the
+`workshop` label, as sub-issues of #80. Nothing in [Still open](#still-open) blocks it — the three
+questions there are presentation and scope, not shape.
 
 ## The problem
 


### PR DESCRIPTION
Follow-up to #83. The domain model was reviewed and approved when that merged, so `docs/session-log.md` says so rather than still calling itself a proposal.

**Status:** proposal → **accepted; not yet built**, pointing at the four sub-issues of #80 the plan was broken into:

- #84 — `src/lib/session_log`, the library
- #85 — the tool cue, so a mounted panel can be told to roll again
- #86 — the column beside the bench, and the replay it triggers
- #87 — reporting and replay in the four tools that already build provenance

The three items in **Still open** are noted as not blocking: they are presentation and scope, not shape.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)