### PR TITLE
Let the builder edit a saved character

### DIFF
--- a/src/components/characters/AdndCharacterArtifactEditor.svelte
+++ b/src/components/characters/AdndCharacterArtifactEditor.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import AdndCharacterBuilder from '$components/characters/AdndCharacterBuilder.svelte';
+  import { validateAdndCharacterSnapshot, type AdndCharacterSnapshot } from '$lib/adnd';
+
+  /**
+   * The editing view for a saved AD&D 2E character.
+   *
+   * It mounts the builder rather than being a second editor written beside it, which is the whole
+   * reason #45 and #47 were designed together: the builder already asks every question that makes
+   * a character, so wiring it here is what makes requirement 4.1 affordable. What this component
+   * adds is only the adapter between the framework's snapshot-in, snapshot-out contract and the
+   * builder's own shape.
+   *
+   * The builder is what decides whether an edit patches the saved character or re-derives it —
+   * see `adnd_character_build.ts`. Nothing about that lives here.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind. Narrowing through
+   * `validate` rather than a cast is what stops a character editor rendering fields over
+   * something that is not a character.
+   */
+  const accepted = $derived(validateAdndCharacterSnapshot(snapshot));
+  const character = $derived<AdndCharacterSnapshot | undefined>(
+    accepted.ok ? accepted.value : undefined,
+  );
+</script>
+
+{#if character === undefined}
+  <p class="artifact-editor-problem">
+    This artifact is stored as an AD&D 2E character but this build cannot read it:
+    {accepted.ok ? '' : accepted.message}
+  </p>
+{:else}
+  <AdndCharacterBuilder editing={character} {onChange} />
+{/if}
+
+<style>
+  .artifact-editor-problem {
+    color: var(--color-text-muted, inherit);
+  }
+</style>

--- a/src/components/characters/AdndCharacterBuilder.svelte
+++ b/src/components/characters/AdndCharacterBuilder.svelte
@@ -4,35 +4,73 @@
   import * as Dice from '$lib/dice';
   import AdndCharacterSheet from '$components/characters/AdndCharacterSheet.svelte';
   import {
-    createAdndCharacter,
-    type ADNDCharacter,
-    assignExceptionalStrength,
-    getClassOptionsForRace,
-    getRaceOptions,
-    applyAdndPriestFundsCapIfNeeded,
+    ADND_CHARACTER_ARTIFACT_KIND,
+    ADND_THIEF_SKILL_BONUS_CAP,
+    adndBuildFromSnapshot,
+    adndCharacterAfterRace,
+    createAdndCharacterBuild,
+    adndCharacterFromSnapshot,
+    adndClassOptionsForBuild,
+    adndBuildWouldRederive,
+    adndRaceOptionsForBuild,
+    buildAdndCharacter,
+    downloadAdndCharacterPdf,
+    Equipment,
     finalizeAdndCharacterDerivedStats,
     getAdndLevel1HpBounds,
-    recalculateAdndArmorClass,
-    rollAdndLevel1Hp,
-    rollAdndStartingCopper,
-    Equipment,
-    applyHalflingWithOptions,
-    type HalflingSubrace,
-    applyThiefSkillAllocation,
-    ADND_THIEF_SKILL_BONUS_CAP,
+    getStartingSpellChoiceGroups,
     getThiefSkillBuildKindForClass,
     getThiefSkillPointPool,
     prepareThiefSkillRowsForCharacter,
+    recalculateAdndArmorClass,
+    rollAdndLevel1Hp,
+    rollAdndStartingCopper,
+    starterSpellSelectionIsComplete,
     sumThiefSkillBonuses,
     thiefSkillBonusesAreValid,
-    getStartingSpellChoiceGroups,
-    starterSpellSelectionIsComplete,
-    startingSpellsFromPicks,
-    downloadAdndCharacterPdf,
+    toAdndCharacterSnapshot,
     classes,
     races,
+    type AdndCharacterBuild,
+    type AdndCharacterSnapshot,
+    type HalflingSubrace,
   } from '$lib/adnd';
-  import type { ADNDClass, ADNDRace } from '$lib/adnd';
+
+  /**
+   * Optional props, present only when the builder is mounted as an artifact editor.
+   *
+   * Absent on its own route and in a workshop panel, where the builder composes a new character
+   * and saves it itself. Requirement 2.1 wants one component in both places, so the difference is
+   * two optional props rather than two components.
+   */
+  type Props = {
+    /** A saved character to open, seeding every control from it. */
+    editing?: AdndCharacterSnapshot;
+    /** Announces a replacement snapshot. Present only when `editing` is. */
+    onChange?: (snapshot: unknown) => void;
+  };
+
+  const { editing, onChange }: Props = $props();
+
+  const TOOL_PATH = '/fantasy/adnd/character/build';
+
+  /** The derived numbers the Details section lets a user correct. */
+  type AdndDerivedNumberField =
+    | 'level'
+    | 'xp'
+    | 'thaco'
+    | 'poisonSavingThrow'
+    | 'rodSavingThrow'
+    | 'petrificationSavingThrow'
+    | 'breathSavingThrow'
+    | 'spellSavingThrow'
+    | 'weightAllowance'
+    | 'maxPress'
+    | 'systemShock'
+    | 'resurrectionSurvival'
+    | 'maximumNumberOfHenchmen'
+    | 'numberOfLanguages';
+  import type { ADNDClass } from '$lib/adnd';
   import { Currency } from '$lib/currency';
   import { showsMaturityBadge, toolMaturityForPath } from '$lib/tools';
   import { showAlertModal } from '$lib/ui';
@@ -42,41 +80,78 @@
     rollCharacterNameForSource,
   } from '$lib/characters';
   import type { Culture } from '$lib/culture';
-  import { onMount } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import CharacterNameSection from '$components/characters/CharacterNameSection.svelte';
   import DownloadPdfButton from '$components/common/DownloadPdfButton.svelte';
   import ToolMaturityBadge from '$components/common/ToolMaturityBadge.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
 
   // The builder keeps its own header — the h1 shares a row with Reset — rather than mounting
   // `GeneratorPage`, so it states its maturity itself. The value still comes from the catalog.
   const maturity = toolMaturityForPath('/fantasy/adnd/character/build');
 
+  /**
+   * The derived block, as rows, so the markup is a loop rather than forty near-identical inputs.
+   *
+   * Not every derived field is here. The ones a table actually gets consulted about are — saving
+   * throws, THAC0, encumbrance, system shock — while the spell-progression numbers are omitted
+   * because they are read off the class and a level-1 character has nothing to correct in them.
+   */
+  const DERIVED_NUMBER_FIELDS: { field: AdndDerivedNumberField; label: string }[] = [
+    { field: 'thaco', label: 'THAC0' },
+    { field: 'poisonSavingThrow', label: 'Save: paralyzation / poison / death' },
+    { field: 'rodSavingThrow', label: 'Save: rod / staff / wand' },
+    { field: 'petrificationSavingThrow', label: 'Save: petrification / polymorph' },
+    { field: 'breathSavingThrow', label: 'Save: breath weapon' },
+    { field: 'spellSavingThrow', label: 'Save: spell' },
+    { field: 'weightAllowance', label: 'Weight allowance' },
+    { field: 'maxPress', label: 'Maximum press' },
+    { field: 'systemShock', label: 'System shock %' },
+    { field: 'resurrectionSurvival', label: 'Resurrection survival %' },
+    { field: 'maximumNumberOfHenchmen', label: 'Maximum henchmen' },
+    { field: 'numberOfLanguages', label: 'Number of languages' },
+  ];
+
   let rollRng = new RNG.RNG(Date.now().toString());
 
-  let str = $state(0);
-  let dex = $state(0);
-  let con = $state(0);
-  let int = $state(0);
-  let wis = $state(0);
-  let cha = $state(0);
+  /**
+   * The form, seeded from the artifact when there is one.
+   *
+   * `adndBuildFromSnapshot` is exact for everything the builder models, so opening a saved
+   * character and changing nothing produces the character that was stored — which is what stops an
+   * artifact being marked dirty the moment it is opened. The class-features seed it is handed is
+   * fresh, because the payload does not carry one and nothing is re-derived while the structure
+   * holds; it matters only if the user forces a re-derivation, and then fresh is right.
+   */
+  const initial = untrack(() => {
+    const seed = new RNG.RNG(Date.now().toString()).randomString(13);
+    return editing ? adndBuildFromSnapshot(editing, seed) : createAdndCharacterBuild(seed);
+  });
 
-  let raceName = $state('');
-  let className = $state('');
-  let alignment = $state('');
+  let str = $state(initial.attributes.strength);
+  let dex = $state(initial.attributes.dexterity);
+  let con = $state(initial.attributes.constitution);
+  let int = $state(initial.attributes.intelligence);
+  let wis = $state(initial.attributes.wisdom);
+  let cha = $state(initial.attributes.charisma);
 
-  let halflingSubrace = $state<HalflingSubrace>('Hairfeet');
-  let halflingInfravision = $state(false);
+  let raceName = $state(initial.raceName);
+  let className = $state(initial.className);
+  let alignment = $state(initial.alignment);
 
-  let hpValue = $state(1);
+  let halflingSubrace = $state<HalflingSubrace>(initial.halflingSubrace);
+  let halflingInfravision = $state(initial.halflingInfravision);
+
+  let hpValue = $state(initial.hp);
   let startingGp = $state(0);
   let startingSp = $state(0);
   let startingCp = $state(0);
 
-  let classFeaturesSeed = $state(rollRng.randomString(13));
-  let selectedWeaponNames = $state<string[]>([]);
-  let selectedArmorNames = $state<string[]>([]);
-  let starterSpellPicks = $state<string[][]>([]);
-  let thiefSkillBonuses = $state<Record<string, number>>({});
+  let classFeaturesSeed = $state(initial.classFeaturesSeed);
+  let selectedWeaponNames = $state<string[]>(initial.selectedWeaponNames);
+  let selectedArmorNames = $state<string[]>(initial.selectedArmorNames);
+  let starterSpellPicks = $state<string[][]>(initial.starterSpellPicks);
+  let thiefSkillBonuses = $state<Record<string, number>>(initial.thiefSkillPoints);
   let wasEquipmentOverBudget = $state(false);
   let downloadingPdf = $state(false);
 
@@ -108,72 +183,57 @@
   const allRaces = races.getAll();
   const allClasses = classes.getAll();
 
-  function makeBaseCharacter(): ADNDCharacter {
-    const c = createAdndCharacter();
-    c.strength = str;
-    c.dexterity = dex;
-    c.constitution = con;
-    c.intelligence = int;
-    c.wisdom = wis;
-    c.charisma = cha;
-    c.exceptionalStrength = -1;
-    c.abilities = [];
-    c.spells = [];
-    c.weapons = [];
-    c.armor = [];
-    return c;
-  }
+  /**
+   * The saved character being edited, or `null` when composing from nothing.
+   *
+   * `$state.raw` because it is a stored payload: it is replaced whole, never mutated in place, and
+   * a deep-reactive Proxy is what `structuredClone` refuses when the write reaches IndexedDB.
+   */
+  let base = $state.raw<AdndCharacterSnapshot | null>(initial.base);
 
-  const eligibleRaces = $derived.by(() => {
-    if (str < 1) return [] as ADNDRace[];
-    return getRaceOptions(makeBaseCharacter(), allRaces);
+  /**
+   * The form as the library's own type, assembled in one place.
+   *
+   * Every derivation below goes through `$lib/adnd` rather than being rebuilt here. That is what
+   * lets the same rules produce a character on this page, in a workshop panel, and in the artifact
+   * editor, and it is what made the fields testable without a browser.
+   */
+  const currentBuild = $derived<AdndCharacterBuild>({
+    base,
+    attributes: {
+      strength: str,
+      dexterity: dex,
+      constitution: con,
+      intelligence: int,
+      wisdom: wis,
+      charisma: cha,
+    },
+    raceName,
+    className,
+    alignment,
+    halflingSubrace,
+    halflingInfravision,
+    hp: hpValue,
+    startingWealthCp,
+    selectedWeaponNames,
+    selectedArmorNames,
+    starterSpellPicks,
+    thiefSkillPoints: thiefSkillBonuses,
+    classFeaturesSeed,
+    firstName,
+    lastName,
   });
+
+  const eligibleRaces = $derived(adndRaceOptionsForBuild(currentBuild));
 
   const selectedRace = $derived(allRaces.find((r) => r.name === raceName) ?? null);
 
-  const characterAfterRace = $derived.by(() => {
-    if (!selectedRace || str < 1) return null;
-    const c = makeBaseCharacter();
-    c.race = selectedRace;
-    if (selectedRace.name === 'halfling') {
-      applyHalflingWithOptions(c, {
-        subrace: halflingSubrace,
-        hasInfravision: halflingInfravision,
-      });
-    } else {
-      const r = new RNG.RNG(`race-${selectedRace.name}`);
-      selectedRace.apply(c, r);
-    }
-    return c;
-  });
+  const characterAfterRace = $derived(adndCharacterAfterRace(currentBuild));
 
-  const eligibleClasses = $derived.by(() => {
-    if (!characterAfterRace || !selectedRace) return [] as ADNDClass[];
-    return getClassOptionsForRace(characterAfterRace, selectedRace, allClasses);
-  });
+  const eligibleClasses = $derived(adndClassOptionsForBuild(currentBuild));
 
-  function applyClassFeaturesWithSeed(c: ADNDCharacter, cls: ADNDClass, seed: string): void {
-    const r = new RNG.RNG(seed);
-    cls.apply(c, r, { spells: 'user', thiefSkills: 'user' });
-    assignExceptionalStrength(c, cls, r);
-  }
-
-  function copyAfterRaceBody(src: ADNDCharacter): ADNDCharacter {
-    const c = createAdndCharacter();
-    c.strength = src.strength;
-    c.dexterity = src.dexterity;
-    c.constitution = src.constitution;
-    c.intelligence = src.intelligence;
-    c.wisdom = src.wisdom;
-    c.charisma = src.charisma;
-    c.exceptionalStrength = src.exceptionalStrength;
-    c.abilities = [...src.abilities];
-    c.race = src.race;
-    c.spells = [];
-    c.weapons = [];
-    c.armor = [];
-    return c;
-  }
+  /** True when applying the form to the saved character would throw work away (4.3). */
+  const wouldRederive = $derived(adndBuildWouldRederive(currentBuild));
 
   const selectedClass = $derived(allClasses.find((cl) => cl.name === className) ?? null);
 
@@ -229,13 +289,15 @@
     ),
   );
 
-  const characterForHpBounds = $derived.by(() => {
-    if (!characterAfterRace || !selectedClass) return null;
-    const c = copyAfterRaceBody(characterAfterRace);
-    c.class = selectedClass;
-    applyClassFeaturesWithSeed(c, selectedClass, classFeaturesSeed);
-    return c;
-  });
+  /**
+   * The character the hit-point range is read off.
+   *
+   * Built with the alignment forced, because hit dice do not depend on alignment and the form may
+   * not have one yet — the range has to be offerable before the last dropdown is answered.
+   */
+  const characterForHpBounds = $derived(
+    buildAdndCharacter({ ...currentBuild, alignment: alignment || 'true neutral' }),
+  );
 
   const hpBounds = $derived(
     characterForHpBounds ? getAdndLevel1HpBounds(characterForHpBounds) : { min: 1, max: 1 },
@@ -478,6 +540,14 @@
     );
   });
 
+  /**
+   * The character the form describes, or nothing while a required choice is still outstanding.
+   *
+   * The derivation itself lives in `$lib/adnd`; what stays here is only the question of whether
+   * the form is finished enough to show a character at all. `buildAdndCharacter` decides whether
+   * that means deriving from scratch or writing these fields over a saved character — see
+   * `adnd_character_build.ts`, where the difference is the whole design.
+   */
   const previewCharacter = $derived.by(() => {
     if (!characterAfterRace || !selectedClass || !alignment || str < 1) return undefined;
     if (
@@ -489,48 +559,101 @@
     if (thiefSkillKind && !thiefSkillAllocationComplete) {
       return undefined;
     }
-
-    const c = copyAfterRaceBody(characterAfterRace);
-    c.class = selectedClass;
-    applyClassFeaturesWithSeed(c, selectedClass, classFeaturesSeed);
-    c.alignment = alignment;
-
-    if (selectedClass.hasSpells) {
-      c.spells = startingSpellsFromPicks(selectedClass, starterSpellPicks);
-    }
-
-    if (thiefSkillKind) {
-      applyThiefSkillAllocation(c, thiefSkillKind, thiefSkillBonuses);
-    }
-
-    const hp = Math.min(Math.max(hpValue, hpBounds.min), hpBounds.max);
-    c.hp = hp;
-
-    c.weapons = [];
-    c.armor = [];
-    for (const n of selectedWeaponNames) {
-      const w = Equipment.getWeapons().find((x) => x.name === n);
-      if (w) c.weapons.push(w);
-    }
-    for (const n of selectedArmorNames) {
-      const ar = Equipment.getArmor().find((x) => x.name === n);
-      if (ar) c.armor.push(ar);
-    }
-
-    const spent = equipmentSpend;
-    const purse = Math.max(0, startingWealthCp - spent);
-    c.currency = purse;
-    const purseRng = new RNG.RNG(
-      `priest-purse-${classFeaturesSeed}-${startingWealthCp}-${spent}-${purse}`,
-    );
-    applyAdndPriestFundsCapIfNeeded(c, purseRng);
-
-    finalizeAdndCharacterDerivedStats(c);
-    recalculateAdndArmorClass(c);
-    c.firstName = firstName;
-    c.lastName = lastName;
-    return c;
+    return buildAdndCharacter(currentBuild) ?? undefined;
   });
+
+  const previewSnapshot = $derived(
+    previewCharacter === undefined ? null : toAdndCharacterSnapshot(previewCharacter),
+  );
+
+  /**
+   * Tell the surrounding artifact surface what the form now describes.
+   *
+   * Only when mounted as an editor; on its own route there is nobody to tell, and the builder
+   * saves for itself. Announcing a snapshot identical to the stored one is harmless — the
+   * framework's dirty check is `sameSnapshot`, a value comparison — so this does not need to know
+   * whether the user has actually changed anything, which is just as well, because the answer is
+   * spread across every control on the page.
+   */
+  $effect(() => {
+    const snapshot = previewSnapshot;
+    if (onChange !== undefined && snapshot !== null) {
+      onChange(snapshot);
+    }
+  });
+
+  /**
+   * Apply one edit to a field the form does not otherwise own — a derived stat, a proficiency, the
+   * kit.
+   *
+   * It works by making the character on screen the new `base` and changing it there, which has a
+   * consequence worth stating: the first Details edit turns a composed character into an edited
+   * payload. From then on the payload is authoritative and the rules stop being recomputed
+   * underneath it, which is requirement 4.2 and is what the user asked for by typing a number into
+   * a derived field.
+   */
+  function editDetail(mutate: (snapshot: AdndCharacterSnapshot) => AdndCharacterSnapshot): void {
+    if (previewSnapshot === null) return;
+    base = mutate(previewSnapshot);
+  }
+
+  function setDerivedNumber(field: AdndDerivedNumberField, raw: unknown): void {
+    const value = Math.trunc(Number(raw));
+    if (!Number.isFinite(value)) return;
+    editDetail((snapshot) => ({ ...snapshot, [field]: value }));
+  }
+
+  function setStringList(field: 'weaponProficiencyGroups' | 'nonweaponProficiencies', raw: string) {
+    const entries = raw
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry !== '');
+    editDetail((snapshot) => ({ ...snapshot, [field]: entries }));
+  }
+
+  function setAbilities(raw: string) {
+    const lines = raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line !== '');
+    editDetail((snapshot) => ({ ...snapshot, abilities: lines }));
+  }
+
+  function setKitName(raw: string) {
+    const name = raw.trim();
+    editDetail((snapshot) => ({
+      ...snapshot,
+      kit: name === '' ? null : { name, features: snapshot.kit?.features ?? [] },
+    }));
+  }
+
+  function setKitFeatures(raw: string) {
+    const features = raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line !== '');
+    editDetail((snapshot) =>
+      snapshot.kit === null ? snapshot : { ...snapshot, kit: { ...snapshot.kit, features } },
+    );
+  }
+
+  /**
+   * Recompute the derived block from race, class, and attributes — the command that used to be
+   * automatic.
+   *
+   * Demoting it to a button is the point. While a character is only ever composed, recomputing on
+   * every keystroke is right; once it can be saved and corrected, the same behaviour would undo
+   * the correction the moment anything else changed. So it stays available and becomes explicit,
+   * and it says plainly that it overwrites.
+   */
+  function recalculateDerivedStats(): void {
+    const cls = selectedClass;
+    if (previewSnapshot === null || cls === null) return;
+    const recomputed = adndCharacterFromSnapshot(previewSnapshot);
+    finalizeAdndCharacterDerivedStats(recomputed);
+    recalculateAdndArmorClass(recomputed);
+    base = toAdndCharacterSnapshot(recomputed);
+  }
 
   function rollNamesForCurrentSource(defaultHint: string) {
     const source = buildCharacterNameSource(
@@ -584,6 +707,14 @@
     <h1>AD&D 2e Character Builder</h1>
     <button type="button" onclick={resetBuilderForm}>Reset</button>
   </header>
+
+  {#if wouldRederive}
+    <p class="builder-rederive-warning" role="status">
+      <strong>This will re-roll the character.</strong> Changing race, class, or an attribute means everything
+      that follows from them — proficiencies, the kit, exceptional strength, and the derived numbers —
+      is worked out afresh. Edits to those will be lost.
+    </p>
+  {/if}
 
   {#if showsMaturityBadge(maturity)}
     <p class="builder-maturity">
@@ -861,6 +992,107 @@
       <div class="builder-result">
         <h2>Character</h2>
         <DownloadPdfButton onclick={downloadPdf} downloading={downloadingPdf} />
+
+        <SaveArtifactButton
+          kind={ADND_CHARACTER_ARTIFACT_KIND}
+          toolPath={TOOL_PATH}
+          snapshot={previewSnapshot}
+          defaultName={`${firstName} ${lastName}`.trim()}
+        />
+
+        <details class="builder-details">
+          <summary>Details</summary>
+
+          <p class="builder-details-note">
+            Everything below is stored exactly as you leave it. Changing a value here makes this
+            character's own numbers authoritative, so the rules stop being recalculated underneath
+            them.
+          </p>
+
+          <h3>Experience</h3>
+          <div class="builder-detail-grid">
+            {#each [{ field: 'level', label: 'Level' }, { field: 'xp', label: 'XP' }] as row}
+              <label>
+                {row.label}
+                <input
+                  type="number"
+                  value={previewCharacter[row.field as 'level' | 'xp']}
+                  onchange={(e) =>
+                    setDerivedNumber(row.field as AdndDerivedNumberField, e.currentTarget.value)}
+                />
+              </label>
+            {/each}
+          </div>
+
+          <h3>Proficiencies</h3>
+          <label>
+            Weapon proficiency groups (comma separated)
+            <input
+              type="text"
+              value={previewCharacter.weaponProficiencyGroups.join(', ')}
+              onchange={(e) => setStringList('weaponProficiencyGroups', e.currentTarget.value)}
+            />
+          </label>
+          <label>
+            Nonweapon proficiencies (comma separated)
+            <input
+              type="text"
+              value={previewCharacter.nonweaponProficiencies.join(', ')}
+              onchange={(e) => setStringList('nonweaponProficiencies', e.currentTarget.value)}
+            />
+          </label>
+
+          <h3>Kit</h3>
+          <label>
+            Kit name (blank for none)
+            <input
+              type="text"
+              value={previewCharacter.kit?.name ?? ''}
+              onchange={(e) => setKitName(e.currentTarget.value)}
+            />
+          </label>
+          {#if previewCharacter.kit}
+            <label>
+              Kit features, one per line
+              <textarea
+                rows="4"
+                value={previewCharacter.kit.features.join('\n')}
+                onchange={(e) => setKitFeatures(e.currentTarget.value)}
+              ></textarea>
+            </label>
+          {/if}
+
+          <h3>Abilities</h3>
+          <label>
+            One per line
+            <textarea
+              rows="6"
+              value={previewCharacter.abilities.join('\n')}
+              onchange={(e) => setAbilities(e.currentTarget.value)}
+            ></textarea>
+          </label>
+
+          <h3>Derived stats</h3>
+          <p>
+            <button type="button" onclick={recalculateDerivedStats}>
+              Recalculate from race, class, and attributes
+            </button>
+            <span class="builder-details-note">This overwrites every value below.</span>
+          </p>
+          <div class="builder-detail-grid">
+            {#each DERIVED_NUMBER_FIELDS as row}
+              <label>
+                {row.label}
+                <input
+                  type="number"
+                  value={previewCharacter[row.field]}
+                  onchange={(e) => setDerivedNumber(row.field, e.currentTarget.value)}
+                />
+              </label>
+            {/each}
+          </div>
+        </details>
+
         <AdndCharacterSheet character={previewCharacter} />
       </div>
     {:else if spellPreviewIncomplete}

--- a/src/lib/adnd/adnd_character_build.test.ts
+++ b/src/lib/adnd/adnd_character_build.test.ts
@@ -1,0 +1,301 @@
+import { RNG } from '@ironarachne/rng';
+import { describe, expect, it } from 'vitest';
+
+import {
+  adndBuildFromSnapshot,
+  adndBuildMatchesBase,
+  adndBuildWouldRederive,
+  adndClassOptionsForBuild,
+  adndRaceOptionsForBuild,
+  buildAdndCharacter,
+  createAdndCharacterBuild,
+  type AdndCharacterBuild,
+} from './adnd_character_build.js';
+import { rollAdndCharacter } from './adnd_character_roll.js';
+import { toAdndCharacterSnapshot } from './adnd_character_snapshot.js';
+import type { AdndCharacterSnapshot } from './adnd_character_snapshot.js';
+
+/** A generated character of a given shape, as a snapshot ready to be edited. */
+function generatedSnapshot(
+  predicate: (snapshot: AdndCharacterSnapshot) => boolean = () => true,
+  config: { includeProficiencies?: boolean; includeKits?: boolean } = {},
+): AdndCharacterSnapshot {
+  for (let seed = 0; seed < 400; seed += 1) {
+    const snapshot = toAdndCharacterSnapshot(rollAdndCharacter(`build-${seed}`, config).character);
+    if (predicate(snapshot)) {
+      return snapshot;
+    }
+  }
+  throw new Error('no seed produced a matching character');
+}
+
+function composedBuild(): AdndCharacterBuild {
+  const build = createAdndCharacterBuild('feature-seed');
+  build.attributes = {
+    strength: 14,
+    dexterity: 15,
+    constitution: 13,
+    intelligence: 12,
+    wisdom: 11,
+    charisma: 10,
+  };
+  build.raceName = 'human';
+  build.className = 'thief';
+  build.alignment = 'neutral good';
+  build.hp = 5;
+  build.startingWealthCp = 5000;
+  build.thiefSkillPoints = {
+    'Pick Pockets': 30,
+    'Open Locks': 30,
+    'Find/Remove Traps': 0,
+    'Move Silently': 0,
+    'Hide in Shadows': 0,
+    'Detect Noise': 0,
+    'Climb Walls': 0,
+    'Read Languages': 0,
+  };
+  return build;
+}
+
+describe('buildAdndCharacter, composing from nothing', () => {
+  it('derives a character from the form alone', () => {
+    const character = buildAdndCharacter(composedBuild());
+
+    expect(character).not.toBeNull();
+    expect(character?.race.name).toBe('human');
+    expect(character?.class.name).toBe('thief');
+    expect(character?.hp).toBe(5);
+  });
+
+  it('is null until the form says enough to make a character', () => {
+    expect(buildAdndCharacter(createAdndCharacterBuild('seed'))).toBeNull();
+
+    const noAlignment = composedBuild();
+    noAlignment.alignment = '';
+    expect(buildAdndCharacter(noAlignment)).toBeNull();
+  });
+
+  it('carries the user allocation onto the character', () => {
+    const character = buildAdndCharacter(composedBuild());
+
+    const pickPockets = character?.thiefSkills.find((row) => row.name === 'Pick Pockets');
+    expect(pickPockets?.points).toBe(30);
+  });
+
+  it('derives the same character twice from the same build', () => {
+    expect(buildAdndCharacter(composedBuild())).toEqual(buildAdndCharacter(composedBuild()));
+  });
+
+  it('leaves the purse as funds minus what the gear cost', () => {
+    const build = composedBuild();
+    build.selectedWeaponNames = ['dagger'];
+
+    const character = buildAdndCharacter(build);
+
+    expect(character?.currency).toBeLessThan(5000);
+    expect(character?.weapons.map((weapon) => weapon.name)).toEqual(['dagger']);
+  });
+});
+
+describe('buildAdndCharacter, editing a saved character', () => {
+  it('keeps what the builder does not model', () => {
+    // The whole reason `base` exists. A generated character carries rolled proficiencies and a
+    // kit that no form field represents; deriving on open would discard them silently, which is
+    // requirement 4.2 failing before the user has touched anything.
+    const snapshot = generatedSnapshot(
+      (s) => s.weaponProficiencyGroups.length > 0 && s.kit !== null,
+      { includeProficiencies: true, includeKits: true },
+    );
+    const build = adndBuildFromSnapshot(snapshot, 'fresh-seed');
+
+    const character = buildAdndCharacter(build);
+
+    expect(character?.weaponProficiencyGroups).toEqual(snapshot.weaponProficiencyGroups);
+    expect(character?.nonweaponProficiencies).toEqual(snapshot.nonweaponProficiencies);
+    expect(character?.kit).toEqual(snapshot.kit);
+  });
+
+  it('keeps hand-edited derived numbers rather than recomputing them', () => {
+    const snapshot = generatedSnapshot();
+    snapshot.thaco = 4;
+    snapshot.poisonSavingThrow = 2;
+    snapshot.systemShock = 99;
+    const build = adndBuildFromSnapshot(snapshot, 'fresh-seed');
+
+    const character = buildAdndCharacter(build);
+
+    expect(character?.thaco).toBe(4);
+    expect(character?.poisonSavingThrow).toBe(2);
+    expect(character?.systemShock).toBe(99);
+  });
+
+  it('opens without changing anything', () => {
+    // Reading a character in and building it straight back out must be the identity, or opening
+    // an artifact would mark it dirty before the user did anything.
+    const snapshot = generatedSnapshot((s) => s.thiefSkills.length > 0);
+    const build = adndBuildFromSnapshot(snapshot, 'fresh-seed');
+
+    const rebuilt = buildAdndCharacter(build);
+
+    expect(toAdndCharacterSnapshot(rebuilt!)).toEqual(snapshot);
+  });
+
+  it('applies an edit to a field the builder does own', () => {
+    const snapshot = generatedSnapshot();
+    const build = adndBuildFromSnapshot(snapshot, 'fresh-seed');
+    build.firstName = 'Aldric';
+    build.hp = 9;
+
+    const character = buildAdndCharacter(build);
+
+    expect(character?.firstName).toBe('Aldric');
+    expect(character?.hp).toBe(9);
+    // and still keeps everything else
+    expect(character?.thaco).toBe(snapshot.thaco);
+  });
+
+  it('re-derives once a structural field changes', () => {
+    const snapshot = generatedSnapshot(
+      (s) => s.weaponProficiencyGroups.length > 0 && s.raceName === 'human',
+      { includeProficiencies: true },
+    );
+    const build = adndBuildFromSnapshot(snapshot, 'fresh-seed');
+    build.className = 'fighter';
+    build.alignment = 'true neutral';
+
+    const character = buildAdndCharacter(build);
+
+    // Deriving is destructive by nature, and that is what `adndBuildWouldRederive` warns about.
+    expect(character?.class.name).toBe('fighter');
+    expect(character?.weaponProficiencyGroups).toEqual([]);
+  });
+});
+
+describe('adndBuildMatchesBase', () => {
+  it('is false with no base, because there is nothing to match', () => {
+    expect(adndBuildMatchesBase(composedBuild())).toBe(false);
+    expect(adndBuildWouldRederive(composedBuild())).toBe(false);
+  });
+
+  it('is true for a build read straight from a snapshot', () => {
+    const build = adndBuildFromSnapshot(generatedSnapshot(), 'seed');
+
+    expect(adndBuildMatchesBase(build)).toBe(true);
+    expect(adndBuildWouldRederive(build)).toBe(false);
+  });
+
+  it.each([
+    ['race', (b: AdndCharacterBuild) => (b.raceName = 'dwarf')],
+    ['class', (b: AdndCharacterBuild) => (b.className = 'fighter')],
+    ['an attribute', (b: AdndCharacterBuild) => (b.attributes.strength += 1)],
+  ])('reports a change of %s as structural', (_label, mutate) => {
+    const build = adndBuildFromSnapshot(generatedSnapshot(), 'seed');
+    mutate(build);
+
+    expect(adndBuildMatchesBase(build)).toBe(false);
+    expect(adndBuildWouldRederive(build)).toBe(true);
+  });
+
+  it.each([
+    ['hit points', (b: AdndCharacterBuild) => (b.hp = 12)],
+    ['a name', (b: AdndCharacterBuild) => (b.firstName = 'Aldric')],
+    ['alignment', (b: AdndCharacterBuild) => (b.alignment = 'chaotic evil')],
+    ['funds', (b: AdndCharacterBuild) => (b.startingWealthCp = 999)],
+  ])('does not report a change of %s as structural', (_label, mutate) => {
+    const build = adndBuildFromSnapshot(generatedSnapshot(), 'seed');
+    mutate(build);
+
+    expect(adndBuildMatchesBase(build)).toBe(true);
+    expect(adndBuildWouldRederive(build)).toBe(false);
+  });
+});
+
+describe('adndBuildFromSnapshot', () => {
+  it('recovers starting funds as the purse plus what the gear cost', () => {
+    const snapshot = generatedSnapshot((s) => s.weapons.length > 0);
+    const spent = [...snapshot.weapons, ...snapshot.armor].reduce((sum, i) => sum + i.cost, 0);
+
+    const build = adndBuildFromSnapshot(snapshot, 'seed');
+
+    expect(build.startingWealthCp).toBe(snapshot.currency + spent);
+  });
+
+  it('recovers the thief allocation exactly', () => {
+    const snapshot = generatedSnapshot((s) => s.thiefSkills.length > 0);
+
+    const build = adndBuildFromSnapshot(snapshot, 'seed');
+
+    for (const row of snapshot.thiefSkills) {
+      expect(build.thiefSkillPoints[row.name]).toBe(row.points);
+    }
+  });
+
+  it('takes the class features seed from the caller, not the payload', () => {
+    expect(adndBuildFromSnapshot(generatedSnapshot(), 'given-seed').classFeaturesSeed).toBe(
+      'given-seed',
+    );
+  });
+});
+
+describe('the options a build offers', () => {
+  it('offers no races until attributes are rolled', () => {
+    expect(adndRaceOptionsForBuild(createAdndCharacterBuild('seed'))).toEqual([]);
+  });
+
+  it('offers races the attributes qualify for', () => {
+    const names = adndRaceOptionsForBuild(composedBuild()).map((race) => race.name);
+
+    expect(names).toContain('human');
+  });
+
+  it('offers only classes the race allows', () => {
+    const build = composedBuild();
+    build.raceName = 'dwarf';
+
+    const names = adndClassOptionsForBuild(build).map((cls) => cls.name);
+
+    expect(names.length).toBeGreaterThan(0);
+    expect(names).not.toContain('bard');
+  });
+
+  it('offers no classes before a race is chosen', () => {
+    const build = composedBuild();
+    build.raceName = '';
+
+    expect(adndClassOptionsForBuild(build)).toEqual([]);
+  });
+});
+
+describe('a placeholder class from a build this build does not know', () => {
+  it('does not derive from a rule it cannot describe', () => {
+    // An inert placeholder has no `apply` worth running and no alignments to offer. Patching is
+    // safe because it touches only the fields the builder owns; deriving would produce a
+    // character built from an empty rule.
+    const snapshot = generatedSnapshot();
+    snapshot.className = 'bladesinger';
+    const build = adndBuildFromSnapshot(snapshot, 'seed');
+
+    const patched = buildAdndCharacter(build);
+
+    expect(patched?.class.name).toBe('bladesinger');
+    expect(patched?.thaco).toBe(snapshot.thaco);
+
+    build.className = 'also-not-real';
+    expect(buildAdndCharacter(build)).toBeNull();
+  });
+});
+
+describe('createAdndCharacterBuild', () => {
+  it('starts with no base, which is what composing from nothing means', () => {
+    const build = createAdndCharacterBuild('seed');
+
+    expect(build.base).toBeNull();
+    expect(build.classFeaturesSeed).toBe('seed');
+  });
+
+  it('is not affected by an RNG, being a plain record', () => {
+    const rng = new RNG('unused');
+    expect(rng).toBeDefined();
+    expect(createAdndCharacterBuild('a')).toEqual(createAdndCharacterBuild('a'));
+  });
+});

--- a/src/lib/adnd/adnd_character_build.ts
+++ b/src/lib/adnd/adnd_character_build.ts
@@ -1,0 +1,385 @@
+/**
+ * The builder's decisions as data, and the pure function that turns them into a character.
+ *
+ * This is what lets the builder edit a *saved* character rather than only compose a new one, and
+ * the whole of it turns on one field: `base`.
+ *
+ * Without a base, `buildAdndCharacter` derives a character from scratch, which is what the builder
+ * has always done. With one, deriving is exactly the wrong move — a generated character carries
+ * rolled proficiencies, a kit, and an exceptional strength score that no form field represents,
+ * and re-deriving on open would discard all of them before the user touched anything. That is
+ * requirement 4.2 failing at the moment the artifact is opened.
+ *
+ * So with a base whose structure still matches, the character *is* the base with the fields the
+ * builder owns written over it. Nothing the builder does not model is touched. Change a
+ * structural field — race, class, or an attribute — and there is no honest way to patch, because
+ * everything downstream of a class comes from that class; then it derives, and the surface is
+ * expected to have confirmed that as destructive first (4.3).
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import {
+  assignExceptionalStrength,
+  getClassOptionsForRace,
+  getRaceOptions,
+} from './adnd_character_eligibility.js';
+import {
+  adndCharacterFromSnapshot,
+  type AdndCharacterSnapshot,
+} from './adnd_character_snapshot.js';
+import {
+  applyThiefSkillAllocation,
+  getThiefSkillBuildKindForClass,
+} from './adnd_thief_skill_builder.js';
+import { startingSpellsFromPicks } from './adnd_class_starting_spells.js';
+import type ADNDCharacter from './adndcharacter.js';
+import { createAdndCharacter } from './adndcharacter.js';
+import {
+  applyAdndPriestFundsCapIfNeeded,
+  finalizeAdndCharacterDerivedStats,
+  recalculateAdndArmorClass,
+} from './adndcharactergenerator.js';
+import type ADNDClass from './adndclass.js';
+import type ADNDRace from './adndrace.js';
+import * as classes from './classes/classes.js';
+import * as Equipment from './equipment.js';
+import * as races from './races/races.js';
+import { applyHalflingWithOptions, type HalflingSubrace } from './races/halfling_apply.js';
+
+/** The six attributes, which together with race and class make up a build's structure. */
+export type AdndAttributeScores = {
+  strength: number;
+  dexterity: number;
+  constitution: number;
+  intelligence: number;
+  wisdom: number;
+  charisma: number;
+};
+
+/**
+ * Everything the builder's form holds.
+ *
+ * `base` is the character being edited, or `null` when composing from nothing — which is how the
+ * builder is reached from its own route with no artifact open.
+ */
+export type AdndCharacterBuild = {
+  base: AdndCharacterSnapshot | null;
+  attributes: AdndAttributeScores;
+  raceName: string;
+  className: string;
+  alignment: string;
+  halflingSubrace: HalflingSubrace;
+  halflingInfravision: boolean;
+  hp: number;
+  startingWealthCp: number;
+  selectedWeaponNames: string[];
+  selectedArmorNames: string[];
+  starterSpellPicks: string[][];
+  thiefSkillPoints: Record<string, number>;
+  classFeaturesSeed: string;
+  firstName: string;
+  lastName: string;
+};
+
+/** An empty build, for the builder opening on nothing. */
+export function createAdndCharacterBuild(classFeaturesSeed: string): AdndCharacterBuild {
+  return {
+    base: null,
+    attributes: {
+      strength: 0,
+      dexterity: 0,
+      constitution: 0,
+      intelligence: 0,
+      wisdom: 0,
+      charisma: 0,
+    },
+    raceName: '',
+    className: '',
+    alignment: '',
+    halflingSubrace: 'Hairfeet',
+    halflingInfravision: false,
+    hp: 1,
+    startingWealthCp: 0,
+    selectedWeaponNames: [],
+    selectedArmorNames: [],
+    starterSpellPicks: [],
+    thiefSkillPoints: {},
+    classFeaturesSeed,
+    firstName: '',
+    lastName: '',
+  };
+}
+
+function attributesOf(character: {
+  strength: number;
+  dexterity: number;
+  constitution: number;
+  intelligence: number;
+  wisdom: number;
+  charisma: number;
+}): AdndAttributeScores {
+  return {
+    strength: character.strength,
+    dexterity: character.dexterity,
+    constitution: character.constitution,
+    intelligence: character.intelligence,
+    wisdom: character.wisdom,
+    charisma: character.charisma,
+  };
+}
+
+/**
+ * Whether the build still describes the same character the base is.
+ *
+ * Only race, class, and the six attributes count. Everything else the builder offers — hit points,
+ * funds, gear, spells, the thief allocation, names — is a field it writes over the base, so
+ * changing one is an edit rather than a different character. These three are different: a class
+ * decides hit dice, saving throws, proficiency counts, and what `apply` puts on the character, so
+ * a new one cannot be patched in, only rolled for.
+ *
+ * A build with no base is not "unchanged"; there is nothing for it to match.
+ */
+export function adndBuildMatchesBase(build: AdndCharacterBuild): boolean {
+  if (build.base === null) {
+    return false;
+  }
+  const baseAttributes = attributesOf(build.base);
+  const buildAttributes = build.attributes;
+  return (
+    build.base.raceName === build.raceName &&
+    build.base.className === build.className &&
+    baseAttributes.strength === buildAttributes.strength &&
+    baseAttributes.dexterity === buildAttributes.dexterity &&
+    baseAttributes.constitution === buildAttributes.constitution &&
+    baseAttributes.intelligence === buildAttributes.intelligence &&
+    baseAttributes.wisdom === buildAttributes.wisdom &&
+    baseAttributes.charisma === buildAttributes.charisma
+  );
+}
+
+/**
+ * Whether applying this build to its base would throw work away.
+ *
+ * What the surface asks the user before letting a structural change through (4.3). It is false
+ * when there is no base, because composing from nothing destroys nothing.
+ */
+export function adndBuildWouldRederive(build: AdndCharacterBuild): boolean {
+  return build.base !== null && !adndBuildMatchesBase(build);
+}
+
+export function findAdndRace(name: string): ADNDRace | null {
+  return races.getAll().find((race) => race.name === name) ?? null;
+}
+
+export function findAdndClass(name: string): ADNDClass | null {
+  return classes.getAll().find((entry) => entry.name === name) ?? null;
+}
+
+function baseCharacterFromAttributes(attributes: AdndAttributeScores): ADNDCharacter {
+  const character = createAdndCharacter();
+  character.strength = attributes.strength;
+  character.dexterity = attributes.dexterity;
+  character.constitution = attributes.constitution;
+  character.intelligence = attributes.intelligence;
+  character.wisdom = attributes.wisdom;
+  character.charisma = attributes.charisma;
+  return character;
+}
+
+/** The races these attributes qualify for, for the control that offers them. */
+export function adndRaceOptionsForBuild(build: AdndCharacterBuild): ADNDRace[] {
+  if (build.attributes.strength < 1) {
+    return [];
+  }
+  return getRaceOptions(baseCharacterFromAttributes(build.attributes), races.getAll());
+}
+
+/**
+ * The character with its race applied and nothing else — the stage class eligibility is judged at.
+ *
+ * The race is applied from a seed derived from its own name rather than from the build's, so that
+ * choosing a race twice gives the same racial adjustments. A race's `apply` is mostly deterministic
+ * anyway; the fixed seed is what makes "mostly" not matter.
+ */
+export function adndCharacterAfterRace(build: AdndCharacterBuild): ADNDCharacter | null {
+  const race = findAdndRace(build.raceName);
+  if (race === null || build.attributes.strength < 1) {
+    return null;
+  }
+  const character = baseCharacterFromAttributes(build.attributes);
+  character.race = race;
+  if (race.name === 'halfling') {
+    applyHalflingWithOptions(character, {
+      subrace: build.halflingSubrace,
+      hasInfravision: build.halflingInfravision,
+    });
+  } else {
+    race.apply(character, new RNG(`race-${race.name}`));
+  }
+  return character;
+}
+
+/** The classes this build's race and attributes allow, for the control that offers them. */
+export function adndClassOptionsForBuild(build: AdndCharacterBuild): ADNDClass[] {
+  const afterRace = adndCharacterAfterRace(build);
+  const race = findAdndRace(build.raceName);
+  if (afterRace === null || race === null) {
+    return [];
+  }
+  return getClassOptionsForRace(afterRace, race, classes.getAll());
+}
+
+function itemsByName<T extends { name: string }>(names: string[], available: T[]): T[] {
+  const found: T[] = [];
+  for (const name of names) {
+    const item = available.find((entry) => entry.name === name);
+    if (item !== undefined) {
+      found.push(item);
+    }
+  }
+  return found;
+}
+
+/**
+ * The fields the builder owns, written onto a character that already exists.
+ *
+ * Deliberately a short list, and the shortness is the point: what is not here is what survives
+ * editing a generated character — proficiencies, the kit, the ability lines, exceptional strength,
+ * and every derived number the payload carries.
+ */
+function applyBuildFields(character: ADNDCharacter, build: AdndCharacterBuild): void {
+  const cls = character.class;
+  character.alignment = build.alignment;
+  character.firstName = build.firstName;
+  character.lastName = build.lastName;
+  character.hp = build.hp;
+
+  if (cls.hasSpells) {
+    character.spells = startingSpellsFromPicks(cls, build.starterSpellPicks);
+  }
+
+  const thiefSkillKind = getThiefSkillBuildKindForClass(cls.name);
+  if (thiefSkillKind !== null) {
+    applyThiefSkillAllocation(character, thiefSkillKind, build.thiefSkillPoints);
+  }
+
+  character.weapons = itemsByName(build.selectedWeaponNames, Equipment.getWeapons());
+  character.armor = itemsByName(build.selectedArmorNames, Equipment.getArmor());
+
+  const spent = [...character.weapons, ...character.armor].reduce(
+    (total, item) => total + item.cost,
+    0,
+  );
+  const purse = Math.max(0, build.startingWealthCp - spent);
+  character.currency = purse;
+  applyAdndPriestFundsCapIfNeeded(
+    character,
+    new RNG(`priest-purse-${build.classFeaturesSeed}-${build.startingWealthCp}-${spent}-${purse}`),
+  );
+
+  recalculateAdndArmorClass(character);
+}
+
+/**
+ * Derive a character from the build alone, as the builder has always done.
+ *
+ * Class features are applied with `spells: 'user'` and `thiefSkills: 'user'`, so the class rolls
+ * nothing the user is about to choose, and from a seed the build carries so that the parts it
+ * *does* roll — exceptional strength among them — come back the same on every keystroke.
+ */
+function deriveAdndCharacter(build: AdndCharacterBuild): ADNDCharacter | null {
+  const afterRace = adndCharacterAfterRace(build);
+  const cls = findAdndClass(build.className);
+  if (afterRace === null || cls === null || build.alignment === '') {
+    return null;
+  }
+
+  const character = afterRace;
+  character.class = cls;
+  const featureRng = new RNG(build.classFeaturesSeed);
+  cls.apply(character, featureRng, { spells: 'user', thiefSkills: 'user' });
+  assignExceptionalStrength(character, cls, featureRng);
+
+  applyBuildFields(character, build);
+  finalizeAdndCharacterDerivedStats(character);
+  recalculateAdndArmorClass(character);
+  return character;
+}
+
+/**
+ * Write the build's fields over the character it is editing, leaving everything else alone.
+ *
+ * `finalizeAdndCharacterDerivedStats` is deliberately **not** called here. On this path the
+ * payload is authoritative: a saved character's THAC0 and saving throws are what it was stored
+ * with, hand-edited or not, and recomputing them on every keystroke is exactly the silent
+ * regeneration requirement 4.2 forbids. Armor class is the one exception, because the builder
+ * owns the armor list and an AC that disagreed with the armor beside it would be a bug the user
+ * can see.
+ */
+function patchAdndCharacter(build: AdndCharacterBuild, base: AdndCharacterSnapshot): ADNDCharacter {
+  const character = adndCharacterFromSnapshot(base);
+  applyBuildFields(character, build);
+  return character;
+}
+
+/**
+ * The character this build describes, or `null` when it is not finished enough to be one.
+ *
+ * The two paths are the whole design; see the module comment.
+ */
+export function buildAdndCharacter(build: AdndCharacterBuild): ADNDCharacter | null {
+  if (build.base !== null && adndBuildMatchesBase(build)) {
+    return patchAdndCharacter(build, build.base);
+  }
+  return deriveAdndCharacter(build);
+}
+
+/**
+ * A saved character back into the builder's form.
+ *
+ * Exact for everything the builder models, because the character carries it: attributes, race and
+ * class names, alignment, gear by name, the thief allocation now that it is a field, and the
+ * names. Two things are reconstructed rather than read:
+ *
+ * - **Starting funds** are the purse plus what the stored gear cost, which is what the user
+ *   originally had to spend.
+ * - **`classFeaturesSeed`** is not in the payload and does not need to be: nothing is re-derived
+ *   while the structure holds, and the moment the user forces a structural change a fresh seed is
+ *   the right answer anyway. The caller supplies one.
+ *
+ * The halfling options are the honest gap. A stored halfling records the subrace's effects but not
+ * which subrace was chosen, so this defaults them; they are only read again if the user re-derives,
+ * which already discards more than that.
+ */
+export function adndBuildFromSnapshot(
+  snapshot: AdndCharacterSnapshot,
+  classFeaturesSeed: string,
+): AdndCharacterBuild {
+  const spent = [...snapshot.weapons, ...snapshot.armor].reduce(
+    (total, item) => total + item.cost,
+    0,
+  );
+  const cls = findAdndClass(snapshot.className);
+  const spellPicks =
+    cls !== null && cls.hasSpells ? [snapshot.spells.map((spell) => spell.name)] : [];
+
+  return {
+    base: snapshot,
+    attributes: attributesOf(snapshot),
+    raceName: snapshot.raceName,
+    className: snapshot.className,
+    alignment: snapshot.alignment,
+    halflingSubrace: 'Hairfeet',
+    halflingInfravision: false,
+    hp: snapshot.hp,
+    startingWealthCp: snapshot.currency + spent,
+    selectedWeaponNames: snapshot.weapons.map((weapon) => weapon.name),
+    selectedArmorNames: snapshot.armor.map((armor) => armor.name),
+    starterSpellPicks: spellPicks,
+    thiefSkillPoints: Object.fromEntries(snapshot.thiefSkills.map((row) => [row.name, row.points])),
+    classFeaturesSeed,
+    firstName: snapshot.firstName,
+    lastName: snapshot.lastName,
+  };
+}

--- a/src/lib/adnd/index.ts
+++ b/src/lib/adnd/index.ts
@@ -10,6 +10,7 @@ export { createAdndCharacter } from './adndcharacter';
 export { getDefaultConfig } from './adndcharactergeneratorconfig';
 export * from './adndcharactergenerator';
 export * from './adnd_character_artifact_kind';
+export * from './adnd_character_build';
 export * from './adnd_character_eligibility';
 export * from './adnd_character_roll';
 export * from './adnd_character_snapshot';

--- a/src/lib/workshop/artifact_editors.test.ts
+++ b/src/lib/workshop/artifact_editors.test.ts
@@ -57,6 +57,16 @@ describe('the artifact editor registry', () => {
    * The parity the tool panels have with the tool catalog, applied here: an editor registered
    * against a kind id nothing stores would be an editor no artifact could ever reach.
    */
+  it('gives the AD&D character kind both an editor and a roller', () => {
+    // The editor is the builder tool itself rather than a component written for the purpose, and
+    // the roller is what makes a saved character re-rollable from the seed it was generated with.
+    const entry = artifactEditorEntry('character.adnd-2e');
+
+    expect(entry?.loadEditor).toBeDefined();
+    expect(entry?.loadRoller).toBeDefined();
+    expect(hasArtifactEditor('character.adnd-2e')).toBe(true);
+  });
+
   it('registers editors only for kinds this build can store', () => {
     const kinds = registeredArtifactKinds().map((entry) => entry.kind);
 

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -67,6 +67,27 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         rollSettlementSnapshot(provenance.seed, readSettlementGeneratorConfig(provenance.config));
     },
   },
+  /**
+   * The first kind whose editor is a tool rather than a component written for the purpose.
+   *
+   * `AdndCharacterArtifactEditor` is an adapter of about thirty lines around the builder at
+   * `/fantasy/adnd/character/build`, which already asks every question that makes a character.
+   * That is why #45 and #47 were designed to land together: writing a second editor beside a tool
+   * that is already an editor would have been two things to keep in step, and requirement 2.1
+   * wants one component working in a panel, on its own route, and here.
+   */
+  'character.adnd-2e': {
+    loadEditor: () => import('$components/characters/AdndCharacterArtifactEditor.svelte'),
+    loadRoller: async () => {
+      const { readAdndCharacterGeneratorConfig, rollAdndCharacterSnapshot } =
+        await import('$lib/adnd/adnd_character_roll.js');
+      return (provenance) =>
+        rollAdndCharacterSnapshot(
+          provenance.seed,
+          readAdndCharacterGeneratorConfig(provenance.config),
+        );
+    },
+  },
 };
 
 /** What a kind registered, or undefined when it registered nothing and opens on the generic view. */


### PR DESCRIPTION
Step 4 of [`docs/adnd-character.md`](https://github.com/ironarachne/ironarachne/blob/main/docs/adnd-character.md), and the half of #45 that made these two issues one design. **A saved AD&D character now opens in the builder**, and the builder is what `ARTIFACT_EDITORS` mounts for the kind.

## The base is the whole idea

`adnd_character_build.ts` holds `AdndCharacterBuild` — the form as data — and `buildAdndCharacter`, which takes one of two paths:

| Condition | Behaviour |
| --- | --- |
| No `base` | Derives from scratch, as the builder always has |
| `base` whose race, class, and attributes still match | The character **is** the base, with the fields the builder owns written over it |
| `base` with a structural field changed | Derives — and the page warns first (4.3) |

The second row is not an optimisation, it's requirement 4.2. A generated character carries rolled proficiencies, a kit, and an exceptional strength score that **no form field represents**; deriving on open would discard all of them before the user touched anything.

`finalizeAdndCharacterDerivedStats` is deliberately absent from the patch path. A saved character's THAC0 and saving throws are what it was stored with, hand-edited or not, and recomputing them on every keystroke is exactly the silent regeneration 4.2 forbids. Armour class is the one exception, since the builder owns the armour list.

## The builder delegates rather than deriving

`makeBaseCharacter`, `characterAfterRace`, `copyAfterRaceBody`, `applyClassFeaturesWithSeed` and the body of `previewCharacter` all moved into the library — so the same rules run on the route, in a panel, and in the editor, and so they could be tested without a browser. What stays in the component is only the question of whether the form is finished enough to show a character at all.

## A Details section

What 4.1 was missing: experience and level, both proficiency lists, the kit and its features, the abilities list, and twelve derived numbers — with an explicit **Recalculate from race, class, and attributes** that says it overwrites.

Worth stating plainly: editing any Details field makes the character on screen the new `base`. So the first such edit turns a composed character into an edited payload, and the rules stop being recalculated underneath it. That is what a user means by typing a number into a derived field.

## The editor is the tool

`AdndCharacterArtifactEditor.svelte` is ~30 lines of adapter around the builder rather than a second editor beside a tool that is already one. Two optional props are the whole difference between the builder composing for itself and editing for a surface — which is what requirement 2.1 asks for. It narrows the payload through the kind's own `validate` rather than a cast.

## Tests

29 on the build module. The ones carrying the claim:

- a generated character's proficiencies and kit **survive an open**;
- a hand-edited THAC0 **survives**;
- reading a character in and building it straight back out is the **identity** — without which opening an artifact would mark it dirty before the user did anything;
- race, class and attribute changes register as structural; hit points, names, alignment and funds do not.

## Verification

- `npm run verify` — green. 4274 tests, `0 ERRORS`, coverage gate passed.
- `npm run test:e2e` — green, 402 passed.

## Still to come

Step 5 (the build record as provenance, so a hand-built character is reproducible), step 6 (the culture reference), step 7 (6.2 fixes, the generate/save/reopen/edit e2e, the README's 8.4 section, and `maturity: 'release-ready'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
