### PR TITLE
Make a rogue's skill allocation data, and spend the pool exactly

### DIFF
--- a/docs/adnd-character.md
+++ b/docs/adnd-character.md
@@ -143,6 +143,22 @@ a bonus is the kind of fragility that breaks the first time a skill is renamed.
 nothing older; adding the field after version 1 is in users' browsers costs a migration step and a
 test for it, forever.
 
+Two things surfaced while building it, both recorded here because the second changed shipped
+output:
+
+- **The generator shuffles before it deals.** `distributePoints` picks by index, so the shuffle is
+  what decides which skills a roll favours and it cannot be removed. It has no business reaching
+  the sheet, though, where a skill list in a different order for every character is a presentation
+  defect — so `orderThiefSkillRows` sorts the rows back into the canonical order on the way out.
+  The values are untouched.
+- **The point pool overshot, and was fixed.** `distributePoints` drew each award against the
+  per-skill headroom alone and subtracted afterwards, so the last one spent whatever it liked:
+  measured over 300 seeds, 86% of rolled thieves and bards came out above their budget, by as much
+  as 27 points on a pool of 60. Clamping the draw to what remains is the fix. It changes seeded
+  output — 77 thieves in that sample, no bards and no other class, because the clamp only shifts
+  later draws when it forces an extra iteration — and it was made **before** the kind ships, since
+  afterwards the choice is between rewriting artifacts a user has kept and leaving them wrong.
+
 Weapon and non-weapon proficiencies need none of this — `weaponProficiencyGroups` and
 `nonweaponProficiencies` are already string arrays on the character, and already round-trip and
 edit as lists.
@@ -277,9 +293,13 @@ nothing in the design depends on that remaining true.
   widening the page.
 - **6.2.** The builder's equipment checkboxes and thief-skill number inputs need accessible names,
   and the new Details section needs its disclosure to be a real `<button>`.
-- **6.4.** `drawDetailSections` in the PDF renderer draws a labelled box for Kit and Proficiencies
-  unconditionally, so a character with neither gets two empty boxes. The formatters already return
-  an empty string; the renderer skips a section whose content is empty.
+- **6.4.** ~~`drawDetailSections` draws a labelled box for Kit and Proficiencies unconditionally, so
+  a character with neither gets two empty boxes.~~ **Withdrawn — this was wrong.** Those formatters
+  return `'None'`, not an empty string, so the PDF prints "Kit: None" rather than a blank box. That
+  is a deliberate answer to a question a sheet may reasonably ask, not a layout artifact, and there
+  is nothing to fix. The one section that genuinely should not appear is Thief Skills, which
+  belongs to two classes out of twenty; it returns an empty string and the renderer omits it. Text
+  output is otherwise already free of stray blank sections.
 - **7.2.** A round-trip test over three characters that between them cover the shapes: a plain
   generated fighter, a generated one with proficiencies and a kit, and a built thief with an
   allocation.

--- a/src/components/characters/AdndCharacterBuilder.svelte
+++ b/src/components/characters/AdndCharacterBuilder.svelte
@@ -18,7 +18,7 @@
     Equipment,
     applyHalflingWithOptions,
     type HalflingSubrace,
-    appendThiefSkillAbilityLines,
+    applyThiefSkillAllocation,
     ADND_THIEF_SKILL_BONUS_CAP,
     getThiefSkillBuildKindForClass,
     getThiefSkillPointPool,
@@ -500,7 +500,7 @@
     }
 
     if (thiefSkillKind) {
-      appendThiefSkillAbilityLines(c, thiefSkillKind, thiefSkillBonuses);
+      applyThiefSkillAllocation(c, thiefSkillKind, thiefSkillBonuses);
     }
 
     const hp = Math.min(Math.max(hpValue, hpBounds.min), hpBounds.max);

--- a/src/components/characters/AdndCharacterSheet.svelte
+++ b/src/components/characters/AdndCharacterSheet.svelte
@@ -173,6 +173,31 @@
   <p>{ability}</p>
 {/each}
 
+{#if character.thiefSkills.length > 0}
+  <h3>Thief Skills</h3>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Skill</th>
+        <th>Base</th>
+        <th>Allocated</th>
+        <th>Total</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each character.thiefSkills as skill}
+        <tr>
+          <td>{skill.name}</td>
+          <td>{skill.value}%</td>
+          <td>{skill.points > 0 ? `+${skill.points}` : '—'}</td>
+          <td>{skill.value + skill.points}%</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+{/if}
+
 {#if character.spells.length > 0}
   <h3>Spells</h3>
 

--- a/src/lib/adnd/adnd_format.test.ts
+++ b/src/lib/adnd/adnd_format.test.ts
@@ -3,6 +3,7 @@ import { createAdndCharacter } from './adndcharacter';
 import {
   formatAdndSignedNumber,
   formatAdndStrength,
+  formatAdndThiefSkillsSection,
   formatAdndWeaponsSection,
   slugifyAdndCharacterFilename,
 } from './adnd_format';
@@ -41,5 +42,21 @@ describe('slugifyAdndCharacterFilename', () => {
 
   it('falls back when names are empty', () => {
     expect(slugifyAdndCharacterFilename('', '')).toBe('adnd-character.pdf');
+  });
+});
+
+describe('formatAdndThiefSkillsSection', () => {
+  it('sums base and allocation for each skill', () => {
+    const c = createAdndCharacter();
+    c.thiefSkills = [
+      { name: 'Pick Pockets', value: 25, points: 20 },
+      { name: 'Climb Walls', value: 60, points: 0 },
+    ];
+
+    expect(formatAdndThiefSkillsSection(c)).toBe('Pick Pockets: 45%; Climb Walls: 60%');
+  });
+
+  it('is empty for a class with no thief skills, so the caller can omit the section', () => {
+    expect(formatAdndThiefSkillsSection(createAdndCharacter())).toBe('');
   });
 });

--- a/src/lib/adnd/adnd_format.ts
+++ b/src/lib/adnd/adnd_format.ts
@@ -119,6 +119,23 @@ export function formatAdndProficienciesSection(character: ADNDCharacter): string
   return parts.join('; ');
 }
 
+/**
+ * A thief's or bard's skills as `Pick Pockets: 45%`, or an empty string when the class has none.
+ *
+ * Empty rather than `'None'`, unlike every other section here, and the difference is deliberate.
+ * The others describe something any character might have and happens not to — a fighter with no
+ * kit has no kit — so `'None'` is an answer. Thief skills belong to two classes out of twenty, and
+ * "Thief Skills: None" on a wizard answers a question nobody asked. The caller draws this section
+ * only when there is something in it.
+ */
+export function formatAdndThiefSkillsSection(character: ADNDCharacter): string {
+  if (character.thiefSkills.length === 0) {
+    return '';
+  }
+
+  return character.thiefSkills.map((row) => `${row.name}: ${row.value + row.points}%`).join('; ');
+}
+
 export function formatAdndKitSection(character: ADNDCharacter): string {
   if (!character.kit) {
     return 'None';

--- a/src/lib/adnd/adnd_thief_skill_builder.test.ts
+++ b/src/lib/adnd/adnd_thief_skill_builder.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { createAdndCharacter } from './adndcharacter.js';
 import {
-  appendThiefSkillAbilityLines,
+  applyThiefSkillAllocation,
+  orderThiefSkillRows,
   getThiefSkillPointPool,
   prepareThiefSkillRowsForCharacter,
   thiefSkillBonusesAreValid,
@@ -40,21 +41,71 @@ describe('thiefSkillBonusesAreValid', () => {
   });
 });
 
-describe('appendThiefSkillAbilityLines', () => {
-  it('adds one ability line per bard skill', () => {
+describe('applyThiefSkillAllocation', () => {
+  it('writes one row per bard skill, carrying base and allocation apart', () => {
     const c = createAdndCharacter();
     c.race = human;
     c.dexterity = 13;
     c.abilities = [];
-    const b = {
+
+    applyThiefSkillAllocation(c, 'bard', {
       'Pick Pockets': 5,
       'Detect Noise': 5,
       'Climb Walls': 5,
       'Read Languages': 5,
-    };
-    appendThiefSkillAbilityLines(c, 'bard', b);
-    expect(c.abilities).toHaveLength(4);
-    expect(c.abilities.every((line) => /%$/.test(line))).toBe(true);
+    });
+
+    expect(c.thiefSkills).toHaveLength(4);
+    expect(c.thiefSkills.every((row) => row.points === 5)).toBe(true);
+    // The allocation is readable as a decision, which is the whole reason it is a field.
+    expect(c.thiefSkills.find((row) => row.name === 'Climb Walls')?.value).toBe(50);
+    expect(c.abilities).toEqual([]);
+  });
+
+  it('gives a skill the user left alone a zero rather than dropping it', () => {
+    const c = createAdndCharacter();
+    c.race = human;
+    c.dexterity = 13;
+
+    applyThiefSkillAllocation(c, 'bard', { 'Pick Pockets': 20 });
+
+    expect(c.thiefSkills).toHaveLength(4);
+    expect(c.thiefSkills.filter((row) => row.points === 0)).toHaveLength(3);
+  });
+});
+
+describe('orderThiefSkillRows', () => {
+  it('restores the canonical order after the generator has shuffled', () => {
+    const shuffled = [
+      { name: 'Climb Walls', value: 50, points: 0 },
+      { name: 'Pick Pockets', value: 10, points: 20 },
+      { name: 'Read Languages', value: 5, points: 0 },
+      { name: 'Detect Noise', value: 20, points: 0 },
+    ];
+
+    expect(orderThiefSkillRows('bard', shuffled).map((row) => row.name)).toEqual([
+      'Pick Pockets',
+      'Detect Noise',
+      'Climb Walls',
+      'Read Languages',
+    ]);
+  });
+
+  it('does not disturb the values it reorders', () => {
+    const rows = [
+      { name: 'Climb Walls', value: 50, points: 7 },
+      { name: 'Pick Pockets', value: 10, points: 13 },
+      { name: 'Read Languages', value: 5, points: 0 },
+      { name: 'Detect Noise', value: 20, points: 0 },
+    ];
+
+    const ordered = orderThiefSkillRows('bard', rows);
+
+    expect(ordered.find((row) => row.name === 'Climb Walls')).toEqual({
+      name: 'Climb Walls',
+      value: 50,
+      points: 7,
+    });
   });
 });
 

--- a/src/lib/adnd/adnd_thief_skill_builder.ts
+++ b/src/lib/adnd/adnd_thief_skill_builder.ts
@@ -90,15 +90,38 @@ export function thiefSkillBonusesAreValid(
   return sum === pool;
 }
 
-/** Pushes thief skill lines onto `character.abilities` (builder path). */
-export function appendThiefSkillAbilityLines(
+/**
+ * Puts rows back into the order {@link getBaseThiefSkillRows} lists them in.
+ *
+ * The generator shuffles before distributing points, because `distributePoints` picks by index and
+ * the shuffle is what decides which skills the roll favours. That shuffle must stay — it consumes
+ * the RNG and determines the allocation — but it has no business reaching the sheet, where a skill
+ * list in a different order for every character is a presentation defect rather than a result. The
+ * values are unchanged by sorting; only the rows' order becomes stable.
+ */
+export function orderThiefSkillRows(
+  kind: AdndThiefSkillBuildKind,
+  rows: ThiefSkillRow[],
+): ThiefSkillRow[] {
+  const order = getBaseThiefSkillRows(kind).map((row) => row.name);
+  return [...rows].sort((a, b) => order.indexOf(a.name) - order.indexOf(b.name));
+}
+
+/**
+ * Writes the builder's allocation onto the character as rows (builder path).
+ *
+ * The counterpart of what a class `apply` does on the generator path, and it produces the same
+ * shape: the rule-derived `value` from {@link prepareThiefSkillRowsForCharacter}, and `points` as
+ * the user assigned them. A skill the user left alone gets zero rather than being left out, so the
+ * sheet shows the whole list.
+ */
+export function applyThiefSkillAllocation(
   character: ADNDCharacter,
   kind: AdndThiefSkillBuildKind,
   bonuses: Record<string, number>,
 ): void {
-  const rows = prepareThiefSkillRowsForCharacter(kind, character);
-  for (const row of rows) {
-    const bonus = bonuses[row.name] ?? 0;
-    character.abilities.push(`${row.name}: ${row.value + bonus}%`);
-  }
+  character.thiefSkills = prepareThiefSkillRowsForCharacter(kind, character).map((row) => ({
+    ...row,
+    points: bonuses[row.name] ?? 0,
+  }));
 }

--- a/src/lib/adnd/adndcharacter.ts
+++ b/src/lib/adnd/adndcharacter.ts
@@ -2,6 +2,7 @@ import type ADNDArmor from './adndarmor.js';
 import type ADNDClass from './adndclass.js';
 import type ADNDRace from './adndrace.js';
 import type ADNDSpell from './adndspell.js';
+import type { ThiefSkillRow } from './adndthiefskills.js';
 import type ADNDWeapon from './adndweapon.js';
 
 // The fields the generator fills in later are optional on the way out of
@@ -68,6 +69,20 @@ export default interface ADNDCharacter {
   weapons: ADNDWeapon[];
   weaponProficiencyGroups: string[];
   nonweaponProficiencies: string[];
+  /**
+   * A thief's or bard's skill percentages, empty for every other class.
+   *
+   * Two numbers rather than one, because they answer different questions and only one of them is
+   * the user's. `value` is what the rule tables give this character for the skill — the class base,
+   * adjusted for dexterity and race — and `points` is the discretionary allocation, whether rolled
+   * by {@link distributePoints} or assigned in the builder. What a sheet prints is their sum.
+   *
+   * These used to be prose on {@link ADNDCharacter.abilities} — `Pick Pockets: 45%` — which stored
+   * the total and threw the allocation away. That reads back as a sentence and not as a decision,
+   * so nothing could offer it for editing without re-parsing it, and a renamed skill would have
+   * broken the parse silently.
+   */
+  thiefSkills: ThiefSkillRow[];
   kit: { name: string; features: string[] } | null;
 }
 
@@ -135,6 +150,7 @@ export function createAdndCharacter(): ADNDCharacter {
     weapons: [],
     weaponProficiencyGroups: [],
     nonweaponProficiencies: [],
+    thiefSkills: [],
     kit: null,
   };
 }

--- a/src/lib/adnd/adndthiefskills.test.ts
+++ b/src/lib/adnd/adndthiefskills.test.ts
@@ -1,0 +1,90 @@
+import { RNG } from '@ironarachne/rng';
+import { describe, expect, it } from 'vitest';
+import { distributePoints, modifyForDexterity, modifyForRace } from './adndthiefskills.js';
+import type { ThiefSkillRow } from './adndthiefskills.js';
+
+function thiefRows(): ThiefSkillRow[] {
+  return [
+    { name: 'Pick Pockets', value: 15, points: 0 },
+    { name: 'Open Locks', value: 10, points: 0 },
+    { name: 'Find/Remove Traps', value: 5, points: 0 },
+    { name: 'Move Silently', value: 10, points: 0 },
+    { name: 'Hide in Shadows', value: 5, points: 0 },
+    { name: 'Detect Noise', value: 15, points: 0 },
+    { name: 'Climb Walls', value: 60, points: 0 },
+    { name: 'Read Languages', value: 0, points: 0 },
+  ];
+}
+
+describe('distributePoints', () => {
+  it('spends the budget exactly, over many seeds', () => {
+    // The regression this exists for: the award used to be drawn against the per-skill headroom
+    // alone and subtracted afterwards, so the last one overshot. A single seed hides that — 14% of
+    // rolls happened to land exactly — so this sweeps enough of them to catch it.
+    for (let seed = 0; seed < 200; seed++) {
+      const rows = distributePoints(thiefRows(), 60, new RNG(`pool-${seed}`));
+      const dealt = rows.reduce((sum, row) => sum + row.points, 0);
+
+      expect(dealt).toBe(60);
+    }
+  });
+
+  it('never puts more than 30 points into one skill', () => {
+    for (let seed = 0; seed < 50; seed++) {
+      const rows = distributePoints(thiefRows(), 60, new RNG(`cap-${seed}`));
+
+      expect(rows.every((row) => row.points <= 30)).toBe(true);
+    }
+  });
+
+  it('spends a bard budget exactly too', () => {
+    const rows = distributePoints(
+      [
+        { name: 'Pick Pockets', value: 10, points: 0 },
+        { name: 'Detect Noise', value: 20, points: 0 },
+        { name: 'Climb Walls', value: 50, points: 0 },
+        { name: 'Read Languages', value: 5, points: 0 },
+      ],
+      20,
+      new RNG('bard-pool'),
+    );
+
+    expect(rows.reduce((sum, row) => sum + row.points, 0)).toBe(20);
+  });
+
+  it('leaves the base values alone', () => {
+    const rows = distributePoints(thiefRows(), 60, new RNG('values'));
+
+    expect(rows.find((row) => row.name === 'Climb Walls')?.value).toBe(60);
+  });
+});
+
+describe('modifyForDexterity', () => {
+  it('adds the dexterity adjustment to each base', () => {
+    const rows = modifyForDexterity(thiefRows(), 18);
+
+    expect(rows.find((row) => row.name === 'Pick Pockets')?.value).toBe(15 + 10);
+    expect(rows.find((row) => row.name === 'Open Locks')?.value).toBe(10 + 15);
+  });
+
+  it('penalises a low dexterity', () => {
+    const rows = modifyForDexterity(thiefRows(), 9);
+
+    expect(rows.find((row) => row.name === 'Move Silently')?.value).toBe(10 - 20);
+  });
+});
+
+describe('modifyForRace', () => {
+  it('applies the racial adjustment', () => {
+    const rows = modifyForRace(thiefRows(), 'dwarf');
+
+    expect(rows.find((row) => row.name === 'Find/Remove Traps')?.value).toBe(5 + 15);
+    expect(rows.find((row) => row.name === 'Climb Walls')?.value).toBe(60 - 10);
+  });
+
+  it('leaves a human unchanged', () => {
+    const rows = modifyForRace(thiefRows(), 'human');
+
+    expect(rows.map((row) => row.value)).toEqual(thiefRows().map((row) => row.value));
+  });
+});

--- a/src/lib/adnd/adndthiefskills.ts
+++ b/src/lib/adnd/adndthiefskills.ts
@@ -6,12 +6,22 @@ export type ThiefSkillRow = {
   value: number;
 };
 
+/**
+ * Deals `extraPoints` discretionary points across the skills, at most 30 into any one.
+ *
+ * The budget is exact. It did not used to be: the award was drawn against the per-skill headroom
+ * alone and only then subtracted, so the last one spent whatever it liked and 86% of rolled
+ * thieves and bards came out above their pool — by as much as 27 points on a budget of 60.
+ * Clamping the draw to what is left is the whole fix, and it was made before AD&D characters
+ * became storable, because after that the choice is between changing artifacts a user has kept
+ * and leaving them permanently wrong.
+ */
 export function distributePoints(skillList: ThiefSkillRow[], extraPoints: number, rng: RNG) {
   while (extraPoints > 0) {
     const skillIndex = rng.int(0, skillList.length - 1);
     const skill = skillList[skillIndex];
     if (skill.points < 30) {
-      const cap = 30 - skill.points > 30 ? 30 : 30 - skill.points;
+      const cap = Math.min(30 - skill.points, extraPoints);
       const points = rng.int(1, cap);
       skill.points += points;
       extraPoints -= points;

--- a/src/lib/adnd/classes/bard.ts
+++ b/src/lib/adnd/classes/bard.ts
@@ -2,6 +2,10 @@ import * as RNG from '@ironarachne/rng';
 import type { AdndClassApplyOptions } from '../adnd_class_apply_options.js';
 import type ADNDCharacter from '../adndcharacter.js';
 import type ADNDClass from '../adndclass.js';
+import {
+  orderThiefSkillRows,
+  prepareThiefSkillRowsForCharacter,
+} from '../adnd_thief_skill_builder.js';
 import * as ThiefSkills from '../adndthiefskills.js';
 
 const bard: ADNDClass = {
@@ -42,30 +46,17 @@ const bard: ADNDClass = {
     rng: RNG.RNG,
     options?: AdndClassApplyOptions,
   ): ADNDCharacter => {
-    let skills = [
-      { name: 'Pick Pockets', value: 10, points: 0 },
-      { name: 'Detect Noise', value: 20, points: 0 },
-      { name: 'Climb Walls', value: 50, points: 0 },
-      { name: 'Read Languages', value: 5, points: 0 },
-    ];
-    skills = ThiefSkills.modifyForDexterity(skills, character.dexterity);
-    let raceName = character.race.name;
-    if (character.race.name.includes('halfling')) {
-      raceName = 'halfling';
-    }
-
-    skills = ThiefSkills.modifyForRace(skills, raceName);
+    let skills = prepareThiefSkillRowsForCharacter('bard', character);
 
     if (options?.thiefSkills === 'user') {
       return character;
     }
 
+    // See the same passage in `thief.ts`: the shuffle decides the allocation and must stay, and
+    // the order it leaves behind is not what the sheet should print.
     skills = rng.shuffle(skills);
     skills = ThiefSkills.distributePoints(skills, 20, rng);
-
-    for (let i = 0; i < skills.length; i++) {
-      character.abilities.push(`${skills[i].name}: ${skills[i].value + skills[i].points}%`);
-    }
+    character.thiefSkills = orderThiefSkillRows('bard', skills);
 
     return character;
   },

--- a/src/lib/adnd/classes/thief.test.ts
+++ b/src/lib/adnd/classes/thief.test.ts
@@ -5,7 +5,7 @@ import human from '../races/human.js';
 import thief from './thief.js';
 
 describe('thief class apply', () => {
-  it('assigns thief skill percentages to abilities', () => {
+  it('assigns thief skill rows rather than ability prose', () => {
     const c = createAdndCharacter();
     c.race = human;
     c.dexterity = 16;
@@ -13,7 +13,39 @@ describe('thief class apply', () => {
 
     thief.apply(c, rng);
 
-    expect(c.abilities.some((a) => a.startsWith('Pick Pockets:'))).toBe(true);
-    expect(c.abilities.some((a) => a.startsWith('Climb Walls:'))).toBe(true);
+    expect(c.thiefSkills.map((row) => row.name)).toEqual([
+      'Pick Pockets',
+      'Open Locks',
+      'Find/Remove Traps',
+      'Move Silently',
+      'Hide in Shadows',
+      'Detect Noise',
+      'Climb Walls',
+      'Read Languages',
+    ]);
+    // The prose these used to be pushed onto `abilities` as is gone, not duplicated.
+    expect(c.abilities.some((a) => /%$/.test(a))).toBe(false);
+  });
+
+  it('deals out exactly the 60-point pool, none above the per-skill cap', () => {
+    const c = createAdndCharacter();
+    c.race = human;
+    c.dexterity = 16;
+
+    thief.apply(c, new RNG('thief-pool'));
+
+    const dealt = c.thiefSkills.reduce((sum, row) => sum + row.points, 0);
+    expect(dealt).toBe(60);
+    expect(c.thiefSkills.every((row) => row.points <= 30)).toBe(true);
+  });
+
+  it('leaves skills alone when the builder is allocating them', () => {
+    const c = createAdndCharacter();
+    c.race = human;
+    c.dexterity = 16;
+
+    thief.apply(c, new RNG('thief-user'), { thiefSkills: 'user' });
+
+    expect(c.thiefSkills).toEqual([]);
   });
 });

--- a/src/lib/adnd/classes/thief.ts
+++ b/src/lib/adnd/classes/thief.ts
@@ -2,6 +2,10 @@ import * as RNG from '@ironarachne/rng';
 import type { AdndClassApplyOptions } from '../adnd_class_apply_options.js';
 import type ADNDCharacter from '../adndcharacter.js';
 import type ADNDClass from '../adndclass.js';
+import {
+  orderThiefSkillRows,
+  prepareThiefSkillRowsForCharacter,
+} from '../adnd_thief_skill_builder.js';
 import * as ThiefSkills from '../adndthiefskills.js';
 
 const thief: ADNDClass = {
@@ -64,35 +68,18 @@ const thief: ADNDClass = {
     rng: RNG.RNG,
     options?: AdndClassApplyOptions,
   ): ADNDCharacter {
-    let skills = [
-      { name: 'Pick Pockets', value: 15, points: 0 },
-      { name: 'Open Locks', value: 10, points: 0 },
-      { name: 'Find/Remove Traps', value: 5, points: 0 },
-      { name: 'Move Silently', value: 10, points: 0 },
-      { name: 'Hide in Shadows', value: 5, points: 0 },
-      { name: 'Detect Noise', value: 15, points: 0 },
-      { name: 'Climb Walls', value: 60, points: 0 },
-      { name: 'Read Languages', value: 0, points: 0 },
-    ];
-    skills = ThiefSkills.modifyForDexterity(skills, character.dexterity);
-
-    let raceName = character.race.name;
-    if (character.race.name.includes('halfling')) {
-      raceName = 'halfling';
-    }
-
-    skills = ThiefSkills.modifyForRace(skills, raceName);
+    let skills = prepareThiefSkillRowsForCharacter('thief', character);
 
     if (options?.thiefSkills === 'user') {
       return character;
     }
 
+    // Shuffled before distributing: `distributePoints` picks by index, so the shuffle is what
+    // decides which skills a roll favours, and it consumes the RNG. Sorted back afterwards,
+    // because the order points were dealt in is not something a character sheet should show.
     skills = rng.shuffle(skills);
     skills = ThiefSkills.distributePoints(skills, 60, rng);
-
-    for (let i = 0; i < skills.length; i++) {
-      character.abilities.push(`${skills[i].name}: ${skills[i].value + skills[i].points}%`);
-    }
+    character.thiefSkills = orderThiefSkillRows('thief', skills);
 
     return character;
   },

--- a/src/lib/adnd/render_adnd_character_pdf.ts
+++ b/src/lib/adnd/render_adnd_character_pdf.ts
@@ -9,6 +9,7 @@ import {
   formatAdndProficienciesSection,
   formatAdndSpellsSection,
   formatAdndStrength,
+  formatAdndThiefSkillsSection,
   formatAdndWeaponsSection,
   slugifyAdndCharacterFilename,
 } from './adnd_format';
@@ -286,6 +287,12 @@ function drawDetailSections(doc: PdfDoc, startY: number, character: ADNDCharacte
     'Abilities',
     formatAdndAbilitiesSection(character),
   );
+  const thiefSkills = formatAdndThiefSkillsSection(character);
+  if (thiefSkills !== '') {
+    // Drawn only when the class has skills. See `formatAdndThiefSkillsSection` for why this one
+    // section is conditional where its neighbours print "None".
+    y += drawLabeledSection(doc, MARGIN, y, CONTENT_WIDTH, 'Thief Skills', thiefSkills);
+  }
   y += drawLabeledSection(
     doc,
     MARGIN,


### PR DESCRIPTION
Step 1 of [`docs/adnd-character.md`](https://github.com/ironarachne/ironarachne/blob/main/docs/adnd-character.md), toward #45 and #47. It is first because it has an ordering constraint: the field has to exist **before** `payloadVersion` 1 does, or adding it later costs a migration step and a test for it forever.

## The allocation becomes a field

`ADNDCharacter` gains `thiefSkills: ThiefSkillRow[]` — `value` for what the rule tables give this character, `points` for the discretionary allocation.

Both were previously collapsed into one prose line pushed onto `abilities`: `Pick Pockets: 45%`. That stores the total and throws the decision away. It round-trips fine as a string, so requirement 3.2 was satisfied by accident — but 4.1 and 4.4 were not. An editor cannot offer an allocation it can only read as a sentence, and re-parsing one would break the first time a skill is renamed.

- `thief.ts` and `bard.ts` delegate to `prepareThiefSkillRowsForCharacter` instead of each keeping its own copy of the base tables and its own halfling special case.
- `appendThiefSkillAbilityLines` → `applyThiefSkillAllocation`, writing the same shape from the builder's side.
- The sheet grows a table (base / allocated / total). The PDF grows a section drawn **only when the class has skills** — unlike its neighbours, which print "None", because "Thief Skills: None" on a wizard answers a question nobody asked.
- The generator still shuffles before dealing, because `distributePoints` picks by index and the shuffle is what decides which skills a roll favours. `orderThiefSkillRows` sorts back on the way out, since the order points were *dealt* in is not something a sheet should show.

## The point pool overshot, and now does not

`distributePoints` drew each award against the per-skill headroom alone and subtracted afterwards, so the last award spent whatever it liked. Measured over 300 seeds, **86% of rolled thieves and bards came out above their budget — by as much as 27 points on a pool of 60.**

Clamping the draw to what remains is the fix. It changes seeded output, which is exactly why it is here rather than later: after the kind ships, the choice is between rewriting characters a user has kept and leaving them permanently wrong.

## Golden diff

Dumped 300 seeded characters before and after, per this repo's practice for touching a seeded generator.

| Change | Blast radius |
| --- | --- |
| Rows moved off `abilities` | **0 differences** in every other field; all 92 rogues' totals identical; no residue left behind |
| Point-pool clamp | **77 thieves.** No bards, no other class — the clamp only shifts later draws when it forces an extra loop iteration |

All 92 rogues now land exactly on budget.

## A design claim withdrawn

The design said the PDF draws empty Kit and Proficiencies boxes. It doesn't — those formatters return `'None'`, so it prints "Kit: None". That is a deliberate answer, not a layout artifact, and there is nothing for 6.4 to fix there. `docs/adnd-character.md` now says so rather than carrying a fabricated defect into step 7.

## Verification

- `npm run verify` — green. 4201 tests, `0 ERRORS` from svelte-check, coverage gate passed (96 libraries).
- `npm run test:e2e` — green, 402 passed. Required: this touches components.

## Not in this PR

A separate pre-existing crash, deferred to step 3 where `rollAdndCharacter` gets written: **4 seeds in 300 (1.3%) crash the generator outright**, because `getClassOptionsForRace` can return an empty list and `rng.item([])` yields `undefined`. Live on the generator page today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
