### PR TITLE
Make a hand-built character reproducible

### DIFF
--- a/docs/adnd-character.md
+++ b/docs/adnd-character.md
@@ -191,8 +191,13 @@ beside `saveToolArtifact`, and it is on the path both tools take.
 
 A character made in the builder is reproducible from the decisions that made it, and it stores
 them: provenance is `toolPath: '/fantasy/adnd/character/build'`, `seed: classFeaturesSeed`, and a
-`config` holding `AdndCharacterBuildRecord` — the attribute rolls, race, class, alignment, the
-halfling options, hit points, funds, gear by name, spell picks, and the thief allocation.
+`config` holding `AdndCharacterBuildRecord` — the attribute rolls, race, subrace, class, alignment,
+hit points, funds, gear by name, spell picks, and the thief allocation.
+
+The record carries neither `base` nor `classFeaturesSeed`. The base is the artifact's own payload,
+and a copy of it inside the record of how it was made would be two answers to one question with the
+payload being the authoritative one. The seed is already provenance's own field, and a record
+holding a second copy could disagree with it.
 
 So the one kind carries **two provenance shapes, told apart by `toolPath`**, and the registered
 roller branches on it: the generator's path calls `rollAdndCharacter(seed, config)`, the builder's
@@ -213,11 +218,19 @@ Three things follow, and each is worth stating because each is a promise:
 - **A structural change stays reproducible.** Changing class re-derives from the stored seed rather
   than a freshly minted one, so the same sequence of decisions gives the same character twice.
 
-The invariant that keeps this from rotting is one line: **the build record is present only when the
-builder last wrote the character.** Any other writer clears it. There is no merge, no staleness
-flag, and no moment where the record and the payload disagree — the payload stays authoritative,
-exactly as `Artifact.payload` says it is, and the record is a description of how it came to be
-rather than a second copy of it.
+The invariant that keeps this from rotting turned out to need no enforcement at all. Provenance is
+written when an artifact is created and never touched afterwards — `applyArtifactEdits` changes the
+payload and the name and leaves it alone — so the record describes how the character was **first
+made**, which is exactly what `ArtifactProvenance` says it is for. There is no merge, no staleness
+flag, and no writer to clear anything.
+
+An earlier draft of this section claimed the record was "present only when the builder last wrote
+the character, and any other writer clears it". That was a rule invented for a problem the store
+does not have, and it is recorded here rather than quietly deleted because it is the kind of
+invariant that sounds prudent and would have cost real code. What follows from the real behaviour
+is simpler and slightly different: a generated character edited in the builder keeps its
+_generator_ provenance, so re-rolling it is a fresh draw that discards those edits — which is what
+re-rolling a generated character should mean.
 
 Robustness costs one more rule: **an unreadable build record is dropped, not fatal.** A record
 written by a build that spelled a field differently loses the recreate affordance and nothing else.
@@ -609,10 +622,10 @@ being thrown away**; recorded alongside it, the two reproduce the character exac
 records `toolPath`, that seed, and an `AdndCharacterBuildRecord` config, and the kind's roller
 branches on `toolPath` to decide whether a re-roll is a fresh draw or a faithful rebuild.
 
-What the old decision got right is kept as the invariant: the payload stays authoritative and the
-record never competes with it. The record is present only when the builder last wrote the
-character, any other writer clears it, and an unreadable one is dropped rather than fatal — losing
-the recreate affordance and nothing else.
+What the old decision got right is kept: the payload stays authoritative and the record never
+competes with it. Provenance is written once, at creation, and never edited, so "which of these is
+the truth" is a question that cannot arise. An unreadable record is dropped rather than fatal,
+losing the recreate affordance and nothing else.
 
 This costs a second shape in provenance `config` under one kind, which is the one thing to watch:
 `readAdndCharacterGeneratorConfig` and `readAdndCharacterBuildRecord` are separate readers and

--- a/src/components/characters/AdndCharacterBuilder.svelte
+++ b/src/components/characters/AdndCharacterBuilder.svelte
@@ -28,6 +28,7 @@
     starterSpellSelectionIsComplete,
     sumThiefSkillBonuses,
     thiefSkillBonusesAreValid,
+    toAdndCharacterBuildRecord,
     toAdndCharacterSnapshot,
     classes,
     races,
@@ -584,6 +585,19 @@
   );
 
   /**
+   * The decisions that made this character, as provenance.
+   *
+   * What makes a hand-built character reproducible. A generated one records a seed and the
+   * generator's settings; this one records the choices, and the kind's roller tells the two apart
+   * by the tool path. `toAdndCharacterBuildRecord` copies every array and object out, because
+   * IndexedDB serialises with `structuredClone` and that refuses the Proxy a deep-reactive value
+   * would hand it.
+   */
+  const buildRecord = $derived(
+    toAdndCharacterBuildRecord(currentBuild) as unknown as Record<string, unknown>,
+  );
+
+  /**
    * Tell the surrounding artifact surface what the form now describes.
    *
    * Only when mounted as an editor; on its own route there is nobody to tell, and the builder
@@ -1010,6 +1024,8 @@
           kind={ADND_CHARACTER_ARTIFACT_KIND}
           toolPath={TOOL_PATH}
           snapshot={previewSnapshot}
+          seed={classFeaturesSeed}
+          config={buildRecord}
           defaultName={`${firstName} ${lastName}`.trim()}
         />
 

--- a/src/lib/adnd/adnd_character_build.test.ts
+++ b/src/lib/adnd/adnd_character_build.test.ts
@@ -9,6 +9,9 @@ import {
   adndRaceOptionsForBuild,
   buildAdndCharacter,
   createAdndCharacterBuild,
+  readAdndCharacterBuildRecord,
+  rebuildAdndCharacterSnapshot,
+  toAdndCharacterBuildRecord,
   type AdndCharacterBuild,
 } from './adnd_character_build.js';
 import { rollAdndCharacter } from './adnd_character_roll.js';
@@ -297,5 +300,123 @@ describe('createAdndCharacterBuild', () => {
     const rng = new RNG('unused');
     expect(rng).toBeDefined();
     expect(createAdndCharacterBuild('a')).toEqual(createAdndCharacterBuild('a'));
+  });
+});
+
+describe('the build record as provenance', () => {
+  it('reproduces the same character from the decisions that made it', () => {
+    // The whole promise of decision 6: a hand-built character has no dice worth re-rolling, so its
+    // re-roll is a faithful rebuild rather than a fresh draw.
+    const build = composedBuild();
+    const record = toAdndCharacterBuildRecord(build);
+
+    const rebuilt = rebuildAdndCharacterSnapshot(build.classFeaturesSeed, record);
+
+    expect(rebuilt).toEqual(toAdndCharacterSnapshot(buildAdndCharacter(build)!));
+  });
+
+  it('survives the round trip through a stored config', () => {
+    const build = composedBuild();
+    const stored = JSON.parse(JSON.stringify(toAdndCharacterBuildRecord(build))) as Record<
+      string,
+      unknown
+    >;
+
+    const rebuilt = rebuildAdndCharacterSnapshot(
+      build.classFeaturesSeed,
+      readAdndCharacterBuildRecord(stored),
+    );
+
+    expect(rebuilt).toEqual(toAdndCharacterSnapshot(buildAdndCharacter(build)!));
+  });
+
+  it('is storable, which a Proxy-backed config would not be', () => {
+    // The trap `$lib/workshop`'s README records: IndexedDB serialises with `structuredClone`,
+    // which refuses a Proxy and fails the write with `could not be cloned`.
+    expect(() => structuredClone(toAdndCharacterBuildRecord(composedBuild()))).not.toThrow();
+  });
+
+  it('carries no base, because the payload is the base', () => {
+    const record = toAdndCharacterBuildRecord(
+      adndBuildFromSnapshot(generatedSnapshot(), 'seed'),
+    ) as Record<string, unknown>;
+
+    expect(record.base).toBeUndefined();
+    expect(record.classFeaturesSeed).toBeUndefined();
+  });
+
+  it('takes its seed from provenance rather than from itself', () => {
+    const record = toAdndCharacterBuildRecord(composedBuild());
+
+    const one = rebuildAdndCharacterSnapshot('seed-one', record);
+    const two = rebuildAdndCharacterSnapshot('seed-two', record);
+
+    // Same decisions, different class-feature seed: the parts the class rolls may differ, the
+    // parts the user chose may not.
+    expect(two?.alignment).toBe(one?.alignment);
+    expect(two?.hp).toBe(one?.hp);
+    expect(two?.thiefSkills).toEqual(one?.thiefSkills);
+  });
+
+  it('rebuilds a subrace choice exactly', () => {
+    const build = composedBuild();
+    build.raceName = 'halfling';
+    build.className = 'thief';
+    build.subraceName = 'Stout';
+
+    const rebuilt = rebuildAdndCharacterSnapshot(
+      build.classFeaturesSeed,
+      toAdndCharacterBuildRecord(build),
+    );
+
+    expect(rebuilt?.subraceName).toBe('Stout');
+    expect(rebuilt?.raceName).toBe('halfling');
+  });
+
+  it('is null when the decisions no longer make a character', () => {
+    const record = toAdndCharacterBuildRecord(composedBuild());
+
+    expect(
+      rebuildAdndCharacterSnapshot('seed', { ...record, className: 'bladesinger' }),
+    ).toBeNull();
+  });
+});
+
+describe('readAdndCharacterBuildRecord', () => {
+  it('drops what it does not recognise rather than coercing it', () => {
+    const record = readAdndCharacterBuildRecord({
+      raceName: 42,
+      className: 'thief',
+      attributes: 'not an object',
+      selectedWeaponNames: ['dagger', 7],
+      thiefSkillPoints: { 'Pick Pockets': 'lots' },
+      starterSpellPicks: 'nope',
+    });
+
+    expect(record.raceName).toBe('');
+    expect(record.className).toBe('thief');
+    expect(record.attributes.strength).toBe(0);
+    expect(record.selectedWeaponNames).toEqual([]);
+    expect(record.thiefSkillPoints).toEqual({});
+    expect(record.starterSpellPicks).toEqual([]);
+  });
+
+  it('reads an empty config without throwing', () => {
+    expect(() => readAdndCharacterBuildRecord({})).not.toThrow();
+    expect(readAdndCharacterBuildRecord({}).raceName).toBe('');
+  });
+
+  it('does not accept a generator config as a build', () => {
+    // The two share a kind and are told apart by tool path alone, so a reader that guessed would
+    // rebuild a character out of the generator's settings.
+    const record = readAdndCharacterBuildRecord({
+      nameGeneratorSet: 'human',
+      includeProficiencies: true,
+      includeKits: true,
+    });
+
+    expect(record.raceName).toBe('');
+    expect(record.className).toBe('');
+    expect(rebuildAdndCharacterSnapshot('seed', record)).toBeNull();
   });
 });

--- a/src/lib/adnd/adnd_character_build.ts
+++ b/src/lib/adnd/adnd_character_build.ts
@@ -26,6 +26,7 @@ import {
 } from './adnd_character_eligibility.js';
 import {
   adndCharacterFromSnapshot,
+  toAdndCharacterSnapshot,
   type AdndCharacterSnapshot,
 } from './adnd_character_snapshot.js';
 import {
@@ -385,4 +386,114 @@ export function adndBuildFromSnapshot(
     firstName: snapshot.firstName,
     lastName: snapshot.lastName,
   };
+}
+
+/**
+ * A build as it is stored in an artifact's provenance: the user's decisions, without the character
+ * they were applied to.
+ *
+ * `base` is absent because the base is the artifact's own payload — storing a copy of it inside
+ * the record of how it was made would be two answers to one question, and the payload is the one
+ * that is authoritative.
+ *
+ * `classFeaturesSeed` is absent for a smaller reason and a similar one: provenance already has a
+ * `seed` field, and a record carrying its own copy could disagree with it. The seed travels there
+ * and {@link rebuildAdndCharacterSnapshot} puts it back.
+ */
+export type AdndCharacterBuildRecord = Omit<AdndCharacterBuild, 'base' | 'classFeaturesSeed'>;
+
+/** A build as provenance. Plain data, which is what `structuredClone` requires of a config. */
+export function toAdndCharacterBuildRecord(build: AdndCharacterBuild): AdndCharacterBuildRecord {
+  const { base: _base, classFeaturesSeed: _seed, ...record } = build;
+  return {
+    ...record,
+    attributes: { ...record.attributes },
+    selectedWeaponNames: [...record.selectedWeaponNames],
+    selectedArmorNames: [...record.selectedArmorNames],
+    starterSpellPicks: record.starterSpellPicks.map((group) => [...group]),
+    thiefSkillPoints: { ...record.thiefSkillPoints },
+  };
+}
+
+function readNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string')
+    ? [...(value as string[])]
+    : [];
+}
+
+/**
+ * Read a stored build record back into the decisions a rebuild needs.
+ *
+ * The same boundary `readAdndCharacterGeneratorConfig` is, and it must not accept that one's
+ * shape: the two live under one artifact kind and are told apart by the tool path alone, so a
+ * reader that guessed would rebuild a character from a generator's settings. Anything
+ * unrecognisable is dropped rather than coerced, which costs the recreate affordance and nothing
+ * else — the character itself is in the payload.
+ */
+export function readAdndCharacterBuildRecord(
+  config: Record<string, unknown>,
+): AdndCharacterBuildRecord {
+  const attributes = asPlainRecord(config.attributes);
+  const thiefSkillPoints = asPlainRecord(config.thiefSkillPoints);
+  const picks = config.starterSpellPicks;
+
+  return {
+    attributes: {
+      strength: readNumber(attributes.strength, 0),
+      dexterity: readNumber(attributes.dexterity, 0),
+      constitution: readNumber(attributes.constitution, 0),
+      intelligence: readNumber(attributes.intelligence, 0),
+      wisdom: readNumber(attributes.wisdom, 0),
+      charisma: readNumber(attributes.charisma, 0),
+    },
+    raceName: readString(config.raceName),
+    className: readString(config.className),
+    alignment: readString(config.alignment),
+    subraceName: readString(config.subraceName),
+    hp: readNumber(config.hp, 1),
+    startingWealthCp: readNumber(config.startingWealthCp, 0),
+    selectedWeaponNames: readStringArray(config.selectedWeaponNames),
+    selectedArmorNames: readStringArray(config.selectedArmorNames),
+    starterSpellPicks: Array.isArray(picks) ? picks.map(readStringArray) : [],
+    thiefSkillPoints: Object.fromEntries(
+      Object.entries(thiefSkillPoints).filter(
+        (entry): entry is [string, number] => typeof entry[1] === 'number',
+      ),
+    ),
+    firstName: readString(config.firstName),
+    lastName: readString(config.lastName),
+  };
+}
+
+function asPlainRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Rebuild a character from the decisions that made it — the re-roll of a hand-built character.
+ *
+ * It is not a fresh draw, and that difference is the point. A generated character re-rolls to
+ * something new; a built one had no dice worth re-rolling, so its re-roll reproduces the same
+ * character and discards edits made to the payload afterwards. Both are the destructive operation
+ * requirement 4.3 describes, and the same warning is honestly true of each.
+ *
+ * `base` is null, so this always derives. That is correct here: a rebuild is being asked for
+ * precisely because the stored payload is what is to be replaced.
+ */
+export function rebuildAdndCharacterSnapshot(
+  seed: string,
+  record: AdndCharacterBuildRecord,
+): AdndCharacterSnapshot | null {
+  const character = buildAdndCharacter({ ...record, base: null, classFeaturesSeed: seed });
+  return character === null ? null : toAdndCharacterSnapshot(character);
 }

--- a/src/lib/workshop/artifact_editors.test.ts
+++ b/src/lib/workshop/artifact_editors.test.ts
@@ -67,6 +67,52 @@ describe('the artifact editor registry', () => {
     expect(hasArtifactEditor('character.adnd-2e')).toBe(true);
   });
 
+  it('rebuilds a hand-built character and re-rolls a generated one', async () => {
+    // One kind, two provenance shapes. The branch is on the tool path, and getting it wrong would
+    // rebuild a character out of the generator's settings — which reads as an empty character
+    // rather than as an error, so it is worth pinning.
+    const roll = await artifactEditorEntry('character.adnd-2e')!.loadRoller!();
+
+    const built = roll({
+      toolPath: '/fantasy/adnd/character/build',
+      seed: 'seed',
+      config: {
+        raceName: 'human',
+        className: 'fighter',
+        alignment: 'true neutral',
+        subraceName: '',
+        attributes: {
+          strength: 14,
+          dexterity: 13,
+          constitution: 12,
+          intelligence: 11,
+          wisdom: 10,
+          charisma: 9,
+        },
+        hp: 8,
+        startingWealthCp: 1000,
+        selectedWeaponNames: [],
+        selectedArmorNames: [],
+        starterSpellPicks: [],
+        thiefSkillPoints: {},
+        firstName: 'Aldric',
+        lastName: 'Vane',
+      },
+    }) as { raceName: string; hp: number; firstName: string };
+
+    expect(built.raceName).toBe('human');
+    expect(built.hp).toBe(8);
+    expect(built.firstName).toBe('Aldric');
+
+    const generated = roll({
+      toolPath: '/fantasy/adnd/character',
+      seed: 'seed',
+      config: { includeKits: true },
+    }) as { raceName: string };
+
+    expect(generated.raceName).not.toBe('');
+  });
+
   it('registers editors only for kinds this build can store', () => {
     const kinds = registeredArtifactKinds().map((entry) => entry.kind);
 

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -1,5 +1,12 @@
 import type { ArtifactKind } from '$lib/artifact_kinds';
 
+/**
+ * The builder's catalog path, which is how an AD&D character's provenance says it was hand-built
+ * rather than rolled. Written out rather than imported from `$lib/tools` so that this module keeps
+ * to the registries it belongs beside.
+ */
+const ADND_BUILDER_TOOL_PATH = '/fantasy/adnd/character/build';
+
 import type { ArtifactEditorEntry, ArtifactEditorRegistry } from './workshop_types';
 
 /**
@@ -78,14 +85,35 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
    */
   'character.adnd-2e': {
     loadEditor: () => import('$components/characters/AdndCharacterArtifactEditor.svelte'),
+    /**
+     * One kind, two provenance shapes, told apart by the tool path.
+     *
+     * A character from the generator re-rolls to a fresh draw. One from the builder had no dice
+     * worth re-rolling, so it rebuilds from the decisions that made it — the same character again,
+     * discarding edits made to the payload since. Both are the destructive operation requirement
+     * 4.3 describes, and the surface's warning is honestly true of either.
+     *
+     * The two readers are separate on purpose and neither may accept the other's record. They
+     * share a kind, so a reader that guessed would rebuild a character out of a generator's
+     * settings.
+     */
     loadRoller: async () => {
-      const { readAdndCharacterGeneratorConfig, rollAdndCharacterSnapshot } =
-        await import('$lib/adnd/adnd_character_roll.js');
-      return (provenance) =>
-        rollAdndCharacterSnapshot(
+      const [roll, build] = await Promise.all([
+        import('$lib/adnd/adnd_character_roll.js'),
+        import('$lib/adnd/adnd_character_build.js'),
+      ]);
+      return (provenance) => {
+        if (provenance.toolPath === ADND_BUILDER_TOOL_PATH) {
+          return build.rebuildAdndCharacterSnapshot(
+            provenance.seed,
+            build.readAdndCharacterBuildRecord(provenance.config),
+          );
+        }
+        return roll.rollAdndCharacterSnapshot(
           provenance.seed,
-          readAdndCharacterGeneratorConfig(provenance.config),
+          roll.readAdndCharacterGeneratorConfig(provenance.config),
         );
+      };
     },
   },
 };


### PR DESCRIPTION
Step 5 of [`docs/adnd-character.md`](https://github.com/ironarachne/ironarachne/blob/main/docs/adnd-character.md) — the decision revised after the domain model was approved, on the instruction that a character build be as robust and recreatable as possible.

A character made in the builder now records the decisions that made it, so it can be **rebuilt** rather than only kept.

## The record

`AdndCharacterBuildRecord` is the build without `base` and without `classFeaturesSeed`. Both omissions are the point:

- **No `base`** — the base *is* the artifact's payload. A copy inside the record of how it was made would be two answers to one question, with the payload being the authoritative one.
- **No `classFeaturesSeed`** — provenance already has a `seed` field, and a record holding a second copy could disagree with it. The seed travels there and `rebuildAdndCharacterSnapshot` puts it back.

That's a small improvement on the design sketch, which had the record carrying its own seed.

## The roller branches

| Provenance `toolPath` | Re-roll means |
| --- | --- |
| `/fantasy/adnd/character` | A fresh draw |
| `/fantasy/adnd/character/build` | Rebuild from the recorded decisions — the same character again |

Both are the destructive operation 4.3 describes, and the surface's warning is honestly true of either.

The two config readers are **strictly separate and neither accepts the other's record**. They share a kind, so a reader that guessed would rebuild a character out of a generator's settings — which reads as an *empty character* rather than as an error. There's a test for that, and one that the roller branches at all: the branch was silently missing from an earlier attempt at this commit, and only eslint's unused-variable check caught it.

## A correction to the design, recorded rather than deleted

Decision 6 said the build record is "present only when the builder last wrote the character, and any other writer clears it."

**That invariant needs no enforcement.** Provenance is written when an artifact is created and never touched afterwards — `applyArtifactEdits` changes the payload and the name and leaves it alone. It was a rule invented for a problem the store doesn't have, and it would have cost real code.

What follows from the actual behaviour is simpler and slightly different, and is now written down: a *generated* character edited in the builder keeps its **generator** provenance, so re-rolling it is a fresh draw that discards those edits — which is what re-rolling a generated character should mean.

## Verification

- `npm run verify` — green. 4306 tests, `0 ERRORS`, coverage gate passed.
- `npm run test:e2e` — green, 402 passed.

## Remaining

Step 6 (the culture reference) and step 7 (accessibility, the generate/save/reopen/edit e2e, the README's 8.4 section, and `maturity: 'release-ready'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
