### PR TITLE
Bring modals and banners onto the shared system, for #117

### DIFF
--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -86,10 +86,19 @@ test.describe('the projects page', () => {
   test('asks before deleting, and says how much goes with it', async ({ page }) => {
     await create(page, 'Ashfall');
 
+    const dialog = page.locator('dialog.panel');
+
+    // The `[open]` trap, and the reason it is checked in a browser rather than by a source sweep.
+    // A `<dialog>` is `display: none` until it is opened, by a user-agent rule about `display` —
+    // and `.panel` declares `display: flex`. A dialog wearing the panel classes without
+    // `modal.css` restating the rule it overrode is a dialog that renders inline, in the page
+    // flow, permanently. That is invisible to a regex and obvious to a viewport, and a stylesheet
+    // edit is exactly what would reintroduce it. See docs/visual-design.md, "The message family".
+    await expect(dialog).toBeHidden();
+
     await projectCard(page, 'Ashfall').getByRole('button', { name: 'Delete' }).click();
 
     // There is no server copy to restore from, so the question has to carry the consequence.
-    const dialog = page.locator('dialog.ironarachne-modal');
     await expect(dialog).toContainText('cannot be undone');
 
     await dialog.getByRole('button', { name: 'Cancel' }).click();

--- a/e2e/vault.spec.ts
+++ b/e2e/vault.spec.ts
@@ -166,7 +166,7 @@ test.describe('the result vault', () => {
     await row(page, 'The Emberfolk').click();
     await inspector(page).getByRole('button', { name: 'Delete' }).click();
 
-    const dialog = page.locator('dialog.ironarachne-modal');
+    const dialog = page.locator('dialog.panel');
     await expect(dialog).toContainText('no copy anywhere else');
     await dialog.getByRole('button', { name: 'Delete', exact: true }).click();
 

--- a/e2e/workshop.spec.ts
+++ b/e2e/workshop.spec.ts
@@ -261,7 +261,7 @@ test.describe('the workshop bench', () => {
 
     // The dialog element is always in the DOM; ModalHost opens and closes it, so "not asked"
     // is hidden rather than absent.
-    await expect(page.locator('dialog.ironarachne-modal')).toBeHidden();
+    await expect(page.locator('dialog.panel')).toBeHidden();
     await expect(panelTitles(page)).toHaveText([/Heraldry/]);
   });
 
@@ -277,7 +277,7 @@ test.describe('the workshop bench', () => {
 
     await mountTool(page, /^Heraldry/);
 
-    const dialog = page.locator('dialog.ironarachne-modal');
+    const dialog = page.locator('dialog.panel');
     await expect(dialog).toContainText('you have not saved');
 
     // Refusing leaves the bench exactly as it was.
@@ -297,7 +297,7 @@ test.describe('the workshop bench', () => {
 
     // The dialog element is always in the DOM; ModalHost opens and closes it, so "not asked"
     // is hidden rather than absent.
-    await expect(page.locator('dialog.ironarachne-modal')).toBeHidden();
+    await expect(page.locator('dialog.panel')).toBeHidden();
     await expect(panelTitles(page)).toHaveText([/Heraldry/]);
   });
 
@@ -473,7 +473,7 @@ test.describe('the session log', () => {
     await mountTool(page, /^Culture/);
     await expect(logEntries(page)).toHaveCount(1);
 
-    const dialog = page.locator('dialog.ironarachne-modal');
+    const dialog = page.locator('dialog.panel');
 
     await sessionLog(page).getByRole('button', { name: 'Clear' }).click();
     await dialog.getByRole('button', { name: 'Cancel' }).click();
@@ -629,7 +629,7 @@ test.describe('saving what a tool made', () => {
  */
 test.describe('building one artifact from another', () => {
   const artifactPanel = (page: Page) => page.locator('.artifact-panel');
-  const confirmDialog = (page: Page) => page.locator('dialog.ironarachne-modal');
+  const confirmDialog = (page: Page) => page.locator('dialog.panel');
 
   test.beforeEach(async ({ page }) => {
     await openEmptyWorkshop(page);
@@ -838,7 +838,7 @@ test.describe('building one artifact from another', () => {
  */
 test.describe('editing a saved artifact', () => {
   const artifactPanel = (page: Page) => page.locator('.artifact-panel');
-  const confirmDialog = (page: Page) => page.locator('dialog.ironarachne-modal');
+  const confirmDialog = (page: Page) => page.locator('dialog.panel');
 
   /** A project with one saved artifact of the named tool in it, open in a panel of its own. */
   async function openASavedArtifact(
@@ -1612,7 +1612,7 @@ test.describe('vault export and import', () => {
   // Export is the storage panel's primary action; what is left in the transfer controls is the way
   // back in. See docs/storage-panel.md.
   const storagePanel = (page: Page) => page.locator('section.storage');
-  const confirmDialog = (page: Page) => page.locator('dialog.ironarachne-modal');
+  const confirmDialog = (page: Page) => page.locator('dialog.panel');
 
   test.beforeEach(async ({ page }) => {
     await openEmptyWorkshop(page);
@@ -1766,7 +1766,7 @@ test.describe('vault export and import', () => {
  * installed before the app boots so the app's own code path is what meets it.
  */
 test.describe('when the browser has no room to save', () => {
-  const storageDialog = (page: Page) => page.locator('dialog.ironarachne-modal .storage-failure');
+  const storageDialog = (page: Page) => page.locator('dialog.panel .storage-failure');
 
   /** Refuses writes to the artifact stores, leaving projects and reads alone. */
   async function fillTheDisk(page: Page): Promise<void> {

--- a/src/components/common/LoadSnapshotDialog.svelte
+++ b/src/components/common/LoadSnapshotDialog.svelte
@@ -1,6 +1,21 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
+  import ListButton from '$components/common/ListButton.svelte';
+
+  /**
+   * A dialog offering a saved thing to load.
+   *
+   * It is a raised panel that happens to be in the top layer, exactly as `ModalHost`'s dialog is,
+   * and it wears the same classes. Before #117 it was a second dialog implementation with its own
+   * frame, its own backdrop and its own keyline — written as `var(--gold, #c9a227)` over
+   * `var(--background, #1a1a1a)`, and `--background` is declared nowhere in the app, so that
+   * second fallback was not a fallback: this dialog painted `#1a1a1a`, a grey in no palette and
+   * not `--charcoal`'s `#1b1e24`. See docs/visual-design.md, "The message family".
+   *
+   * Folding it into `modalState`, so the app has literally one `<dialog>`, is behaviour rather
+   * than look and is left for whoever wants it.
+   */
 
   type Props = {
     title: string;
@@ -21,97 +36,83 @@
   export function close() {
     dialog?.close();
   }
+
+  function load(item: { name: string; seed: string }) {
+    onLoad(item);
+    close();
+  }
 </script>
 
-<dialog bind:this={dialog} class="load-snapshot-dialog">
-  <form method="dialog" class="load-snapshot-dialog-content">
-    <h2>{title}</h2>
+<dialog bind:this={dialog} class="panel">
+  <form method="dialog" class="panel__field">
+    <header class="panel__header">
+      <div class="panel__header-field">
+        <h2 class="panel__title">{title}</h2>
+      </div>
+    </header>
 
-    {#if items.length === 0}
-      <p>{emptyMessage}</p>
-    {:else}
-      <ul class="load-snapshot-list">
-        {#each items as item, index (index)}
-          <li class="load-snapshot-item">
-            <div class="load-snapshot-item-details">
-              <p class="load-snapshot-item-name">{item.name}</p>
-              <p class="load-snapshot-item-seed">Seed: {item.seed}</p>
-            </div>
-            <BaseButton onclick={() => onLoad(item)}>Load</BaseButton>
-          </li>
-        {/each}
-      </ul>
-    {/if}
+    <div class="panel__body">
+      {#if items.length === 0}
+        <p class="load-snapshot__empty">{emptyMessage}</p>
+      {:else}
+        <!-- A well of list rows: a saved snapshot is picked the same way an artifact or a tool is,
+             and the row itself is the choice rather than a row with a button on the end of it. -->
+        <ul class="well load-snapshot__list">
+          {#each items as item, index (index)}
+            <li>
+              <ListButton onclick={() => load(item)} class="load-snapshot__row">
+                <span class="load-snapshot__name">{item.name}</span>
+                <span class="load-snapshot__seed">Seed: {item.seed}</span>
+              </ListButton>
+            </li>
+          {/each}
+        </ul>
+      {/if}
 
-    {#if children}
-      {@render children()}
-    {/if}
+      {#if children}
+        {@render children()}
+      {/if}
 
-    <div class="load-snapshot-dialog-actions">
-      <BaseButton value="cancel">Cancel</BaseButton>
+      <!-- A dialog is a question, so its answer sits where the eye finishes. `submit` rather than
+           the default `button`, because this form is `method="dialog"` and submitting it is what
+           closes the dialog — as `value="cancel"` always meant it to. Until #117 neither this nor
+           the rows closed anything, and Escape was the only way out. -->
+      <div class="panel__footer">
+        <BaseButton type="submit" value="cancel">Cancel</BaseButton>
+      </div>
     </div>
   </form>
 </dialog>
 
 <style>
-  dialog.load-snapshot-dialog {
-    border: 1px solid var(--gold, #c9a227);
-    border-radius: 4px;
-    padding: 0;
-    max-width: 40rem;
-    width: calc(100% - 2rem);
-    background: var(--background, #1a1a1a);
-    color: inherit;
+  /* The frame, the plate, the well and the rows are all the system's. What is left is how a row
+     lays its two parts out. */
+
+  .load-snapshot__empty {
+    color: var(--ink-muted);
+    font: var(--t-small);
+    margin: 0;
   }
 
-  dialog.load-snapshot-dialog::backdrop {
-    background: rgb(0 0 0 / 50%);
-  }
-
-  .load-snapshot-dialog-content {
-    padding: 1rem 1.25rem;
-  }
-
-  .load-snapshot-list {
+  .load-snapshot__list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s1);
     list-style: none;
     margin: 0;
-    padding: 0;
   }
 
-  .load-snapshot-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    padding: 0.75rem 0;
-    border-bottom: 1px solid rgb(255 255 255 / 10%);
+  :global(.load-snapshot__row) {
+    width: 100%;
   }
 
-  .load-snapshot-item:last-child {
-    border-bottom: none;
+  .load-snapshot__name {
+    overflow-wrap: anywhere;
   }
 
-  .load-snapshot-item-details {
-    min-width: 0;
-  }
-
-  .load-snapshot-item-name,
-  .load-snapshot-item-seed {
-    margin: 0;
-  }
-
-  .load-snapshot-item-name {
-    font-weight: 600;
-  }
-
-  .load-snapshot-item-seed {
-    font-size: 0.875rem;
-    opacity: 0.8;
-  }
-
-  .load-snapshot-dialog-actions {
-    margin-top: 1rem;
-    display: flex;
-    justify-content: flex-end;
+  .load-snapshot__seed {
+    color: var(--ink-muted);
+    font: var(--t-small);
+    overflow-wrap: anywhere;
   }
 </style>

--- a/src/components/common/ModalDialog.svelte
+++ b/src/components/common/ModalDialog.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
-  import type { AlertModalStyle } from '$lib/ui';
   import BaseButton from '$components/common/BaseButton.svelte';
+
+  /**
+   * The body of the ordinary dialog: a sentence, and either one action or a choice between two.
+   *
+   * The frame is `ModalHost`'s `<dialog>`, which wears the panel classes. What this renders is the
+   * liner and its contents — the header plate, the body and the footer — so a dialog is the same
+   * surface as a panel, differing only in being in the top layer. See docs/visual-design.md,
+   * "The message family".
+   */
 
   type Props = {
     kind: 'alert' | 'confirm';
     message: string;
     title?: string;
-    style?: AlertModalStyle;
     okLabel?: string;
     cancelLabel?: string;
     dangerous?: boolean;
@@ -18,38 +25,53 @@
     kind,
     message,
     title,
-    style = 'message',
     okLabel = 'OK',
     cancelLabel = 'Cancel',
     dangerous = false,
     onResolveAlert,
     onResolveConfirm,
   }: Props = $props();
-
-  const panelStyle = $derived(kind === 'confirm' ? 'message' : style);
 </script>
 
-<div class="modal-dialog-content modal-dialog-content--{panelStyle}">
+<div class="panel__field">
   {#if title}
-    <h2 id="modal-dialog-title" class="modal-dialog-title">{title}</h2>
+    <header class="panel__header">
+      <div class="panel__header-field">
+        <h2 id="modal-dialog-title" class="panel__title">{title}</h2>
+      </div>
+    </header>
   {/if}
-  <p id="modal-dialog-message" class="modal-dialog-message">{message}</p>
-  <div class="modal-dialog-actions">
-    {#if kind === 'confirm'}
-      <!-- The base plate rather than `quiet`: these two are peer actions in a dialog that exists to
-           ask which one you meant, and a tertiary treatment on one of a pair reads as the pair
-           being unequal. Quiet is for an action sitting beside work, not for half of a choice. -->
-      <BaseButton onclick={() => onResolveConfirm?.(false)}>
-        {cancelLabel}
-      </BaseButton>
-      <BaseButton
-        variant={dangerous ? 'destructive' : 'secondary'}
-        onclick={() => onResolveConfirm?.(true)}
-      >
-        {okLabel}
-      </BaseButton>
-    {:else}
-      <BaseButton onclick={() => onResolveAlert?.()}>{okLabel}</BaseButton>
-    {/if}
+
+  <div class="panel__body">
+    <p id="modal-dialog-message">{message}</p>
+
+    <!-- A dialog is a question, so its answers sit where the eye finishes. -->
+    <div class="panel__footer">
+      {#if kind === 'confirm'}
+        <!-- The base plate rather than `quiet`: these two are peer actions in a dialog that exists to
+             ask which one you meant, and a tertiary treatment on one of a pair reads as the pair
+             being unequal. Quiet is for an action sitting beside work, not for half of a choice. -->
+        <BaseButton onclick={() => onResolveConfirm?.(false)}>
+          {cancelLabel}
+        </BaseButton>
+        <BaseButton
+          variant={dangerous ? 'destructive' : 'secondary'}
+          onclick={() => onResolveConfirm?.(true)}
+        >
+          {okLabel}
+        </BaseButton>
+      {:else}
+        <BaseButton onclick={() => onResolveAlert?.()}>{okLabel}</BaseButton>
+      {/if}
+    </div>
   </div>
 </div>
+
+<style>
+  /* The tone is the surface, never the sentence: crimson is 2.2:1 on charcoal and emerald 2.65:1,
+     so the words are `--ink` whichever tone the dialog around them is wearing. */
+  p {
+    margin: 0;
+    max-width: var(--measure);
+  }
+</style>

--- a/src/components/common/Notice.svelte
+++ b/src/components/common/Notice.svelte
@@ -1,0 +1,86 @@
+<script lang="ts" module>
+  /**
+   * What a message is saying, which is not the same as what colour it is.
+   *
+   * `plain` is a statement of fact, and it is the default because most of what the app says is
+   * one. The other three are spent on the cases that differ.
+   */
+  export type Tone = 'plain' | 'notice' | 'success' | 'danger';
+
+  /** The class that carries a tone. Shared with the dialog, so both read one vocabulary. */
+  export const TONE_CLASS: Record<Tone, string> = {
+    plain: '',
+    notice: 'panel--notice',
+    success: 'panel--success',
+    danger: 'panel--danger',
+  };
+</script>
+
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  /**
+   * A notice: the app saying something beside the work rather than in front of it.
+   *
+   * A notice and a dialog are the same toned panel at two levels of interruption — the panel's
+   * liner, keyline, notch, padding ramp and lift, with no new box and no second recipe. They
+   * differ in how much they interrupt, and in one deliberate detail: a dialog's actions are
+   * right-aligned because a dialog is a question, and a notice's follow the text from the left
+   * because a notice is a sentence.
+   *
+   * This is not a `Panel`, and the reason is the element rather than the styling. A notice is a
+   * live region — `role="status"` — and a landmark is not a live region. It is also titleless,
+   * where `Panel` requires a title because a panel without a heading is a box. The panel is the
+   * classes in `main.css`; `Panel`, `Notice` and the dialog are three assemblies of them, because
+   * a region, a status message and a top-layer dialog are three different elements and the wrong
+   * element is not a styling problem.
+   *
+   * See docs/visual-design.md, "The message family".
+   */
+
+  type Props = {
+    /** What the notice is saying, which is not the same as what colour it is. */
+    tone?: Tone;
+    /** What may be done about the sentence. Follows the text from the left. */
+    actions?: Snippet;
+    /** The caller's own layout — where the notice sits. Never the look. */
+    class?: string;
+    children: Snippet;
+  };
+
+  const { tone = 'plain', actions, class: extraClass = '', children }: Props = $props();
+</script>
+
+<div class="panel notice {TONE_CLASS[tone]} {extraClass}" role="status">
+  <div class="panel__field">
+    <div class="panel__body">
+      {@render children()}
+
+      {#if actions}
+        <div class="notice__actions">
+          {@render actions()}
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  /* The only things scoped here. Everything else about a notice is `main.css`'s, so it is the
+     same panel the rest of the app is. */
+
+  /* A notice is a sentence, so its text is capped at the measure however wide it is placed. */
+  .notice :global(p) {
+    margin: 0;
+    max-width: var(--measure);
+  }
+
+  /* Left-aligned, unlike a dialog's footer: these follow the text rather than answering a
+     question. `--s4` either way, because the buttons are one group. */
+  .notice__actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--s4);
+  }
+</style>

--- a/src/components/common/StorageDisclosureNotice.svelte
+++ b/src/components/common/StorageDisclosureNotice.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import BaseButton from '$components/common/BaseButton.svelte';
+  import Notice from '$components/common/Notice.svelte';
   // Said once, at the moment the user first has something to lose, and never again — see
   // docs/storage-disclosure.md. Inline and dismissible rather than a modal: a dialog over the first
   // thing somebody ever made is a toll gate, and this is a sentence.
@@ -17,42 +18,29 @@
   const { backupHref, onDismiss }: Props = $props();
 </script>
 
-<div class="storage-disclosure" role="status">
+<!-- Plain, and deliberately so. This is a statement of fact rather than a warning, and nothing has
+     gone wrong — a tone here would be colour spent on the ordinary case, which is what makes a
+     tone stop meaning anything. Plain is not quiet: the copy is unchanged and
+     docs/storage-disclosure.md owns it. -->
+<Notice class="storage-disclosure">
   <p>
     <strong>Your work is saved in this browser only.</strong> There is no account and no server, and nothing
     is copied anywhere else. Exporting a file is how your work leaves this browser — and it is what survives
     clearing site data, a new machine, or a browser that decides to reclaim the space.
   </p>
-  <div class="storage-disclosure__actions">
+
+  {#snippet actions()}
     <!-- A fragment on the page the reader is already on, not a route: there is nothing for
          resolve() to add, and a base path would make it point off the page. -->
     <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
     <a href={backupHref}>Back up your work</a>
     <BaseButton onclick={onDismiss}>Got it</BaseButton>
-  </div>
-</div>
+  {/snippet}
+</Notice>
 
 <style>
-  .storage-disclosure {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-    padding: 0.6rem 0.75rem;
-    border: 1px solid var(--tan);
-    border-radius: 4px;
-    background: var(--slate);
-  }
-
-  .storage-disclosure p {
-    margin: 0;
-    font-size: 0.9rem;
-  }
-
-  .storage-disclosure__actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    align-items: center;
+  /* Layout only: where the notice sits. The look is the panel's. */
+  :global(.storage-disclosure) {
+    margin-bottom: var(--s6);
   }
 </style>

--- a/src/components/common/StorageFailureModalContent.svelte
+++ b/src/components/common/StorageFailureModalContent.svelte
@@ -65,96 +65,88 @@
   }
 </script>
 
-<div class="storage-failure">
-  <h2 id="modal-dialog-title">{title}</h2>
+<div class="panel__field">
+  <header class="panel__header">
+    <div class="panel__header-field">
+      <h2 id="modal-dialog-title" class="panel__title">{title}</h2>
+    </div>
+  </header>
 
-  <p class="storage-failure__what">{message}</p>
+  <div class="panel__body storage-failure">
+    <p class="storage-failure__what">{message}</p>
 
-  <!-- Said before anything is asked of them. The transaction rolled back, so there is no
-       half-written artifact to reconcile, and a user who thinks their whole project may be damaged
-       will act very differently from one who knows only this save did not happen. -->
-  <p class="storage-failure__safe">
-    Everything you had already saved is unharmed — this write was undone completely. What is on
-    screen has not been lost either; it is still there and still saveable.
-  </p>
-
-  {#if usage !== null}
-    <p class="storage-failure__usage">
-      This site is using {usage} in this browser.
-      {#if hasLargeProject}
-        Its largest project is one place to make room.
-      {/if}
+    <!-- Said before anything is asked of them. The transaction rolled back, so there is no
+         half-written artifact to reconcile, and a user who thinks their whole project may be damaged
+         will act very differently from one who knows only this save did not happen. -->
+    <p class="storage-failure__safe">
+      Everything you had already saved is unharmed — this write was undone completely. What is on
+      screen has not been lost either; it is still there and still saveable.
     </p>
-  {/if}
 
-  <div class="storage-failure__actions">
-    <!-- The primary action, and the only one that needs no storage at all — which is precisely the
-         situation the user is in. -->
-    <BaseButton variant="primary" onclick={download}>
-      {downloaded ? 'Downloaded — download again' : downloadLabel}
-    </BaseButton>
-    {#if onExportVault !== undefined}
-      <BaseButton onclick={exportVault}>
-        {exported ? 'Exported — export again' : 'Export everything'}
-      </BaseButton>
+    {#if usage !== null}
+      <p class="storage-failure__usage">
+        This site is using {usage} in this browser.
+        {#if hasLargeProject}
+          Its largest project is one place to make room.
+        {/if}
+      </p>
     {/if}
-  </div>
 
-  {#if problem !== null}
-    <p class="storage-failure__problem" role="alert">{problem}</p>
-  {/if}
+    <div class="storage-failure__actions">
+      <!-- The primary action, and the only one that needs no storage at all — which is precisely the
+           situation the user is in. -->
+      <BaseButton variant="primary" onclick={download}>
+        {downloaded ? 'Downloaded — download again' : downloadLabel}
+      </BaseButton>
+      {#if onExportVault !== undefined}
+        <BaseButton onclick={exportVault}>
+          {exported ? 'Exported — export again' : 'Export everything'}
+        </BaseButton>
+      {/if}
+    </div>
 
-  {#if downloaded}
-    <p class="storage-failure__saved" role="status">
-      Saved to your downloads. That file imports back into any project once there is room.
-    </p>
-  {/if}
+    {#if problem !== null}
+      <p class="inset storage-failure__problem" role="alert">{problem}</p>
+    {/if}
 
-  <div class="storage-failure__actions storage-failure__actions--closing">
-    <!-- Freeing space happens outside this page, so retry is the point of keeping the value on
-         screen: come back and press it. -->
-    <BaseButton onclick={onRetry}>Try saving again</BaseButton>
-    <BaseButton onclick={onDismiss}>Not now</BaseButton>
+    {#if downloaded}
+      <p class="storage-failure__saved" role="status">
+        Saved to your downloads. That file imports back into any project once there is room.
+      </p>
+    {/if}
+
+    <!-- A dialog is a question, so its answers sit where the eye finishes. Freeing space happens
+         outside this page, so retry is the point of keeping the value on screen: come back and
+         press it. -->
+    <div class="panel__footer">
+      <BaseButton onclick={onRetry}>Try saving again</BaseButton>
+      <BaseButton onclick={onDismiss}>Not now</BaseButton>
+    </div>
   </div>
 </div>
 
 <style>
+  /* The frame, the plate and the spacing are the panel's. What is left here is the two things
+     that are this dialog's own: how tightly its paragraphs sit, and which of them are asides. */
   .storage-failure {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    max-width: 32rem;
-  }
-
-  .storage-failure h2 {
-    margin: 0;
-    font-size: 1.2rem;
+    gap: var(--s5);
   }
 
   .storage-failure p {
     margin: 0;
-    font-size: 0.95rem;
+    max-width: var(--measure);
   }
 
+  /* The numbers and the receipt are asides beside the sentence that matters. */
   .storage-failure__usage,
   .storage-failure__saved {
-    font-size: 0.85rem;
-    opacity: 0.85;
+    color: var(--ink-muted);
+    font: var(--t-small);
   }
 
   .storage-failure__actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-
-  .storage-failure__actions--closing {
-    margin-top: 0.25rem;
-  }
-
-  .storage-failure__problem {
-    padding: 0.4rem 0.6rem;
-    border: 1px solid var(--tan);
-    border-radius: 4px;
+    gap: var(--s4);
   }
 </style>

--- a/src/components/common/StorageWarningBanner.svelte
+++ b/src/components/common/StorageWarningBanner.svelte
@@ -4,6 +4,7 @@
   import { resolve } from '$app/paths';
   import { onArtifactsChanged } from '$lib/artifacts';
   import BaseButton from '$components/common/BaseButton.svelte';
+  import Notice from '$components/common/Notice.svelte';
   import {
     dismissStorageWarning,
     hasDismissedStorageWarning,
@@ -56,43 +57,28 @@
 </script>
 
 {#if shown && warning !== null}
-  <div class="storage-warning" role="status">
+  <!-- `notice`-toned: a browser that is nearly full is a thing wanting attention, which is what
+       that tone says. The gold is the edge and the wash; the sentence stays `--ink`, because a
+       tone is never a word. -->
+  <Notice tone="notice" class="storage-warning">
     <p>
       <strong>This browser is nearly full for this site.</strong>
       {usageSentence(warning.usage)} If it fills, saving will start to fail — and a file is the only copy
       of this work that survives anything happening to this browser.
     </p>
-    <div class="storage-warning__actions">
+
+    {#snippet actions()}
       <!-- A fragment appended to a resolved route. -->
       <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
       <a href={storagePanelHref}>Storage and backup</a>
       <BaseButton onclick={dismiss}>Dismiss</BaseButton>
-    </div>
-  </div>
+    {/snippet}
+  </Notice>
 {/if}
 
 <style>
-  .storage-warning {
-    background: var(--slate);
-    border: 1px solid var(--gold);
-    border-radius: 4px;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-    padding: 0.6rem 0.75rem;
-  }
-
-  .storage-warning p {
-    font-size: 0.9rem;
-    margin: 0;
-    max-width: var(--measure);
-  }
-
-  .storage-warning__actions {
-    align-items: center;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
+  /* Layout only: where the notice sits. The look is the panel's. */
+  :global(.storage-warning) {
+    margin-bottom: var(--s6);
   }
 </style>

--- a/src/components/heraldry/HeraldryPersistenceModalContent.svelte
+++ b/src/components/heraldry/HeraldryPersistenceModalContent.svelte
@@ -12,6 +12,7 @@
   import { showAlertModal } from '$lib/ui';
   import type { RNG } from '@ironarachne/rng';
   import BaseButton from '$components/common/BaseButton.svelte';
+  import ListButton from '$components/common/ListButton.svelte';
 
   type Props = {
     arms: Arms;
@@ -69,44 +70,136 @@
   }
 </script>
 
-<div class="modal-dialog-content modal-dialog-content--message heraldry-persistence-modal">
-  <h2 id="modal-dialog-title" class="modal-dialog-title">
-    {title ?? 'Heraldry'}
-  </h2>
+<div class="panel__field">
+  <header class="panel__header">
+    <div class="panel__header-field">
+      <h2 id="modal-dialog-title" class="panel__title">{title ?? 'Heraldry'}</h2>
+    </div>
+  </header>
 
-  <p class="heraldry-persistence-blazon">{arms.blazon}</p>
+  <div class="panel__body">
+    <p class="heraldry-persistence__blazon">{arms.blazon}</p>
 
-  <div class="heraldry-persistence-preview">
-    <!-- Renders app-generated markup (no external or user-supplied input). -->
-    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-    {@html renderHeraldryDeviceSvg(arms.device, previewWidth, previewHeight, rng)}
+    <div class="heraldry-persistence__preview">
+      <!-- Renders app-generated markup (no external or user-supplied input). -->
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html renderHeraldryDeviceSvg(arms.device, previewWidth, previewHeight, rng)}
+    </div>
+
+    <!-- A dialog is a question, so its answers sit where the eye finishes. -->
+    <div class="panel__footer">
+      <BaseButton onclick={saveCurrentHeraldry} disabled={isCurrentBlazonSaved}>Save</BaseButton>
+      <BaseButton onclick={onDismiss}>Close</BaseButton>
+    </div>
+
+    <div class="heraldry-persistence__saved">
+      <h3>Replace with saved heraldry</h3>
+
+      {#if savedHeraldries.length === 0}
+        <p class="heraldry-persistence__empty">No saved heraldry yet.</p>
+      {:else}
+        <!-- A well: a run of rows that has to read as held by the dialog rather than as continuing
+             past its edge, and the one surface allowed to be cut off mid-row. The rows are list
+             rows, so a saved coat of arms is picked the same way an artifact or a tool is —
+             the row itself is the choice, rather than a row with a button on the end of it. -->
+        <ul class="well heraldry-persistence__list">
+          {#each savedHeraldries as saved, index (index)}
+            <li>
+              <ListButton
+                onclick={() => replaceWithSavedHeraldry(saved)}
+                class="heraldry-persistence__row"
+              >
+                <span class="heraldry-persistence__row-preview">
+                  <!-- Renders app-generated markup (no external or user-supplied input). -->
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                  {@html renderHeraldryDeviceSvg(
+                    heraldryFromSnapshot(saved).arms.device,
+                    48,
+                    53,
+                    rng,
+                  )}
+                </span>
+                <span class="heraldry-persistence__row-details">
+                  <span class="heraldry-persistence__row-name">{saved.name}</span>
+                  <span class="heraldry-persistence__row-seed">Seed: {saved.seed}</span>
+                </span>
+              </ListButton>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
   </div>
-
-  <div class="modal-dialog-actions heraldry-persistence-actions">
-    <BaseButton onclick={saveCurrentHeraldry} disabled={isCurrentBlazonSaved}>Save</BaseButton>
-    <BaseButton onclick={onDismiss}>Close</BaseButton>
-  </div>
-
-  <h3 class="heraldry-persistence-saved-heading">Replace with saved heraldry</h3>
-
-  {#if savedHeraldries.length === 0}
-    <p class="heraldry-persistence-empty">No saved heraldry yet.</p>
-  {:else}
-    <ul class="heraldry-persistence-list">
-      {#each savedHeraldries as saved, index (index)}
-        <li class="heraldry-persistence-item">
-          <div class="heraldry-persistence-item-preview">
-            <!-- Renders app-generated markup (no external or user-supplied input). -->
-            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-            {@html renderHeraldryDeviceSvg(heraldryFromSnapshot(saved).arms.device, 48, 53, rng)}
-          </div>
-          <div class="heraldry-persistence-item-details">
-            <p class="heraldry-persistence-item-name">{saved.name}</p>
-            <p class="heraldry-persistence-item-seed">Seed: {saved.seed}</p>
-          </div>
-          <BaseButton onclick={() => replaceWithSavedHeraldry(saved)}>Use</BaseButton>
-        </li>
-      {/each}
-    </ul>
-  {/if}
 </div>
+
+<style>
+  /* The frame, the plate, the well and the rows are all the system's. What is left here is the
+     preview's own geometry, which is a picture's size rather than a spacing decision, and the way
+     a row lays its three parts out. */
+
+  .heraldry-persistence__blazon {
+    color: var(--ink-muted);
+    font: var(--t-small);
+    margin: 0;
+    max-width: var(--measure);
+  }
+
+  /* The device's own aspect, not a spacing step: a shield is 120 by 132. */
+  .heraldry-persistence__preview {
+    height: 132px;
+    margin-inline: auto;
+    width: 120px;
+  }
+
+  .heraldry-persistence__saved {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-height: 0;
+  }
+
+  .heraldry-persistence__saved h3 {
+    margin: 0;
+  }
+
+  .heraldry-persistence__empty {
+    color: var(--ink-muted);
+    font: var(--t-small);
+    margin: 0;
+  }
+
+  .heraldry-persistence__list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s1);
+    list-style: none;
+    margin: 0;
+    max-height: 16rem;
+  }
+
+  :global(.heraldry-persistence__row) {
+    width: 100%;
+  }
+
+  .heraldry-persistence__row-preview {
+    flex: 0 0 48px;
+    height: 53px;
+    width: 48px;
+  }
+
+  .heraldry-persistence__row-details {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .heraldry-persistence__row-name {
+    overflow-wrap: anywhere;
+  }
+
+  .heraldry-persistence__row-seed {
+    color: var(--ink-muted);
+    font: var(--t-small);
+    overflow-wrap: anywhere;
+  }
+</style>

--- a/src/components/heraldry/HeraldryPreviewSelect.svelte
+++ b/src/components/heraldry/HeraldryPreviewSelect.svelte
@@ -167,7 +167,7 @@
     margin: 0;
     padding: 0.125rem 0;
     list-style: none;
-    background: var(--background, #1a1a1a);
+    background: var(--surface-raised);
     border: 1px solid rgb(255 255 255 / 25%);
     box-shadow: 0 0.25rem 0.75rem rgb(0 0 0 / 35%);
   }

--- a/src/components/layout/ModalHost.svelte
+++ b/src/components/layout/ModalHost.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import HeraldryPersistenceModalContent from '$components/heraldry/HeraldryPersistenceModalContent.svelte';
   import ModalDialog from '$components/common/ModalDialog.svelte';
+  import { TONE_CLASS, type Tone } from '$components/common/Notice.svelte';
   import StorageFailureModalContent from '$components/common/StorageFailureModalContent.svelte';
   import {
     modalState,
@@ -28,6 +29,22 @@
       return 'error';
     }
     return current.style;
+  });
+
+  /* The three `AlertModalStyle` names map onto tones without changing their spelling: `message` is
+     plain, because a dialog is already the most interruptive thing the app does — top layer,
+     scrim, focus taken — and does not need a coloured edge on top of that. Every dialog used to be
+     gold-edged, which made gold the colour of "a dialog" rather than of "attention"; a tone every
+     instance wears is not a tone. Colour is spent on the two outcomes that differ. */
+  const tone = $derived.by((): Tone => {
+    switch (panelStyle) {
+      case 'error':
+        return 'danger';
+      case 'success':
+        return 'success';
+      default:
+        return 'plain';
+    }
   });
 
   const isAlertDialog = $derived(
@@ -71,12 +88,14 @@
   }
 </script>
 
+<!-- A dialog is a raised panel that happens to be in the top layer: the same liner, keyline, notch
+     and padding ramp as every other surface. It wears the panel classes directly rather than
+     holding a `Panel`, because a `<dialog>` is already a labelled thing with its own
+     `aria-labelledby` — a `<section aria-label>` inside it would give one object two accessible
+     names and two landmarks, and a screen reader would read the wrapper before the message. -->
 <dialog
   bind:this={dialogEl}
-  class="ironarachne-modal"
-  class:ironarachne-modal--message={panelStyle === 'message'}
-  class:ironarachne-modal--error={panelStyle === 'error'}
-  class:ironarachne-modal--success={panelStyle === 'success'}
+  class="panel {TONE_CLASS[tone]}"
   role={isAlertDialog ? 'alertdialog' : 'dialog'}
   aria-labelledby={modalState.current?.kind === 'heraldry' ||
   modalState.current?.kind === 'storage' ||
@@ -113,7 +132,6 @@
       kind={modalState.current.kind}
       message={modalState.current.message}
       title={modalState.current.title}
-      style={modalState.current.kind === 'alert' ? modalState.current.style : 'message'}
       okLabel={modalState.current.kind === 'confirm' ? modalState.current.okLabel : 'OK'}
       cancelLabel={modalState.current.kind === 'confirm'
         ? modalState.current.cancelLabel

--- a/src/components/objects/MerchantGenerator.svelte
+++ b/src/components/objects/MerchantGenerator.svelte
@@ -218,7 +218,7 @@
   .merchant-result {
     margin-top: 1.5rem;
     padding: 1rem;
-    border: 1px solid var(--border-color, #ccc);
+    border: 1px solid var(--border);
     border-radius: 8px;
   }
 

--- a/src/components/objects/PotionGenerator.svelte
+++ b/src/components/objects/PotionGenerator.svelte
@@ -112,7 +112,7 @@
   .potion-result {
     margin-top: 1.5rem;
     padding: 1rem;
-    border: 1px solid var(--border-color, #ccc);
+    border: 1px solid var(--border);
     border-radius: 0.5rem;
   }
 

--- a/src/lib/styles/main.css
+++ b/src/lib/styles/main.css
@@ -617,6 +617,47 @@ label {
   min-width: 0;
 }
 
+/* ---- Tones ----------------------------------------------------------------------------------
+   A message is a toned panel: the app has something to say, and it is saying it on a surface. A
+   tone sets the panel's two custom properties and nothing else, which is what makes it a variant
+   rather than a second panel — the same claim a level and a genre skin make.
+
+   One mix ratio for all three, for the reason there is one `--plate`: a per-tone number is three
+   things to keep in step and nobody can say what the right difference between them would be.
+
+   The tone is the edge and the wash, and the words are always `--ink`. Crimson is 2.2:1 on
+   charcoal and emerald is 2.65:1 — two of the three cannot be read as text at all, so a rule that
+   holds for two is not a rule. No message ever colours its own sentence.
+
+   A tone is only ever carried by a *raised* surface. There is deliberately no `.inset--danger`: a
+   red box inside a red box is two edges saying one thing, and an error message sitting on a panel
+   is an untoned inset. See docs/visual-design.md, "The message family". */
+
+.panel--notice {
+  --panel-edge: var(--accent-quiet);
+  --panel-surface: color-mix(in srgb, var(--accent-quiet) 12%, var(--surface-raised));
+}
+
+.panel--success {
+  --panel-edge: var(--success);
+  --panel-surface: color-mix(in srgb, var(--success) 12%, var(--surface-raised));
+}
+
+.panel--danger {
+  --panel-edge: var(--danger);
+  --panel-surface: color-mix(in srgb, var(--danger) 12%, var(--surface-raised));
+}
+
+/* The foot of a dialog. A dialog is a question, and a question's answers belong where the eye
+   finishes; a notice is a sentence, and its actions follow the text from the left, which is the
+   body's own flow and needs no class. `--s4` either way: the buttons are one group. */
+.panel__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s4);
+  justify-content: flex-end;
+}
+
 /* An inset is the panel inverted: sunk into the surface rather than raised off it, and unclipped,
    because it sits inside a panel's liner already and a second diagonal in the middle of a panel
    is a cut where nothing is cut. */

--- a/src/lib/styles/modal.css
+++ b/src/lib/styles/modal.css
@@ -1,128 +1,37 @@
-dialog.ironarachne-modal {
-  border: 1px solid var(--modal-border-message);
-  border-radius: 4px;
-  padding: 0;
-  max-width: 40rem;
-  width: calc(100% - 2rem);
-  background: var(--charcoal);
-  color: inherit;
+/* The top layer, and nothing else.
+ *
+ * A dialog is a raised panel that happens to be in the top layer, so its frame is `main.css`'s
+ * `.panel` and `.panel__field` — the same liner, keyline, notch and padding ramp as every other
+ * surface in the app. What is left here is the three things that are genuinely the top layer's
+ * own business. This file was 128 lines of a second design system before #117: its own keyline
+ * colours, its own 4px radius, its own `1rem 1.25rem` padding, its own 1.5rem title, and one
+ * component's styles living in it as a stowaway.
+ *
+ * See docs/visual-design.md, "The message family".
+ */
+
+/* The trap, and the reason this rule exists at all.
+ *
+ * A `<dialog>` is `display: none` until it is opened — the user agent's `dialog:not([open])` rule
+ * is what closes it, and it is a rule about `display`. `.panel` declares `display: flex`. So a
+ * dialog wearing the panel classes is a dialog that is *always* on screen: every modal in the app
+ * renders inline, in the page flow, permanently. This restates the rule the class overrode, and
+ * it is the same class of fact as a clipped focus ring painting nothing — a browser rule that a
+ * system rule silently defeats. `e2e/projects.spec.ts` holds it. */
+dialog.panel:not([open]) {
+  display: none;
 }
 
-dialog.ironarachne-modal::backdrop {
+/* The scrim. `--modal-backdrop` is the one token the modal system owns, and the shell's drawer
+   reads it too, so the page is dimmed by one amount from one place. */
+dialog.panel::backdrop {
   background: var(--modal-backdrop);
 }
 
-dialog.ironarachne-modal--error {
-  border-color: var(--modal-border-error);
-}
-
-dialog.ironarachne-modal--success {
-  border-color: var(--modal-border-success);
-}
-
-.modal-dialog-content {
-  padding: 1rem 1.25rem;
-}
-
-.modal-dialog-content--error {
-  background: color-mix(in srgb, var(--crimson) 12%, var(--charcoal));
-}
-
-.modal-dialog-content--success {
-  background: color-mix(in srgb, var(--emerald) 12%, var(--charcoal));
-}
-
-.modal-dialog-title {
-  margin: 0 0 0.75rem;
-  font-size: 1.5rem;
-  line-height: 1.5rem;
-}
-
-.modal-dialog-message {
-  margin: 0 0 1rem;
-}
-
-.modal-dialog-actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 0.5rem;
-}
-
-/* No danger rule here any more. The dialog's dangerous action *is* the destructive button variant,
-   so `ModalDialog` puts `.btn-destructive` on the element and this file stops carrying a second
-   `rgb(92, 86, 73)` gradient with a hover and a press hand-drawn to match. The rest of the
-   literals below are #117's to remove. */
-
-.heraldry-persistence-modal .heraldry-persistence-blazon {
-  margin: 0 0 0.75rem;
-  font-size: 0.9375rem;
-  opacity: 0.9;
-}
-
-.heraldry-persistence-preview {
-  width: 120px;
-  height: 132px;
-  margin: 0 auto 1rem;
-}
-
-.heraldry-persistence-actions {
-  margin-bottom: 1.25rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid rgb(255 255 255 / 10%);
-}
-
-.heraldry-persistence-saved-heading {
-  margin: 0 0 0.75rem;
-  font-size: 1.125rem;
-}
-
-.heraldry-persistence-empty {
-  margin: 0;
-  opacity: 0.8;
-}
-
-.heraldry-persistence-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  max-height: 16rem;
-  overflow-y: auto;
-}
-
-.heraldry-persistence-item {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.625rem 0;
-  border-bottom: 1px solid rgb(255 255 255 / 10%);
-}
-
-.heraldry-persistence-item:last-child {
-  border-bottom: none;
-}
-
-.heraldry-persistence-item-preview {
-  flex: 0 0 48px;
-  width: 48px;
-  height: 53px;
-}
-
-.heraldry-persistence-item-details {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.heraldry-persistence-item-name,
-.heraldry-persistence-item-seed {
-  margin: 0;
-}
-
-.heraldry-persistence-item-name {
-  font-weight: 600;
-}
-
-.heraldry-persistence-item-seed {
-  font-size: 0.875rem;
-  opacity: 0.8;
+/* A dialog is a column of prose the same width as every other column of prose in the app.
+   `--measure` rather than the 40rem that was written here: they resolve to about the same number
+   today, and naming the token means a dialog follows the measure if it ever moves. */
+dialog.panel {
+  max-width: var(--measure);
+  width: calc(100% - var(--s8));
 }

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -58,19 +58,23 @@
 
   --accent: var(--iron-arachne-green); /* 10.6:1 */
   --accent-quiet: var(--gold); /* 7.1:1 */
-  /* Crimson on charcoal is 2.2:1. Destructive intent is a crimson edge and fill under
-     `--ink`-coloured text; this is never a text colour. */
+  /* Crimson on charcoal is 2.2:1 and emerald is 2.65:1. Neither is readable, so both are an edge
+     and a fill under `--ink`-coloured text and neither is ever a text colour. That one fact is
+     what the message family is built on: two of the three tones a message can take cannot be said
+     in words at all, so a tone is always the surface and never the sentence. */
   --danger: var(--crimson);
+  --success: var(--emerald);
   --focus: var(--acid-green); /* 13.4:1 — the focus ring, and nothing else */
 
-  /* The modal system's roles. The brand file maps success/error/message to palette entries
-     itself, so the mapping is stated in one place too. The backdrop is not a brand colour, and
-     the shell's drawer scrim reads it as well — the page is dimmed by one amount from one
-     place. */
+  /* The scrim, and the only token the modal system owns. It is not a brand colour, and the
+     shell's drawer scrim reads it as well — the page is dimmed by one amount from one place.
+
+     `--modal-border-message` / `-error` / `-success` were here until issue 117 and are deliberately
+     gone. They mapped a role onto a palette entry in one place, which is the right shape, but
+     they were named after the one component that happened to need them first — and a banner, an
+     inline notice and anything later that has to say how something went want the same three
+     meanings. All three are already roles: `--accent-quiet`, `--success` and `--danger`. */
   --modal-backdrop: rgb(0 0 0 / 50%);
-  --modal-border-message: var(--ia-status-message);
-  --modal-border-error: var(--ia-status-error);
-  --modal-border-success: var(--ia-status-success);
 
   /* ---- Type ramp -----------------------------------------------------------------------
      Six steps, in `px`. Cinzel Decorative carries headings, controls and labels; Inclusive Sans

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -79,6 +79,20 @@ function siteStylesheets(): { name: string; css: string }[] {
   }));
 }
 
+/**
+ * A component's `<style>` block, with its comments stripped.
+ *
+ * `siteStylesheets` hands back the whole `.svelte` file, which is what the checkbox sweep wants —
+ * it reads markup. A sweep looking for a CSS selector has to read the stylesheet alone, or the
+ * word `dialog` in a doc comment counts as a rule.
+ */
+function styleBlock(css: string): string {
+  return [...css.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)]
+    .map(([, block]) => block)
+    .join('\n')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
 describe('brand colour tokens', () => {
   const brandTokens = new Set(declaredProperties(brandSource));
 
@@ -152,11 +166,9 @@ describe('site colour tokens', () => {
       '--accent',
       '--accent-quiet',
       '--danger',
+      '--success',
       '--focus',
       '--modal-backdrop',
-      '--modal-border-message',
-      '--modal-border-error',
-      '--modal-border-success',
     ];
 
     const missing = roles.filter((role) => !tokens.has(role));
@@ -379,22 +391,76 @@ describe('the control system', () => {
   });
 });
 
+describe('the message family', () => {
+  // docs/visual-design.md, "What the message family enforces". Each of these guards a rule that
+  // was broken before #117: three implementations of one idea, one of them painting a grey that
+  // is in no palette.
+
+  it('leaves the dialog frame to the stylesheets', () => {
+    // A dialog is a raised panel in the top layer, and its frame is `main.css`'s panel classes
+    // plus the three rules in `modal.css`. A component's own `<style>` block reaching for
+    // `dialog` is the second implementation starting again — which is exactly what
+    // `LoadSnapshotDialog` was, with its own border, its own radius and its own backdrop.
+    const offenders = siteStylesheets()
+      .filter(({ name }) => name.endsWith('.svelte'))
+      .filter(({ css }) => /(^|[\s&>+~,(])dialog\b/.test(styleBlock(css)))
+      .map(({ name }) => name);
+
+    expect(offenders, 'a component declaring a dialog frame of its own').toEqual([]);
+  });
+
+  it('has no role named after a component', () => {
+    // The three `--modal-border-*` aliases mapped a role onto a palette entry in one place, which
+    // is the right shape — but they were named for the one component that needed them first, and
+    // a banner and an inline notice want the same three meanings. All three are already roles.
+    const offenders = [...siteStylesheets(), { name: 'tokens.css', css: tokensSource }]
+      .filter(({ css }) => css.replace(/\/\*[\s\S]*?\*\//g, '').includes('--modal-border'))
+      .map(({ name }) => name);
+
+    expect(offenders, 'a role named after the component that wanted it first').toEqual([]);
+  });
+
+  it('never hides a literal behind a custom-property fallback', () => {
+    // The sweep that would have caught `#1a1a1a`. `LoadSnapshotDialog` declared
+    // `background: var(--background, #1a1a1a)`, and `--background` is declared nowhere in the app
+    // — so that fallback was not a fallback, and the dialog rendered a grey that is in no palette
+    // for as long as it existed. A fallback is a hex the other sweeps cannot see, and a token that
+    // might not be declared is a token whose name is wrong. Every role and every `--ia-*` is in a
+    // stylesheet the app always loads, so there is nothing for a fallback to protect against.
+    // A *colour* fallback specifically. `var(--project-view-max-height, 20rem)` is a deliberate
+    // component API — a length a parent may set, with a stated default — and it is not what this
+    // is about. A hex behind a `var()` is.
+    const offenders: string[] = [];
+
+    for (const { name, css } of siteStylesheets()) {
+      const stripped = name.endsWith('.svelte')
+        ? styleBlock(css)
+        : css.replace(/\/\*[\s\S]*?\*\//g, '');
+      for (const [declaration] of stripped.matchAll(
+        /var\(\s*--[\w-]+\s*,[^)]*(?:#[0-9a-fA-F]{3,8}|rgba?\(|hsla?\()[^)]*\)?\s*\)/g,
+      )) {
+        offenders.push(`${name}: ${declaration}`);
+      }
+    }
+
+    expect(offenders, 'a literal hidden behind a var() fallback').toEqual([]);
+  });
+});
+
 describe('the panel language', () => {
   // docs/visual-design.md, "What the panel language enforces". Each of these guards a rule that
   // was broken in the files it checks before #116: nineteen components declared the same box, and
   // three of them hand-rolled the same pill with `--gold` written into two.
   //
-  // Two sets of files are deferred rather than exempt, and the design says which: the banners and
-  // the dialog belong to #117, and the surfaces that hold *generated output* belong to the skins
-  // in #119–#121, which is why #116 precedes them. Each name here is a file the panel language
-  // has not reached yet — the list is meant to shrink, and adding to it is how the sweep stops
-  // meaning anything.
+  // One set of files is deferred rather than exempt, and the design says which: the surfaces that
+  // hold *generated output* belong to the skins in #119–#121, which is why #116 precedes them.
+  // Each name here is a file the panel language has not reached yet — the list is meant to shrink,
+  // and adding to it is how the sweep stops meaning anything.
+  //
+  // #117's four entries — the two banners, the storage failure dialog and the snapshot dialog —
+  // are gone, which is the first time this list has shrunk. They are the message family now, and
+  // they are swept like everything else.
   const DEFERRED = new Set([
-    // #117: banners, notices and the modal dialog.
-    'src/components/common/StorageDisclosureNotice.svelte',
-    'src/components/common/StorageFailureModalContent.svelte',
-    'src/components/common/StorageWarningBanner.svelte',
-    'src/components/common/LoadSnapshotDialog.svelte',
     // #119-#121: surfaces that hold generated output, which is what a genre skin dresses.
     'src/components/characters/AdndCharacterBuilder.svelte',
     'src/components/factions/CultureArtifactEditor.svelte',


### PR DESCRIPTION
Implements #117, to the design merged in #138.

## What changed

Three implementations of one idea become one. A notice and a dialog are the same **toned panel** at two levels of interruption — the panel's liner, keyline, notch, padding ramp and `--lift`, with no new box and no second recipe. They differ in how much they interrupt, and in one deliberate detail: a dialog's actions are right-aligned because a dialog is a question, and a notice's follow the text from the left because a notice is a sentence.

|                      | Before                                                                                                                             | After                                                             |
| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| `modal.css`          | 128 lines: its own keylines, 4px radius, `1rem 1.25rem` padding, 1.5rem title, backdrop, plus one component's styles as a stowaway | ~12 lines: the scrim, the width, the `[open]` rule                |
| The two banners      | `background: var(--slate)` over `border: 1px solid` over `border-radius: 4px`, written twice                                       | one `Notice` component                                            |
| `LoadSnapshotDialog` | a second `<dialog>` with its own frame and backdrop                                                                                | the same panel classes                                            |
| Colour roles         | 12, three of them named `--modal-border-*`                                                                                         | 13; `--success` joins `--danger`, the modal-shaped roles are gone |

**Four tones**, each setting `--panel-edge` and `--panel-surface` and nothing else, at one 12% mix. The default dialog is now **plain rather than gold-edged** — every dialog wore gold before, which made gold the colour of "a dialog" rather than of "attention", and a tone every instance wears is not a tone. `AlertModalStyle` keeps its three spellings; only what they paint moves.

**The tone is never the words.** Crimson is 2.2:1 on charcoal and emerald 2.65:1, so two of the three tone colours cannot be read as text at all. The tone is the edge and the wash; the sentence is always `--ink`.

## Two things the work turned up

**The `var(--token, <literal>)` sweep found four phantom tokens, not the one the design named.** `--background`, `--border-color` and `--color-text-muted` are declared nowhere in the app, so those fallbacks were never fallbacks — they were the value:

- `LoadSnapshotDialog` and `HeraldryPreviewSelect` were painting `#1a1a1a`, a grey in no palette and not `--charcoal`'s `#1b1e24`
- `MerchantGenerator` and `PotionGenerator` were painting `#ccc`

All fixed to `--surface-raised` and `--border`. The sweep is narrowed to _colour_ fallbacks, so the deliberate `var(--project-view-max-height, 20rem)` component-API pattern stays legal.

**`LoadSnapshotDialog`'s own buttons never closed it** — and this one is a judgement call worth flagging. Both Load and Cancel are `type="button"` inside a `method="dialog"` form, so `value="cancel"` did nothing and Escape was the only way out. That is behaviour, which #117 explicitly puts out of scope. I fixed it anyway (Cancel is a submit; Load closes after loading) because I was rewriting those exact lines and shipping a knowingly-dead Cancel button seemed worse than a two-line behaviour fix. **Happy to split it into its own issue if you'd rather the scope line held.**

One smaller behaviour consequence, in scope: the heraldry saved-arms rows lose their separate "Use" button, because the design says those lists are wells of list rows and a list row _is_ the choice. No test referenced that button.

## Enforcement

`tokens.test.ts` gains three sweeps — no component declares a `dialog` rule, no `--modal-border-*` survives anywhere, and no `var()` hides a colour literal — and **the `DEFERRED` list loses its four #117 entries, which is the first time it has shrunk.** `e2e/projects.spec.ts` gains the `[open]` assertion: a `<dialog>` is `display: none` by a user-agent rule and `.panel` declares `display: flex`, so without `modal.css` restating what it overrode, every modal renders inline in the page flow permanently. That is invisible to a regex and obvious to a viewport.

## Verification

`npm run verify:all` green — 0 svelte-check errors, 4418 unit tests, **428 Playwright tests** including every mobile width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQb8pv4eiBkyY7We7NPiaZ
