### PR TITLE
Roll an AD&D character from a seed, and let it be saved

### DIFF
--- a/src/components/characters/AdndCharacterGenerator.svelte
+++ b/src/components/characters/AdndCharacterGenerator.svelte
@@ -2,8 +2,13 @@
   import * as RNG from '@ironarachne/rng';
   import { resolve } from '$app/paths';
   import AdndCharacterSheet from '$components/characters/AdndCharacterSheet.svelte';
-  import { generateCharacter, getDefaultConfig, downloadAdndCharacterPdf } from '$lib/adnd';
-  import type { ADNDCharacter } from '$lib/adnd';
+  import {
+    ADND_CHARACTER_ARTIFACT_KIND,
+    downloadAdndCharacterPdf,
+    rollAdndCharacter,
+    toAdndCharacterSnapshot,
+  } from '$lib/adnd';
+  import type { ADNDCharacter, AdndCharacterGeneratorConfigRecord } from '$lib/adnd';
   import {
     buildCharacterNameSource,
     isCustomCharacterNameSource,
@@ -17,17 +22,26 @@
   import SeedControls from '$components/common/SeedControls.svelte';
   import CharacterNameSection from '$components/characters/CharacterNameSection.svelte';
   import DownloadPdfButton from '$components/common/DownloadPdfButton.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
+
+  const TOOL_PATH = '/fantasy/adnd/character';
 
   const rng = new RNG.RNG(Date.now().toString());
   let seed = $state(rng.randomString(13));
   let lockSeed = $state(false);
   let includeProficiencies = $state(false);
   let includeKits = $state(false);
-  $effect(() => {
-    rng.setSeed(seed);
-  });
   let character = $state<ADNDCharacter | undefined>();
   let downloadingPdf = $state(false);
+  /**
+   * The settings the character on screen was actually rolled with.
+   *
+   * `$state.raw` rather than `$state`, and that is not a style choice: IndexedDB serialises with
+   * `structuredClone`, which refuses a Proxy, so a deep-reactive config fails the write with
+   * `could not be cloned`. A roll replaces the whole record rather than mutating it. The same trap
+   * is written up in `$lib/workshop`'s README beside `saveToolArtifact`.
+   */
+  let rolledConfig = $state.raw<Record<string, unknown>>({});
 
   let savedCultures = $state<Culture[]>([]);
   let nameSourceKind = $state<'default' | 'preset' | 'saved_culture'>('default');
@@ -38,6 +52,19 @@
   let lockName = $state(false);
   let namingGender = $state<'male' | 'female' | 'random'>('random');
 
+  /**
+   * What gets stored, with the names the page is showing rather than the ones the roll produced.
+   *
+   * The two differ whenever the user has typed a name or locked one, and the sheet below already
+   * renders the character that way. Saving the roll's name instead would keep something the user
+   * can see is not what they asked for.
+   */
+  const characterSnapshot = $derived(
+    character === undefined ? null : toAdndCharacterSnapshot({ ...character, firstName, lastName }),
+  );
+
+  const defaultArtifactName = $derived(`${firstName} ${lastName}`.trim());
+
   function applyNamesToCharacter(target: ADNDCharacter | undefined) {
     if (!target) {
       return;
@@ -46,14 +73,23 @@
     target.lastName = lastName;
   }
 
-  function rollNamesForCurrentSource(defaultHint: string) {
+  /**
+   * Names for the current source, from a stream the seed decides.
+   *
+   * `nameSeed` is what makes requirement 2.2 true here. This used to draw from
+   * `new RNG(\`${Date.now()}-adnd-name\`)`, so a locked seed reproduced the character's body and
+   * a different name every time — the tool was not in fact deterministic. The one caller that
+   * still wants a fresh draw is the "generate a name" button, which passes its own value because
+   * asking for another name is a deliberate act rather than part of the roll.
+   */
+  function rollNamesForCurrentSource(defaultHint: string, nameSeed: string) {
     const source = buildCharacterNameSource(
       nameSourceKind,
       presetSetName,
       savedCultureName,
       savedCultures,
     );
-    const nameRng = new RNG.RNG(`${Date.now()}-adnd-name`);
+    const nameRng = new RNG.RNG(nameSeed);
     return rollCharacterNameForSource(nameRng, source, defaultHint, namingGender);
   }
 
@@ -72,28 +108,50 @@
       return;
     }
 
-    const generated = rollNamesForCurrentSource(defaultHint);
+    const generated = rollNamesForCurrentSource(defaultHint, `${seed}-adnd-name`);
     target.firstName = generated.firstName;
     target.lastName = generated.lastName;
     firstName = generated.firstName;
     lastName = generated.lastName;
   }
 
+  /**
+   * The settings a roll takes, and the ones provenance records.
+   *
+   * `nameGeneratorSet` is the preset set only. A character named from a saved culture takes its
+   * names from that culture's own generators, which are not one of the build's named sets — that
+   * link is an artifact reference, and recording it is composition's job rather than this step's.
+   */
+  function currentConfig(): AdndCharacterGeneratorConfigRecord {
+    return {
+      ...(nameSourceKind === 'preset' ? { nameGeneratorSet: presetSetName } : {}),
+      namingGender,
+      includeProficiencies,
+      includeKits,
+    };
+  }
+
   function generate() {
     if (!lockSeed) {
       seed = rng.randomString(13);
     }
-    rng.setSeed(seed);
 
     const lockedFirstName = firstName;
     const lockedLastName = lastName;
 
-    const genConfig = getDefaultConfig(rng);
-    genConfig.includeProficiencies = includeProficiencies;
-    genConfig.includeKits = includeKits;
-    character = generateCharacter(genConfig);
+    const config = currentConfig();
+    const rolled = rollAdndCharacter(seed, config);
+    character = rolled.character;
+    // The resolved set, not the requested one: a set this build has since dropped would otherwise
+    // be recorded as provenance that a re-roll could not honour.
+    rolledConfig = { ...config, nameGeneratorSet: rolled.nameGeneratorSet };
+
     if (lockName) {
       restoreLockedCharacterName(character, lockedFirstName, lockedLastName);
+    } else if (nameSourceKind === 'preset') {
+      // Already named by the roll, from the seed. Mirror it into the fields the page shows.
+      firstName = character.firstName;
+      lastName = character.lastName;
     } else {
       applyGeneratedNamesFromSource(character, character.race.name);
     }
@@ -104,7 +162,9 @@
       return;
     }
     const defaultHint = character?.race.name ?? 'human';
-    const generated = rollNamesForCurrentSource(defaultHint);
+    // A fresh stream, deliberately: asking for another name is the one place a clock-driven draw
+    // is right, because the user is asking for something different rather than for this roll.
+    const generated = rollNamesForCurrentSource(defaultHint, `${Date.now()}-adnd-name`);
     firstName = generated.firstName;
     lastName = generated.lastName;
     if (character) {
@@ -186,6 +246,15 @@
 
   <button onclick={generate}>Generate</button>
   <DownloadPdfButton onclick={downloadPdf} downloading={downloadingPdf || !character} />
+
+  <SaveArtifactButton
+    kind={ADND_CHARACTER_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={characterSnapshot}
+    {seed}
+    config={rolledConfig}
+    defaultName={defaultArtifactName}
+  />
 
   {#if character}
     <AdndCharacterSheet character={{ ...character, firstName, lastName }} />

--- a/src/lib/adnd/adnd_character_roll.test.ts
+++ b/src/lib/adnd/adnd_character_roll.test.ts
@@ -1,0 +1,166 @@
+import { RNG } from '@ironarachne/rng';
+import { describe, expect, it } from 'vitest';
+
+import {
+  readAdndCharacterGeneratorConfig,
+  rollAdndCharacter,
+  rollAdndCharacterSnapshot,
+} from './adnd_character_roll.js';
+import { generateCharacter } from './adndcharactergenerator.js';
+import { getDefaultConfig } from './adndcharactergeneratorconfig.js';
+
+describe('rollAdndCharacter', () => {
+  it('is deterministic for a seed and configuration', () => {
+    // Requirement 2.2, and the reason this function exists rather than a config assembled in the
+    // page: determinism that depends on nobody editing a Svelte component is not determinism.
+    const first = rollAdndCharacter('same-seed', { includeProficiencies: true, includeKits: true });
+    const second = rollAdndCharacter('same-seed', {
+      includeProficiencies: true,
+      includeKits: true,
+    });
+
+    expect(second.character).toEqual(first.character);
+  });
+
+  it('names deterministically too, which the page did not', () => {
+    // The name used to come off a clock-seeded RNG, so a locked seed reproduced the body and a
+    // different name every time.
+    const first = rollAdndCharacter('named-seed', { nameGeneratorSet: 'human' });
+    const second = rollAdndCharacter('named-seed', { nameGeneratorSet: 'human' });
+
+    expect(first.character.firstName).not.toBe('');
+    expect(second.character.firstName).toBe(first.character.firstName);
+    expect(second.character.lastName).toBe(first.character.lastName);
+  });
+
+  it('gives different seeds different characters', () => {
+    const a = rollAdndCharacter('seed-a');
+    const b = rollAdndCharacter('seed-b');
+
+    expect(b.character).not.toEqual(a.character);
+  });
+
+  it('leaves a character unnamed when no pattern set was asked for', () => {
+    // The generator's naming control defaults to offering none, and "a level 1 elf thief" is a
+    // usable character. Absent means do not name, not pick one for me.
+    const rolled = rollAdndCharacter('unnamed');
+
+    expect(rolled.character.firstName).toBe('');
+    expect(rolled.nameGeneratorSet).toBe('');
+  });
+
+  it('drops a pattern set this build no longer has rather than substituting one', () => {
+    const rolled = rollAdndCharacter('gone', { nameGeneratorSet: 'a-set-that-was-removed' });
+
+    expect(rolled.nameGeneratorSet).toBe('');
+    expect(rolled.character.firstName).toBe('');
+  });
+
+  it('reports the set it actually used, so provenance records what happened', () => {
+    const rolled = rollAdndCharacter('reported', { nameGeneratorSet: 'human' });
+
+    expect(rolled.nameGeneratorSet).toBe('human');
+  });
+
+  it('honours the naming gender', () => {
+    const male = rollAdndCharacter('gendered', { nameGeneratorSet: 'human', namingGender: 'male' });
+    const female = rollAdndCharacter('gendered', {
+      nameGeneratorSet: 'human',
+      namingGender: 'female',
+    });
+
+    expect(male.character.firstName).not.toBe(female.character.firstName);
+  });
+
+  it('applies the proficiency and kit switches', () => {
+    const plain = rollAdndCharacter('switches');
+    const loaded = rollAdndCharacter('switches', {
+      includeProficiencies: true,
+      includeKits: true,
+    });
+
+    expect(plain.character.weaponProficiencyGroups).toEqual([]);
+    expect(loaded.character.weaponProficiencyGroups.length).toBeGreaterThan(0);
+  });
+});
+
+describe('rollAdndCharacterSnapshot', () => {
+  it('produces a snapshot rather than a live character', () => {
+    const snapshot = rollAdndCharacterSnapshot('snap', { nameGeneratorSet: 'human' });
+
+    expect(typeof snapshot.raceName).toBe('string');
+    expect(snapshot).not.toHaveProperty('race');
+    expect(() => structuredClone(snapshot)).not.toThrow();
+  });
+
+  it('reproduces the same character on a re-roll', () => {
+    const config = { nameGeneratorSet: 'human', includeKits: true };
+
+    expect(rollAdndCharacterSnapshot('reroll', config)).toEqual(
+      rollAdndCharacterSnapshot('reroll', config),
+    );
+  });
+});
+
+describe('readAdndCharacterGeneratorConfig', () => {
+  it('reads what a tool stored', () => {
+    expect(
+      readAdndCharacterGeneratorConfig({
+        nameGeneratorSet: 'human',
+        namingGender: 'female',
+        includeProficiencies: true,
+        includeKits: false,
+      }),
+    ).toEqual({
+      nameGeneratorSet: 'human',
+      namingGender: 'female',
+      includeProficiencies: true,
+      includeKits: false,
+    });
+  });
+
+  it('drops what it does not recognise rather than coercing it', () => {
+    // A config written by a build that spelled these differently should fall back to the
+    // defaults, not roll a character from a field it misread.
+    expect(
+      readAdndCharacterGeneratorConfig({
+        nameGeneratorSet: 42,
+        namingGender: 'enby-but-not-a-valid-value',
+        includeProficiencies: 'yes',
+        somethingElse: true,
+      }),
+    ).toEqual({});
+  });
+
+  it('treats an empty pattern set as absent', () => {
+    expect(readAdndCharacterGeneratorConfig({ nameGeneratorSet: '' })).toEqual({});
+  });
+
+  it('reads an empty config', () => {
+    expect(readAdndCharacterGeneratorConfig({})).toEqual({});
+  });
+});
+
+describe('rolling a character the dice qualify for no class', () => {
+  it('rolls again instead of crashing', () => {
+    // These four seeds threw `Cannot read properties of undefined (reading 'apply')` before the
+    // retry existed: `getClassOptionsForRace` came back empty and `rng.item([])` gave undefined.
+    // Two of them had a race that would have worked; two rolled stats no class takes under any
+    // race, which is the case the PHB answers by telling you to roll again.
+    for (const seed of ['golden-18', 'golden-138', 'golden-171', 'golden-252']) {
+      const config = getDefaultConfig(new RNG(seed));
+
+      expect(() => generateCharacter(config)).not.toThrow();
+      expect(generateCharacter(getDefaultConfig(new RNG(seed))).class.name).not.toBe('');
+    }
+  });
+
+  it('produces a class for every seed across a wide sweep', () => {
+    for (let seed = 0; seed < 400; seed += 1) {
+      const character = generateCharacter(getDefaultConfig(new RNG(`sweep-${seed}`)));
+
+      expect(character.class).toBeDefined();
+      expect(character.race).toBeDefined();
+    }
+  });
+});

--- a/src/lib/adnd/adnd_character_roll.ts
+++ b/src/lib/adnd/adnd_character_roll.ts
@@ -1,0 +1,159 @@
+/**
+ * The single path from a seed to an AD&D 2E character, and the record of how it was rolled.
+ *
+ * Modelled on `settlement_roll.ts`, and here for the same reason: requirement 2.2 in
+ * docs/workshop.md wants the same seed and configuration to give the same character, and a
+ * generator whose configuration is assembled inline in a Svelte component satisfies that only for
+ * as long as nobody edits the component. Once an artifact can be re-rolled, "reproduce this" also
+ * needs somewhere to read the settings back from.
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import {
+  generateCharacterName,
+  peopleNameGeneratorsFromNameSet,
+  type NamingGender,
+} from '$lib/characters';
+import { getFantasyNameGeneratorSet, getFantasyNameGeneratorSetNames } from '$lib/names';
+
+import { generateCharacter } from './adndcharactergenerator.js';
+import { getDefaultConfig } from './adndcharactergeneratorconfig.js';
+import { toAdndCharacterSnapshot, type AdndCharacterSnapshot } from './adnd_character_snapshot.js';
+import type ADNDCharacter from './adndcharacter.js';
+
+/**
+ * What the generator records about how it rolled, and what a re-roll reads back.
+ *
+ * Stated as a type rather than read field by field at the call site so the two ends — what is
+ * written as provenance and what a re-roll expects to find — are in one place and drift loudly
+ * instead of quietly.
+ */
+export type AdndCharacterGeneratorConfigRecord = {
+  /**
+   * The name pattern set the character was named from.
+   *
+   * A character named from a saved culture records that culture's own pattern set here rather
+   * than the culture's id, so a re-roll produces a name of the same tongue without reaching back
+   * into the store for an artifact it has no way to ask for. The link to the culture is an
+   * artifact reference and lives beside the payload, not in this record.
+   */
+  nameGeneratorSet?: string;
+  /** Which name to draw. `random` lets the seed decide, as the page's picker does. */
+  namingGender?: NamingGender;
+  includeProficiencies?: boolean;
+  includeKits?: boolean;
+};
+
+/**
+ * A rolled character and the pattern set its name actually came from.
+ *
+ * The resolved set travels back out because a roll may choose one itself, and provenance has to
+ * record what was used rather than what was asked for. "Any set" stored as provenance would make
+ * a re-roll a fresh draw, which is not what re-rolling an artifact means.
+ */
+export type AdndCharacterRoll = {
+  character: ADNDCharacter;
+  nameGeneratorSet: string;
+};
+
+function readBoolean(value: unknown, key: string): Record<string, boolean> {
+  return typeof value === 'boolean' ? { [key]: value } : {};
+}
+
+const NAMING_GENDERS: NamingGender[] = ['male', 'female', 'random'];
+
+/**
+ * The pattern set a roll should name from, or `''` for a character the user left unnamed.
+ *
+ * Unnamed is the ordinary case and not a failure: the generator's naming control defaults to
+ * offering no names at all, and an AD&D character is perfectly usable as "a level 1 elf thief".
+ * So an absent set means "do not name this one" rather than "pick one for me" — which is the
+ * opposite of what `$lib/settlements` does with the same field, because a settlement is a place
+ * that must be called something and a character here need not be.
+ *
+ * A set this build no longer has also lands here, and is dropped rather than substituted. Naming
+ * a character in a tongue nobody asked for is worse than leaving the name the payload already
+ * carries, and on the re-roll path the payload is what the user is about to overwrite.
+ */
+function resolveNameGeneratorSet(requested: string | undefined): string {
+  if (requested === undefined || requested === '') {
+    return '';
+  }
+  return getFantasyNameGeneratorSetNames().includes(requested) ? requested : '';
+}
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Provenance is `Record<string, unknown>` because the store cannot know what any tool puts in it,
+ * so this is the boundary where that becomes typed. Anything unrecognisable is dropped rather
+ * than coerced: a config written by a build that spelled these differently should fall back to
+ * the defaults, not roll a character from a field it misread.
+ */
+export function readAdndCharacterGeneratorConfig(
+  config: Record<string, unknown>,
+): AdndCharacterGeneratorConfigRecord {
+  return {
+    ...(typeof config.nameGeneratorSet === 'string' && config.nameGeneratorSet !== ''
+      ? { nameGeneratorSet: config.nameGeneratorSet }
+      : {}),
+    ...(NAMING_GENDERS.includes(config.namingGender as NamingGender)
+      ? { namingGender: config.namingGender as NamingGender }
+      : {}),
+    ...readBoolean(config.includeProficiencies, 'includeProficiencies'),
+    ...readBoolean(config.includeKits, 'includeKits'),
+  };
+}
+
+/**
+ * Roll a character from a seed and a set of options — the one path the generator page and a
+ * re-roll both take.
+ *
+ * The name is drawn from a stream of its own, derived from the seed rather than taken off the
+ * character's. Two reasons, and both matter. A name drawn off the main stream would shift every
+ * roll after it, so choosing a pattern set explicitly and having one chosen would produce
+ * different characters. And the page used to draw its name from a clock-seeded RNG, which meant
+ * the same seed did not in fact produce the same character — 2.2 was already broken here, and
+ * this is the fix.
+ */
+export function rollAdndCharacter(
+  seed: string,
+  config: AdndCharacterGeneratorConfigRecord = {},
+): AdndCharacterRoll {
+  const rng = new RNG(seed);
+  const generatorConfig = getDefaultConfig(rng);
+  generatorConfig.includeProficiencies = config.includeProficiencies === true;
+  generatorConfig.includeKits = config.includeKits === true;
+
+  const character = generateCharacter(generatorConfig);
+  const nameGeneratorSet = resolveNameGeneratorSet(config.nameGeneratorSet);
+
+  if (nameGeneratorSet !== '') {
+    const nameRng = new RNG(`${seed}-adnd-name`);
+    const nameSet = getFantasyNameGeneratorSet(nameGeneratorSet, nameRng);
+    const name = generateCharacterName(
+      nameRng,
+      peopleNameGeneratorsFromNameSet(nameSet),
+      config.namingGender ?? 'random',
+    );
+    character.firstName = name.firstName;
+    character.lastName = name.lastName;
+  }
+
+  return { character, nameGeneratorSet };
+}
+
+/**
+ * Roll a fresh character snapshot from a seed and the settings it was first made with — the
+ * destructive half of editing (requirement 4.3) for a character that came from the generator.
+ *
+ * A character that came from the builder re-rolls a different way; see
+ * `adnd_character_build.ts`, which reads the build record instead.
+ */
+export function rollAdndCharacterSnapshot(
+  seed: string,
+  config: AdndCharacterGeneratorConfigRecord = {},
+): AdndCharacterSnapshot {
+  return toAdndCharacterSnapshot(rollAdndCharacter(seed, config).character);
+}

--- a/src/lib/adnd/adndcharactergenerator.ts
+++ b/src/lib/adnd/adndcharactergenerator.ts
@@ -18,7 +18,25 @@ import {
   selectWeaponProficiencyGroups,
 } from './adnd_proficiency_selection.js';
 
-export function generateCharacter(config: ADNDCharacterGeneratorConfig): ADNDCharacter {
+/**
+ * How many times a roll may start over when the dice produce a character no class will take.
+ *
+ * There is no cleverer recovery available. Straight 3d6 down the line can produce 6/5/15/5/8/5,
+ * which meets no class's minimums under any race, so relaxing the race would not help — the only
+ * answer, and the one the PHB itself gives, is to roll again. Each attempt fails about 1.3% of
+ * the time, so twenty of them fail together about once in 10^38 rolls.
+ */
+const MAX_ROLL_ATTEMPTS = 20;
+
+/**
+ * One attempt at rolling a character up to the point a class is chosen, or `null` when the dice
+ * qualified for none.
+ *
+ * Split out so the retry can restart cleanly. It draws in exactly the order the generator always
+ * has, which is what keeps every seed that already worked producing the character it always did:
+ * a seed only reaches a second attempt if the first one used to crash.
+ */
+function attemptCharacterUpToClass(config: ADNDCharacterGeneratorConfig): ADNDCharacter | null {
   let character = createAdndCharacter();
 
   character.charisma = Dice.roll('3d6', config.rng);
@@ -28,14 +46,34 @@ export function generateCharacter(config: ADNDCharacterGeneratorConfig): ADNDCha
   character.strength = Dice.roll('3d6', config.rng);
   character.wisdom = Dice.roll('3d6', config.rng);
 
-  character.race = config.rng.item(getRaceOptions(character, config.allowedRaces));
+  const raceOptions = getRaceOptions(character, config.allowedRaces);
+  if (raceOptions.length === 0) {
+    return null;
+  }
+  character.race = config.rng.item(raceOptions);
   // `apply` is a domain method on ADNDRace, not Function.prototype.apply.
   // eslint-disable-next-line prefer-spread
   character = character.race.apply(character, config.rng);
 
-  character.class = config.rng.item(
-    getClassOptionsForRace(character, character.race, config.allowedClasses),
-  );
+  const classOptions = getClassOptionsForRace(character, character.race, config.allowedClasses);
+  if (classOptions.length === 0) {
+    return null;
+  }
+  character.class = config.rng.item(classOptions);
+  return character;
+}
+
+export function generateCharacter(config: ADNDCharacterGeneratorConfig): ADNDCharacter {
+  let character: ADNDCharacter | null = null;
+  for (let attempt = 0; attempt < MAX_ROLL_ATTEMPTS && character === null; attempt += 1) {
+    character = attemptCharacterUpToClass(config);
+  }
+  if (character === null) {
+    throw new Error(
+      `could not roll an AD&D character that qualifies for any class in ${MAX_ROLL_ATTEMPTS} attempts`,
+    );
+  }
+
   // `apply` is a domain method on ADNDClass, not Function.prototype.apply.
   // eslint-disable-next-line prefer-spread
   character = character.class.apply(character, config.rng);

--- a/src/lib/adnd/index.ts
+++ b/src/lib/adnd/index.ts
@@ -11,6 +11,7 @@ export { getDefaultConfig } from './adndcharactergeneratorconfig';
 export * from './adndcharactergenerator';
 export * from './adnd_character_artifact_kind';
 export * from './adnd_character_eligibility';
+export * from './adnd_character_roll';
 export * from './adnd_character_snapshot';
 export type * from './adnd_class_apply_options';
 export * from './adnd_class_starting_spells';


### PR DESCRIPTION
Step 3 of [`docs/adnd-character.md`](https://github.com/ironarachne/ironarachne/blob/main/docs/adnd-character.md), and the rest of #47's tool half: one roll path, honest provenance, and a save button. **The generator can now keep what it makes.**

## One path from a seed

`adnd_character_roll.ts` holds `rollAdndCharacter`, `rollAdndCharacterSnapshot`, and `readAdndCharacterGeneratorConfig` — the typed boundary where the store's `Record<string, unknown>` becomes settings, dropping what it doesn't recognise rather than coercing it. The page used to assemble its generator config inline, which made requirement 2.2 true only for as long as nobody edited the component, and left a re-roll nothing to reproduce from.

## 2.2 really was broken

The name came off `new RNG(\`${Date.now()}-adnd-name\`)`, so a **locked seed reproduced the body and a different name every press**. Names now derive from `${seed}-adnd-name`, on a stream of their own so naming doesn't shift the rolls after it.

The one clock draw that stays is the explicit "generate a name" button, where asking for a different name is the point rather than an accident.

## The generator no longer crashes on unlucky dice

`rng.item([])` returned `undefined` when `getClassOptionsForRace` came back empty, and `character.class.apply` then threw — **4 seeds in 300, live on the page today.**

Diagnosis split it in two, which changed the fix:

| Seed | Stats | Cause |
| --- | --- | --- |
| `golden-18`, `golden-171` | — | Unlucky race pick; another race would have worked |
| `golden-138`, `golden-252` | `6/5/15/5/8/5` | Qualifies for **no class under any race** |

So filtering races wouldn't have been enough. The only answer, and the PHB's own, is to roll again. `attemptCharacterUpToClass` returns `null` rather than crashing, and `generateCharacter` retries up to 20 times.

**Attempt one draws in exactly the order the generator always did**, so a seed reaches attempt two only if it used to crash:

- Golden diff over 300 seeds: all 4 recovered, **0 previously-working seeds changed**.
- 5000-seed sweep: 0 failures.

## Saving

`SaveArtifactButton` on the generator, recording tool path, seed, and the settings actually used — the **resolved** pattern set rather than the requested one, since a set this build has dropped would be provenance a re-roll couldn't honour.

`rolledConfig` is `$state.raw` because IndexedDB serialises with `structuredClone`, which refuses a Proxy — the trap `$lib/workshop`'s README records. The snapshot carries the names the page is showing rather than the roll's, so a typed or locked name is what gets kept.

## One scope call

Provenance records `nameGeneratorSet` for **preset** sets only. A character named from a saved culture draws on that culture's own generators, which aren't one of the build's named sets — that link is an artifact reference and belongs to composition in step 6, rather than being half-built here. The saved-culture naming path is otherwise untouched.

## Verification

- `npm run verify` — green. 4245 tests, `0 ERRORS`, coverage gate passed.
- `npm run test:e2e` — green, 402 passed. Required: this touches a component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
