### PR TITLE
Let a pull request be based on something other than main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,31 @@ name: CI
 # Note that `verify` runs on documentation-only changes too. `npm run lint`
 # calls `prettier --check .`, which covers Markdown, so this is the check that
 # stops a badly formatted document landing and breaking `lint` on `main`.
+#
+# `pull_request` carries no `branches` filter, and that omission is deliberate:
+# the filter matches a pull request's *base*, so `branches: [main]` meant a pull
+# request aimed at anything else never triggered this workflow at all. The
+# required context "verify" was then never posted, and because `main` protection
+# has `enforce_admins` on, nobody could merge past it. A stacked pull request —
+# one based on another branch rather than on `main` — was therefore not merely
+# discouraged, it was impossible. Removing the filter is what makes stacking
+# work; the cost is an `npm ci` and a `verify` run on pull requests aimed at
+# branches other than `main`, which is cheap next to a workflow that silently
+# cannot be satisfied.
+#
+# The checkout for a pull request is the merge of head into base, so a stacked
+# pull request is verified against the cumulative state of the stack below it
+# rather than against its own commits alone. That is the behaviour worth having.
+#
+# Two things about stacking that this file cannot enforce, recorded because they
+# are how a stack goes wrong. **Merge the bottom first** — merging an upper pull
+# request first drags the lower one's commits into `main` with it, closing that
+# pull request as already-merged without it ever being reviewed. And **only add
+# commits to a branch someone has stacked on**: restacking after a rewrite needs
+# a force-push, which `.claude/hooks/guard_protected_branch.sh` refuses outright.
 
 on:
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,9 @@ Notes:
   rendering.** This is not optional politeness: no Playwright runs against a PR, so you are the
   only thing standing between a browser-visible regression and `main`.
 - CI is two workflows. `.github/workflows/ci.yaml` runs `verify` on every PR and every merge,
-  and is the only required check. `.github/workflows/e2e.yaml` runs the browser suite on
+  and is the only required check. It carries no base-branch filter, so a PR based on another
+  branch is checked like any other — see [Stacked pull requests](#stacked-pull-requests).
+  `.github/workflows/e2e.yaml` runs the browser suite on
   merges to `main` only — never on a PR, because the suite takes about seventeen minutes and
   `npm run verify:all` locally is the faster loop for a rendering change. A red run there is a
   signal to investigate, not a blocked merge; `e2e.yaml` carries the full reasoning.
@@ -228,6 +230,31 @@ Break a design into work items only after the model is approved.
   `verify` reports green. That is the only required context — the browser suite deliberately
   does not gate a PR (see `.github/workflows/e2e.yaml`). Work on a branch and open a PR; there
   is no path that bypasses this.
+
+### Stacked pull requests
+
+A PR may be based on another branch rather than on `main`. This used not to work at all:
+`ci.yaml` filtered `pull_request` by base branch, so a stacked PR never triggered it, the
+required `verify` context was never posted, and `enforce_admins` meant nobody could merge past
+the gap. The filter is gone, and a stacked PR is now verified against the cumulative state of
+the stack below it, which is what the merge-commit checkout gives you for free.
+
+Two rules make a stack behave, and neither is enforceable by CI:
+
+- **Merge the bottom first.** An upper PR merged first drags the lower branch's commits into
+  `main` along with it, and the lower PR then closes as already-merged without ever having been
+  reviewed on its own.
+- **Only add commits to a branch someone has stacked on.** Restacking after a rewrite needs a
+  force-push, and `.claude/hooks/guard_protected_branch.sh` refuses every force-push including
+  `--force-with-lease`. Adding a commit is what the guard's own message tells you to do instead.
+
+Squash-merging would undo all of this — `main` would hold a commit the upper branch does not
+have, so every stack would need a rebase after each merge and would show phantom conflicts. The
+merge-commit strategy is what keeps retargeting clean, and it is worth keeping for that reason.
+
+Stacking earns its keep for independent work reviewed in parallel. Steps of one feature that
+genuinely depend on each other are usually better merged one at a time, because e2e only runs
+after a merge to `main`.
 
 ## Agent configuration
 


### PR DESCRIPTION
`ci.yaml` filtered `pull_request` by `branches: [main]`. That filter matches a pull request's **base**, not its head — so a PR aimed at any other branch never triggered the workflow at all. The required context `verify` was then never posted, and with `enforce_admins` on, nobody could merge past the gap.

Stacked PRs weren't discouraged here, they were **impossible** — and the failure mode looked like a check that hadn't finished yet rather than one that would never start.

## The change

```diff
 on:
   pull_request:
-    branches: [main]
   push:
     branches: [main]
```

That's it. The cost is an `npm ci` and a `verify` run on PRs aimed at branches other than `main`, which is cheap beside a gate that cannot be satisfied.

A pull request checks out the merge of head into base, so a stacked PR is verified against the **cumulative state of the stack below it** rather than against its own commits alone. That's the behaviour worth having.

## Why nothing else needed touching

The repo already suits stacking, mostly by good luck:

- **Merges are merge commits** and `required_linear_history` is off. Once the bottom lands, `main` holds its exact commits and the next branch retargets cleanly. Squash-merging would break this — `main` would hold a commit the upper branch doesn't have, so every stack would need a rebase after each merge and would show phantom conflicts. Worth keeping merge commits for this reason.
- **`strict` is off**, so a stack doesn't need restacking every time `main` moves.
- Merged branches are deleted, which is what triggers GitHub's auto-retarget of the next PR.

## Two rules CI can't enforce

Recorded in both `ci.yaml` and `CLAUDE.md`:

- **Merge the bottom first.** An upper PR merged first drags the lower branch's commits into `main` with it, and the lower PR then closes as already-merged without ever having been reviewed on its own.
- **Only add commits to a branch someone has stacked on.** Restacking after a rewrite needs a force-push, and `.claude/hooks/guard_protected_branch.sh` refuses every one of those, `--force-with-lease` included. Adding a commit is what the guard's own message tells you to do instead.

## Unchanged

`e2e.yaml` still runs on merges to `main` only. A stack gets no Playwright coverage per PR, and `npm run verify:all` locally is still the only thing between a rendering regression and `main`.

## Verification

`npm run lint` green. This PR is itself based on `main`, so it exercises the ordinary path; the stacked path is exercised the first time something stacks on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
