### PR TITLE
Let a workshop panel be told to roll again

### DIFF
--- a/src/components/common/ToolPanel.svelte
+++ b/src/components/common/ToolPanel.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import type { Tool } from '$lib/tools';
-  import { toolPanelLoader } from '$lib/workshop';
+  import { toolPanelComponent, toolPanelLoader, type ToolCue } from '$lib/workshop';
 
   type Props = {
     /** Tool to render. Its component is fetched on demand the first time it is shown. */
     tool: Tool;
+    /**
+     * A request for this tool to roll a particular result again. Passed straight through: what a
+     * tool makes of it is the tool's business, and most tools make nothing of it at all.
+     */
+    cue?: ToolCue;
   };
 
-  const { tool }: Props = $props();
+  const { tool, cue }: Props = $props();
 
   const loadPanel = $derived(toolPanelLoader(tool.path));
 </script>
@@ -16,13 +21,15 @@
 <section class="tool-panel">
   {#if loadPanel}
     <!-- Keyed on the path so switching tools mounts a fresh component rather than reusing the
-         previous one's state. -->
+         previous one's state. Deliberately *not* keyed on the cue: re-keying would remount the
+         tool — throwing away everything else in its panel, and flickering — to deliver a message
+         the tool can simply read. -->
     {#key tool.path}
       {#await loadPanel()}
         <p class="tool-panel__status">Loading {tool.label}…</p>
       {:then panel}
-        {@const ToolComponent = panel.default}
-        <ToolComponent />
+        {@const ToolComponent = toolPanelComponent(panel.default)}
+        <ToolComponent {cue} />
       {:catch}
         <p class="tool-panel__status">{tool.label} could not be loaded.</p>
       {/await}

--- a/src/lib/workshop/README.md
+++ b/src/lib/workshop/README.md
@@ -46,6 +46,47 @@ Add the entry to `TOOL_PANELS` alongside the `defineTool` entry in the catalog. 
 check the two agree in both directions: every catalog tool has a panel, and no panel is
 registered for a path that is not a tool.
 
+## Telling a mounted tool to roll again
+
+`ToolPanel` mounts its component keyed on the tool's path, so until `ToolCue` there was no way to
+say anything to a tool already on the bench — the only way to reach one was to mount a different
+one. The one precedent, heraldry's `?blazon=` URL cue, does not compose with panels: the workshop
+is a single route, so a query parameter on it cannot say which panel it addresses.
+
+A cue is a seed, a config, and an id. A tool opts in by declaring the prop:
+
+```ts
+import type { ToolCue } from '$lib/workshop';
+
+const { cue }: { cue?: ToolCue } = $props();
+
+let lastCueId: string | undefined;
+$effect(() => {
+  if (cue === undefined || cue.id === lastCueId) {
+    return;
+  }
+  lastCueId = cue.id;
+  applyCue(cue);
+});
+```
+
+Two rules make it behave, and both are contracts rather than types:
+
+- **Watch the `id`, not the contents.** Replaying the same result twice is two distinct requests,
+  and comparing seeds would swallow the second. The id is minted at the moment of the request.
+- **Apply the config keys you recognise and ignore the rest.** A config from a differently-shaped
+  build cannot arrive, because the session log that mints these does not outlive the build
+  (decision 2 in `docs/session-log.md`).
+
+The panel is deliberately **not** re-keyed on the cue: re-keying would remount the tool, throwing
+away everything else in its panel and flickering, to deliver a message the tool can simply read.
+
+Reading a cue is opt-in, and a tool that ignores one needs no edit — Svelte drops a prop a
+component does not declare. `toolPanelComponent` is the one place that is reconciled with the
+registry's type, and it carries the reasoning: Svelte types a component's props contravariantly,
+so widening `ToolPanelLoader` to `Component<ToolPanelProps>` fails to compile against the thirty
+panels that declare no props at all.
+
 ## Artifact kinds
 
 `ARTIFACT_KINDS` is every kind of content this build can store, built by registering the

--- a/src/lib/workshop/tool_panels.test.ts
+++ b/src/lib/workshop/tool_panels.test.ts
@@ -1,6 +1,14 @@
 import { expect, describe, it } from 'vitest';
+import type { Component } from 'svelte';
+
 import { allTools } from '$lib/tools';
-import { TOOL_PANELS, hasToolPanel, pathsWithToolPanels, toolPanelLoader } from './tool_panels';
+import {
+  TOOL_PANELS,
+  hasToolPanel,
+  pathsWithToolPanels,
+  toolPanelComponent,
+  toolPanelLoader,
+} from './tool_panels';
 
 describe('the tool panel registry', () => {
   // No exemption list, and that is the assertion: every tool has a panel, so a missing one is
@@ -114,4 +122,21 @@ describe('every registered panel resolves to a component', () => {
     },
     30_000,
   );
+});
+
+describe('toolPanelComponent', () => {
+  it('hands back the component it was given', () => {
+    const component = (() => undefined) as unknown as Component;
+
+    expect(toolPanelComponent(component)).toBe(component);
+  });
+
+  it('lets a registered panel be mounted with a cue', async () => {
+    const loader = toolPanelLoader('/culture');
+    const module = await loader?.();
+
+    // The point of the cast, exercised: a tool that declares no props is still something the
+    // bench can hand a cue to, because Svelte drops a prop a component does not read.
+    expect(typeof toolPanelComponent(module!.default)).toBe('function');
+  }, 30_000);
 });

--- a/src/lib/workshop/tool_panels.ts
+++ b/src/lib/workshop/tool_panels.ts
@@ -1,5 +1,7 @@
 import type { RouteId } from '$app/types';
-import type { ToolPanelLoader, ToolPanelRegistry } from './workshop_types';
+import type { Component } from 'svelte';
+
+import type { ToolPanelLoader, ToolPanelProps, ToolPanelRegistry } from './workshop_types';
 
 /**
  * Which component renders each tool, keyed by the tool's catalog path.
@@ -78,4 +80,23 @@ export function hasToolPanel(path: RouteId): boolean {
 /** Every path with a panel, in registry order. */
 export function pathsWithToolPanels(): RouteId[] {
   return Object.keys(TOOL_PANELS) as RouteId[];
+}
+
+/**
+ * A loaded panel component, seen as one that may be handed a {@link ToolPanelProps} cue.
+ *
+ * The one place the registry's type and the panel's props are reconciled, and a cast rather than
+ * a widening because the alternative is worse. Svelte types a component's props
+ * contravariantly, so a component declaring none is `Component<Record<string, never>>` and
+ * `ToolPanelProps` is not assignable to it: typing {@link ToolPanelLoader} as
+ * `Component<ToolPanelProps>` fails to compile against thirty of the thirty-four registered
+ * panels, and the only fix would be thirty tools declaring a prop they never read.
+ *
+ * What makes the cast honest is Svelte's own behaviour: a prop a component does not declare is
+ * ignored, so handing a cue to a tool that does not read one changes nothing about it. Reading a
+ * cue is the opt-in, and a tool opts in by declaring `cue` — which, unlike the widening, every
+ * other tool remains compatible with.
+ */
+export function toolPanelComponent(component: Component): Component<ToolPanelProps> {
+  return component as Component<ToolPanelProps>;
 }

--- a/src/lib/workshop/workshop_types.ts
+++ b/src/lib/workshop/workshop_types.ts
@@ -10,8 +10,55 @@ import type {
 } from '$lib/artifacts';
 
 /**
+ * A request to a tool that is already mounted: roll this seed, with these settings.
+ *
+ * The tool↔panel boundary needed one, because nothing in the codebase could signal a mounted
+ * tool. `ToolPanel` mounts its component keyed on the tool's path, so the only way to say anything
+ * to a tool was to mount a different one — and the one precedent, heraldry's `?blazon=` URL cue,
+ * does not compose with panels: the workshop is a single route, so a query parameter on it cannot
+ * say which panel it addresses.
+ *
+ * `id` is minted at the moment of the request and is deliberately **not** carried over from
+ * whatever the request came from. Replaying the same session-log entry twice is two distinct
+ * requests, and a tool comparing seeds would swallow the second.
+ */
+export type ToolCue = {
+  /** Fresh per request. What a tool watches; see {@link ToolPanelProps}. */
+  id: string;
+  seed: string;
+  /** Settings as the tool understood them when it rolled. A tool applies what it recognises. */
+  config: Record<string, unknown>;
+};
+
+/**
+ * What a tool component may be handed when it is mounted in a panel.
+ *
+ * The contract for a tool that reads a cue, since the tools adopting it are the audience:
+ *
+ * - Read it with an effect that fires when the cue's **`id`** changes, not its contents.
+ *   Replaying the same entry twice is two distinct requests, and comparing seeds would swallow
+ *   the second.
+ * - Apply the config keys you recognise and ignore the rest. A config from a differently-shaped
+ *   build cannot arrive, because the session log does not outlive the build (decision 2 in
+ *   docs/session-log.md).
+ *
+ * Reading a cue is opt-in, and a tool that ignores it needs no edit at all — see
+ * {@link toolPanelComponent} for why the registry cannot say so in its own type.
+ */
+export type ToolPanelProps = {
+  /** Absent unless something has asked this tool to roll a particular result again. */
+  cue?: ToolCue;
+};
+
+/**
  * Loads the component that renders a tool inside a panel. Loading is deferred so a workshop
  * pulls in only the tool the user asked for, rather than every generator on the site.
+ *
+ * Deliberately still `Component` and not `Component<ToolPanelProps>`. A Svelte component's props
+ * are contravariant in assignability, and a component declaring no props is
+ * `Component<Record<string, never>>` — so widening the loader would reject all thirty tools that
+ * do not read a cue, and the fix would be thirty files growing a prop they ignore.
+ * {@link toolPanelComponent} is where that is reconciled instead.
  */
 export type ToolPanelLoader = () => Promise<{ default: Component }>;
 


### PR DESCRIPTION
Step 2 of the plan in [docs/session-log.md](https://github.com/ironarachne/ironarachne/blob/main/docs/session-log.md#the-plan) — the hard part of #80 and the reason it needed a design.

`ToolPanel` mounted its component with **no props at all**, keyed on the tool's path, so the only way to say anything to a tool was to mount a different one. The one precedent, heraldry's `?blazon=` URL cue, does not compose with panels: the workshop is a single route, so a query parameter on it cannot say which panel it addresses.

`ToolCue` (`id`, `seed`, `config`) and `ToolPanelProps` (`cue?`) now live in `$lib/workshop` beside `ToolArtifactDraft`, and `ToolPanel` carries a cue through to whatever it mounted.

The panel stays **keyed on `tool.path`**. Re-keying on the cue would remount the tool — throwing away everything else in its panel, and flickering — to deliver a message the tool can simply read.

## The typing question, answered

The issue asked to settle this before writing the rest. **It does not hold.**

A tool declaring no props does *not* satisfy a `ToolPanelLoader` widened to `Component<ToolPanelProps>`. Svelte types a component's props contravariantly, so a component with none is `Component<Record<string, never>>`, and svelte-check rejects the widening against **thirty of the thirty-four** registered panels:

```
Type 'Component<Record<string, never>, {}, "">' is not assignable to type 'Component<ToolPanelProps, {}, string>'.
  Types of parameters 'props' and 'props' are incompatible.
    Type 'ToolPanelProps' is not assignable to type 'Record<string, never>'.
      Property 'cue' is incompatible with index signature.
```

The reverse *does* hold, and it is what makes the design work: a component that declares an optional `cue` still satisfies the registry's **existing** type — verified by adding the prop to `SpeciesStatsCalculator` and getting `0 ERRORS` from svelte-check.

So rather than an opt-in wrapper component or thirty tools growing a prop they never read, `ToolPanelLoader` is unchanged and `toolPanelComponent` reconciles the two in one named, documented place. What makes the cast honest is Svelte's own behaviour: a prop a component does not declare is ignored, so handing a cue to a tool that does not read one changes nothing about it. Reading the cue is the opt-in.

## The contract, documented where the adopters will look

In `ToolPanelProps`' doc comment and in the library README, since the tools adopting it in #87 are the audience:

- **Watch the `id`, not the contents.** Replaying the same entry twice is two distinct requests; comparing seeds would swallow the second. The id is minted at replay, not taken from the entry.
- **Apply the config keys you recognise and ignore the rest.** A config from a differently-shaped build cannot arrive, because the log does not outlive the build (decision 2).

## Done when

`npm run verify` green: `0 ERRORS`, 4322 tests, coverage gate at 96/96 with no baselined debt. Nothing sends a cue yet — that is #86.

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)