### PR TITLE
Give the tool catalog a page of its own

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,11 @@ Every generator/editor/reference page has an entry in the tool catalog, created 
 tool browser and the home page's featured list are both built from it — it's the single source of
 truth for a tool's name and classification. A new tool route needs a catalog entry.
 
-Tools are **not** in the site's navigation: the sidebar has five destinations
-(`src/lib/navigation`) and the workshop's browser is how a tool is reached. Tool routes still
-resolve by URL, for search-engine arrivals and one-off use. See `docs/app-shell.md`.
+No individual tool is in the site's navigation. The sidebar has six destinations
+(`src/lib/navigation`), one of which is **All Tools** (`/tools`) — the catalog as a page of links,
+grouped by domain, and the way a visitor reaches a tool without the bench. The workshop's browser
+reaches the same tools as panels. Tool routes also still resolve by URL, for search-engine
+arrivals and one-off use. See `docs/app-shell.md`.
 
 `workshop` maps a catalog `path` to the Svelte component that renders it (`TOOL_PANELS`), so tools
 can be mounted in a panel (e.g. a multi-tool workspace) instead of only on their own route. Import
@@ -136,10 +138,11 @@ before it is persisted or exported.
 ### The application shell (`src/lib/navigation`, `src/routes/+layout.svelte`)
 
 Every route renders inside a shell: a pinned top bar (lockup, live tool/artifact counts, the open
-project, the date) and a left sidebar of exactly five destinations — Home, Workshop, Projects,
-Result Vault, Release Notes. `NAV_DESTINATIONS` is the single source of truth for that list and
-five is a cap, not a coincidence. Below 768px the sidebar is a drawer and the page region goes
-`inert` behind it.
+project, the date) and a left sidebar of exactly six destinations — Home, Workshop, All Tools,
+Projects, Result Vault, Release Notes. `NAV_DESTINATIONS` is the single source of truth for that
+list and six is a cap, not a coincidence: it read five until #105, and decision 5 in
+`docs/app-shell.md` records why All Tools is the exception rather than a precedent. Below 768px the
+sidebar is a drawer and the page region goes `inert` behind it.
 
 Prose is capped by `--measure` on `section.main`, not by `html`. A page that wants the full width
 opts out by not being `section.main` — that is the whole of the opt-out mechanism, and it is how

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,9 +107,11 @@ Every generator/editor/reference page has an entry in the tool catalog, created 
 tool browser and the home page's featured list are both built from it — it's the single source of
 truth for a tool's name and classification. A new tool route needs a catalog entry.
 
-Tools are **not** in the site's navigation: the sidebar has five destinations
-(`src/lib/navigation`) and the workshop's browser is how a tool is reached. Tool routes still
-resolve by URL, for search-engine arrivals and one-off use. See `docs/app-shell.md`.
+No individual tool is in the site's navigation. The sidebar has six destinations
+(`src/lib/navigation`), one of which is **All Tools** (`/tools`) — the catalog as a page of links,
+grouped by domain, and the way a visitor reaches a tool without the bench. The workshop's browser
+reaches the same tools as panels. Tool routes also still resolve by URL, for search-engine
+arrivals and one-off use. See `docs/app-shell.md`.
 
 `workshop` maps a catalog `path` to the Svelte component that renders it (`TOOL_PANELS`), so tools
 can be mounted in a panel (e.g. a multi-tool workspace) instead of only on their own route. Import
@@ -149,10 +151,11 @@ before it is persisted or exported.
 ### The application shell (`src/lib/navigation`, `src/routes/+layout.svelte`)
 
 Every route renders inside a shell: a pinned top bar (lockup, live tool/artifact counts, the open
-project, the date) and a left sidebar of exactly five destinations — Home, Workshop, Projects,
-Result Vault, Release Notes. `NAV_DESTINATIONS` is the single source of truth for that list and
-five is a cap, not a coincidence. Below 768px the sidebar is a drawer and the page region goes
-`inert` behind it.
+project, the date) and a left sidebar of exactly six destinations — Home, Workshop, All Tools,
+Projects, Result Vault, Release Notes. `NAV_DESTINATIONS` is the single source of truth for that
+list and six is a cap, not a coincidence: it read five until #105, and decision 5 in
+`docs/app-shell.md` records why All Tools is the exception rather than a precedent. Below 768px the
+sidebar is a drawer and the page region goes `inert` behind it.
 
 Prose is capped by `--measure` on `section.main`, not by `html`. A page that wants the full width
 opts out by not being `section.main` — that is the whole of the opt-out mechanism, and it is how

--- a/docs/app-shell.md
+++ b/docs/app-shell.md
@@ -1,7 +1,7 @@
 # The application shell
 
 This design document describes the navigation and layout Iron Arachne is rebuilt on: a persistent
-**shell** — a top bar and a left sidebar — wrapped around five destinations, replacing the header
+**shell** — a top bar and a left sidebar — wrapped around six destinations, replacing the header
 and tool taxonomy the site has today.
 
 It is the layout half of [the workshop](workshop.md). The workshop settled what a user's work
@@ -56,7 +56,7 @@ One shell, always present, on every route:
 
 - **Top bar** — identity on the left, status in the middle, today's date on the right. It tells you
   where you are and what you have; it holds no navigation.
-- **Left sidebar** — the five destinations, and nothing else. This is the whole of the site's
+- **Left sidebar** — the six destinations, and nothing else. This is the whole of the site's
   navigation.
 - **Page region** — everything else, filling the remaining viewport in both directions.
 
@@ -65,18 +65,23 @@ first column, so the page region is a single grid cell that owns exactly the spa
 does not scroll the shell away: the sidebar and top bar are pinned, and scrolling happens inside
 the page region.
 
-### Five destinations
+### Six destinations
 
-The sidebar is deliberately short. Five items is a list you read rather than scan, and the moment a
-sixth is proposed the question is which of these five it belongs inside.
+The sidebar is deliberately short. Six items is a list you read rather than scan, and the moment a
+seventh is proposed the question is which of these six it belongs inside.
 
 | Destination       | Route            | What it is                                                     |
 | ----------------- | ---------------- | -------------------------------------------------------------- |
 | **Home**          | `/`              | What this site is, what to try, what changed.                  |
 | **Workshop**      | `/workshop`      | The bench. The main screen; where the work is done.            |
+| **All Tools**     | `/tools`         | The whole catalog, grouped by domain, every entry a link.      |
 | **Projects**      | `/projects`      | The projects a user has, and which one is open.                |
 | **Result Vault**  | `/vault`         | Every saved artifact, across every project, with an inspector. |
 | **Release Notes** | `/release-notes` | What changed and when.                                         |
+
+This document was written with five, and the sixth was added afterwards by
+[#105](https://github.com/ironarachne/ironarachne/issues/105); see
+[decision 5](#decisions-taken-here) for why it is the one exception the cap has.
 
 #### Home
 
@@ -120,8 +125,8 @@ artifacts they hold. Create, rename, describe, tag, delete, export, import, and 
 
 Below the cards is the **storage panel** — what is in this browser, how long it has been the only
 copy, and what to do about it, including the whole-vault export and the per-project sizes the cards
-no longer carry. It is a section of this page with the id `storage` rather than a sixth
-destination, because five destinations is a cap; the workshop reaches it by link and, when the
+no longer carry. It is a section of this page with the id `storage` rather than a destination of
+its own, because the sidebar is capped; the workshop reaches it by link and, when the
 browser is nearly full, by banner. See [the storage panel](storage-panel.md).
 
 #### Result Vault
@@ -378,6 +383,15 @@ lists better. Navigation no longer surfaces tools; URLs still resolve them.
 This narrows, but does not contradict, the Routes section of `docs/workshop.md`. That section
 should be amended to say the routes are an entry point rather than a navigational destination.
 
+**Amended by [#105](https://github.com/ironarachne/ironarachne/issues/105).** The half of this that
+was wrong is "links that `ToolBrowser` lists better". `ToolBrowser` lists them _differently_: it
+renders a button that mounts a panel, and a button is not a link. With the index pages gone, and
+the home page linking only the two featured entries, thirty-two of the thirty-four tools had no
+anchor pointing at them anywhere on the site — nothing for a crawler to follow, nothing to
+bookmark, nothing to open in a new tab. Deleting five taxonomy pages was still right. Leaving the
+catalog with no linked index at all was not, and `/tools` is that index: one page, every entry an
+anchor to the tool's own route.
+
 **2. The vault is global; the Inspector is read-only.** Covered above. The pairing is the decision:
 a global vault is only safe because nothing in it can be edited in place, and an editable global
 vault would be a way to build cross-project references by accident.
@@ -388,9 +402,21 @@ vault would be a way to build cross-project references by accident.
 to every route including the tool routes, rather than being a `(app)` route group that some pages
 sit outside. A tool route that renders without the shell would have no way back to anything.
 
-**5. Five destinations is the cap.** An About page, a search, a settings screen — each of these has
-been reasonable to want, and each belongs inside one of the five rather than beside them. The
+**5. Six destinations is the cap.** An About page, a search, a settings screen — each of these has
+been reasonable to want, and each belongs inside one of the six rather than beside them. The
 sidebar's value is that it is short enough not to need reading.
+
+**Amended by [#105](https://github.com/ironarachne/ironarachne/issues/105); it read five.** The cap
+is unchanged in kind — the test is still "which of these does it belong inside?" — and All Tools is
+the one entry that failed to have an answer. It is not a tool, so it does not reopen the taxonomy
+this document deleted; no individual generator appears in the sidebar and none may. What it is is
+the catalog's front door, and per the amendment to decision 1 there was no other door. Home is
+where someone reads what the site is, the workshop is where the work happens, and neither can be
+the place thirty-four links live without becoming the taxonomy page in disguise.
+
+Raising a cap is cheap to do twice, which is the risk. So the number lives in a test that asserts
+the destination list itself rather than its length (`nav_destinations.test.ts`): a seventh
+destination cannot be added without editing an assertion that says, in words, that it is capped.
 
 **6. No icons; the rail is a narrower sidebar.** Taken during implementation, and it drops the
 `iconName` the approved model carried. The brand repo has no icon set, and five marks drawn in the

--- a/docs/storage-panel.md
+++ b/docs/storage-panel.md
@@ -57,7 +57,7 @@ The panel therefore states; it does not alarm. Nothing in sections 1–3 is styl
 region that is already there.** The workshop reaches it by a link.
 
 The issue asks for a panel "reachable from the workshop", and that wording predates the shell. Since
-[docs/app-shell.md](app-shell.md) the site has **five destinations and five is a cap**, and project
+[docs/app-shell.md](app-shell.md) the site's **sidebar is capped**, and project
 management — export, import, delete, and how much room each project takes — has already moved to
 `/projects`. That leaves three candidate homes, and two of them are worse:
 
@@ -398,8 +398,8 @@ and routes, so they are what `npm run verify:all` exists for.
 
 ## Decisions taken here
 
-**1. The panel is a section of `/projects` with the id `storage`, not a sixth destination and not a
-bench panel.** Five destinations is a cap, and administration was moved off the bench on purpose. The
+**1. The panel is a section of `/projects` with the id `storage`, not a destination of its own and
+not a bench panel.** The sidebar is capped, and administration was moved off the bench on purpose. The
 workshop reaches it with a link and, when there is something to escalate, a banner.
 
 **2. The panel absorbs the Backup region rather than sitting beside it.** Whole-vault export moves

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -476,7 +476,7 @@ told them about. Two moments and one place.
 
 The panel, the table and the escalation below are designed for implementation in
 [The storage panel](storage-panel.md), which settles where the panel lives now that the shell caps
-the sidebar at five destinations, how a figure that is an estimate is phrased, and what the eighty
+the sidebar, how a figure that is an estimate is phrased, and what the eighty
 per cent banner may say.
 
 **At first project creation — said once, plainly.** Work is stored in this browser only; there is

--- a/e2e/all_tools.spec.ts
+++ b/e2e/all_tools.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+const DESKTOP = { width: 1400, height: 900 };
+
+const index = (page: Page) => page.locator('section.all-tools');
+const toolLinks = (page: Page) => index(page).locator('a.all-tools__tool');
+
+test.describe('the tool index', () => {
+  test('links every tool in the catalog', async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await visitRoute(page, '/tools', { title: 'All Tools | Iron Arachne' });
+
+    // Counted against the top bar's own figure rather than against a number written here, and
+    // rather than against `TOOL_CATALOG` imported from `src`: the suites mirror the app instead of
+    // reading its constants, so a test cannot pass by agreeing with a catalog that failed to
+    // render. The bar reads the catalog's length on every page, so "the index lists as many tools
+    // as the shell says exist" is the whole claim — a tool added without an anchor fails here.
+    const declared = Number(
+      await page.locator('.top-bar .top-bar__stat--tools dd').first().innerText(),
+    );
+
+    expect(declared).toBeGreaterThan(0);
+    await expect(toolLinks(page)).toHaveCount(declared);
+  });
+
+  test('goes to the tool on its own route rather than opening a panel', async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await visitRoute(page, '/tools', { title: 'All Tools | Iron Arachne' });
+
+    // The reason the page exists: these are anchors, so following one navigates. A button that
+    // mounted a panel would leave the URL on /tools, which is the dead end the workshop's browser
+    // already is for anyone who wanted a link.
+    // Matched on the start of the accessible name, not the whole of it: the maturity badge sits
+    // inside the anchor, so the name a screen reader reads is "Culture Experimental" today and
+    // "Culture" on the day that tool is finished. No other label begins with the word.
+    await index(page)
+      .getByRole('link', { name: /^Culture\b/ })
+      .click();
+
+    await expect(page).toHaveURL(/\/culture\/?$/);
+    await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible();
+  });
+
+  test('narrows to a name and says how much is left', async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await visitRoute(page, '/tools', { title: 'All Tools | Iron Arachne' });
+
+    const all = await toolLinks(page).count();
+
+    await index(page).getByLabel('Filter').fill('heraldry');
+
+    await expect(toolLinks(page)).toHaveCount(1);
+    await expect(index(page).getByRole('status')).toHaveText(`1 of ${all} tools`);
+
+    await index(page).getByLabel('Filter').fill('nothing matches this');
+
+    await expect(toolLinks(page)).toHaveCount(0);
+    await expect(index(page).getByText('No tools match.')).toBeVisible();
+  });
+
+  test('marks itself in the sidebar, as a destination and not a tool route', async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await visitRoute(page, '/tools', { title: 'All Tools | Iron Arachne' });
+
+    const sidebar = page.getByRole('navigation', { name: 'Main' });
+    await expect(sidebar.getByRole('link', { name: 'All Tools', exact: true })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,12 +1,19 @@
 import { expect, type Page } from '@playwright/test';
 
 /**
- * The five shell destinations, in sidebar order. Mirrors `NAV_DESTINATIONS` in `$lib/navigation`
+ * The six shell destinations, in sidebar order. Mirrors `NAV_DESTINATIONS` in `$lib/navigation`
  * deliberately rather than importing it: this is the browser's view of the navigation, and a test
  * that read the same constant the component reads could not tell a rendering failure from an
  * empty list.
  */
-const SIDEBAR_LINKS = ['Home', 'Workshop', 'Projects', 'Result Vault', 'Release Notes'] as const;
+const SIDEBAR_LINKS = [
+  'Home',
+  'Workshop',
+  'All Tools',
+  'Projects',
+  'Result Vault',
+  'Release Notes',
+] as const;
 
 export async function visitRoute(
   page: Page,
@@ -20,7 +27,7 @@ export async function visitRoute(
 }
 
 /**
- * The shell every route renders inside: the lockup in the top bar, the five sidebar destinations,
+ * The shell every route renders inside: the lockup in the top bar, the six sidebar destinations,
  * and the footer links.
  *
  * The sidebar is only asserted at widths where it is in the layout. Below 768px it is an

--- a/e2e/page_manifest.ts
+++ b/e2e/page_manifest.ts
@@ -36,6 +36,16 @@ export const PAGE_MANIFEST: PageEntry[] = [
     kind: 'static',
   },
   {
+    // The catalog index (#105). 'static' rather than 'hub': the kind that died with the domain
+    // index pages meant "a page of links and nothing else", and the checks it carried are gone.
+    // What matters here is what every static page is checked for — it renders, it is titled, and
+    // `pages.mobile` proves thirty-four rows of links fit a phone without overflowing it.
+    path: '/tools',
+    title: 'All Tools | Iron Arachne',
+    heading: 'All Tools',
+    kind: 'static',
+  },
+  {
     path: '/character',
     title: 'Character | Iron Arachne',
     heading: 'Character',

--- a/e2e/shell.spec.ts
+++ b/e2e/shell.spec.ts
@@ -10,14 +10,15 @@ const RAIL = { width: 1000, height: 800 };
 const DRAWER = { width: 375, height: 700 };
 
 test.describe('the application shell', () => {
-  test('puts the same five destinations on every route', async ({ page }) => {
+  test('puts the same six destinations on every route', async ({ page }) => {
     await page.setViewportSize(DESKTOP);
 
-    for (const route of ['/', '/workshop', '/vault', '/projects', '/release-notes']) {
+    for (const route of ['/', '/workshop', '/tools', '/vault', '/projects', '/release-notes']) {
       await visitRoute(page, route);
       await expect(sidebar(page).getByRole('link')).toHaveText([
         'Home',
         'Workshop',
+        'All Tools',
         'Projects',
         'Result Vault',
         'Release Notes',

--- a/src/components/layout/AllToolsPage.svelte
+++ b/src/components/layout/AllToolsPage.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { allTools, groupToolsByDomain, searchTools } from '$lib/tools';
+  import ToolMaturityBadge from '$components/common/ToolMaturityBadge.svelte';
+
+  const tools = allTools();
+
+  const uid = $props.id();
+  const filterId = `${uid}-filter`;
+
+  let query = $state('');
+
+  const visibleTools = $derived(searchTools(tools, { query }));
+  const groups = $derived(groupToolsByDomain(visibleTools));
+
+  /**
+   * No genre or system filter, deliberately. Those exist on the workshop's `ToolBrowser` to narrow
+   * the catalog against the open project's setting; this page has no project and no setting, so
+   * they would be a second filtering UI answering a question nobody standing here has asked. The
+   * name filter is the whole of it — thirty-odd tools in five groups is a page you read.
+   */
+  const isFiltering = $derived(query.trim() !== '');
+</script>
+
+<svelte:head>
+  <title>All Tools | Iron Arachne</title>
+</svelte:head>
+
+<section class="all-tools">
+  <h1>All Tools</h1>
+  <p class="all-tools__lede">
+    Every generator, editor, and reference on the site. Each one works on its own — pick one and
+    start — or open it as a panel on the
+    <a href={resolve('/workshop')}>workshop</a> bench to work alongside a project.
+  </p>
+
+  <div class="all-tools__filters">
+    <div class="input-group">
+      <label for={filterId}>Filter</label>
+      <input
+        id={filterId}
+        type="search"
+        bind:value={query}
+        placeholder="Filter by name"
+        autocomplete="off"
+      />
+    </div>
+    <!-- Only while the list is actually narrowed. Announced, because on this page the list is the
+         entire content: someone filtering by ear otherwise types into a box and hears nothing. -->
+    {#if isFiltering}
+      <p class="all-tools__count" role="status">
+        {visibleTools.length} of {tools.length} tools
+      </p>
+    {/if}
+  </div>
+
+  <div class="all-tools__list">
+    {#each groups as group (group.domain)}
+      <section class="all-tools__group">
+        <h2>{group.heading}</h2>
+        <ul>
+          {#each group.tools as tool (tool.path)}
+            <li>
+              <!-- A plain anchor to the tool's own route, which is the point of the page: it can be
+                   opened in a new tab, bookmarked, and followed by a crawler. The workshop's
+                   browser mounts a panel from a button instead, so before this page nothing on the
+                   site linked to most of these routes at all.
+
+                   The cast is the one `resolve` forces: it is typed against a single route id, so
+                   a value typed as the union of every route id does not satisfy it. Every catalog
+                   path is a parameterless static route, as the home page's featured links are. -->
+              <a class="all-tools__tool" href={resolve(tool.path as '/')}>
+                <span class="all-tools__name">{tool.label}</span>
+                <!-- Same rule the workshop's browser follows, settled in #43: a release-ready tool
+                     says nothing, because the level is a qualifier on what will happen to the
+                     user's work rather than a grade. An unmarked row is a finished tool. -->
+                <ToolMaturityBadge maturity={tool.maturity} plain />
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {:else}
+      <p class="all-tools__empty">No tools match.</p>
+    {/each}
+  </div>
+</section>
+
+<style>
+  /* Not `section.main`: the measure is for running text, and a list of thirty-four names read at
+     70ch is a column of links with a screen of empty beside it. The lede below keeps the measure
+     because it is prose; the list takes the width it can use. */
+  .all-tools {
+    padding: 0.5rem;
+    max-width: 70rem;
+  }
+
+  .all-tools__lede {
+    max-width: var(--measure);
+  }
+
+  .all-tools__filters {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 1rem 0;
+  }
+
+  .all-tools__filters .input-group {
+    align-items: center;
+    display: flex;
+    gap: 0.35rem;
+    margin: 0;
+    min-width: 0;
+  }
+
+  .all-tools__count {
+    margin: 0;
+    font-size: 0.85rem;
+    opacity: 0.8;
+  }
+
+  .all-tools__group + .all-tools__group {
+    margin-top: 1.5rem;
+  }
+
+  .all-tools__group h2 {
+    color: var(--gold);
+    font-size: 0.85rem;
+    letter-spacing: 0.04em;
+    margin: 0 0 0.5rem;
+    text-transform: uppercase;
+  }
+
+  .all-tools__group ul {
+    display: grid;
+    /* One column on a phone, more as the room appears. `min(...)` rather than a bare `18rem` is
+       what keeps it from overflowing at 320px, where the track would otherwise be wider than the
+       page. */
+    grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* main.css sets `ul li { list-style-type: disc; margin-left: 2rem }` globally, which is right for
+     prose and wrong for a grid of link targets — and it is on the `li`, so undoing it on the `ul`
+     would not beat it. The sidebar undoes the same rule for the same reason. */
+  .all-tools__group li {
+    list-style-type: none;
+    margin-left: 0;
+  }
+
+  .all-tools__tool {
+    align-items: baseline;
+    background: var(--slate);
+    border: 1px solid var(--granite);
+    border-radius: 4px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: space-between;
+    padding: 0.6rem 0.75rem;
+    text-decoration: none;
+  }
+
+  .all-tools__tool:hover,
+  .all-tools__tool:focus-visible {
+    border-color: var(--tan);
+  }
+
+  .all-tools__name {
+    /* A name is one unbroken string on a 320px screen — "Species Height and Weight Calculator" is
+       the long one — and the grid track is only as wide as the page there. */
+    overflow-wrap: anywhere;
+    min-width: 0;
+  }
+
+  .all-tools__empty {
+    font-style: italic;
+    opacity: 0.8;
+  }
+</style>

--- a/src/lib/navigation/README.md
+++ b/src/lib/navigation/README.md
@@ -5,9 +5,11 @@ bar reports. See `docs/app-shell.md` for the design this implements.
 
 ## What is here
 
-- **`NAV_DESTINATIONS`** — the five sidebar destinations, in order. The single source of truth for
-  the site's navigation, the way `TOOL_CATALOG` is for tools. Five is a cap, not a coincidence:
-  a sixth entry is a sign that something belongs inside one of these rather than beside it.
+- **`NAV_DESTINATIONS`** — the six sidebar destinations, in order. The single source of truth for
+  the site's navigation, the way `TOOL_CATALOG` is for tools. Six is a cap, not a coincidence:
+  a seventh entry is a sign that something belongs inside one of these rather than beside it. It
+  read five until #105 added All Tools, the catalog's own page; see decision 5 in
+  `docs/app-shell.md` for why that one is an exception and not a precedent.
 - **`activeDestination(pathname)`** — which destination a pathname is inside, or `undefined` on a
   page that is under none of them. Tool routes are the `undefined` case: they keep their URLs but
   are not navigational destinations.

--- a/src/lib/navigation/nav_destinations.test.ts
+++ b/src/lib/navigation/nav_destinations.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
+import { allTools } from '$lib/tools';
 import { NAV_DESTINATIONS, activeDestination } from './nav_destinations';
 import type { NavDestination } from './nav_types';
 
 describe('NAV_DESTINATIONS', () => {
-  it('holds exactly the five destinations the shell is capped at', () => {
-    // The cap is decision 5 in docs/app-shell.md, and this is what makes adding a sixth a
-    // deliberate act rather than a quiet one.
+  it('holds exactly the six destinations the shell is capped at', () => {
+    // The cap is decision 5 in docs/app-shell.md, and this is what makes adding a seventh a
+    // deliberate act rather than a quiet one. It read five until #105 added the tool catalog,
+    // which is why the assertion is the list and not the length: raising the number has to be a
+    // line someone wrote on purpose.
     expect(NAV_DESTINATIONS.map((destination) => destination.id)).toEqual([
       'home',
       'workshop',
+      'tools',
       'projects',
       'vault',
       'release-notes',
@@ -29,11 +33,12 @@ describe('NAV_DESTINATIONS', () => {
   });
 
   it('lists no tool routes', () => {
-    // Tools are reached through the workshop. A tool path appearing here would be the old
-    // navigation growing back one entry at a time.
-    const toolish = NAV_DESTINATIONS.filter((destination) =>
-      destination.path.startsWith('/fantasy'),
-    );
+    // An individual tool appearing here would be the old navigation growing back one entry at a
+    // time. Checked against the catalog rather than against a path prefix: `/tools` is a
+    // destination now, so "does this look like a tool route" is no longer a question a prefix can
+    // answer, and the catalog is the only thing that knows what a tool is.
+    const catalogPaths = new Set(allTools().map((tool) => tool.path));
+    const toolish = NAV_DESTINATIONS.filter((destination) => catalogPaths.has(destination.path));
 
     expect(toolish).toEqual([]);
   });

--- a/src/lib/navigation/nav_destinations.ts
+++ b/src/lib/navigation/nav_destinations.ts
@@ -4,15 +4,26 @@ import type { NavDestination } from './nav_types';
  * Every destination the site navigates to, in sidebar order. The single source of truth for the
  * shell's navigation, the way `TOOL_CATALOG` is for tools.
  *
- * Five, and five is a cap rather than a coincidence — see
- * [decision 5](../../../docs/app-shell.md#decisions-taken-here). A sixth entry is a sign that
- * something belongs *inside* one of these, not beside it. Tools are deliberately absent: they are
- * reached through the workshop's browser, and the taxonomy that used to list them here was a
- * taxonomy of tools on a site that is no longer organised around them.
+ * Six, and six is a cap rather than a coincidence — see
+ * [decision 5](../../../docs/app-shell.md#decisions-taken-here). A seventh entry is a sign that
+ * something belongs *inside* one of these, not beside it.
+ *
+ * The sixth was taken deliberately, and it is the one exception the cap has: the catalog is not
+ * a tool, and no individual tool appears here. What put it here is that nothing else linked to a
+ * tool at all. The workshop's `ToolBrowser` renders buttons that mount a panel, and the home page
+ * links only the handful of featured entries, so thirty-two of the thirty-four tools had no
+ * anchor pointing at them anywhere on the site — not for a crawler, not for a bookmark, not for a
+ * middle click. See [decision 1](../../../docs/app-shell.md#decisions-taken-here), which deleted
+ * the five domain index pages on the understanding that the browser listed those links better.
+ * It lists them differently; it does not list links.
+ *
+ * All Tools sits beside the workshop rather than at the top, because the two are both ways into a
+ * tool and the bench keeps the position a returning user reaches for.
  */
 export const NAV_DESTINATIONS: NavDestination[] = [
   { id: 'home', label: 'Home', path: '/' },
   { id: 'workshop', label: 'Workshop', path: '/workshop' },
+  { id: 'tools', label: 'All Tools', path: '/tools' },
   { id: 'projects', label: 'Projects', path: '/projects' },
   { id: 'vault', label: 'Result Vault', path: '/vault' },
   { id: 'release-notes', label: 'Release Notes', path: '/release-notes' },

--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import AllToolsPage from '$components/layout/AllToolsPage.svelte';
+</script>
+
+<AllToolsPage />


### PR DESCRIPTION
Closes #105.

Adds `/tools` — the whole catalog, grouped by domain, every entry an anchor — and a sixth sidebar destination pointing at it.

## Why

Triage found that the issue's premise is stronger than it was stated. This is not really about discoverability; it is about links.

Decision 1 of `docs/app-shell.md` deleted the five domain index pages on the grounds that they held "links that `ToolBrowser` lists better". `ToolBrowser` lists them *differently*: it renders a `<button>` that mounts a workshop panel, and a button is not a link. With the index pages gone and the home page linking only the two `featured` entries, **32 of the 34 tools had no anchor pointing at them anywhere on the site** — nothing for a crawler to follow, nothing to bookmark, nothing to open in a new tab. The routes resolved; nothing led to them.

## The cap goes to six

Decision 5 read five, and the sixth was taken deliberately with owner sign-off on the issue. The cap is unchanged in kind — the test is still "which of these does it belong inside?" — and All Tools is the one entry with no answer. Home is where someone reads what the site is, the workshop is where the work happens, and neither can hold thirty-four links without becoming the taxonomy page this shell deleted. It is not a tool, and no individual generator appears in the sidebar.

Both decisions carry an **Amended by #105** note in the style `docs/renderers.md` already uses, so the reasoning sits where the next reader will look for it rather than only in this PR.

Raising a cap is cheap to do twice, which is the risk. `NAV_DESTINATIONS` is asserted as a list rather than a length, so a seventh destination cannot be added without editing a line that says in words that it is capped.

## What is here

- **`AllToolsPage.svelte` + `src/routes/tools/+page.svelte`** — domain grouping via `groupToolsByDomain`, a name filter over `searchTools`, maturity badges under the rule #43 settled. A plain `<a href>` per tool.
- **Sixth `NAV_DESTINATIONS` entry**, `All Tools` at `/tools`, placed after Workshop so the bench keeps the position a returning user reaches for.
- **`e2e/all_tools.spec.ts`** — four tests. The load-bearing one asserts the page links *as many tools as the top bar says exist*, counted against the shell's own figure rather than an imported constant, in keeping with how these suites mirror the app instead of reading its constants. A tool added without an anchor fails there.
- **Docs** — `app-shell.md` decisions 1 and 5, plus the stale "five destinations" claims in `CLAUDE.md`, `AGENTS.md`, the navigation README, `workshop.md`, and `storage-panel.md`.

Two decisions worth naming:

- **No catalog entry for `/tools`**, on the precedent `tool_catalog.ts` already states for the workshop: a surface is not an instrument, and an entry would make the page list itself.
- **The page is not `section.main`.** The measure is for running text, and thirty-four names read at 70ch is a column of links beside a screen of nothing. The lede keeps the measure; the grid does not.

The nav test that guarded against tool routes checked for a `/fantasy` prefix. That stopped being answerable the moment `/tools` became a destination, so it now checks against the catalog — the only thing that knows what a tool is.

## Verification

- `npm run verify` — green.
- **Full Playwright suite: 418 passed, 0 failed.** It covers `/tools` at all five phone widths, in the smoke suite, and in the static-hosting check that proves it prerenders to its own `index.html`.

## For the reviewer

- `CODE_STYLE.md` says "a new route that a visitor can reach from navigation needs a catalog entry". `/tools` deliberately has none, per the decision recorded on the issue — which means that line is now literally contradicted twice, the workshop being the first. Left alone rather than widening this change; happy to amend it.
- The anchors' accessible name is "Culture Experimental", since the badge sits inside the link. That matches `ToolBrowser`'s existing shape, but it is a real detail on a page that is nothing but links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
