### PR TITLE
Mark the visual design document accepted

### DIFF
--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -12,9 +12,10 @@ omission is the whole of [#77](https://github.com/ironarachne/ironarachne/issues
 works and does not look finished, because spacing, type and colour are decided per component and
 so nothing lines up between two pages.
 
-**Status:** proposal, awaiting human approval. Per CLAUDE.md, implementation does not start until
-a human has read the [token taxonomy](#token-taxonomy) and approved it; this line records that
-approval when it is given.
+**Status:** accepted. The [token taxonomy](#token-taxonomy) was reviewed and approved on
+2026-08-26, which is the gate CLAUDE.md puts in front of implementation: the tokens issue can be
+built from it without further design work. Nothing here is built yet — see [What this
+changes](#what-this-changes) for what the implementation covers.
 
 Written against the rough-cut mockup published from the [design
 canvas](https://claude.ai/code/artifact/c2f18fd6-1a76-46bd-9044-c8cfc888befb) — five artboards:


### PR DESCRIPTION
One line. `docs/visual-design.md` still read `**Status:** proposal, awaiting human approval` after #126 merged.

That was deliberate at the time: #126 carried the icon set as well as the document, so merging it was not on its own an approval of the token taxonomy. Confirmed since — the taxonomy is approved.

This flips the line to `accepted`, which is the gate CLAUDE.md puts in front of implementation. The tokens issue can now be built from the document without further design work.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)