### PR TITLE
Keep the keyboard's place when a panel moves or closes

### DIFF
--- a/e2e/workshop.spec.ts
+++ b/e2e/workshop.spec.ts
@@ -218,7 +218,7 @@ test.describe('the workshop bench', () => {
     await expect(panelTitles(page)).toHaveText([/Heraldry/]);
   });
 
-  test('moves and closes panels from the keyboard-operable controls', async ({ page }) => {
+  test('moves and closes panels from the controls', async ({ page }) => {
     // A tool and an artifact, since two tools can no longer be open together.
     await benchWithToolAndArtifact(page, 'The Emberfolk');
     await expect(panelTitles(page)).toHaveText([/Culture/, /The Emberfolk/]);
@@ -232,6 +232,54 @@ test.describe('the workshop bench', () => {
     await page.getByRole('button', { name: /^Close The Emberfolk$/ }).click();
     await expect(panels(page)).toHaveCount(1);
     await expect(panelTitles(page)).toHaveText([/Culture/]);
+  });
+
+  /**
+   * Requirement 6.2, driven rather than asserted: the test above finds the controls by their
+   * accessible names and clicks them, which proves they are named but not that anyone can reach
+   * or fire them without a mouse. This one uses the keyboard for every step.
+   *
+   * What it is really guarding is focus. Both operations destroy the button that was just
+   * pressed — a move can disable it, a close unmounts it — and a button that vanishes from under
+   * the focus ring drops the user back to the top of the document, which on this page means
+   * tabbing through a whole generator to get back. Losing your place is how a keyboard user
+   * experiences a broken control, so "operable" has to mean focus survives.
+   */
+  test('moves and closes panels from the keyboard, keeping the user’s place', async ({ page }) => {
+    await benchWithToolAndArtifact(page, 'The Emberfolk');
+    await expect(panelTitles(page)).toHaveText([/Culture/, /The Emberfolk/]);
+
+    const focusedName = () =>
+      page.evaluate(() => document.activeElement?.getAttribute('aria-label') ?? '');
+
+    // The controls sit in the tab order in the order they are read. The rightmost panel cannot
+    // move right, and that button being disabled takes it out of the tab order rather than
+    // leaving a stop that does nothing — so Close is one Tab from Move left, not two.
+    await page.getByRole('button', { name: /^Move The Emberfolk left$/ }).focus();
+    await page.keyboard.press('Tab');
+    expect(await focusedName()).toBe('Close The Emberfolk');
+
+    // Enter fires the control, and the panel moves to the head of the bench.
+    await page.getByRole('button', { name: /^Move The Emberfolk left$/ }).focus();
+    await page.keyboard.press('Enter');
+    await expect(panelTitles(page)).toHaveText([/The Emberfolk/, /Culture/]);
+
+    // That move disabled the button under the ring — the panel is leftmost and cannot go
+    // further — so focus moves to the control that can still act on the panel the user was
+    // working with, rather than being dropped.
+    expect(await focusedName()).toBe('Move The Emberfolk right');
+
+    // Space fires it too, which is what a button promises, and sends the panel back.
+    await page.keyboard.press('Space');
+    await expect(panelTitles(page)).toHaveText([/Culture/, /The Emberfolk/]);
+
+    // Closing unmounts the focused button. Focus lands on the neighbouring panel's first
+    // control, so the next Tab carries on from the bench rather than from the document.
+    await page.getByRole('button', { name: /^Close The Emberfolk$/ }).focus();
+    await page.keyboard.press('Enter');
+    await expect(panels(page)).toHaveCount(1);
+    await expect(panelTitles(page)).toHaveText([/Culture/]);
+    expect(await focusedName()).toBe('Close Culture');
   });
 
   test('restores the bench when the project is reopened', async ({ page }) => {

--- a/src/components/common/WorkshopPanel.svelte
+++ b/src/components/common/WorkshopPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Snippet } from 'svelte';
+  import { tick, type Snippet } from 'svelte';
 
   type Props = {
     /** What the panel holds, shown in its header and used to name its controls. */
@@ -23,6 +23,32 @@
   // alongside it to be operable at all, and two buttons are that equivalent without the drag.
   const canMoveLeft = $derived(position > 1);
   const canMoveRight = $derived(position < total);
+
+  let moveLeftButton: HTMLButtonElement | undefined;
+  let moveRightButton: HTMLButtonElement | undefined;
+
+  /**
+   * A move can disable the button that performed it: a panel arriving at either end of the bench
+   * cannot go further. A disabled button loses the focus ring, and the browser drops focus to the
+   * document, which on this page means tabbing through a whole generator to get back to the
+   * bench. So focus follows the panel to the control that can still act on it.
+   *
+   * This works because the bench's `{#each}` is keyed by panel, so a panel keeps this component —
+   * and these two buttons — as it moves. Positional reuse would leave them pointing at whichever
+   * panel had taken this slot instead.
+   */
+  async function moveWithFocusKept(
+    onMove: () => void,
+    pressed: HTMLButtonElement | undefined,
+    counterpart: HTMLButtonElement | undefined,
+  ): Promise<void> {
+    onMove();
+    await tick();
+
+    if (pressed?.disabled === true && counterpart?.disabled === false) {
+      counterpart.focus();
+    }
+  }
 </script>
 
 <!-- A labelled `section` is a region landmark, so a panel is reachable by landmark as well as by
@@ -42,7 +68,8 @@
     <div class="workshop-panel__controls">
       <button
         type="button"
-        onclick={onMoveLeft}
+        bind:this={moveLeftButton}
+        onclick={() => void moveWithFocusKept(onMoveLeft, moveLeftButton, moveRightButton)}
         disabled={!canMoveLeft}
         aria-label="Move {title} left"
         title="Move left"
@@ -51,7 +78,8 @@
       </button>
       <button
         type="button"
-        onclick={onMoveRight}
+        bind:this={moveRightButton}
+        onclick={() => void moveWithFocusKept(onMoveRight, moveRightButton, moveLeftButton)}
         disabled={!canMoveRight}
         aria-label="Move {title} right"
         title="Move right"

--- a/src/components/layout/WorkshopPage.svelte
+++ b/src/components/layout/WorkshopPage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
 
   import ArtifactPanel from '$components/common/ArtifactPanel.svelte';
   import ProjectContextBar from '$components/common/ProjectContextBar.svelte';
@@ -41,6 +41,14 @@
    * and this is the seam between the two.
    */
   let artifactRevision = $state(0);
+
+  /**
+   * Bound for `placeFocusAfterClose`, which has to find what is on the bench after a close.
+   * `$state` because the empty-bench message comes and goes with the panels, so its binding is
+   * reassigned rather than set once.
+   */
+  let benchElement = $state<HTMLDivElement | undefined>(undefined);
+  let emptyBenchMessage = $state<HTMLParagraphElement | undefined>(undefined);
 
   const openToolPaths = $derived(
     bench.panels
@@ -182,6 +190,33 @@
       }
     }
     updateBench(withPanelClosed(bench, targetOf(panel)));
+    await placeFocusAfterClose(panel.order);
+  }
+
+  /**
+   * Closing a panel unmounts the button that closed it, and a browser with nowhere to put the
+   * focus ring puts it on the document — which on this page means tabbing back through a whole
+   * generator to reach the bench again. Losing your place is how a keyboard user experiences a
+   * broken control, so focus is placed deliberately: on the panel that took the closed one's
+   * position, or on the message that replaces the bench when the last panel goes.
+   *
+   * Read from the DOM rather than from `bench`, because what has to be focused is whichever
+   * control is actually enabled — a lone panel can move nowhere, so its only live control is its
+   * own Close.
+   */
+  async function placeFocusAfterClose(closedOrder: number): Promise<void> {
+    await tick();
+
+    const remaining = benchElement?.querySelectorAll('section.workshop-panel') ?? [];
+    const next = remaining[Math.min(closedOrder, remaining.length - 1)];
+    const control = next?.querySelector('.workshop-panel__controls button:not([disabled])');
+
+    if (control instanceof HTMLElement) {
+      control.focus();
+      return;
+    }
+
+    emptyBenchMessage?.focus();
   }
 
   function panelTitle(panel: PanelState): string {
@@ -236,7 +271,7 @@
       <ProjectView projectId={project?.id} {openArtifactIds} onOpenArtifact={openArtifact} />
     </div>
 
-    <div class="workshop__bench">
+    <div class="workshop__bench" bind:this={benchElement}>
       {#each bench.panels as panel (panelKey(panel))}
         <WorkshopPanel
           title={panelTitle(panel)}
@@ -257,7 +292,10 @@
           {/if}
         </WorkshopPanel>
       {:else}
-        <p class="workshop__empty">
+        <!-- `tabindex="-1"` so closing the last panel has somewhere to put focus: not a tab stop,
+             but a focusable target, which also reads this sentence out to a screen reader at the
+             moment the bench empties. -->
+        <p class="workshop__empty" tabindex="-1" bind:this={emptyBenchMessage}>
           Nothing on the bench. Pick a tool to start, or open something you have saved.
         </p>
       {/each}


### PR DESCRIPTION
Requirement 6.2 for the workshop — the last applicable gap in #73.

## What I found

I checked the remaining requirements before writing anything, and most were already met by #36. The exception was 6.2, and it was met only on paper: `moves and closes panels from the keyboard-operable controls` finds the controls **by accessible name and clicks them**, which proves they are named and nothing about operating them without a mouse.

Driving them from the keyboard found a real defect. Both operations destroy the button just pressed — a move can disable it (a panel at either end of the bench cannot go further), a close unmounts it — so the focus ring has nowhere to go and the browser drops it on `<body>`. On this page that means tabbing through an entire generator to get back to the bench. Losing your place is how a keyboard user experiences a broken control.

Verified before fixing: the assertion after Enter read `""` for the focused element.

## The fix

- **A move** hands focus to the control that can still act on the same panel. The panel does this itself, which works because the bench's `{#each}` is keyed by panel — a panel keeps its component as it moves. Positional reuse would have pointed those refs at whichever panel took the slot.
- **A close** hands focus to the panel that took the closed one's position, or — when the last panel goes — to the empty-bench message, now `tabindex="-1"`: focusable, not a tab stop, and it reads the sentence out at the moment the bench empties.

## The test

Keyboard for every step: Tab to reach the controls in reading order, Enter and Space to fire them, and a focus assertion after each. It also pins a property worth keeping — a disabled move button leaves the tab order rather than sitting in it as a dead stop, so Close is one Tab from Move left, not two. (My first draft asserted two and was wrong; the app was right.)

The old click-driven test stays, renamed to `moves and closes panels from the controls`, since what it actually checks — the controls work and the end panel refuses to wrap around — is still worth checking.

## Section-by-section, per #73's acceptance

| Section | Verdict |
| --- | --- |
| 1 Discoverability | Inapplicable — not in the catalog (decision 9); reached from `NAV_DESTINATIONS` |
| 2 Behaviour | Inapplicable — no panel of its own, no seed, generates nothing |
| 3, 4, 5 | Inapplicable — produces no artifact of its own |
| 6.1 Mobile | **Met** — mobile suite at all five widths, plus a two-panel bench and an open artifact at 320px |
| 6.2 Keyboard | **Met as of this PR** |
| 6.3, 6.4 Output | Inapplicable — no output of its own; the vault provides export |
| 7.1 Unit tests | **Met** — `src/lib/workshop` clears the coverage gate |
| 7.4 (as a surface) | **Met** — the #36 acceptance path: open project → mount → save → reload → restored bench |
| 8 Documentation | **Met** — README, `index.ts`, CODE_STYLE |

That closes out #73.

## Checks

- `npm run verify` — green.
- `npm run verify:all` — green. **402 Playwright tests passed** (one more than before: the new keyboard test), 4186 unit tests, coverage gate passed on all 96 libraries.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)