### PR TITLE
Name an AD&D character from a culture in the project

### DIFF
--- a/src/components/characters/AdndCharacterBuilder.svelte
+++ b/src/components/characters/AdndCharacterBuilder.svelte
@@ -79,6 +79,7 @@
     loadCulturesForNaming,
     rollCharacterNameForSource,
   } from '$lib/characters';
+  import type { ArtifactReference } from '$lib/artifacts';
   import type { Culture } from '$lib/culture';
   import { onMount, untrack } from 'svelte';
   import CharacterNameSection from '$components/characters/CharacterNameSection.svelte';
@@ -155,13 +156,17 @@
   let downloadingPdf = $state(false);
 
   let savedCultures = $state<Culture[]>([]);
-  let nameSourceKind = $state<'default' | 'preset' | 'saved_culture'>('default');
+  let nameSourceKind = $state<'default' | 'preset' | 'saved_culture' | 'referenced_culture'>(
+    'default',
+  );
   let presetSetName = $state('human');
   let savedCultureName = $state('');
   let firstName = $state('');
   let lastName = $state('');
   let lockName = $state(false);
   let namingGender = $state<'male' | 'female' | 'random'>('random');
+  let referencedCulture = $state<Culture | undefined>();
+  let cultureReference = $state<ArtifactReference | undefined>();
 
   function wealthCpFromCoinFields(gp: unknown, sp: unknown, cp: unknown): number {
     const g = Math.max(0, Math.floor(Number(gp) || 0));
@@ -692,6 +697,7 @@
       presetSetName,
       savedCultureName,
       savedCultures,
+      referencedCulture,
     );
     const nameRng = new RNG.RNG(`${Date.now()}-adnd-build-name`);
     return rollCharacterNameForSource(nameRng, source, defaultHint, namingGender);
@@ -762,6 +768,9 @@
   </p>
 
   <CharacterNameSection
+    offerReferencedCulture
+    bind:referencedCulture
+    bind:cultureReference
     bind:nameSourceKind
     bind:presetSetName
     bind:savedCultureName
@@ -1027,6 +1036,9 @@
           seed={classFeaturesSeed}
           config={buildRecord}
           defaultName={`${firstName} ${lastName}`.trim()}
+          references={cultureReference === undefined || nameSourceKind !== 'referenced_culture'
+            ? []
+            : [cultureReference]}
         />
 
         <details class="builder-details">

--- a/src/components/characters/AdndCharacterGenerator.svelte
+++ b/src/components/characters/AdndCharacterGenerator.svelte
@@ -12,10 +12,12 @@
   import {
     buildCharacterNameSource,
     isCustomCharacterNameSource,
+    nameGeneratorSetForSource,
     restoreLockedCharacterName,
     rollCharacterNameForSource,
     loadCulturesForNaming,
   } from '$lib/characters';
+  import type { ArtifactReference } from '$lib/artifacts';
   import type { Culture } from '$lib/culture';
   import { onMount } from 'svelte';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
@@ -44,13 +46,26 @@
   let rolledConfig = $state.raw<Record<string, unknown>>({});
 
   let savedCultures = $state<Culture[]>([]);
-  let nameSourceKind = $state<'default' | 'preset' | 'saved_culture'>('default');
+  let nameSourceKind = $state<'default' | 'preset' | 'saved_culture' | 'referenced_culture'>(
+    'default',
+  );
   let presetSetName = $state('human');
   let savedCultureName = $state('');
   let firstName = $state('');
   let lastName = $state('');
   let lockName = $state(false);
   let namingGender = $state<'male' | 'female' | 'random'>('random');
+  /** The culture the picker loaded, and the link to record for it. */
+  let referencedCulture = $state<Culture | undefined>();
+  let cultureReference = $state<ArtifactReference | undefined>();
+  /**
+   * The link, recorded only when the character on screen was actually named from that culture.
+   *
+   * Gated on the roll rather than on the picker, for the reason the settlement generator gates
+   * its own: a reference is a record of what the tool was handed, and one written for a character
+   * whose names came from somewhere else would claim an input that was never used.
+   */
+  let rolledCultureReference = $state.raw<ArtifactReference | undefined>();
 
   /**
    * What gets stored, with the names the page is showing rather than the ones the roll produced.
@@ -88,6 +103,7 @@
       presetSetName,
       savedCultureName,
       savedCultures,
+      referencedCulture,
     );
     const nameRng = new RNG.RNG(nameSeed);
     return rollCharacterNameForSource(nameRng, source, defaultHint, namingGender);
@@ -99,6 +115,7 @@
       presetSetName,
       savedCultureName,
       savedCultures,
+      referencedCulture,
     );
     if (!isCustomCharacterNameSource(source)) {
       target.firstName = '';
@@ -122,9 +139,25 @@
    * names from that culture's own generators, which are not one of the build's named sets — that
    * link is an artifact reference, and recording it is composition's job rather than this step's.
    */
+  /**
+   * The settings a roll takes, and the ones provenance records.
+   *
+   * `nameGeneratorSet` comes from whichever source is chosen: a preset records its own name, and a
+   * culture records the pattern set its generators carry. That second case is what lets a re-roll
+   * produce names of the same tongue without reaching back into the store for an artifact it has
+   * no way to ask for — the bargain `$lib/settlements` and `$lib/religion` already make.
+   */
   function currentConfig(): AdndCharacterGeneratorConfigRecord {
+    const source = buildCharacterNameSource(
+      nameSourceKind,
+      presetSetName,
+      savedCultureName,
+      savedCultures,
+      referencedCulture,
+    );
+    const nameGeneratorSet = nameGeneratorSetForSource(source);
     return {
-      ...(nameSourceKind === 'preset' ? { nameGeneratorSet: presetSetName } : {}),
+      ...(nameGeneratorSet === '' ? {} : { nameGeneratorSet }),
       namingGender,
       includeProficiencies,
       includeKits,
@@ -145,10 +178,14 @@
     // The resolved set, not the requested one: a set this build has since dropped would otherwise
     // be recorded as provenance that a re-roll could not honour.
     rolledConfig = { ...config, nameGeneratorSet: rolled.nameGeneratorSet };
+    rolledCultureReference =
+      nameSourceKind === 'referenced_culture' && referencedCulture !== undefined
+        ? cultureReference
+        : undefined;
 
     if (lockName) {
       restoreLockedCharacterName(character, lockedFirstName, lockedLastName);
-    } else if (nameSourceKind === 'preset') {
+    } else if (nameSourceKind === 'preset' || nameSourceKind === 'referenced_culture') {
       // Already named by the roll, from the seed. Mirror it into the fields the page shows.
       firstName = character.firstName;
       lastName = character.lastName;
@@ -232,6 +269,9 @@
   </div>
 
   <CharacterNameSection
+    offerReferencedCulture
+    bind:referencedCulture
+    bind:cultureReference
     bind:nameSourceKind
     bind:presetSetName
     bind:savedCultureName
@@ -254,6 +294,7 @@
     {seed}
     config={rolledConfig}
     defaultName={defaultArtifactName}
+    references={rolledCultureReference === undefined ? [] : [rolledCultureReference]}
   />
 
   {#if character}

--- a/src/components/characters/CharacterNameControls.svelte
+++ b/src/components/characters/CharacterNameControls.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import type { Culture } from '$lib/culture';
 
-  type NameSourceKind = 'default' | 'preset' | 'saved_culture';
+  type NameSourceKind = 'default' | 'preset' | 'saved_culture' | 'referenced_culture';
 
   type Props = {
     nameSourceKind?: NameSourceKind;
     presetSetName?: string;
     savedCultureName?: string;
+    /** Whether the tool offers a project culture through the artifact picker above these fields. */
+    offerReferencedCulture?: boolean;
     savedCultures?: Culture[];
     nameSetNames?: string[];
     namingGender?: 'male' | 'female' | 'random';
@@ -28,6 +30,7 @@
     lastName = $bindable(''),
     lockName = $bindable(false),
     showGenderPicker = false,
+    offerReferencedCulture = false,
     onGenerateName,
   }: Props = $props();
 
@@ -51,6 +54,13 @@
         <option value="preset">Preset name set</option>
         {#if hasSavedCultures}
           <option value="saved_culture">Saved culture</option>
+        {/if}
+        {#if offerReferencedCulture}
+          <!--
+            Chosen through the picker above rather than here, so this option only reports what the
+            picker did. Disabled because selecting it would claim a culture nobody chose.
+          -->
+          <option value="referenced_culture" disabled>Culture from this project</option>
         {/if}
       </select>
     </div>

--- a/src/components/characters/CharacterNameSection.svelte
+++ b/src/components/characters/CharacterNameSection.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { loadCulturesForNaming } from '$lib/characters';
-  import type { Culture } from '$lib/culture';
+  import type { ArtifactReference } from '$lib/artifacts';
+  import { CULTURE_ARTIFACT_KIND, type Culture } from '$lib/culture';
+  import SavedArtifactPicker from '$components/common/SavedArtifactPicker.svelte';
   import { getAllFantasyNameGeneratorSets } from '$lib/names';
   import { RNG } from '@ironarachne/rng';
   import CharacterNameControls from '$components/characters/CharacterNameControls.svelte';
 
-  type NameSourceKind = 'default' | 'preset' | 'saved_culture';
+  type NameSourceKind = 'default' | 'preset' | 'saved_culture' | 'referenced_culture';
 
   type Props = {
     nameSourceKind?: NameSourceKind;
@@ -19,6 +21,19 @@
     showGenderPicker?: boolean;
     onGenerateName?: () => void;
     seed?: string;
+    /**
+     * Offer a culture from the open project, as an artifact link rather than a copied name set.
+     *
+     * Off by default, so the four character tools that have not been converted yet render exactly
+     * what they always did — the option is not in their dropdown and the picker is not on their
+     * page. A tool opts in when its own readiness issue wires the reference and the provenance
+     * through; #45 is the first.
+     */
+    offerReferencedCulture?: boolean;
+    /** The culture the picker loaded, for the consumer to name from. */
+    referencedCulture?: Culture;
+    /** The link to record when the consumer saves. Set only once the culture has loaded. */
+    cultureReference?: ArtifactReference;
   };
 
   let {
@@ -32,7 +47,32 @@
     showGenderPicker = false,
     onGenerateName,
     seed = 'character-name-sets',
+    offerReferencedCulture = false,
+    referencedCulture = $bindable(),
+    cultureReference = $bindable(),
   }: Props = $props();
+
+  let useReferencedCulture = $state(false);
+  let cultureProblem = $state<string | null>(null);
+
+  /**
+   * Keep the source kind and the picker's checkbox saying the same thing.
+   *
+   * They are two controls describing one decision — the checkbox belongs to the picker and the
+   * kind belongs to the naming controls — so each has to follow the other or the page can show a
+   * culture chosen and a source of "default" at the same time.
+   */
+  $effect(() => {
+    if (useReferencedCulture && nameSourceKind !== 'referenced_culture') {
+      nameSourceKind = 'referenced_culture';
+    }
+  });
+
+  $effect(() => {
+    if (!useReferencedCulture && nameSourceKind === 'referenced_culture') {
+      nameSourceKind = 'default';
+    }
+  });
 
   let savedCultures = $state<Culture[]>([]);
   let nameSetNames = $state<string[]>([]);
@@ -50,6 +90,19 @@
   });
 </script>
 
+{#if offerReferencedCulture}
+  <SavedArtifactPicker
+    kind={CULTURE_ARTIFACT_KIND}
+    role="naming-culture"
+    checkboxLabel="Name from a saved culture in this project"
+    selectLabel="Culture"
+    bind:enabled={useReferencedCulture}
+    bind:value={referencedCulture}
+    bind:reference={cultureReference}
+    bind:problem={cultureProblem}
+  />
+{/if}
+
 <CharacterNameControls
   bind:nameSourceKind
   bind:presetSetName
@@ -60,6 +113,7 @@
   bind:namingGender
   {savedCultures}
   {nameSetNames}
+  {offerReferencedCulture}
   {showGenderPicker}
   {onGenerateName}
 />

--- a/src/lib/characters/character_name_generation.test.ts
+++ b/src/lib/characters/character_name_generation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { RNG } from '@ironarachne/rng';
 import { generateCulture, getDefaultCultureGenerationConfig } from '$lib/culture';
 import { getFantasyNameGeneratorSet } from '$lib/names';
+import type { Culture } from '$lib/culture';
 import {
   applyNameGeneratorsToCharacterGenerationConfig,
   buildCharacterNameSource,
@@ -9,6 +10,7 @@ import {
   fantasyHintToNameSetName,
   generateCharacterName,
   isCustomCharacterNameSource,
+  nameGeneratorSetForSource,
   peopleNameGeneratorsFromNameSet,
   resolveCharacterNameGeneratorSet,
   resolveNamingGender,
@@ -111,5 +113,68 @@ describe('character_name_generation', () => {
       lastName: 'Person',
       name: 'Locked Person',
     });
+  });
+});
+
+describe('referenced_culture as a name source', () => {
+  const culture = {
+    name: 'Vashai',
+    nameGenerators: getFantasyNameGeneratorSet('elf', new RNG('culture')),
+  } as unknown as Culture;
+
+  it('builds from a culture handed in by the picker', () => {
+    const source = buildCharacterNameSource('referenced_culture', 'human', '', [], culture);
+
+    expect(source.kind).toBe('referenced_culture');
+  });
+
+  it('falls back to default while the picker is still loading', () => {
+    // A tool that named from a culture it does not have yet would be naming from nothing and
+    // calling it a culture.
+    const source = buildCharacterNameSource('referenced_culture', 'human', '', []);
+
+    expect(source.kind).toBe('default');
+  });
+
+  it('names from the culture rather than a preset', () => {
+    const source = buildCharacterNameSource('referenced_culture', 'human', '', [], culture);
+
+    expect(resolveCharacterNameGeneratorSet(new RNG('x'), source)).toBe(culture.nameGenerators);
+  });
+
+  it('is a custom source, so a tool knows to use it', () => {
+    const source = buildCharacterNameSource('referenced_culture', 'human', '', [], culture);
+
+    expect(isCustomCharacterNameSource(source)).toBe(true);
+  });
+
+  it('does not disturb the three sources that already existed', () => {
+    expect(buildCharacterNameSource('default', 'human', '', []).kind).toBe('default');
+    expect(buildCharacterNameSource('preset', 'dwarf', '', []).kind).toBe('preset');
+    expect(buildCharacterNameSource('saved_culture', 'human', 'Vashai', [culture]).kind).toBe(
+      'saved_culture',
+    );
+  });
+});
+
+describe('nameGeneratorSetForSource', () => {
+  const culture = {
+    name: 'Vashai',
+    nameGenerators: getFantasyNameGeneratorSet('elf', new RNG('culture')),
+  } as unknown as Culture;
+
+  it('records a preset by its own name', () => {
+    expect(nameGeneratorSetForSource({ kind: 'preset', setName: 'dwarf' })).toBe('dwarf');
+  });
+
+  it('records a culture by the pattern set its generators carry', () => {
+    // This is what lets a re-roll produce names of the same tongue without reaching back into the
+    // store for an artifact it has no way to ask for.
+    expect(nameGeneratorSetForSource({ kind: 'referenced_culture', culture })).toBe('elf');
+    expect(nameGeneratorSetForSource({ kind: 'saved_culture', culture })).toBe('elf');
+  });
+
+  it('records nothing for the default source', () => {
+    expect(nameGeneratorSetForSource({ kind: 'default' })).toBe('');
   });
 });

--- a/src/lib/characters/character_name_generation.ts
+++ b/src/lib/characters/character_name_generation.ts
@@ -4,10 +4,24 @@ import type { NameGenerator } from '@ironarachne/made-up-names';
 import type { RNG } from '@ironarachne/rng';
 import type { CharacterGenerationConfig } from './character_types';
 
+/**
+ * Where a character's names come from.
+ *
+ * `saved_culture` and `referenced_culture` both name from a culture and are not the same thing.
+ * The first is the legacy affordance: a dropdown of every culture the browser can find, whose
+ * names are copied out and whose origin is not recorded anywhere. The second is composition
+ * proper — the culture is chosen through the artifact picker, the link is stored on the artifact
+ * by id (requirement 5.2), and the culture's own pattern set goes into provenance so a re-roll
+ * stays faithful without reaching back into the store.
+ *
+ * Both exist because the second is being adopted one character tool at a time. A tool that has
+ * not been converted still offers the first, and nothing about it changed.
+ */
 export type CharacterNameSource =
   | { kind: 'default' }
   | { kind: 'preset'; setName: string }
-  | { kind: 'saved_culture'; culture: Culture };
+  | { kind: 'saved_culture'; culture: Culture }
+  | { kind: 'referenced_culture'; culture: Culture };
 
 export type NamingGender = 'male' | 'female' | 'random';
 
@@ -77,7 +91,7 @@ export function resolveCharacterNameGeneratorSet(
   if (source.kind === 'preset') {
     return getFantasyNameGeneratorSet(source.setName, rng);
   }
-  if (source.kind === 'saved_culture') {
+  if (source.kind === 'saved_culture' || source.kind === 'referenced_culture') {
     return source.culture.nameGenerators;
   }
   return getFantasyNameGeneratorSet(fantasyHintToNameSetName(defaultHint), rng);
@@ -138,11 +152,23 @@ export function generateDccCharacterNames(
   return generated;
 }
 
+/**
+ * The source a naming control's fields describe.
+ *
+ * `referencedCulture` is the culture the artifact picker loaded, when the tool offers one. It is
+ * handed in already rebuilt rather than looked up by name, because a referenced culture is
+ * identified by artifact id and two projects may hold cultures called the same thing.
+ *
+ * A kind of `referenced_culture` with nothing loaded falls through to `default`, which is the
+ * ordinary state while the picker is still reading from the store: a tool that named from a
+ * culture it does not have yet would be naming from nothing and calling it a culture.
+ */
 export function buildCharacterNameSource(
-  kind: 'default' | 'preset' | 'saved_culture',
+  kind: 'default' | 'preset' | 'saved_culture' | 'referenced_culture',
   presetSetName: string,
   savedCultureName: string,
   savedCultures: Culture[],
+  referencedCulture?: Culture,
 ): CharacterNameSource {
   if (kind === 'preset') {
     return { kind: 'preset', setName: presetSetName };
@@ -153,7 +179,24 @@ export function buildCharacterNameSource(
       return { kind: 'saved_culture', culture };
     }
   }
+  if (kind === 'referenced_culture' && referencedCulture !== undefined) {
+    return { kind: 'referenced_culture', culture: referencedCulture };
+  }
   return { kind: 'default' };
+}
+
+/**
+ * The name-generator set a source draws on, for provenance. Empty when there is nothing stable to
+ * record — a preset records its own name, a culture records the set its generators carry.
+ */
+export function nameGeneratorSetForSource(source: CharacterNameSource): string {
+  if (source.kind === 'preset') {
+    return source.setName;
+  }
+  if (source.kind === 'saved_culture' || source.kind === 'referenced_culture') {
+    return source.culture.nameGenerators.name;
+  }
+  return '';
 }
 
 export function formatCharacterDisplayName(firstName: string, lastName: string): string {


### PR DESCRIPTION
Step 6 of [`docs/adnd-character.md`](https://github.com/ironarachne/ironarachne/blob/main/docs/adnd-character.md) — composition for both AD&D character tools, and requirement 5.1 for the kind.

## What changed

`CharacterNameSource` gains `referenced_culture`, and `CharacterNameSection` gains a `SavedArtifactPicker` with `role: 'naming-culture'`. The link travels on the draft and is **stored by artifact id** — requirement 5.2. Previously the names were copied out of whichever culture the browser could find, with nothing recording where they came from.

## The provenance question resolved better than step 3 assumed

Step 3 recorded a pattern set for **preset** sources only, on the grounds that a culture's generators aren't one of the build's named sets.

They are. `getFantasyNameGeneratorSet` returns `{ name: setName, … }`, so `culture.nameGenerators.name` is a real preset name. `nameGeneratorSetForSource` records it, and a re-roll produces names of the same tongue without reaching back into the store for an artifact it has no way to ask for — the bargain `$lib/settlements` and `$lib/religion` already make.

## Additive, as designed

`offerReferencedCulture` defaults to `false`, so the DCC, SWN, Uncharted Worlds and fantasy character generators render **exactly** what they always did: no picker, and the option absent from their name-source dropdown. Only the two AD&D tools opt in.

When #46, #48, #49 and #50 come round, each is a prop and a reference to wire rather than a component to write.

## Two decisions worth recording

- **The `referenced_culture` dropdown option is `disabled`.** It reports what the picker did rather than being selectable. Two controls describing one decision is how a page ends up showing a culture chosen and a source of "default" at the same time; the picker's checkbox drives it and two `$effect`s keep them in step.
- **The reference is gated on the roll, not the checkbox.** Ticking the box and pressing nothing records no link, because a reference is a record of what the tool was *handed* — the same gating `SettlementGenerator` uses for its culture link.

## Verification

- `npm run verify` — green. 4314 tests, `0 ERRORS`, coverage gate passed.
- `npm run test:e2e` — green, 402 passed. Mattering more than usual here: `CharacterNameSection` is shared by five tools, and four of them must be untouched.

## Remaining

Step 7 only: accessibility (6.2), the generate/save/reopen/edit end-to-end test (7.4), the README's 8.4 section, and flipping `maturity: 'release-ready'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
