### PR TITLE
Remember what the tools have rolled this session

### DIFF
--- a/src/lib/session_log/README.md
+++ b/src/lib/session_log/README.md
@@ -1,0 +1,72 @@
+# Session log
+
+What the tools have rolled since the page was loaded, so a result the user did not keep is not lost
+the moment the next one replaces it. Designed in [docs/session-log.md](../../../docs/session-log.md).
+
+A generator overwrites itself: press Generate and what was on screen is gone. By the RNG contract a
+run is fully determined by its seed and its configuration, so everything needed to get any roll back
+is small, cheap, and — until this library — discarded. The log stops discarding it.
+
+## What it is not
+
+- **Not the vault.** `/vault` and the project view list what was _kept_. This lists what was not.
+- **Not provenance.** `ArtifactProvenance` records how a saved artifact was first made, and the
+  payload is the truth there. A log entry has no payload to be the truth of, which is why replaying
+  one destroys nothing.
+- **Not undo.** Replaying an entry is a fresh run that happens to be identical, not a restoration.
+
+## Usage
+
+A tool reports at the end of its `generate()`, with the seed it rolled from and the settings it
+rolled **with** — not the ones in its controls now:
+
+```ts
+import { recordGeneration } from '$lib/session_log';
+
+recordGeneration({
+  toolPath: '/fantasy/settlement',
+  summary: settlement.name,
+  seed,
+  config: rolledConfig,
+});
+```
+
+Reporting is opt-in per tool, and a tool that cannot honour a replay does not report: an entry that
+cannot bring its result back is a list item that looks like a way back and is not.
+
+A surface reads and follows the log the way the project view follows the artifact store:
+
+```ts
+import { clearSessionLog, listSessionLog, onSessionLogChanged } from '$lib/session_log';
+
+onMount(() => {
+  refresh();
+  return onSessionLogChanged(refresh);
+});
+```
+
+## In memory, and it says so
+
+Module state, cleared by a reload. Not `localStorage`, not `sessionStorage`, not the
+`ProjectWorkspace` record — so there is no persisted shape, no version field, no migration chain,
+and nothing new in a vault file. It is also what makes replay safe without versioning: a config
+recorded by this build can only ever be replayed into this build's tool.
+
+The obligation that comes with it is on whatever renders the log: **say that nothing here is
+stored**, and that Save is what keeps a result. A list that looks like saved things but empties on
+refresh is exactly the trap [the storage disclosure](../../../docs/storage-disclosure.md) exists to
+prevent.
+
+## Two behaviours worth knowing
+
+- **Identical runs move rather than duplicate.** A run whose tool, seed, and config match an entry
+  already in the log moves that entry to the top and gives it the new time, keeping its id. Without
+  this, replaying an entry would log a copy every time — the replay causes a real generation run,
+  and a tool reports every run it makes. Comparison is `sessionRunKey`, a canonical string over the
+  path, the seed, and the config with its object keys sorted at every depth.
+- **The cap is 50, newest kept.** Not a storage limit. A bound on an array that somebody holding
+  down Generate would otherwise grow without limit.
+
+A recorded config is a canonical deep copy rather than the object it was handed. Several generators
+mutate their config in place between rolls, and a value handed over from a Svelte component is a
+deep proxy; copying is what keeps an entry a record of what the run actually used.

--- a/src/lib/session_log/index.ts
+++ b/src/lib/session_log/index.ts
@@ -1,0 +1,3 @@
+export * from './session_log';
+export * from './session_log_events';
+export * from './session_log_types';

--- a/src/lib/session_log/session_log.test.ts
+++ b/src/lib/session_log/session_log.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  canonicalSessionConfig,
+  clearSessionLog,
+  listSessionLog,
+  newSessionLogEntryId,
+  recordGeneration,
+  sessionLogSize,
+  sessionRunKey,
+  SESSION_CONFIG_CYCLE,
+  SESSION_LOG_CAP,
+} from './session_log';
+import { onSessionLogChanged, resetSessionLogListeners } from './session_log_events';
+import type { GenerationReport } from './session_log_types';
+
+const settlement: GenerationReport = {
+  toolPath: '/fantasy/settlement',
+  summary: 'Ashvale',
+  seed: 'abc',
+  config: { size: 'small', nameGeneratorSet: 'human' },
+};
+
+/** A recorded run with its id and time pinned, so nothing here races the clock. */
+function record(report: GenerationReport, id: string, now: number) {
+  return recordGeneration(report, { id, now });
+}
+
+beforeEach(() => {
+  clearSessionLog();
+  resetSessionLogListeners();
+});
+
+afterEach(() => {
+  clearSessionLog();
+  resetSessionLogListeners();
+  vi.restoreAllMocks();
+});
+
+describe('recordGeneration', () => {
+  it('turns a report into an entry, taking the supplied id and time', () => {
+    const entry = record(settlement, 'run-1', 1000);
+
+    expect(entry).toEqual({
+      id: 'run-1',
+      toolPath: '/fantasy/settlement',
+      summary: 'Ashvale',
+      seed: 'abc',
+      config: { nameGeneratorSet: 'human', size: 'small' },
+      at: 1000,
+    });
+  });
+
+  it('gives a tool with no settings an empty config rather than none', () => {
+    const entry = record({ toolPath: '/heraldry', seed: 'xyz' }, 'run-1', 1000);
+
+    expect(entry.config).toEqual({});
+  });
+
+  it('leaves the summary off an entry whose tool had no name to give', () => {
+    const entry = record({ toolPath: '/heraldry', seed: 'xyz' }, 'run-1', 1000);
+
+    expect('summary' in entry).toBe(false);
+  });
+
+  it('lists runs newest first', () => {
+    record(settlement, 'run-1', 1000);
+    record({ ...settlement, seed: 'def' }, 'run-2', 2000);
+    record({ ...settlement, seed: 'ghi' }, 'run-3', 3000);
+
+    expect(listSessionLog().map((entry) => entry.id)).toEqual(['run-3', 'run-2', 'run-1']);
+  });
+
+  it('mints an id when it is not given one', () => {
+    const entry = recordGeneration(settlement);
+
+    expect(entry.id).not.toBe('');
+    expect(listSessionLog()[0].id).toBe(entry.id);
+  });
+
+  it('times a run by the clock when it is not given one', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(4242);
+
+    expect(recordGeneration(settlement).at).toBe(4242);
+  });
+
+  it('announces the change', () => {
+    const listener = vi.fn();
+    onSessionLogChanged(listener);
+
+    record(settlement, 'run-1', 1000);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('records a copy of the config, so a tool mutating its own cannot rewrite history', () => {
+    const config: Record<string, unknown> = { size: 'small', tinctures: ['Or'] };
+    const entry = record({ ...settlement, config }, 'run-1', 1000);
+
+    config.size = 'large';
+    (config.tinctures as string[]).push('azure');
+
+    expect(entry.config).toEqual({ size: 'small', tinctures: ['Or'] });
+    expect(listSessionLog()[0].config).toEqual({ size: 'small', tinctures: ['Or'] });
+  });
+});
+
+describe('an identical run', () => {
+  it('moves its entry to the top rather than adding a second', () => {
+    record(settlement, 'run-1', 1000);
+    record({ ...settlement, seed: 'def' }, 'run-2', 2000);
+
+    const again = record(settlement, 'ignored', 3000);
+
+    expect(listSessionLog().map((entry) => entry.id)).toEqual(['run-1', 'run-2']);
+    expect(again.id).toBe('run-1');
+    expect(again.at).toBe(3000);
+  });
+
+  it('is identical whatever order the config keys arrive in', () => {
+    record(settlement, 'run-1', 1000);
+
+    record(
+      { ...settlement, config: { nameGeneratorSet: 'human', size: 'small' } },
+      'ignored',
+      2000,
+    );
+
+    expect(sessionLogSize()).toBe(1);
+  });
+
+  it('is identical whatever order the keys of a nested object arrive in', () => {
+    record({ ...settlement, config: { field: { first: 'Or', second: 'azure' } } }, 'run-1', 1000);
+
+    record({ ...settlement, config: { field: { second: 'azure', first: 'Or' } } }, 'ignored', 2000);
+
+    expect(sessionLogSize()).toBe(1);
+  });
+
+  it('is not identical when an array is in a different order, because a roll is not', () => {
+    record({ ...settlement, config: { categories: ['a', 'b'] } }, 'run-1', 1000);
+    record({ ...settlement, config: { categories: ['b', 'a'] } }, 'run-2', 2000);
+
+    expect(sessionLogSize()).toBe(2);
+  });
+
+  it('is not identical when the seed differs', () => {
+    record(settlement, 'run-1', 1000);
+    record({ ...settlement, seed: 'def' }, 'run-2', 2000);
+
+    expect(sessionLogSize()).toBe(2);
+  });
+
+  it('is not identical when the tool differs', () => {
+    record(settlement, 'run-1', 1000);
+    record({ ...settlement, toolPath: '/culture' }, 'run-2', 2000);
+
+    expect(sessionLogSize()).toBe(2);
+  });
+
+  it('is not identical when a setting differs', () => {
+    record(settlement, 'run-1', 1000);
+    record({ ...settlement, config: { ...settlement.config, size: 'large' } }, 'run-2', 2000);
+
+    expect(sessionLogSize()).toBe(2);
+  });
+});
+
+describe('the cap', () => {
+  it('keeps the newest and drops the oldest past it', () => {
+    for (let index = 0; index < SESSION_LOG_CAP + 5; index += 1) {
+      record({ ...settlement, seed: `seed-${index}` }, `run-${index}`, 1000 + index);
+    }
+
+    const log = listSessionLog();
+    expect(log).toHaveLength(SESSION_LOG_CAP);
+    expect(log[0].id).toBe(`run-${SESSION_LOG_CAP + 4}`);
+    expect(log[log.length - 1].id).toBe('run-5');
+  });
+
+  it('does not push an entry off the end when an existing run is merely moved', () => {
+    for (let index = 0; index < SESSION_LOG_CAP; index += 1) {
+      record({ ...settlement, seed: `seed-${index}` }, `run-${index}`, 1000 + index);
+    }
+
+    record({ ...settlement, seed: 'seed-0' }, 'ignored', 9000);
+
+    const log = listSessionLog();
+    expect(log).toHaveLength(SESSION_LOG_CAP);
+    expect(log[0].id).toBe('run-0');
+    expect(log.map((entry) => entry.id)).toContain('run-1');
+  });
+});
+
+describe('listSessionLog', () => {
+  it('hands back a copy, so a caller cannot reorder the log by holding it', () => {
+    record(settlement, 'run-1', 1000);
+    record({ ...settlement, seed: 'def' }, 'run-2', 2000);
+
+    listSessionLog().reverse();
+
+    expect(listSessionLog().map((entry) => entry.id)).toEqual(['run-2', 'run-1']);
+  });
+});
+
+describe('clearSessionLog', () => {
+  it('forgets every run and says so', () => {
+    const listener = vi.fn();
+    record(settlement, 'run-1', 1000);
+    onSessionLogChanged(listener);
+
+    clearSessionLog();
+
+    expect(listSessionLog()).toEqual([]);
+    expect(sessionLogSize()).toBe(0);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('sessionRunKey', () => {
+  it('is the same for the same run', () => {
+    expect(sessionRunKey('/culture', 'abc', { a: 1, b: 2 })).toBe(
+      sessionRunKey('/culture', 'abc', { b: 2, a: 1 }),
+    );
+  });
+
+  it('separates a missing config from an empty one only by not doing so', () => {
+    expect(sessionRunKey('/culture', 'abc', undefined)).toBe(sessionRunKey('/culture', 'abc', {}));
+  });
+
+  it('is different for a different tool, seed, or setting', () => {
+    const base = sessionRunKey('/culture', 'abc', { a: 1 });
+
+    expect(sessionRunKey('/heraldry', 'abc', { a: 1 })).not.toBe(base);
+    expect(sessionRunKey('/culture', 'def', { a: 1 })).not.toBe(base);
+    expect(sessionRunKey('/culture', 'abc', { a: 2 })).not.toBe(base);
+  });
+
+  it('never matches anything when the config cannot be written down', () => {
+    const unwritable = { size: 1n as unknown as number };
+
+    const first = sessionRunKey('/culture', 'abc', unwritable);
+    const second = sessionRunKey('/culture', 'abc', unwritable);
+
+    expect(first).not.toBe(second);
+  });
+
+  it('records a run whose config cannot be written down rather than losing the roll', () => {
+    const entry = recordGeneration({
+      toolPath: '/culture',
+      seed: 'abc',
+      config: { size: 1n as unknown as number },
+    });
+
+    expect(listSessionLog()[0].id).toBe(entry.id);
+  });
+});
+
+describe('canonicalSessionConfig', () => {
+  it('sorts object keys at every depth and leaves arrays alone', () => {
+    const canonical = canonicalSessionConfig({
+      b: 1,
+      a: { d: 2, c: [{ f: 3, e: 4 }] },
+    });
+
+    expect(JSON.stringify(canonical)).toBe('{"a":{"c":[{"e":4,"f":3}],"d":2},"b":1}');
+  });
+
+  it('turns an absent config into an empty one', () => {
+    expect(canonicalSessionConfig(undefined)).toEqual({});
+  });
+
+  it('keeps null apart from an object', () => {
+    expect(canonicalSessionConfig({ religion: null })).toEqual({ religion: null });
+  });
+
+  it('cuts a cycle rather than recursing into it', () => {
+    const cyclic: Record<string, unknown> = { size: 'small' };
+    cyclic.self = cyclic;
+
+    expect(canonicalSessionConfig(cyclic)).toEqual({
+      self: SESSION_CONFIG_CYCLE,
+      size: 'small',
+    });
+  });
+
+  it('writes a value that merely appears twice out both times', () => {
+    const shared = { tincture: 'Or' };
+
+    expect(canonicalSessionConfig({ first: shared, second: shared })).toEqual({
+      first: { tincture: 'Or' },
+      second: { tincture: 'Or' },
+    });
+  });
+});
+
+describe('newSessionLogEntryId', () => {
+  it('mints something unique', () => {
+    expect(newSessionLogEntryId()).not.toBe(newSessionLogEntryId());
+  });
+
+  it('falls back to a home-made id where the browser has no UUID to give', () => {
+    vi.spyOn(globalThis, 'crypto', 'get').mockReturnValue(
+      undefined as unknown as typeof globalThis.crypto,
+    );
+
+    expect(newSessionLogEntryId()).toMatch(/^run-/);
+  });
+});

--- a/src/lib/session_log/session_log.ts
+++ b/src/lib/session_log/session_log.ts
@@ -1,0 +1,174 @@
+import { notifySessionLogChanged } from './session_log_events';
+import type {
+  GenerationReport,
+  SessionLogEntry,
+  SessionLogRecordOptions,
+} from './session_log_types';
+
+/**
+ * How many runs the log keeps, newest first.
+ *
+ * Not a storage limit — nothing is stored — but a bound on an array that somebody leaning on
+ * Generate would otherwise grow without limit. Fifty is comfortably more than "the one three
+ * rolls back", which is the whole of what this is for.
+ */
+export const SESSION_LOG_CAP = 50;
+
+/**
+ * The log itself: module state, cleared by a reload.
+ *
+ * That is the definition of "this session" (decision 2 in docs/session-log.md), and it is what
+ * makes replay safe without versioning — a config recorded by this build can only ever be replayed
+ * into this build's tool, so a config key that changed shape between releases cannot reach a tool
+ * that would misread it. Newest first, so the list is in the order the panel renders it.
+ */
+let entries: SessionLogEntry[] = [];
+
+/** Counter behind {@link unmatchableKey}. */
+let keyFallbacks = 0;
+
+/**
+ * A random, never-reused entry id. Mirrors `newArtifactId`, fallback and all: an id with less
+ * entropy behind it is a better outcome than a roll that throws on its way out of a generator.
+ */
+export function newSessionLogEntryId(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid !== undefined) {
+    return uuid;
+  }
+  return `run-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * What a cycle in a config becomes. A config should not have one — this is a tool handing over a
+ * live object graph rather than settings — but recursing into it would take the whole page down,
+ * and losing a user's roll to a generator's bug is the wrong trade.
+ */
+export const SESSION_CONFIG_CYCLE = '[cycle]';
+
+/**
+ * A value rebuilt as plain data with its object keys in sorted order.
+ *
+ * Two jobs in one pass. It is what makes {@link sessionRunKey} a canonical key — `{a, b}` and
+ * `{b, a}` are the same settings and must produce the same string — and it is what keeps the
+ * stored config honest: several generators mutate their config object in place between rolls, and
+ * a `$state` value handed over from a component is a deep proxy. Copying here means an entry
+ * records what the run actually used and cannot be rewritten afterwards.
+ *
+ * `ancestors` is the path from the root rather than every object seen, so a value that appears
+ * twice in the same config is written out twice — only a genuine cycle is cut.
+ */
+function canonicalise(value: unknown, ancestors: object[]): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (ancestors.includes(value)) {
+    return SESSION_CONFIG_CYCLE;
+  }
+  const path = [...ancestors, value];
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalise(item, path));
+  }
+  const source = value as Record<string, unknown>;
+  const copy: Record<string, unknown> = {};
+  for (const key of Object.keys(source).sort()) {
+    copy[key] = canonicalise(source[key], path);
+  }
+  return copy;
+}
+
+/** A config as the log stores it: plain, deeply copied, keys in a fixed order. */
+export function canonicalSessionConfig(
+  config: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  return canonicalise(config ?? {}, []) as Record<string, unknown>;
+}
+
+/**
+ * A key that can never equal another, for a config the key cannot be built from.
+ *
+ * Cycles are already cut by {@link canonicalise}, so what is left is a config holding something
+ * `JSON` has no notation for — a `BigInt`, most plausibly — which no generator should be handing
+ * over. When it happens the honest answer is "this run matches nothing", which costs a duplicate
+ * row; refusing to record the run, or throwing back into the `generate()` that called us, would
+ * cost the user their roll.
+ */
+function unmatchableKey(): string {
+  keyFallbacks += 1;
+  return `unmatchable:${keyFallbacks}`;
+}
+
+/**
+ * The identity of a run: its tool, its seed, and its settings.
+ *
+ * This is what decides whether a report is a new entry or an old one seen again, and it is the
+ * single most test-worthy thing in this library. Replaying an entry causes a real generation run,
+ * and a tool reports every run it makes, so without a canonical comparison the list would grow a
+ * copy every time somebody pressed the same entry twice.
+ */
+export function sessionRunKey(
+  toolPath: string,
+  seed: string,
+  config: Record<string, unknown> | undefined,
+): string {
+  try {
+    return JSON.stringify([toolPath, seed, canonicalSessionConfig(config)]);
+  } catch {
+    return unmatchableKey();
+  }
+}
+
+/** The key of an entry already in the log. */
+function keyOf(entry: SessionLogEntry): string {
+  return sessionRunKey(entry.toolPath, entry.seed, entry.config);
+}
+
+/**
+ * Record a run, and hand back the entry that now stands for it.
+ *
+ * A run whose tool, seed, and config match one already in the log **moves that entry to the top**
+ * rather than adding a second: it is the same run, seen again, so it keeps its id and takes the
+ * new time. Anything else becomes a new entry, and the oldest falls off the end at
+ * {@link SESSION_LOG_CAP}.
+ */
+export function recordGeneration(
+  report: GenerationReport,
+  options: SessionLogRecordOptions = {},
+): SessionLogEntry {
+  const config = canonicalSessionConfig(report.config);
+  const at = options.now ?? Date.now();
+  const key = sessionRunKey(report.toolPath, report.seed, config);
+  const existing = entries.find((entry) => keyOf(entry) === key);
+
+  const entry: SessionLogEntry =
+    existing === undefined
+      ? {
+          id: options.id ?? newSessionLogEntryId(),
+          toolPath: report.toolPath,
+          ...(report.summary === undefined ? {} : { summary: report.summary }),
+          seed: report.seed,
+          config,
+          at,
+        }
+      : { ...existing, at };
+
+  entries = [entry, ...entries.filter((other) => other.id !== entry.id)].slice(0, SESSION_LOG_CAP);
+  notifySessionLogChanged();
+  return entry;
+}
+
+/** Every run this session, newest first. A copy, so a caller cannot reorder the log by holding it. */
+export function listSessionLog(): SessionLogEntry[] {
+  return [...entries];
+}
+
+/** How many runs the log is holding. What the panel asks before it decides to exist at all. */
+export function sessionLogSize(): number {
+  return entries.length;
+}
+
+/** Forget every run. What the Clear button does once the user has confirmed it. */
+export function clearSessionLog(): void {
+  entries = [];
+  notifySessionLogChanged();
+}

--- a/src/lib/session_log/session_log_events.test.ts
+++ b/src/lib/session_log/session_log_events.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  notifySessionLogChanged,
+  onSessionLogChanged,
+  resetSessionLogListeners,
+} from './session_log_events';
+
+afterEach(() => {
+  resetSessionLogListeners();
+  vi.restoreAllMocks();
+});
+
+describe('onSessionLogChanged', () => {
+  it('tells every listener the log moved', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    onSessionLogChanged(first);
+    onSessionLogChanged(second);
+
+    notifySessionLogChanged();
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops calling a listener that has unsubscribed', () => {
+    const listener = vi.fn();
+    const unsubscribe = onSessionLogChanged(listener);
+
+    unsubscribe();
+    notifySessionLogChanged();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('registers a listener once, however many times it is added', () => {
+    const listener = vi.fn();
+    onSessionLogChanged(listener);
+    onSessionLogChanged(listener);
+
+    notifySessionLogChanged();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the rest when one listener throws, and reports it', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const survivor = vi.fn();
+    onSessionLogChanged(() => {
+      throw new Error('a panel failed to redraw');
+    });
+    onSessionLogChanged(survivor);
+
+    notifySessionLogChanged();
+
+    expect(survivor).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  it('is not disturbed by a listener that unsubscribes while being notified', () => {
+    const second = vi.fn();
+    const stopFirst = onSessionLogChanged(() => stopFirst());
+    onSessionLogChanged(second);
+
+    notifySessionLogChanged();
+
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops every listener on reset', () => {
+    const listener = vi.fn();
+    onSessionLogChanged(listener);
+
+    resetSessionLogListeners();
+    notifySessionLogChanged();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/session_log/session_log_events.ts
+++ b/src/lib/session_log/session_log_events.ts
@@ -1,0 +1,38 @@
+import type { SessionLogListener } from './session_log_types';
+
+const listeners = new Set<SessionLogListener>();
+
+/**
+ * Be told when the log changes. Returns the unsubscribe.
+ *
+ * Deliberately plain, the way `artifacts/artifact_events.ts` is: no framework and no reactivity
+ * system, because libraries here know nothing about Svelte and a component subscribing on mount
+ * and unsubscribing on teardown is all this needs to be.
+ */
+export function onSessionLogChanged(listener: SessionLogListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Announce that the log has changed.
+ *
+ * A listener that throws is reported and the rest still run. One panel failing to redraw is not a
+ * reason for a generator's roll to look like it failed.
+ */
+export function notifySessionLogChanged(): void {
+  for (const listener of [...listeners]) {
+    try {
+      listener();
+    } catch (error: unknown) {
+      console.error(error);
+    }
+  }
+}
+
+/** Drop every listener. For tests. */
+export function resetSessionLogListeners(): void {
+  listeners.clear();
+}

--- a/src/lib/session_log/session_log_types.ts
+++ b/src/lib/session_log/session_log_types.ts
@@ -1,0 +1,59 @@
+import type { RouteId } from '$app/types';
+
+/**
+ * One generation run, as the log remembers it.
+ *
+ * It carries no label, no payload, and no project: the tool catalog owns the first — a stored copy
+ * would be a second name for a tool that can disagree with the first — there is no second, and a
+ * run is not a thing a project holds until somebody saves it.
+ */
+export type SessionLogEntry = {
+  /** Stable identity for the life of the session. Never reused. */
+  id: string;
+  /** A tool catalog path, the one edge from the log to the tool registry. */
+  toolPath: RouteId;
+  /** A one-line name for what came out. Absent for a tool with no name to give. */
+  summary?: string;
+  /** The seed the run rolled from. */
+  seed: string;
+  /**
+   * The settings the run rolled *with*, as the tool understood them — not the settings in its
+   * controls now. The log does not interpret it; it is a courier.
+   *
+   * Stored as a canonical deep copy, so a tool that mutates its own config object in place cannot
+   * rewrite history, and a `$state` proxy cannot leak into the log.
+   */
+  config: Record<string, unknown>;
+  /** Epoch milliseconds, per decision 2 of the workshop model. */
+  at: number;
+};
+
+/**
+ * What a tool hands over at the end of its `generate()`.
+ *
+ * `config` is optional because a generator with no settings has none to report; it becomes `{}` on
+ * the entry rather than being absent, so every entry answers the same question the same way.
+ */
+export type GenerationReport = {
+  toolPath: RouteId;
+  summary?: string;
+  seed: string;
+  config?: Record<string, unknown>;
+};
+
+/**
+ * Identity and time, supplied rather than generated — the same bargain `ArtifactMutationOptions`
+ * makes, and for the same reason: a test that has to race the clock is a test that fails on CI.
+ */
+export type SessionLogRecordOptions = {
+  id?: string;
+  now?: number;
+};
+
+/**
+ * Told that the log changed, and nothing about how.
+ *
+ * There is one list in one place and reading it is cheap, so an event carrying a delta would be a
+ * second, staler copy of something the listener is about to read anyway.
+ */
+export type SessionLogListener = () => void;


### PR DESCRIPTION
Step 1 of the plan in [docs/session-log.md](https://github.com/ironarachne/ironarachne/blob/main/docs/session-log.md#the-plan). Adds `src/lib/session_log` — the record of what the tools have rolled this session. Pure, knows nothing about Svelte, nothing renders it yet.

## What is here

`SessionLogEntry` exactly as the approved domain model declares it: `id`, `toolPath`, `summary?`, `seed`, `config`, `at`. No tool label — the catalog owns that, and a stored copy is a second name that can disagree with the first.

- `recordGeneration(report, options?)` — ids and timestamps injectable through `options`, the way `ArtifactMutationOptions` makes them, so tests do not race the clock.
- `listSessionLog()`, `sessionLogSize()`, `clearSessionLog()`.
- `onSessionLogChanged(listener)` — mirrors `artifacts/artifact_events.ts`: a plain listener set, a listener that throws is reported and the rest still run, and a reset for tests.

Module state, cleared by a reload (decision 2). No `localStorage`, no `sessionStorage`, nothing in `ProjectWorkspace`.

## The two behaviours that carry the reasoning

**Identical runs move rather than duplicate** (decision 7). A run whose tool, seed, and config match an existing entry moves that entry to the top — keeping its id, taking the new time — instead of adding a second. Without it, replaying an entry logs a copy every time, because the replay causes a real generation run and a tool reports every run it makes. Comparison is `sessionRunKey`, a canonical string over the path, the seed, and the config with its object keys sorted **at every depth** (religion's config nests; heraldry's nests two deep). Array order is deliberately significant — a roll is not order-insensitive.

**The cap is 50, newest kept** (decision 7). Not a storage limit, since nothing is stored. Moving an existing entry does not push anything off the end.

## Two things the issue did not call for, and why they are here

- **A recorded config is a canonical deep copy, not the object handed over.** Heraldry and culture both mutate their config object in place between rolls, and a `$state` value from a component is a deep proxy. Without the copy an entry would not be a record of what the run used.
- **A cycle in a config is cut rather than recursed into**, and a config `JSON` has no notation for (a `BigInt`) still records — it simply matches nothing and costs a duplicate row. Neither should ever arrive, but throwing back into the `generate()` that called us would cost the user the roll it was reporting.

## Done when

`npm run verify` green: `0 ERRORS` from svelte-check, 4357 tests, and the coverage gate reporting **97 libraries checked, 97 at or above 80%, 0 carrying baselined debt** — no entry added to `scripts/library_coverage_baseline.json`.

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)