### PR TITLE
Build the shell's look for #114

### DIFF
--- a/src/components/layout/Sidebar.svelte
+++ b/src/components/layout/Sidebar.svelte
@@ -36,17 +36,23 @@
 </nav>
 
 <style>
+  /* The sidebar is flush to the left edge of the screen and square on that side: the items run
+     edge to edge and carry their own inset padding, which is why the inline padding here is zero
+     at every width. No notch on the outer edge — `--notch` cuts a corner off a plate that sits on
+     a surface, and a cut on an edge with nothing beyond it reads as damage rather than as a cut.
+     See docs/visual-design.md, "The shell". */
   .sidebar {
-    background: var(--slate);
-    border-right: 1px solid var(--granite);
+    background: var(--surface-raised);
+    border-right: 1px solid var(--border);
+    box-shadow: var(--edge);
     overflow-y: auto;
-    padding: 0.75rem 0.5rem;
+    padding: var(--s5) 0;
   }
 
   .sidebar ul {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: var(--s1);
     margin: 0;
     padding: 0;
   }
@@ -60,57 +66,83 @@
     margin-left: 0;
   }
 
+  /* One size at every width. The 768–1199px band used to override `font-size` and `padding` to
+     fit narrower labels; `--t-micro` is 11px uppercase Cinzel, and `RELEASE NOTES` — the longest
+     label — clears the 128px column's usable width, so that override is deleted rather than
+     restated.
+
+     The transparent keyline is geometry rather than decoration: the current item takes a
+     `--border-strong` edge on three sides, and an item that grew a border only on becoming
+     current would shift its own label by a pixel. Rest still shows no keyline. */
   .sidebar a {
     border: 1px solid transparent;
-    border-radius: 6px;
-    color: var(--iron-arachne-green);
+    border-inline-start: 0;
+    color: var(--ink-muted);
     display: block;
-    font-family: 'cinzel', system-ui, Helvetica, sans-serif;
-    padding: 0.5rem 0.6rem;
+    font: var(--t-micro);
+    letter-spacing: var(--t-micro-tracking);
+    padding: var(--s3) var(--s3) var(--s3) var(--s5);
     text-decoration: none;
+    text-transform: uppercase;
+    transition:
+      background-color var(--motion-swift) ease,
+      color var(--motion-swift) ease;
   }
 
+  /* No keyline on hover: one would compete with the current item's marker, which is the thing the
+     eye is meant to find without reading. */
   .sidebar a:hover {
-    background: var(--granite);
-    color: white;
+    background-color: var(--surface-inset);
+    color: var(--ink);
+  }
+
+  .sidebar a:focus-visible {
+    outline: 2px solid var(--focus);
+    outline-offset: 2px;
   }
 
   /* The current destination, marked by the same attribute a screen reader reads, so the visual
-     state and the announced state cannot drift apart. */
-  .sidebar a[aria-current='page'] {
-    background: linear-gradient(0deg, var(--granite) 0%, var(--tan) 100%);
-    border-color: var(--tan);
-    color: black;
-  }
+     state and the announced state cannot drift apart. It outranks the hover rule on specificity,
+     which is the intent: current plus hover is current. The destination you are already on is not
+     a target worth lighting, and a hover state there is how a user learns that clicking it does
+     nothing.
 
-  /* 768–1199px: narrower, with the same labels at a smaller size. There is no icon rail — the
-     brand repo has no icon set, and five marks drawn here would sit badly beside the wordmark.
-     See docs/app-shell.md, decision 6. */
-  @media (max-width: 1199px) {
-    .sidebar a {
-      font-size: 0.85rem;
-      padding: 0.45rem 0.4rem;
-    }
+     The marker is an inset shadow rather than a border or a pseudo-element because `--corner-nav`
+     is a `clip-path`, and a clip cuts everything the element paints, borders included — a
+     `border-inline-start` would be shaved at both ends by the very corners it needs to survive.
+     An inset shadow is painted inside the clip, on the one edge the clip does not touch. */
+  .sidebar a[aria-current='page'] {
+    background: var(--plate);
+    border-color: var(--border-strong);
+    box-shadow:
+      var(--edge),
+      inset 3px 0 0 var(--accent);
+    clip-path: var(--corner-nav);
+    color: var(--ink);
   }
 
   /* Below 768px it is a drawer: off-canvas, over the page rather than beside it. The shell owns
-     whether it is open; this owns where it sits. */
+     whether it is open; this owns where it sits. It is the one part of the shell that takes
+     `--lift` — the one place where something genuinely overlaps content, which is the condition
+     the elevation model states for a shadow. */
   @media (max-width: 767px) {
     .sidebar {
       bottom: 0;
+      box-shadow: var(--edge), var(--lift);
       left: 0;
       position: fixed;
       top: 0;
       transform: translateX(-100%);
       /* `visibility` and not transform alone. A drawer parked off-canvas by a transform is still
          rendered: its links stay in the tab order and in the accessibility tree, so tabbing out of
-         the top bar walks into five invisible destinations. `visibility: hidden` takes it out of
-         both, and delaying it until the slide has finished keeps the animation. */
+         the top bar walks into six invisible destinations. `visibility: hidden` takes it out of
+         both, and delaying it by exactly the slide's own duration keeps the animation — the two
+         read the same token, or the drawer disappears mid-slide. */
       visibility: hidden;
       transition:
-        transform 0.2s ease,
-        visibility 0s linear 0.2s;
-      width: min(16rem, 80vw);
+        transform var(--motion-swift) ease,
+        visibility 0s linear var(--motion-swift);
+      width: min(272px, 80vw);
       z-index: 20;
     }
 
@@ -118,8 +150,18 @@
       transform: translateX(0);
       visibility: visible;
       transition:
-        transform 0.2s ease,
+        transform var(--motion-swift) ease,
         visibility 0s;
+    }
+  }
+
+  /* The hit target keys off the pointer rather than off the width: a touch laptop at 1280px wants
+     the same 44px target, and a phone plugged into a mouse does not. */
+  @media (pointer: coarse) {
+    .sidebar a {
+      align-items: center;
+      display: flex;
+      min-height: 44px;
     }
   }
 

--- a/src/components/layout/TopBar.svelte
+++ b/src/components/layout/TopBar.svelte
@@ -104,13 +104,25 @@
 </header>
 
 <style>
+  /* 44px tall at every width, which is the hit-target floor — a bar that is exactly one target
+     tall needs no separate rule to be tappable. The block padding is what centres a 28px lockup
+     in that height.
+
+     No `--lift`, and that is not an omission: the bar is a grid row rather than an overlay, and
+     scrolling happens inside the page region, so nothing ever passes underneath it. A shadow
+     says "this is above that", and here there is no that — the keyline carries the separation.
+     No notch either, for the reason the sidebar's outer edge has none. See
+     docs/visual-design.md, "The shell". */
   .top-bar {
     align-items: center;
-    background: var(--slate);
-    border-bottom: 1px solid var(--granite);
+    background: var(--surface-raised);
+    border-bottom: 1px solid var(--border);
+    box-shadow: var(--edge);
+    box-sizing: border-box;
     display: flex;
-    gap: 1rem;
-    padding: 0.35rem 0.75rem;
+    gap: var(--s6);
+    height: 44px;
+    padding: var(--s4) var(--s5);
   }
 
   .top-bar__identity {
@@ -119,67 +131,91 @@
 
     & img {
       display: block;
-      height: 2.25rem;
+      height: 28px;
       width: auto;
     }
   }
 
-  /* Only the drawer band has a drawer to toggle. Hidden rather than not rendered, so the button
-     is present the instant the viewport narrows past the breakpoint. */
+  /* The icon button from the control vocabulary: 28×28 and square, because a cut corner on a
+     28px square eats the glyph. Only the drawer band has a drawer to toggle — hidden rather than
+     not rendered, so the button is present the instant the viewport narrows past the
+     breakpoint. */
   .top-bar__menu {
-    display: none;
-    background: none;
-    border: 1px solid var(--granite);
-    border-radius: 6px;
-    color: var(--iron-arachne-green);
+    align-items: center;
+    background: var(--plate);
+    border: 1px solid var(--border-strong);
+    box-shadow: var(--edge);
+    color: var(--ink);
     cursor: pointer;
+    display: none;
     flex: 0 0 auto;
-    font-size: 1.1rem;
+    font: var(--t-micro);
+    height: 28px;
+    justify-content: center;
     line-height: 1;
-    padding: 0.35rem 0.5rem;
+    padding: 0;
+    transition:
+      border-color var(--motion-swift) ease,
+      color var(--motion-swift) ease;
+    width: 28px;
   }
 
   .top-bar__menu:hover {
-    border-color: white;
-    color: white;
+    border-color: var(--focus);
+  }
+
+  .top-bar__menu:active {
+    color: var(--accent);
+  }
+
+  .top-bar__menu:focus-visible {
+    outline: 2px solid var(--focus);
+    outline-offset: 2px;
   }
 
   /* The status items sit together in the middle; the date is pushed to the far right by this
      margin rather than by `justify-content`, which would spread the identity too. */
   .top-bar__status {
     display: flex;
-    gap: 1.25rem;
-    margin: 0 auto 0 0.5rem;
+    gap: var(--s6);
+    margin: 0 auto 0 var(--s4);
   }
 
   .top-bar__stat {
     display: flex;
     align-items: baseline;
-    gap: 0.35rem;
+    gap: var(--s3);
     white-space: nowrap;
   }
 
-  /* Lightened off the raw tan, which at 0.7rem on the slate bar sat close enough to the
-     background to read as disabled rather than as a label. */
+  /* `--t-micro` carries the uppercasing and the tracking this rule used to set by hand, at the
+     ramp's 0.08em rather than a local 0.04em. */
   .top-bar__stat dt {
-    color: color-mix(in srgb, var(--tan) 55%, white 45%);
-    font-family: 'cinzel', system-ui, Helvetica, sans-serif;
-    font-size: 0.7rem;
-    letter-spacing: 0.04em;
+    color: var(--ink-faint);
+    font: var(--t-micro);
+    letter-spacing: var(--t-micro-tracking);
     text-transform: uppercase;
   }
 
   .top-bar__stat dd {
-    color: white;
-    font-size: 0.9rem;
+    color: var(--ink);
+    font: var(--t-small);
     margin: 0;
   }
 
+  /* The one status that is also a control, so it takes the accent every other link on the site
+     takes rather than reading as a value. */
+  .top-bar__stat--project dd a {
+    color: var(--accent);
+  }
+
   .top-bar__date {
-    color: color-mix(in srgb, var(--tan) 55%, white 45%);
+    color: var(--ink-faint);
     flex: 0 0 auto;
-    font-size: 0.8rem;
+    font: var(--t-micro);
+    letter-spacing: var(--t-micro-tracking);
     margin: 0;
+    text-transform: uppercase;
     white-space: nowrap;
   }
 
@@ -203,11 +239,11 @@
 
   @media (max-width: 767px) {
     .top-bar {
-      gap: 0.5rem;
+      gap: var(--s4);
     }
 
     .top-bar__menu {
-      display: block;
+      display: flex;
     }
 
     .top-bar__stat--tools,
@@ -216,7 +252,25 @@
     }
 
     .top-bar__identity img {
-      height: 1.75rem;
+      height: 24px;
+    }
+  }
+
+  /* 28px is the visual size of the control; the tap area is padded out to 44px. The condition is
+     the pointer and not the width — a touch laptop at 1280px wants the same target, and a phone
+     plugged into a mouse does not. The bar is 44px tall, so the target fills it exactly. */
+  @media (pointer: coarse) {
+    .top-bar__menu {
+      position: relative;
+    }
+
+    /* Grown as an overlay rather than as padding, because padding would grow the plate itself and
+       the button would stop being a 28px control. The bar is 44px tall, so 8px either side of a
+       28px body fills it exactly. */
+    .top-bar__menu::after {
+      content: '';
+      inset: calc(var(--s4) * -1) 0;
+      position: absolute;
     }
   }
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -135,20 +135,29 @@
     grid-area: bar;
   }
 
+  /* The shell's widths are stated in `px` and not in `rem`. `main.css` sets a fluid root —
+     `clamp(1em, 0.909em + 0.45vmin, 1.25em)` — so every `rem` here would be relative to a moving
+     target, and the sidebar would be a different fraction of a 1280px screen than of a 1920px
+     one despite `width` being one number. The type ramp is already in `px`; this makes the frame
+     agree with it. See docs/visual-design.md, "The shell". */
   .shell > :global(.sidebar) {
     grid-area: nav;
-    width: 12rem;
+    width: 176px;
   }
 
+  /* The Page level of the elevation model: flat, no border, no shadow. */
   .shell__page {
+    background: var(--surface-page);
     grid-area: page;
     min-width: 0;
     overflow-y: auto;
-    padding: 0.5rem;
+    padding: var(--s7);
   }
 
+  /* The shell and the modals dim the page for the same reason, so they dim it by the same amount
+     from the same place. */
   .shell__scrim {
-    background: rgb(0 0 0 / 50%);
+    background: var(--modal-backdrop);
     inset: 0;
     position: fixed;
     z-index: 10;
@@ -156,7 +165,7 @@
 
   @media (max-width: 1199px) {
     .shell > :global(.sidebar) {
-      width: 8.5rem;
+      width: 128px;
     }
   }
 
@@ -171,7 +180,11 @@
     }
 
     .shell > :global(.sidebar) {
-      width: min(16rem, 80vw);
+      width: min(272px, 80vw);
+    }
+
+    .shell__page {
+      padding: var(--s5);
     }
   }
 </style>


### PR DESCRIPTION
Implements #114 — the application shell's *look*, from the **The shell** section of `docs/visual-design.md` (#129). Structure is untouched: six destinations, three breakpoints, and what drops in what order are all `docs/app-shell.md`'s, and none of it is reopened.

## Top bar

44px at every width — the hit-target floor, so the bar is exactly one target tall. `--surface-raised`, a `--border` bottom keyline, `--edge`, and deliberately **no `--lift` and no notch**: the bar is a grid row rather than an overlay, so nothing passes underneath it, and a cut corner on an edge with nothing beyond it reads as damage.

Four hand-mixed values become ramp steps and roles — two `color-mix(--tan 55%, white)` labels, a `color: white` value, and a local `0.04em` tracking that `--t-micro` carries at `0.08em`. The drawer toggle becomes the control vocabulary's icon button: 28×28, square, `--plate`, `--border-strong`, hover lights the keyline to `--focus`.

## Sidebar

Flush to the left edge, zero inline padding at every width, items running edge to edge at `--t-micro` in `--ink-muted`. The current destination takes `--plate`, `--edge`, a three-sided `--border-strong` keyline, the `--corner-nav` clip and a 3px `--accent` marker — as an **inset shadow**, because a `clip-path` shaves a border at both ends by the very corners the marker needs to survive. `linear-gradient(--granite, --tan)` under `color: black` is gone.

The 768–1199px `font-size`/`padding` overrides are **deleted rather than restated**: `--t-micro` fits `RELEASE NOTES` in a 128px column, so one size covers every width.

## Drawer, scrim, targets

The slide and the `visibility` delay that keeps the drawer out of the tab order both read `--motion-swift`, so they cannot fall out of step mid-slide. The scrim reads `--modal-backdrop` instead of a hand-written `rgb(0 0 0 / 50%)`. The 44px tap target keys off `(pointer: coarse)` rather than the drawer breakpoint — the condition is the pointer, not the width — and is grown as an overlay rather than as padding, so the button stays a 28px control.

Behaviour is unchanged: `inert`, Escape, scrim tap and the breakpoint close all as they were.

## Widths in px

`main.css` sets a fluid root, so every `rem` in the frame rode a moving target — the sidebar was a different fraction of a 1280px screen than of a 1920px one despite `width` being one number. 176 / 128 / `min(272px, 80vw)`.

## Verification

- `npm run verify` green — 4400 unit tests, coverage gate passed.
- Playwright desktop: **220 passed**, plus the 5 `preview_goldens` cases below.
- Playwright mobile: **200 passed**, every width in `MOBILE_VIEWPORTS`.

**The golden baselines need regenerating before this merges.** `preview_goldens.spec.ts` documents the reason in its own header: the previews sit at fractional offsets and are compared as element screenshots, so anything that moves one down its route invalidates its baseline — the 44px bar and the `--s7` page padding do exactly that. All five fail at a ~0.03 diff ratio with no change to the render itself, and all five pass against the unmodified shell, which is what confirms it is the offset and not the picture. They are regenerated with `.github/workflows/goldens.yaml` on this branch, never with `--update-snapshots` locally.

Closes #114.