### PR TITLE
Take both AD&D 2E character tools to Release-ready

### DIFF
--- a/docs/adnd-character.md
+++ b/docs/adnd-character.md
@@ -10,7 +10,8 @@ because the two make the same thing and the readiness spec requires them to make
 kind. It sits inside [the workshop](workshop.md) and is measured against
 [Tool release readiness](workshop.md#tool-release-readiness).
 
-**Status:** accepted; not yet built. The [domain model](#domain-model) was reviewed and approved, so
+**Status:** accepted; **built**. Both tools are Release-ready, assessed section by section in
+[What shipped](#what-shipped). The [domain model](#domain-model) was reviewed and approved, so
 [the plan](#the-plan) is clear to start.
 
 One decision moved after that approval, on the instruction that a character build be as robust and
@@ -683,3 +684,47 @@ None of these blocks the model; each is presentation or scope.
 - **Should the derived-stats block be editable in the panel as well as on the route?** It is a long
   block of number inputs and the panel is narrow. Requirement 2.1 says the tool must work
   identically in both, which argues yes; the collapsed Details section is what makes that bearable.
+
+## What shipped
+
+Both tools reached `maturity: 'release-ready'` on 2026-08-25. Assessed against every requirement
+that applies, rather than declared:
+
+| Section               | How it is met                                                                                                                                                                                                                                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1 Discoverability** | Both were already met and are unchanged: catalog entries with the right `kind` and `domain`, `genre:fantasy` and `system:adnd-2e`, both in `TOOL_PANELS`, and labels that already read correctly out of context.                                                                                                 |
+| **2 Behaviour**       | `rollAdndCharacter` is the one path from a seed, and it fixed a real 2.2 failure — the name was drawn from the clock, so a locked seed gave a different character each press. Neither tool generates over user input.                                                                                            |
+| **3 Artifacts**       | `character.adnd-2e` at `payloadVersion` 1, shared by both tools. Race and class stored by name; every derived number kept. `validate` returns a rejection rather than throwing; `migrate` rejects and says so. Provenance records tool path, seed, and settings — a generator's config or a builder's decisions. |
+| **4 Editing**         | The builder **is** the kind's editor. It patches a saved character rather than re-deriving it, so rolled proficiencies and a kit survive being opened. Derived numbers are editable, with recalculation demoted to an explicit command. A structural change re-derives and says so first.                        |
+| **5 Composition**     | A culture is taken through `SavedArtifactPicker` and recorded by id, with the culture's own pattern set in provenance so a re-roll keeps the tongue. Both tools work with no culture at all.                                                                                                                     |
+| **6 Output**          | Both routes render at every width in `e2e/mobile_viewports.ts`. Every control is reachable by role and name — asserted by driving the whole builder that way. PDF export is the presentation format.                                                                                                             |
+| **7 Verification**    | Round-trip, migration, build, subrace and roll tests in `$lib/adnd`; `e2e/adnd_character.spec.ts` covers generate, save, reopen, edit for both tools.                                                                                                                                                            |
+| **8 Documentation**   | `$lib/adnd/README.md` says which edition, that everything is level 1, and what is deliberately left out.                                                                                                                                                                                                         |
+
+### What the end-to-end test found
+
+Requirement 7.4 was the last thing built and it earned its place immediately. Five bugs, none of
+which any unit test could have seen, because each lived in the space between Svelte's reactivity
+and the store:
+
+- **The generator could not save at all.** `character` was deep-reactive `$state`, so the
+  snapshot's arrays were Proxies and `structuredClone` — what IndexedDB writes with — refused them:
+  `[object Array] could not be cloned`. Guarding the provenance config was not enough; the payload
+  goes to the same place. Broken since the save button was added.
+- **The builder crashed for every spellcasting class.** `buildAdndCharacter` runs on each
+  keystroke, including for the hit-point bounds, and `startingSpellsFromPicks` throws on a partial
+  set. Choosing a caster took the page down before the alignment step appeared.
+- **Reopening a saved caster showed nothing.** The stored spellbook was rebuilt as one flat list
+  rather than one row per choice group, so the form read as unfinished forever.
+- **Reopening a character with equipment deleted its gear.** Starting funds were not seeded from
+  the artifact, so the over-budget guard fired on mount, cleared the equipment, and put an error
+  dialog over the page.
+- **The editor never settled.** Announcing a freshly built snapshot on every render meant a new
+  object describing an identical character, which the surface stored and re-rendered — a loop that
+  left the Save button unclickable.
+
+The last three share a cause worth naming: **the builder is the first artifact editor with state
+of its own.** Culture, religion and settlement editors hold everything in the snapshot prop, so
+nothing about seeding or re-announcing could go wrong for them. A tool mounted as an editor has to
+be seeded completely and has to announce only real changes, and neither requirement existed before
+this kind.

--- a/e2e/adnd_character.spec.ts
+++ b/e2e/adnd_character.spec.ts
@@ -1,0 +1,222 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the AD&D 2E character kind: generate, save, reopen, edit.
+ *
+ * This is the half no unit test can settle. The library tests prove a character round-trips
+ * through the codec and that the builder patches rather than re-derives; what they cannot prove is
+ * that a user can press Generate, keep the result, come back to it in a different page, change
+ * something, and still have the character they saved. Every step of that crosses a boundary the
+ * unit tests stub out — the artifact store, IndexedDB, the editor registry, and a page reload.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool on this page has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/**
+ * Drive the builder to a complete human fighter.
+ *
+ * A fighter deliberately: casters must have their level 1 spells chosen and rogues their skill
+ * points allocated before a character appears, and neither is what these tests are about. Human
+ * because its ability ranges accept any roll, so the race is always on offer.
+ */
+async function chooseFighter(page: Page): Promise<void> {
+  // Rolled until a fighter is on offer. The builder's dice are its own — there is no seed control
+  // on this page — and straight 3d6 sometimes qualifies for no class at all, which is real
+  // behaviour rather than a fault. Re-rolling is what a user would do.
+  const race = page.getByRole('combobox', { name: 'Race' });
+  const cls = page.getByRole('combobox', { name: 'Class' });
+
+  for (let attempt = 0; attempt < 25; attempt += 1) {
+    await page.getByRole('button', { name: 'Roll 6 × 3d6' }).click();
+    await expect(race).toBeVisible();
+    await race.selectOption('human');
+    const classes = await cls.locator('option').allTextContents();
+    if (classes.includes('fighter')) {
+      break;
+    }
+  }
+
+  await expect(cls).toBeVisible();
+  await cls.selectOption('fighter');
+
+  const alignment = page.getByRole('combobox', { name: 'Alignment' });
+  await expect(alignment).toBeVisible();
+  await alignment.selectOption({ index: 1 });
+}
+
+/** A culture in the open project, so the naming picker has something to offer. */
+async function saveACulture(page: Page, name: string): Promise<void> {
+  await visitRoute(page, '/culture', { title: 'Culture Generator | Iron Arachne' });
+  await saveAs(page, name);
+}
+
+test.describe('an AD&D 2E character', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'Greyhawk');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/fantasy/adnd/character', {
+      title: 'AD&D 2e Character Generator | Iron Arachne',
+    });
+
+    // The generator rolls on mount, so there is a character to keep straight away.
+    await expect(page.getByRole('heading', { name: 'Attributes' })).toBeVisible();
+    await saveAs(page, 'Aldric Vane');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability
+    // test rather than a state test.
+    await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+    await expect(vaultRow(page, 'Aldric Vane')).toBeVisible();
+    await vaultRow(page, 'Aldric Vane').click();
+
+    // The kind's editor is the builder itself, so the artifact opens into the tool that makes
+    // characters rather than into a generic snapshot view — which is what makes editing it the
+    // same act as building one.
+    await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+    await page
+      .locator('section.project-view')
+      .getByRole('button', { name: /^Aldric Vane( |$)/ })
+      .click();
+    const panel = page.locator('.artifact-panel');
+    await expect(panel).toBeVisible();
+    await expect(panel.getByRole('heading', { name: /AD&D 2e Character Builder/ })).toBeVisible();
+
+    // Editing it marks the artifact dirty, which is the framework noticing that the builder
+    // announced a different snapshot than the one it was handed.
+    // Typed rather than filled: `fill` sets the value in one go, and the point of this assertion
+    // is that the builder's own bindings carry a user's keystrokes through to the snapshot it
+    // announces.
+    const firstName = panel.getByRole('textbox', { name: 'First name' });
+    await firstName.click();
+    await firstName.pressSequentially('Aldrich');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+  });
+
+  test('is built by hand, saved, and reopened', async ({ page }) => {
+    await visitRoute(page, '/fantasy/adnd/character/build', {
+      title: 'AD&D 2e Character Builder | Iron Arachne',
+    });
+
+    // Every control is reached by its accessible *role and name*, which is requirement 6.2 tested
+    // rather than asserted: a control that cannot be found that way is a control a screen reader
+    // cannot announce.
+    await page.getByRole('button', { name: 'Roll 6 × 3d6' }).click();
+
+    await chooseFighter(page);
+
+    // A character only appears once every required choice is made, so its presence is the proof
+    // that the form was driven entirely through accessible names.
+    const sheet = page.locator('.builder-result');
+    await expect(sheet.getByRole('heading', { name: 'Character' })).toBeVisible();
+
+    await saveAs(page, 'Perrin Thistlewood');
+
+    await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+    await expect(vaultRow(page, 'Perrin Thistlewood')).toBeVisible();
+  });
+
+  test('exposes its derived numbers for correction', async ({ page }) => {
+    // Requirement 4.1: every field displayed is a field a user may change. The derived block used
+    // to be computed and unreachable.
+    await visitRoute(page, '/fantasy/adnd/character/build', {
+      title: 'AD&D 2e Character Builder | Iron Arachne',
+    });
+
+    await chooseFighter(page);
+
+    // `<details>` is natively keyboard-operable, so reaching it by role is the whole check.
+    await page.getByRole('group', { name: 'Details' }).click();
+
+    await expect(page.getByLabel('THAC0')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Recalculate from race, class, and attributes' }),
+    ).toBeVisible();
+  });
+
+  test('offers a project culture to name from, and only once there is one', async ({ page }) => {
+    await visitRoute(page, '/fantasy/adnd/character', {
+      title: 'AD&D 2e Character Generator | Iron Arachne',
+    });
+
+    // No cultures in the project, so no offer. An offer with nothing behind it is noise, and
+    // requirement 5.3 is what makes its absence correct rather than a gap: the tool generates its
+    // own names and saves perfectly well without one.
+    await expect(page.getByLabel('Name from a saved culture in this project')).toHaveCount(0);
+    await saveAs(page, 'Unnamed Wanderer');
+
+    await saveACulture(page, 'The Emberfolk');
+
+    await visitRoute(page, '/fantasy/adnd/character', {
+      title: 'AD&D 2e Character Generator | Iron Arachne',
+    });
+
+    // Composition is opt-in (rule 1): the offer is there and starts unticked.
+    const offer = page.getByLabel('Name from a saved culture in this project');
+    await expect(offer).toBeVisible();
+    await expect(offer).not.toBeChecked();
+  });
+
+  test('downloads a character sheet a user can take to the table', async ({ page }) => {
+    // Requirement 6.3. The PDF is the presentation export, distinct from artifact export.
+    await visitRoute(page, '/fantasy/adnd/character', {
+      title: 'AD&D 2e Character Generator | Iron Arachne',
+    });
+
+    const download = page.waitForEvent('download');
+    await page.getByRole('button', { name: /Download PDF/ }).click();
+
+    expect((await download).suggestedFilename()).toMatch(/\.pdf$/);
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -21,13 +21,6 @@ const maturityBadge = (page: Page) => page.locator('.maturity__level');
 const TOOL_PAGES = [
   { path: '/planet', title: 'Planet Generator | Iron Arachne', level: 'Experimental' },
   { path: '/heraldry', title: 'Heraldry Generator | Iron Arachne', level: 'Beta' },
-  {
-    // Its own header rather than `GeneratorPage`, so it states its maturity itself and is worth
-    // checking separately.
-    path: '/fantasy/adnd/character/build',
-    title: 'AD&D 2e Character Builder | Iron Arachne',
-    level: 'Experimental',
-  },
 ] as const;
 
 /** The release-ready tools, which must say nothing at all. */
@@ -35,6 +28,14 @@ const SILENT_TOOL_PAGES = [
   { path: '/culture', title: 'Culture Generator | Iron Arachne' },
   { path: '/fantasy/settlement', title: 'Settlement Generator | Iron Arachne' },
   { path: '/fantasy/religion', title: 'Religion Generator | Iron Arachne' },
+  { path: '/fantasy/adnd/character', title: 'AD&D 2e Character Generator | Iron Arachne' },
+  {
+    // Its own header rather than `GeneratorPage`, so it decides for itself whether to show a
+    // badge. Worth keeping in the list for exactly that reason: the rule is the same but the code
+    // making the call is not.
+    path: '/fantasy/adnd/character/build',
+    title: 'AD&D 2e Character Builder | Iron Arachne',
+  },
 ] as const;
 
 for (const { path, title, level } of TOOL_PAGES) {
@@ -84,9 +85,9 @@ test('maturity: the tool browser marks every tool that has something to warn abo
   const tools = browser.locator('.tool-browser__tool');
   await expect(tools.first()).toBeVisible();
 
-  // Exactly the release-ready tools are unmarked, and all three of them are mountable so all
-  // three are listed here. Counted rather than spot-checked: a tool that quietly lost its badge
-  // would otherwise pass every assertion below it.
+  // Exactly the release-ready tools are unmarked, and every one of them is mountable so every one
+  // is listed here. Counted rather than spot-checked: a tool that quietly lost its badge would
+  // otherwise pass every assertion below it.
   const unmarked = tools.filter({ hasNot: page.locator('.maturity__level') });
   await expect(unmarked).toHaveCount(SILENT_TOOL_PAGES.length);
 
@@ -96,6 +97,9 @@ test('maturity: the tool browser marks every tool that has something to warn abo
   await expect(browser.getByRole('button', { name: /^Settlement/ })).not.toContainText(
     'Release-ready',
   );
+  await expect(
+    browser.getByRole('button', { name: /^AD&D 2E Character Builder/ }),
+  ).not.toContainText('Release-ready');
   await expect(browser.getByRole('button', { name: /^Heraldry/ })).toContainText('Beta');
   await expect(browser.getByRole('button', { name: /^Planet/ })).toContainText('Experimental');
 });

--- a/src/components/characters/AdndCharacterBuilder.svelte
+++ b/src/components/characters/AdndCharacterBuilder.svelte
@@ -143,9 +143,13 @@
   let subraceName = $state(initial.subraceName);
 
   let hpValue = $state(initial.hp);
-  let startingGp = $state(0);
-  let startingSp = $state(0);
-  let startingCp = $state(0);
+  // Seeded from the artifact, not zeroed. Left at zero, a reopened character's gear costs more
+  // than its funds the instant the form mounts, so the over-budget guard fired: it cleared the
+  // equipment and put an error dialog over the page. The purse and the gear are one decision and
+  // have to arrive together.
+  let startingGp = $state(Math.floor(initial.startingWealthCp / 100));
+  let startingSp = $state(Math.floor((initial.startingWealthCp % 100) / 10));
+  let startingCp = $state(initial.startingWealthCp % 10);
 
   let classFeaturesSeed = $state(initial.classFeaturesSeed);
   let selectedWeaponNames = $state<string[]>(initial.selectedWeaponNames);
@@ -161,8 +165,8 @@
   );
   let presetSetName = $state('human');
   let savedCultureName = $state('');
-  let firstName = $state('');
-  let lastName = $state('');
+  let firstName = $state(initial.firstName);
+  let lastName = $state(initial.lastName);
   let lockName = $state(false);
   let namingGender = $state<'male' | 'female' | 'random'>('random');
   let referencedCulture = $state<Culture | undefined>();
@@ -368,8 +372,26 @@
     }
   });
 
+  /**
+   * What these two reset effects were keyed on when they last ran.
+   *
+   * `null` means "has not run yet", and the first run is the one that must do nothing. Both
+   * effects exist to clear a choice that belongs to a class the user has moved away from, and both
+   * used to fire on mount as well — which silently wiped the spell picks and the thief allocation
+   * that `adndBuildFromSnapshot` had just restored. A saved caster then read as an unfinished form
+   * and showed no character at all.
+   */
+  let lastSpellClass: string | null = null;
+  let lastThiefKey: string | null = null;
+
   $effect(() => {
     const cls = selectedClass;
+    const key = cls?.name ?? '';
+    if (lastSpellClass === null || lastSpellClass === key) {
+      lastSpellClass = key;
+      return;
+    }
+    lastSpellClass = key;
     if (!cls?.hasSpells) {
       starterSpellPicks = [];
       return;
@@ -380,11 +402,12 @@
 
   $effect(() => {
     const key = thiefSkillBonusResetKey;
-    if (!thiefSkillKind || !characterAfterRace) {
-      thiefSkillBonuses = {};
+    if (lastThiefKey === null || lastThiefKey === key) {
+      lastThiefKey = key;
       return;
     }
-    if (!key) {
+    lastThiefKey = key;
+    if (!thiefSkillKind || !characterAfterRace || !key) {
       thiefSkillBonuses = {};
       return;
     }
@@ -603,19 +626,33 @@
   );
 
   /**
+   * What was last announced to the surrounding surface, as a value rather than a reference.
+   *
+   * `toAdndCharacterSnapshot` builds a fresh object every time it runs, so announcing on every
+   * render meant announcing a *different object* describing an *identical character*. The surface
+   * stored it, re-rendered, and the effect ran again — a loop that never settled. The panel stayed
+   * visibly alive and its Save button could not be clicked, because nothing was ever stable long
+   * enough. Comparing by value is what stops it.
+   */
+  let lastAnnounced: string | null = null;
+
+  /**
    * Tell the surrounding artifact surface what the form now describes.
    *
    * Only when mounted as an editor; on its own route there is nobody to tell, and the builder
-   * saves for itself. Announcing a snapshot identical to the stored one is harmless — the
-   * framework's dirty check is `sameSnapshot`, a value comparison — so this does not need to know
-   * whether the user has actually changed anything, which is just as well, because the answer is
-   * spread across every control on the page.
+   * saves for itself.
    */
   $effect(() => {
     const snapshot = previewSnapshot;
-    if (onChange !== undefined && snapshot !== null) {
-      onChange(snapshot);
+    if (onChange === undefined || snapshot === null) {
+      return;
     }
+    const announced = JSON.stringify(snapshot);
+    if (announced === lastAnnounced) {
+      return;
+    }
+    lastAnnounced = announced;
+    onChange(snapshot);
   });
 
   /**
@@ -1041,7 +1078,13 @@
             : [cultureReference]}
         />
 
-        <details class="builder-details">
+        <!--
+          `aria-label` because a `<details>` maps to an unnamed `group`: the `<summary>` names the
+          disclosure visually but does not name the group in the accessibility tree, so a screen
+          reader announces "group" with nothing after it. Native `<details>` keeps the keyboard
+          behaviour that a custom disclosure would have to reimplement (6.2).
+        -->
+        <details class="builder-details" aria-label="Details">
           <summary>Details</summary>
 
           <p class="builder-details-note">

--- a/src/components/characters/AdndCharacterGenerator.svelte
+++ b/src/components/characters/AdndCharacterGenerator.svelte
@@ -33,7 +33,18 @@
   let lockSeed = $state(false);
   let includeProficiencies = $state(false);
   let includeKits = $state(false);
-  let character = $state<ADNDCharacter | undefined>();
+  /**
+   * The rolled character.
+   *
+   * `$state.raw`, and this is not a preference. Deep-reactive `$state` wraps every array and
+   * object inside the character in a Proxy, and `structuredClone` — what IndexedDB stores with —
+   * refuses a Proxy outright. Saving failed with
+   * `[object Array] could not be cloned` and kept failing until an end-to-end test tried it: no
+   * unit test touches Svelte state, so nothing below the browser could see it. The same trap is
+   * written up in `$lib/workshop`'s README beside `saveToolArtifact`, and guarding the config
+   * alone was not enough — the payload goes to the same place.
+   */
+  let character = $state.raw<ADNDCharacter | undefined>();
   let downloadingPdf = $state(false);
   /**
    * The settings the character on screen was actually rolled with.
@@ -67,6 +78,11 @@
    */
   let rolledCultureReference = $state.raw<ArtifactReference | undefined>();
 
+  /** The character with the names the page is showing, which is what the sheet and the PDF want. */
+  const namedCharacter = $derived(
+    character === undefined ? undefined : { ...character, firstName, lastName },
+  );
+
   /**
    * What gets stored, with the names the page is showing rather than the ones the roll produced.
    *
@@ -75,18 +91,10 @@
    * can see is not what they asked for.
    */
   const characterSnapshot = $derived(
-    character === undefined ? null : toAdndCharacterSnapshot({ ...character, firstName, lastName }),
+    namedCharacter === undefined ? null : toAdndCharacterSnapshot(namedCharacter),
   );
 
   const defaultArtifactName = $derived(`${firstName} ${lastName}`.trim());
-
-  function applyNamesToCharacter(target: ADNDCharacter | undefined) {
-    if (!target) {
-      return;
-    }
-    target.firstName = firstName;
-    target.lastName = lastName;
-  }
 
   /**
    * Names for the current source, from a stream the seed decides.
@@ -204,21 +212,19 @@
     const generated = rollNamesForCurrentSource(defaultHint, `${Date.now()}-adnd-name`);
     firstName = generated.firstName;
     lastName = generated.lastName;
-    if (character) {
-      character.firstName = generated.firstName;
-      character.lastName = generated.lastName;
-    }
+    // The character is not touched: it is raw state, and every reader already composes the names
+    // the page is showing over it.
   }
 
   async function downloadPdf() {
-    if (downloadingPdf || !character) {
+    const sheet = namedCharacter;
+    if (downloadingPdf || sheet === undefined) {
       return;
     }
 
-    applyNamesToCharacter(character);
     downloadingPdf = true;
     try {
-      await downloadAdndCharacterPdf(character);
+      await downloadAdndCharacterPdf(sheet);
     } finally {
       downloadingPdf = false;
     }
@@ -298,6 +304,6 @@
   />
 
   {#if character}
-    <AdndCharacterSheet character={{ ...character, firstName, lastName }} />
+    <AdndCharacterSheet character={namedCharacter!} />
   {/if}
 </GeneratorPage>

--- a/src/lib/adnd/README.md
+++ b/src/lib/adnd/README.md
@@ -70,3 +70,48 @@ import { downloadAdndCharacterPdf } from '$lib/adnd';
 
 await downloadAdndCharacterPdf(character);
 ```
+
+## What edition this is, and what it leaves out
+
+Requirement 8.4 in [the readiness spec](../../../docs/workshop.md#8-documentation) asks a tool
+that implements a game system to say which edition and what it deliberately omits. This is
+**AD&D 2nd Edition**, from the Player's Handbook.
+
+Everything here is **level 1**. That is the single largest omission and the one every other
+follows from: there is no experience progression, no hit dice past the first, no spell progression
+table, and no saving-throw improvement. A character is made and then read; it is not advanced.
+
+Also deliberately absent:
+
+- **Multi-classing and dual-classing.** A character has exactly one class. The demihuman
+  multi-class combinations are a large part of the PHB and none of them are here.
+- **Psionics.** Not modelled at all.
+- **Non-weapon proficiency slots and checks.** `selectNonweaponProficiencies` picks a plausible
+  list of names. It does not track slot costs, does not spend them against an allowance, and there
+  is no proficiency check.
+- **The mechanical half of kits.** `adnd_kits_data.ts` is curated narrative features, chosen for
+  what they suggest at a table. A kit's real hindrances, weapon restrictions, and benefits are not
+  applied to the character.
+- **Encumbrance, movement, and combat resolution.** Weight allowance and maximum press are
+  computed and shown, but nothing consumes them.
+- **Spheres and schools beyond filtering.** A priest's spells are drawn through `SpellFilter`
+  rather than by modelling sphere access.
+
+Two rules are implemented in a way worth naming, because they are easy to misread as bugs:
+
+- **Discretionary thief skill points are spent exactly.** `distributePoints` clamps its last award
+  to whatever is left of the pool. It did not always: 86% of rolled rogues used to come out above
+  their budget, by as much as 27 points on a pool of 60.
+- **A roll that qualifies for no class is re-rolled**, up to twenty times. Straight 3d6 down the
+  line can produce a character no class will take under any race — the PHB's own answer is to roll
+  again, and `generateCharacter` does.
+
+## Storage
+
+An AD&D character is an artifact of kind `character.adnd-2e`, shared by the generator at
+`/fantasy/adnd/character` and the builder at `/fantasy/adnd/character/build`. `ADNDRace` and
+`ADNDClass` each carry an `apply` function and so are stored by name; everything else on the
+character, including every derived number, travels as it is. See
+[the design](../../../docs/adnd-character.md) for why the numbers are kept rather than recomputed,
+and [subraces](../../../docs/adnd-subraces.md) for why a variety is a field on the character rather
+than a rewrite of its race.

--- a/src/lib/adnd/adnd_character_build.test.ts
+++ b/src/lib/adnd/adnd_character_build.test.ts
@@ -9,11 +9,13 @@ import {
   adndRaceOptionsForBuild,
   buildAdndCharacter,
   createAdndCharacterBuild,
+  findAdndClass,
   readAdndCharacterBuildRecord,
   rebuildAdndCharacterSnapshot,
   toAdndCharacterBuildRecord,
   type AdndCharacterBuild,
 } from './adnd_character_build.js';
+import { getStartingSpellChoiceGroups } from './adnd_class_starting_spells.js';
 import { rollAdndCharacter } from './adnd_character_roll.js';
 import { toAdndCharacterSnapshot } from './adnd_character_snapshot.js';
 import type { AdndCharacterSnapshot } from './adnd_character_snapshot.js';
@@ -418,5 +420,97 @@ describe('readAdndCharacterBuildRecord', () => {
     expect(record.raceName).toBe('');
     expect(record.className).toBe('');
     expect(rebuildAdndCharacterSnapshot('seed', record)).toBeNull();
+  });
+});
+
+describe('a form that is only part-filled', () => {
+  /**
+   * The regression this exists for.
+   *
+   * `buildAdndCharacter` runs on every keystroke, including from the hit-point bounds, which need
+   * a character long before the spell step has been reached. `startingSpellsFromPicks` throws on a
+   * partial set, so building a caster with no picks yet took the whole builder down: the derived
+   * value threw, the page stopped updating, and the alignment step never appeared. No unit test
+   * saw it because none built a caster mid-form, and no end-to-end test saw it because none drove
+   * the builder past choosing a class.
+   */
+  it('builds a caster whose spells have not been chosen yet', () => {
+    const build = composedBuild();
+    build.className = 'cleric';
+    build.alignment = 'true neutral';
+    build.starterSpellPicks = [];
+
+    const character = buildAdndCharacter(build);
+
+    expect(character).not.toBeNull();
+    expect(character?.class.name).toBe('cleric');
+    expect(character?.spells).toEqual([]);
+  });
+
+  it('never throws while the form is being filled in', () => {
+    const build = composedBuild();
+    build.className = 'cleric';
+    build.alignment = 'true neutral';
+
+    for (const picks of [[], [[]], [['']], [['Bless', '']]]) {
+      build.starterSpellPicks = picks;
+      expect(() => buildAdndCharacter(build)).not.toThrow();
+    }
+  });
+
+  it('uses the picks once they are complete', () => {
+    const build = composedBuild();
+    build.className = 'cleric';
+    build.alignment = 'true neutral';
+    const groups = getStartingSpellChoiceGroups(findAdndClass('cleric')!);
+    build.starterSpellPicks = groups.map((group) =>
+      group.candidates.slice(0, group.count).map((spell) => spell.name),
+    );
+
+    const character = buildAdndCharacter(build);
+
+    expect(character?.spells.length).toBeGreaterThan(0);
+  });
+});
+
+describe('reopening a saved caster', () => {
+  /**
+   * A saved caster used to reopen as nothing at all.
+   *
+   * `adndBuildFromSnapshot` rebuilt the spell picks as one flat list, but
+   * `starterSpellSelectionIsComplete` checks each of the class's groups against its own count, so
+   * the form read as unfinished and the preview — which waits for complete picks — waited forever.
+   * The builder showed a blank page for a character that was saved perfectly well.
+   */
+  it('shows the character it was handed', () => {
+    const snapshot = generatedSnapshot((s) => s.spells.length > 0);
+
+    const character = buildAdndCharacter(adndBuildFromSnapshot(snapshot, 'seed'));
+
+    expect(character).not.toBeNull();
+    expect(character?.spells.map((spell) => spell.name)).toEqual(
+      snapshot.spells.map((spell) => spell.name),
+    );
+  });
+
+  it('round-trips a caster unchanged, so opening one is not an edit', () => {
+    const snapshot = generatedSnapshot((s) => s.spells.length > 0);
+
+    const rebuilt = buildAdndCharacter(adndBuildFromSnapshot(snapshot, 'seed'));
+
+    expect(toAdndCharacterSnapshot(rebuilt!)).toEqual(snapshot);
+  });
+
+  it('gives every group one entry per slot', () => {
+    const snapshot = generatedSnapshot((s) => s.spells.length > 0);
+    const cls = findAdndClass(snapshot.className)!;
+
+    const build = adndBuildFromSnapshot(snapshot, 'seed');
+
+    const groups = getStartingSpellChoiceGroups(cls);
+    expect(build.starterSpellPicks).toHaveLength(groups.length);
+    build.starterSpellPicks.forEach((row, index) => {
+      expect(row).toHaveLength(groups[index].count);
+    });
   });
 });

--- a/src/lib/adnd/adnd_character_build.ts
+++ b/src/lib/adnd/adnd_character_build.ts
@@ -33,7 +33,11 @@ import {
   applyThiefSkillAllocation,
   getThiefSkillBuildKindForClass,
 } from './adnd_thief_skill_builder.js';
-import { startingSpellsFromPicks } from './adnd_class_starting_spells.js';
+import {
+  getStartingSpellChoiceGroups,
+  starterSpellSelectionIsComplete,
+  startingSpellsFromPicks,
+} from './adnd_class_starting_spells.js';
 import type ADNDCharacter from './adndcharacter.js';
 import { createAdndCharacter } from './adndcharacter.js';
 import {
@@ -261,7 +265,12 @@ function applyBuildFields(character: ADNDCharacter, build: AdndCharacterBuild): 
   character.lastName = build.lastName;
   character.hp = build.hp;
 
-  if (cls.hasSpells) {
+  // Only once the picks are complete. `startingSpellsFromPicks` throws on a partial set, and this
+  // function runs on every keystroke of a form the user is still filling in — including from
+  // `characterForHpBounds`, which needs a character before the spell step has been reached. A
+  // half-filled form is not an error, it is a form; the caller decides when to show what it
+  // describes.
+  if (cls.hasSpells && starterSpellSelectionIsComplete(cls, build.starterSpellPicks)) {
     character.spells = startingSpellsFromPicks(cls, build.starterSpellPicks);
   }
 
@@ -357,6 +366,28 @@ export function buildAdndCharacter(build: AdndCharacterBuild): ADNDCharacter | n
  * The subrace comes back exactly, now that it is a field on the payload rather than something
  * smuggled into the race's name (#99).
  */
+/**
+ * A stored spellbook back into the per-group picks the builder's controls hold.
+ *
+ * The groups matter. `getStartingSpellChoiceGroups` may return several — a priest chooses from
+ * more than one sphere — and `starterSpellSelectionIsComplete` checks each against its own count.
+ * Reconstructing the picks as one flat list therefore read as an unfinished form, and a saved
+ * caster reopened in the builder showed no character at all: the preview waits for complete picks,
+ * so it waited forever. Splitting the stored spells across the groups in order is what the builder
+ * itself did to produce them.
+ */
+function spellPicksFromSpells(cls: ADNDClass, snapshot: AdndCharacterSnapshot): string[][] {
+  const names = snapshot.spells.map((spell) => spell.name);
+  let taken = 0;
+  return getStartingSpellChoiceGroups(cls).map((group) => {
+    const slice = names.slice(taken, taken + group.count);
+    taken += group.count;
+    // Padded, so a group short of spells still has one entry per slot: the completeness check
+    // counts entries, and a short row would be indistinguishable from a form still being filled.
+    return Array.from({ length: group.count }, (_, index) => slice[index] ?? '');
+  });
+}
+
 export function adndBuildFromSnapshot(
   snapshot: AdndCharacterSnapshot,
   classFeaturesSeed: string,
@@ -366,8 +397,7 @@ export function adndBuildFromSnapshot(
     0,
   );
   const cls = findAdndClass(snapshot.className);
-  const spellPicks =
-    cls !== null && cls.hasSpells ? [snapshot.spells.map((spell) => spell.name)] : [];
+  const spellPicks = cls !== null && cls.hasSpells ? spellPicksFromSpells(cls, snapshot) : [];
 
   return {
     base: snapshot,

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -101,13 +101,23 @@ describe('TOOL_CATALOG', () => {
     expect(findToolByPath('/culture')?.maturity).toBe('release-ready');
     expect(findToolByPath('/fantasy/religion')?.maturity).toBe('release-ready');
     expect(findToolByPath('/heraldry')?.maturity).toBe('beta');
+    // The AD&D pair, assessed together because they share an artifact kind (#45, #47).
+    expect(findToolByPath('/fantasy/adnd/character')?.maturity).toBe('release-ready');
+    expect(findToolByPath('/fantasy/adnd/character/build')?.maturity).toBe('release-ready');
   });
 
   it('leaves every other tool Experimental until it is taken further', () => {
     // A tripwire rather than a rule: raising a tool's level means adding it here, in the same
     // change that earns it. That is the point — a level should not be able to rise as a side
     // effect of editing a catalog entry for some other reason.
-    const assessedHigher = ['/culture', '/fantasy/religion', '/fantasy/settlement', '/heraldry'];
+    const assessedHigher = [
+      '/culture',
+      '/fantasy/religion',
+      '/fantasy/settlement',
+      '/heraldry',
+      '/fantasy/adnd/character',
+      '/fantasy/adnd/character/build',
+    ];
 
     const claimingMore = TOOL_CATALOG.filter(
       (tool) => !assessedHigher.includes(tool.path) && tool.maturity !== 'experimental',
@@ -201,6 +211,8 @@ describe('toolsWithMaturity', () => {
 
     expect(releaseReady.map((tool) => tool.path).sort()).toEqual([
       '/culture',
+      '/fantasy/adnd/character',
+      '/fantasy/adnd/character/build',
       '/fantasy/religion',
       '/fantasy/settlement',
     ]);
@@ -248,6 +260,8 @@ describe('filterTools', () => {
     });
 
     expect(durableFantasy.map((tool) => tool.path)).toEqual([
+      '/fantasy/adnd/character/build',
+      '/fantasy/adnd/character',
       '/culture',
       '/fantasy/religion',
       '/fantasy/settlement',

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -25,7 +25,10 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     label: 'AD&D 2E Character Builder',
     kind: 'editor',
     domain: 'characters',
-    maturity: 'experimental',
+    // Release-ready, assessed section by section against docs/workshop.md and recorded in
+    // docs/adnd-character.md (#45). It is also the editor `ARTIFACT_EDITORS` mounts for
+    // `character.adnd-2e`, so editing a saved character and building a new one are the same tool.
+    maturity: 'release-ready',
     genres: ['fantasy'],
     systems: ['adnd-2e'],
     tags: ['character'],
@@ -44,7 +47,8 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     label: 'AD&D 2E Character',
     kind: 'generator',
     domain: 'characters',
-    maturity: 'experimental',
+    // Release-ready, assessed with the builder it shares a kind with (#47, docs/adnd-character.md).
+    maturity: 'release-ready',
     genres: ['fantasy'],
     systems: ['adnd-2e'],
     tags: ['character'],


### PR DESCRIPTION
Step 7, the last of [`docs/adnd-character.md`](https://github.com/ironarachne/ironarachne/blob/main/docs/adnd-character.md). **Closes #45 and #47.**

Both catalog entries now read `maturity: 'release-ready'` — assessed section by section against the readiness spec rather than declared. The assessment is in the design document under "What shipped".

## The end-to-end test earned its place immediately

Requirement 7.4 was the last thing built, and it found **five bugs**, none of which any unit test could have seen — each lived between Svelte's reactivity and the store.

| Bug | Effect |
| --- | --- |
| `character` was deep-reactive `$state` | **The generator could not save at all.** `structuredClone` — what IndexedDB writes with — refused the Proxy arrays. Guarding the provenance config wasn't enough; the payload goes to the same place. |
| `buildAdndCharacter` threw on partial spell picks | **The builder crashed for every spellcasting class**, before the alignment step appeared |
| Spellbook rebuilt as one flat list | **Reopening a saved caster showed nothing** — the form read as unfinished forever |
| Starting funds not seeded from the artifact | **Reopening a character with equipment deleted the gear** and put an error dialog over the page |
| A new snapshot announced every render | The editor never settled; Save was unclickable |

**The last three share a cause worth naming.** The builder is the first artifact editor with state of its own. Culture, religion and settlement editors hold everything in the snapshot prop, so nothing about seeding or re-announcing could go wrong for them. A *tool* mounted as an editor has to be seeded completely and has to announce only real changes — neither requirement existed before this kind, and neither was in the design.

Both the spell and thief-skill reset effects also had to stop firing on their first run, which was wiping the allocation the builder had just restored.

## Accessibility

6.2 is met by **driving the whole builder through roles and accessible names** in the test rather than asserting it. That found the one real defect: `<details>` maps to an unnamed `group`, so the Details disclosure announced as "group" with nothing after it. It has an `aria-label` now.

The equipment checkboxes and thief-skill inputs were already named by their wrapping labels — the design's claim that they weren't was wrong, as its claim about empty PDF sections was. Both corrections are recorded.

## Two tripwires fired, both correctly

- The catalog's maturity test requires a tool to be **named in the same change that raises it**.
- `tool_maturity.spec.ts` asserts release-ready reaches **no screen at all** (#43), so both tools moved from "shows Experimental" to "shows no badge" and the browser's unmarked count went from three to five.

## Documentation

`$lib/adnd/README.md` gains what 8.4 asks for: AD&D 2nd Edition from the Player's Handbook, everything level 1, with multi-classing, psionics, proficiency slot accounting, the mechanical half of kits, and encumbrance deliberately absent.

## Verification

- `npm run verify` — green. 4320 tests, `0 ERRORS`, coverage gate passed.
- `npm run test:e2e` — green, **408 passed** (up from 402).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
