### PR TITLE
Grow tokens.css into the type, space, colour and elevation scales

### DIFF
--- a/src/lib/styles/README.md
+++ b/src/lib/styles/README.md
@@ -8,7 +8,7 @@ what lives here is what applies site-wide.
 main.css        # The entry point — imports everything below, then the base element styles
 reset.css       # Normalizes browser defaults
 brand/          # Vendored from the brand repo: the colour palette, as --ia-* tokens
-tokens.css      # Custom properties — the site's names for the palette, plus spacing
+tokens.css      # Custom properties — colour roles, the type and space ramps, elevation, motion
 fonts.css       # The @font-face declarations
 modal.css       # The shared modal system's styles
 fantasy.css     # Genre themes, applied to generated output
@@ -31,6 +31,17 @@ specificity.
 
 Define a new spacing value as a custom property in `tokens.css` rather than inline, so it is
 available to components and to the genre themes alike.
+
+## Tokens
+
+`tokens.css` holds the whole vocabulary a component builds from: the colour roles, the six-step
+type ramp, the eight-step space ramp, the elevation and corner tokens, and the one motion
+duration. It is the middle of three layers, and the direction is one-way — `brand/colors.css`
+below it, components above it. A role resolves to a palette alias or to a `color-mix()` of two
+and never holds a hex; a component names a role or a ramp step and never reaches past this file
+to `--ia-*`; a genre skin overrides a permitted subset of the roles and never touches a ramp.
+`docs/visual-design.md` states the taxonomy and the reasoning; `tokens.test.ts` enforces the
+parts of it that a regex can see.
 
 ## Colours
 

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -1,4 +1,10 @@
-/* Custom properties for the site.
+/* Custom properties for the site — the whole vocabulary a component builds from.
+ *
+ * This file is the middle layer of the three in docs/visual-design.md: the vendored palette in
+ * `brand/colors.css` below it, components above it. The direction is one-way. A role here
+ * resolves to a palette entry or to a `color-mix()` of two and never holds a hex; a component
+ * references a role or a ramp step and never reaches past this file to `--ia-*`; a genre skin
+ * overrides a permitted subset of the roles and never touches a ramp.
  *
  * Every colour value lives in `brand/colors.css`, which is vendored from the brand repo and is
  * the declared source of truth for the palette (see docs/brand-assets.md). The names below are
@@ -13,6 +19,10 @@
  */
 
 :root {
+  /* ---- The palette, under the site's names ---------------------------------------------
+     Aliases only. A component names a *role* below rather than one of these; these exist so a
+     role — and a genre skin, which is the one other thing allowed to name a hue — has something
+     short to resolve to. */
   --acid-green: var(--ia-green-acid);
   --amethyst: var(--ia-amethyst);
   --charcoal: var(--ia-charcoal);
@@ -27,14 +37,156 @@
   --slate: var(--ia-slate);
   --tan: var(--ia-tan);
 
+  /* ---- Colour roles --------------------------------------------------------------------
+     What a component actually names. Ratios are measured against `--surface-page`; every text
+     role clears 4.5:1, which is the target docs/visual-design.md holds them to.
+
+     `--ink-faint` is a 48% mix rather than the flat grey the mockup drew: that value measures
+     4.16:1 and would have shipped a failure at the one size it is used at. */
+  --surface-page: var(--charcoal);
+  --surface-raised: var(--slate);
+  --surface-inset: color-mix(in srgb, var(--charcoal) 80%, black);
+  --surface-sunken: color-mix(in srgb, var(--charcoal) 60%, black);
+
+  --border: var(--granite);
+  --border-strong: var(--tan);
+
+  --ink: color-mix(in srgb, white 95%, var(--charcoal)); /* 15.2:1 */
+  --ink-muted: color-mix(in srgb, white 60%, var(--charcoal)); /* 6.8:1 */
+  /* 4.8:1 — labels and kickers only, never a sentence. */
+  --ink-faint: color-mix(in srgb, white 48%, var(--charcoal));
+
+  --accent: var(--iron-arachne-green); /* 10.6:1 */
+  --accent-quiet: var(--gold); /* 7.1:1 */
+  /* Crimson on charcoal is 2.2:1. Destructive intent is a crimson edge and fill under
+     `--ink`-coloured text; this is never a text colour. */
+  --danger: var(--crimson);
+  --focus: var(--acid-green); /* 13.4:1 — the focus ring, and nothing else */
+
   /* The modal system's roles. The brand file maps success/error/message to palette entries
-     itself, so the mapping is stated in one place too. The backdrop is not a brand colour. */
+     itself, so the mapping is stated in one place too. The backdrop is not a brand colour, and
+     the shell's drawer scrim reads it as well — the page is dimmed by one amount from one
+     place. */
   --modal-backdrop: rgb(0 0 0 / 50%);
   --modal-border-message: var(--ia-status-message);
   --modal-border-error: var(--ia-status-error);
   --modal-border-success: var(--ia-status-success);
 
-  /* How wide a column of prose is allowed to get, per docs/app-shell.md.
+  /* ---- Type ramp -----------------------------------------------------------------------
+     Six steps, in `px`. Cinzel Decorative carries headings, controls and labels; Inclusive Sans
+     carries anything read as a sentence.
+
+     Each step comes in three forms, because both are needed in practice: `--t-body` is a `font`
+     shorthand carrying weight, size, line height and face together, and `--t-body-size` /
+     `--t-body-line` are the parts, for a rule setting one of them on an element that already has
+     the rest. They are declared from the same numbers, so they cannot disagree.
+
+     The ramp is designed to be read inside `--measure`, which is roughly 640px at `--t-body` —
+     not at the full bench width. */
+  --face-display: 'cinzel', system-ui, Helvetica, sans-serif;
+  --face-body: 'Inclusive Sans', system-ui, Helvetica, sans-serif;
+
+  --t-display-size: 26px;
+  --t-display-line: 1.05;
+  --t-display: 700 var(--t-display-size) / var(--t-display-line) var(--face-display);
+
+  --t-title-size: 20px;
+  --t-title-line: 1.1;
+  --t-title: 700 var(--t-title-size) / var(--t-title-line) var(--face-display);
+
+  --t-heading-size: 16px;
+  --t-heading-line: 1.2;
+  --t-heading: 700 var(--t-heading-size) / var(--t-heading-line) var(--face-display);
+
+  --t-body-size: 14px;
+  --t-body-line: 1.45;
+  --t-body: 400 var(--t-body-size) / var(--t-body-line) var(--face-body);
+
+  --t-small-size: 12.5px;
+  --t-small-line: 1.4;
+  --t-small: 400 var(--t-small-size) / var(--t-small-line) var(--face-body);
+
+  /* Labels, kickers, badges and buttons. The tracking and the uppercasing are part of the step,
+     but `font` can carry neither, so they are separate: every use of `--t-micro` sets
+     `letter-spacing: var(--t-micro-tracking)` and `text-transform: uppercase` beside it. */
+  --t-micro-size: 11px;
+  --t-micro-line: 1.4;
+  --t-micro-tracking: 0.08em;
+  --t-micro: 400 var(--t-micro-size) / var(--t-micro-line) var(--face-display);
+
+  /* ---- Space ramp ----------------------------------------------------------------------
+     Eight steps, and a component may not invent a value outside them. Nothing above `--s8`
+     exists: a gap that wants 48px is a layout that wants rethinking, and making that awkward is
+     the point. The ramp is dense at the bottom because 2px to 8px is the range where a control
+     either reads as one object or as three. */
+  --s1: 2px; /* hairline gaps, label to field */
+  --s2: 4px; /* badge padding */
+  --s3: 6px; /* icon to text, chip gaps */
+  --s4: 8px; /* gap inside a control group */
+  --s5: 12px; /* panel padding, gap between panels */
+  --s6: 16px; /* section spacing inside a panel body */
+  --s7: 24px; /* page padding, gap between sections */
+  --s8: 32px; /* page-level separation, hero spacing */
+
+  /* ---- Elevation -----------------------------------------------------------------------
+     Depth is a keyline plus a one-pixel top highlight, not blur: pressed metal at 100% zoom
+     rather than a floating card. The border carries the identity of a plate; `--lift` exists
+     only so a raised plate does not float against the page, and is the one shadow in the
+     system. A skin may change a border colour safely; a shadow that changed per genre would sit
+     panels at different heights beside each other. */
+
+  /* The control gradient — a 4%-white mix of slate down to a 6%-black mix. This is the one
+     place it is written; `main.css`, `fantasy.css` and `modal.css` each held their own copy of
+     `rgb(92, 86, 73)`. */
+  --plate: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--slate) 96%, white) 0%,
+    color-mix(in srgb, var(--slate) 94%, black) 100%
+  );
+  --edge: inset 0 1px 0 rgb(255 255 255 / 7%);
+  --lift: 0 1px 0 rgb(0 0 0 / 60%), 0 6px 14px rgb(0 0 0 / 35%);
+
+  /* ---- Corners -------------------------------------------------------------------------
+     Three treatments, and three is a cap. A component picks one of these, and a skin picks
+     between cut, bevelled and square from this vocabulary; inventing a fourth is what the rule
+     exists to make awkward.
+
+     A `clip-path` cuts everything the element paints, borders included — so an edge marker on a
+     clipped element is an inset shadow, not a border, or the clip shaves it at both ends. */
+
+  /* A panel: 9px off the top-right and bottom-left. */
+  --notch: polygon(0 0, calc(100% - 9px) 0, 100% 9px, 100% 100%, 9px 100%, 0 calc(100% - 9px));
+
+  /* A control: the same diagonal shape at 7px, because a control is not the size of a panel. */
+  --corner-control: polygon(
+    0 0,
+    calc(100% - 7px) 0,
+    100% 7px,
+    100% 100%,
+    7px 100%,
+    0 calc(100% - 7px)
+  );
+
+  /* A nav item: square on the flush edge, both corners cut on the inner one. Neither of the
+     other two is that shape. 7px, matching the control — a nav item is control-sized. */
+  --corner-nav: polygon(
+    0 0,
+    calc(100% - 7px) 0,
+    100% 7px,
+    100% calc(100% - 7px),
+    calc(100% - 7px) 100%,
+    0 100%
+  );
+
+  /* ---- Motion --------------------------------------------------------------------------
+     Every hover and press transition uses this, and nothing in the interface animates for
+     longer. A `visibility` delay that holds an element out of the tab order must read the same
+     token, or the two fall out of step mid-transition. Ambient genre motion is capped at one
+     effect per skin and is off entirely under `prefers-reduced-motion: reduce`. */
+  --motion-swift: 120ms;
+
+  /* ---- Measure -------------------------------------------------------------------------
+     How wide a column of prose is allowed to get, per docs/app-shell.md.
 
      This used to be `max-width` on `html`, which capped the entire document and is why the site
      used a quarter of a wide display. It is a token rather than a repeated literal because it is

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -1,5 +1,6 @@
 /**
- * Guards the seam between the vendored brand palette and the site's names for it.
+ * Guards the seam between the vendored brand palette and the site's names for it, and the shape
+ * of the token system those names sit in.
  *
  * `brand/colors.css` is copied from the brand repo, which declares itself the source of truth
  * for colour values; `tokens.css` aliases those values under the names the site uses. The
@@ -7,6 +8,13 @@
  * a sync brings it in, and every alias pointing at the old name resolves to nothing. CSS says
  * nothing about an undefined custom property — the declaration is simply dropped at computed
  * value time — so the symptom is an unstyled element noticed by whoever happens to look.
+ *
+ * The ramps and roles added by the visual system (docs/visual-design.md) fail the same silent
+ * way, and one layer deeper: a role is built from an alias and a ramp step is built from its own
+ * parts, so a token can dangle without a rename ever crossing the brand seam. The suites below
+ * therefore check that *every* `var()` inside `tokens.css` resolves, and that each ramp still
+ * holds the steps and the values the approved taxonomy names — a ramp that quietly grows a ninth
+ * step or loses a corner treatment is the system coming apart at the place it was meant to hold.
  *
  * These tests are cheap because nothing here parses CSS properly: the files are small, flat,
  * and vendored, so matching declarations and `var()` references by regex is enough.
@@ -33,6 +41,21 @@ function declaredProperties(css: string): string[] {
 function referencedProperties(css: string): string[] {
   return [...css.matchAll(/var\(\s*(--[\w-]+)/g)].map((match) => match[1]);
 }
+
+/**
+ * Custom property values by name, with comments stripped first so a token named in a comment is
+ * not mistaken for a declaration. A declaration runs to its semicolon and a value never contains
+ * one, which is what makes this safe for the multi-line `polygon()` and `linear-gradient()`
+ * values.
+ */
+function declarations(css: string): Map<string, string> {
+  const source = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const pairs = [...source.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)];
+
+  return new Map(pairs.map(([, name, value]) => [name, value.replace(/\s+/g, ' ').trim()]));
+}
+
+const tokens = declarations(tokensSource);
 
 /**
  * Everywhere on this side of the seam that CSS can be written: the global stylesheets, and the
@@ -88,12 +111,6 @@ describe('brand colour tokens', () => {
 describe('site colour tokens', () => {
   const aliases = [...tokensSource.matchAll(/^\s*(--[\w-]+)\s*:\s*var\(\s*(--ia-[\w-]+)\s*\)/gm)];
 
-  it('aliases the brand palette rather than restating it', () => {
-    // Thirteen palette entries plus the three modal roles. A new alias is welcome; an alias
-    // that stopped being an alias — a hex pasted back in — is what this counts.
-    expect(aliases.length).toBeGreaterThanOrEqual(16);
-  });
-
   it('resolves every alias to a declared brand token', () => {
     const brandTokens = new Set(declaredProperties(brandSource));
 
@@ -103,5 +120,182 @@ describe('site colour tokens', () => {
         `${alias} aliases ${target}, which brand/colors.css does not declare`,
       ).toContain(target);
     }
+  });
+
+  it('resolves every token this file builds on another', () => {
+    // The count assertion this replaces — "at least sixteen aliases" — was a proxy for "nobody
+    // pasted a hex back in", which the no-hex test above says directly. What matters now is
+    // that the layers hold: a role resolves to an alias, a ramp step resolves to its own parts,
+    // and nothing in the file points at a name the file (or the brand palette) does not declare.
+    const brandTokens = new Set(declaredProperties(brandSource));
+    const dangling = referencedProperties(tokensSource).filter(
+      (property) => !tokens.has(property) && !brandTokens.has(property),
+    );
+
+    expect(dangling, 'tokens.css reads custom properties nothing declares').toEqual([]);
+  });
+
+  it('declares every colour role the taxonomy names', () => {
+    // The vocabulary components are given. Dropping one does not break a build; it leaves a
+    // component with a declaration the browser discards, which is the failure this file exists
+    // to make loud.
+    const roles = [
+      '--surface-page',
+      '--surface-raised',
+      '--surface-inset',
+      '--surface-sunken',
+      '--border',
+      '--border-strong',
+      '--ink',
+      '--ink-muted',
+      '--ink-faint',
+      '--accent',
+      '--accent-quiet',
+      '--danger',
+      '--focus',
+      '--modal-backdrop',
+      '--modal-border-message',
+      '--modal-border-error',
+      '--modal-border-success',
+    ];
+
+    const missing = roles.filter((role) => !tokens.has(role));
+
+    expect(missing, 'components build from these roles by name').toEqual([]);
+  });
+
+  it('declares no token twice', () => {
+    const declared = declaredProperties(tokensSource);
+    const duplicates = declared.filter((name, index) => declared.indexOf(name) !== index);
+
+    expect(duplicates, 'a redeclared token silently wins over the one above it').toEqual([]);
+  });
+});
+
+describe('the type ramp', () => {
+  // Six steps, and the sizes the approved taxonomy states. They are asserted literally because
+  // the ramp is the one thing every surface is measured against: a step that drifts by a pixel
+  // is a page that stops agreeing with the page beside it.
+  const steps: [string, string, string][] = [
+    ['--t-display', '26px', '1.05'],
+    ['--t-title', '20px', '1.1'],
+    ['--t-heading', '16px', '1.2'],
+    ['--t-body', '14px', '1.45'],
+    ['--t-small', '12.5px', '1.4'],
+    ['--t-micro', '11px', '1.4'],
+  ];
+
+  it.each(steps)('declares %s at its stated size and line height', (step, size, line) => {
+    expect(tokens.get(`${step}-size`)).toBe(size);
+    expect(tokens.get(`${step}-line`)).toBe(line);
+  });
+
+  it.each(steps)('builds the %s shorthand from its own parts', (step) => {
+    // The shorthand and the parts are two forms of one step, so they are declared from the same
+    // numbers rather than restated — a shorthand carrying its own literal size is how the two
+    // forms of a step come to disagree.
+    const shorthand = tokens.get(step);
+
+    expect(shorthand).toContain(`var(${step}-size)`);
+    expect(shorthand).toContain(`var(${step}-line)`);
+    expect(shorthand).toMatch(/var\(--face-(display|body)\)/);
+  });
+
+  it('carries the two faces and nothing else', () => {
+    expect(tokens.get('--face-display')).toContain('cinzel');
+    expect(tokens.get('--face-body')).toContain('Inclusive Sans');
+
+    const faces = [...tokens.keys()].filter((name) => name.startsWith('--face-'));
+    expect(faces).toEqual(['--face-display', '--face-body']);
+  });
+
+  it('gives --t-micro the tracking the step is defined with', () => {
+    // `font` cannot carry letter-spacing, so the tracking is a separate token rather than part
+    // of the shorthand. It is still part of the step, and a use of `--t-micro` without it is
+    // 11px Cinzel set too tight to read.
+    expect(tokens.get('--t-micro-tracking')).toBe('0.08em');
+  });
+
+  it('holds exactly the six steps', () => {
+    const declared = [...tokens.keys()].filter(
+      (name) => name.startsWith('--t-') && !/-(size|line|tracking)$/.test(name),
+    );
+
+    expect(declared).toEqual(steps.map(([step]) => step));
+  });
+});
+
+describe('the space ramp', () => {
+  it('holds its eight steps, in order, at their stated values', () => {
+    const ramp = ['2px', '4px', '6px', '8px', '12px', '16px', '24px', '32px'];
+
+    expect(ramp.map((_, index) => tokens.get(`--s${index + 1}`))).toEqual(ramp);
+  });
+
+  it('stops at --s8', () => {
+    // Nothing above `--s8` exists: a gap that wants 48px is a layout that wants rethinking, and
+    // the ramp making that awkward is the point of having a ramp at all.
+    const steps = [...tokens.keys()].filter((name) => /^--s\d+$/.test(name));
+
+    expect(steps).toHaveLength(8);
+    expect(tokens.has('--s9')).toBe(false);
+  });
+});
+
+describe('elevation and corners', () => {
+  it('declares the one plate gradient and the one shadow', () => {
+    expect(tokens.get('--plate')).toContain('linear-gradient');
+    expect(tokens.get('--edge')).toContain('inset');
+    expect(tokens.get('--lift')).toContain('rgb(');
+  });
+
+  it('mixes the plate from a role rather than a literal', () => {
+    // The gradient replaced three copies of `rgb(92, 86, 73)`. Written as a mix of `--slate` it
+    // follows the palette; written as two more literals it would be a fourth copy in the one
+    // file that is supposed to end them.
+    expect(tokens.get('--plate')).toContain('color-mix');
+    expect(tokens.get('--plate')).toContain('var(--slate)');
+    expect(tokens.get('--plate')).not.toMatch(/rgb\(\s*\d/);
+  });
+
+  it('holds exactly three corner treatments', () => {
+    // Three is a cap, not a count. A component picks from these and a skin picks between cut,
+    // bevelled and square from the same vocabulary; a fourth is what the rule exists to prevent.
+    const corners = ['--notch', '--corner-control', '--corner-nav'];
+
+    for (const corner of corners) {
+      expect(tokens.get(corner), `${corner} is a clip-path polygon`).toMatch(/^polygon\(/);
+    }
+
+    const declared = [...tokens.keys()].filter(
+      (name) => name === '--notch' || name.startsWith('--corner-'),
+    );
+    expect(declared.sort()).toEqual([...corners].sort());
+  });
+
+  it('cuts the nav corner on one edge and the other two diagonally', () => {
+    // The three shapes are easy to confuse and impossible to tell apart by name. The nav item is
+    // square on its flush edge and cut at both corners of the inner one; the notch and the
+    // control cut diagonally opposite corners, at 9px and 7px respectively.
+    expect(tokens.get('--notch')).toContain('9px');
+    expect(tokens.get('--corner-control')).toContain('7px');
+
+    expect(tokens.get('--corner-nav')).toContain('100% calc(100% - 7px)');
+    expect(tokens.get('--notch')).not.toContain('100% calc(100% - 9px)');
+  });
+});
+
+describe('motion', () => {
+  it('declares one duration, and it is swift', () => {
+    expect(tokens.get('--motion-swift')).toBe('120ms');
+
+    const durations = [...tokens.keys()].filter((name) => name.startsWith('--motion-'));
+    expect(durations).toEqual(['--motion-swift']);
+  });
+});
+
+describe('the measure', () => {
+  it('stays in ch, because it is a line length', () => {
+    expect(tokens.get('--measure')).toBe('70ch');
   });
 });


### PR DESCRIPTION
Closes #113.

`tokens.css` was 47 lines — thirteen palette aliases, three modal roles and `--measure`. It now carries the taxonomy `docs/visual-design.md` approved:

- **Colour roles** — four surfaces, two borders, three ink levels, accent/accent-quiet, danger and focus. Each resolves to a palette alias or a `color-mix()` of two; no hex is written here, so `brand/colors.css` stays the only place a colour value exists. `--ink-faint` is the corrected 48% mix (4.8:1), not the mockup's flat grey that measured 4.16:1.
- **Type ramp** — six steps in `px`, each as a `font` shorthand plus its `-size` and `-line` parts, declared from the same numbers so the two forms cannot disagree. `--t-micro` carries its tracking separately, because `font` cannot.
- **Space ramp** — eight steps, 2px to 32px. Nothing above `--s8`.
- **Elevation** — `--plate` (the gradient that replaces three copies of `rgb(92, 86, 73)`), `--edge`, `--lift`.
- **Corners** — `--notch`, `--corner-control`, and `--corner-nav` from the shell design in #114: square on the flush edge, both corners of the inner one cut, which is neither of the other two.
- **Motion** — `--motion-swift: 120ms`.

Nothing is applied. No existing token changed value, so the site looks exactly as it did; the surface issues (#114–#118) spend this vocabulary.

`tokens.test.ts` grows alongside: every `var()` in the file has to resolve to something the file or the brand palette declares, each ramp holds the steps and values the taxonomy names, the corner list is capped at three, and no token is declared twice. The old `aliases.length >= 16` count is gone — it was a proxy for "nobody pasted a hex back in", which the no-hex test says directly, and the doc asked for it to become "every role resolves".

`npm run verify` is green: 4400 tests, coverage gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)