### PR TITLE
Apply the open project's genre to panels, for #118

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -103,9 +103,7 @@ export async function expectGeneratorOutput(
       });
       return;
     default: {
-      const main = page
-        .locator('section.main, section.fantasy, section.navigation, section.home')
-        .first();
+      const main = page.locator('section.main, section.navigation, section.home').first();
       await expect(main).toBeVisible();
       await expect(main).not.toHaveText(/^[\s]*$/);
       return;

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -126,6 +126,43 @@ test.describe('the projects page', () => {
     await expect(projectCard(page, 'Ashfall')).not.toContainText('0 B');
   });
 
+  test('dresses the page in the open project genre, and follows a change live', async ({
+    page,
+  }) => {
+    // docs/visual-design.md, "Applying a skin". Checked in a browser rather than by a source
+    // sweep because both halves are computed relationships: which element ends up carrying the
+    // attribute, and whether it follows a change without the page being reloaded.
+    await projectsPage(page).getByLabel('New project').fill('Ashfall');
+    await projectsPage(page).getByLabel('Genre').selectOption('fantasy');
+    await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+    await expect(projectCard(page, 'Ashfall')).toBeVisible();
+
+    const pageRegion = page.locator('main.shell__page');
+    await expect(pageRegion).toHaveAttribute('data-genre', 'fantasy');
+
+    // A skin dresses the user's work, never the app's own voice. The bar and the sidebar are the
+    // page region's siblings in the shell grid, so they are neutral by position rather than by
+    // opting out of anything — there is no list for anyone to forget to add to.
+    await expect(page.locator('.top-bar')).not.toHaveAttribute('data-genre');
+    await expect(page.locator('.sidebar')).not.toHaveAttribute('data-genre');
+
+    // Live, with no reload in between: decision 7 in docs/workshop.md promises changing a genre
+    // invalidates nothing, and a skin that only followed at load would make that visibly untrue.
+    await projectCard(page, 'Ashfall').getByRole('button', { name: 'Rename' }).click();
+    await editingCard(page).getByLabel('Genre').selectOption('cyberpunk');
+    await editingCard(page).getByRole('button', { name: 'Save' }).click();
+
+    await expect(pageRegion).toHaveAttribute('data-genre', 'cyberpunk');
+
+    // And clearing it returns the page to the base appearance, which is the design rather than a
+    // degraded mode.
+    await projectCard(page, 'Ashfall').getByRole('button', { name: 'Rename' }).click();
+    await editingCard(page).getByLabel('Genre').selectOption('');
+    await editingCard(page).getByRole('button', { name: 'Save' }).click();
+
+    await expect(pageRegion).not.toHaveAttribute('data-genre');
+  });
+
   test('sets what a project is set in, and changes it again', async ({ page }) => {
     await projectsPage(page).getByLabel('New project').fill('Ashfall');
     await projectsPage(page).getByLabel('Genre').selectOption('fantasy');

--- a/e2e/workshop.spec.ts
+++ b/e2e/workshop.spec.ts
@@ -14,7 +14,12 @@ const projectContext = (page: Page) => page.locator('section.project-context');
 const projectView = (page: Page) => page.locator('section.project-view');
 const toolBrowser = (page: Page) => page.locator('section.tool-browser');
 const panels = (page: Page) => page.locator('section.workshop-panel');
-const panelTitles = (page: Page) => page.locator('.workshop-panel .panel__title');
+// The panel's *own* header, by the child chain rather than by a descendant match. A dialog is a
+// panel too since #117 — same classes, same header plate — and `LoadSnapshotDialog` is rendered by
+// the heraldry tool from inside its panel, so a plain `.workshop-panel .panel__title` counts
+// "Load Saved Heraldry" as a third bench panel. It is in the DOM whether or not it is open.
+const panelTitles = (page: Page) =>
+  page.locator('.workshop-panel > .panel__field > .panel__header .panel__title');
 
 async function openWorkshop(page: Page): Promise<void> {
   await visitRoute(page, '/workshop', { title: 'Workshop | Iron Arachne' });

--- a/src/components/characters/AdndCharacterBuilder.svelte
+++ b/src/components/characters/AdndCharacterBuilder.svelte
@@ -777,7 +777,7 @@
   }
 </script>
 
-<section class="fantasy main">
+<section class="main">
   <header class="builder-header">
     <h1>AD&D 2e Character Builder</h1>
     <BaseButton onclick={resetBuilderForm}>Reset</BaseButton>

--- a/src/components/characters/AdndCharacterGenerator.svelte
+++ b/src/components/characters/AdndCharacterGenerator.svelte
@@ -245,11 +245,7 @@
   });
 </script>
 
-<GeneratorPage
-  toolPath="/fantasy/adnd/character"
-  theme="fantasy"
-  title="AD&D 2e Character Generator"
->
+<GeneratorPage toolPath="/fantasy/adnd/character" title="AD&D 2e Character Generator">
   {#snippet description()}
     <p>This is an AD&D 2e character generator.</p>
 

--- a/src/components/characters/DccCharacterGenerator.svelte
+++ b/src/components/characters/DccCharacterGenerator.svelte
@@ -160,11 +160,7 @@
   });
 </script>
 
-<GeneratorPage
-  toolPath="/fantasy/dcc/character"
-  theme="fantasy"
-  title="Dungeon Crawl Classics Character Generator"
->
+<GeneratorPage toolPath="/fantasy/dcc/character" title="Dungeon Crawl Classics Character Generator">
   {#snippet description()}
     <p>This is a DCC 0-level character generator.</p>
   {/snippet}

--- a/src/components/characters/SwnCharacterGenerator.svelte
+++ b/src/components/characters/SwnCharacterGenerator.svelte
@@ -143,11 +143,7 @@
   });
 </script>
 
-<GeneratorPage
-  toolPath="/swn/character"
-  theme="scifi"
-  title="Stars Without Number Character Generator"
->
+<GeneratorPage toolPath="/swn/character" title="Stars Without Number Character Generator">
   <SeedControls bind:seed bind:lockSeed />
 
   <CharacterNameSection

--- a/src/components/characters/UnchartedWorldsCharacterGenerator.svelte
+++ b/src/components/characters/UnchartedWorldsCharacterGenerator.svelte
@@ -143,11 +143,7 @@
   });
 </script>
 
-<GeneratorPage
-  toolPath="/unchartedworlds/character"
-  theme="scifi"
-  title="Uncharted Worlds Character Generator"
->
+<GeneratorPage toolPath="/unchartedworlds/character" title="Uncharted Worlds Character Generator">
   {#snippet description()}
     <p>Generate starting characters for Uncharted Worlds.</p>
   {/snippet}

--- a/src/components/characters/VelgarthGiftsGenerator.svelte
+++ b/src/components/characters/VelgarthGiftsGenerator.svelte
@@ -29,7 +29,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/velgarth-gifts" theme="fantasy" title="Velgarth Gifts Generator">
+<GeneratorPage toolPath="/velgarth-gifts" title="Velgarth Gifts Generator">
   {#snippet description()}
     <p>This gives you a set of Gifts for a character from Mercedes Lackey's Velgarth setting.</p>
   {/snippet}

--- a/src/components/factions/ArmsManufacturerGenerator.svelte
+++ b/src/components/factions/ArmsManufacturerGenerator.svelte
@@ -23,7 +23,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/arms-manufacturer" theme="scifi" title="Arms Manufacturer Generator">
+<GeneratorPage toolPath="/arms-manufacturer" title="Arms Manufacturer Generator">
   {#snippet description()}
     <p>This generator produces sci-fi arms manufacturing companies.</p>
   {/snippet}

--- a/src/components/factions/CultureGenerator.svelte
+++ b/src/components/factions/CultureGenerator.svelte
@@ -311,7 +311,7 @@
   }
 </script>
 
-<GeneratorPage toolPath={TOOL_PATH} theme="fantasy" title="Culture Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Culture Generator">
   {#snippet description()}
     <p>This generator lets you create fantasy cultures.</p>
   {/snippet}

--- a/src/components/factions/FamilyGenerator.svelte
+++ b/src/components/factions/FamilyGenerator.svelte
@@ -193,7 +193,7 @@
   }
 </script>
 
-<GeneratorPage toolPath="/fantasy/family" theme="fantasy" title="Fantasy Family Generator">
+<GeneratorPage toolPath="/fantasy/family" title="Fantasy Family Generator">
   {#snippet description()}
     <p>
       This generator creates a family. Note that more than 10 iterations can be quite slow. More

--- a/src/components/factions/OrganizationGenerator.svelte
+++ b/src/components/factions/OrganizationGenerator.svelte
@@ -177,7 +177,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/organization" theme="fantasy" title="Organization Generator">
+<GeneratorPage toolPath="/fantasy/organization" title="Organization Generator">
   {#snippet description()}
     <p>
       Generate organizations with hierarchy, visual identity, and member roles. Fantasy and science

--- a/src/components/factions/ReligionGenerator.svelte
+++ b/src/components/factions/ReligionGenerator.svelte
@@ -561,7 +561,7 @@
   }
 </script>
 
-<GeneratorPage toolPath={TOOL_PATH} theme="fantasy" title="Fantasy Religion Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Fantasy Religion Generator">
   {#snippet description()}
     <p>Generate a fictional fantasy religion.</p>
   {/snippet}

--- a/src/components/factions/StarNationGenerator.svelte
+++ b/src/components/factions/StarNationGenerator.svelte
@@ -142,7 +142,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/star-nation" theme="scifi" title="Star Nation Generator">
+<GeneratorPage toolPath="/star-nation" title="Star Nation Generator">
   {#snippet description()}
     <p>
       The previews pick how to draw themselves from what this machine can do; the controls below

--- a/src/components/heraldry/HeraldryGenerator.svelte
+++ b/src/components/heraldry/HeraldryGenerator.svelte
@@ -509,7 +509,7 @@
   }
 </script>
 
-<GeneratorPage toolPath={TOOL_PATH} theme="fantasy" title="Heraldry Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Heraldry Generator">
   {#snippet description()}
     <p>
       Generate fantasy coats-of-arms. Note: if you change the seed, the page URL won't change, but

--- a/src/components/layout/GeneratorPage.svelte
+++ b/src/components/layout/GeneratorPage.svelte
@@ -5,7 +5,6 @@
   import ToolMaturityBadge from '$components/common/ToolMaturityBadge.svelte';
 
   type Props = {
-    theme?: string;
     title: string;
     /**
      * Catalog path of the tool this page renders. Required rather than optional, because it is
@@ -17,12 +16,16 @@
     children: Snippet;
   };
 
-  const { theme = '', title, toolPath, description, children }: Props = $props();
+  const { title, toolPath, description, children }: Props = $props();
 
   const maturity = $derived(toolMaturityForPath(toolPath));
 </script>
 
-<section class="{theme} main">
+<!-- No genre class. A tool's genre is the catalog's, and the page region wears it as `data-genre`
+     — one writer instead of the thirty this prop had. The prop was a free string besides: three
+     pages passed `"default"`, which names no stylesheet, and one of those three is a tool the
+     catalog calls `fantasy`. See docs/visual-design.md, "Applying a skin". -->
+<section class="main">
   <h1>{title}</h1>
   <!-- Directly under the title, above anything the tool renders: the point of the level is that a
        user reads it before they start, not after they have generated something they wanted to keep.

--- a/src/components/locations/ChopShopGenerator.svelte
+++ b/src/components/locations/ChopShopGenerator.svelte
@@ -16,7 +16,7 @@
   generateChopShop();
 </script>
 
-<GeneratorPage toolPath="/chop-shop" theme="cyberpunk" title="Chop Shop Generator">
+<GeneratorPage toolPath="/chop-shop" title="Chop Shop Generator">
   {#snippet description()}
     <p>This is a cyberpunk chop shop generator.</p>
   {/snippet}

--- a/src/components/locations/DungeonGenerator.svelte
+++ b/src/components/locations/DungeonGenerator.svelte
@@ -178,7 +178,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/dungeon" theme="fantasy" title="Dungeon Generator">
+<GeneratorPage toolPath="/fantasy/dungeon" title="Dungeon Generator">
   {#snippet description()}
     <p>Grid-based dungeons with themed rooms, doors, keys, encounters, and treasure.</p>
   {/snippet}

--- a/src/components/locations/EnvironmentGenerator.svelte
+++ b/src/components/locations/EnvironmentGenerator.svelte
@@ -105,7 +105,7 @@
   }
 </script>
 
-<GeneratorPage toolPath="/environment" theme="default" title="Environment Generator">
+<GeneratorPage toolPath="/environment" title="Environment Generator">
   {#snippet description()}
     <p>This generates fictional environments. This is mostly useful for debugging.</p>
   {/snippet}

--- a/src/components/locations/PlanetGenerator.svelte
+++ b/src/components/locations/PlanetGenerator.svelte
@@ -132,7 +132,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/planet" theme="scifi" title="Planet Generator">
+<GeneratorPage toolPath="/planet" title="Planet Generator">
   {#snippet description()}
     <p>
       This lets you generate a planet. The preview picks how to draw itself from what this machine

--- a/src/components/locations/RegionGenerator.svelte
+++ b/src/components/locations/RegionGenerator.svelte
@@ -108,7 +108,7 @@
   }
 </script>
 
-<GeneratorPage toolPath="/region" theme="fantasy" title="Region Generator">
+<GeneratorPage toolPath="/region" title="Region Generator">
   {#snippet description()}
     <p>Generate fantasy regions.</p>
   {/snippet}

--- a/src/components/locations/SettlementGenerator.svelte
+++ b/src/components/locations/SettlementGenerator.svelte
@@ -260,7 +260,7 @@
   }
 </script>
 
-<GeneratorPage toolPath={TOOL_PATH} theme="fantasy" title="Settlement Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Settlement Generator">
   {#snippet description()}
     <p>
       Generate a settlement with derived facets (law, commerce, food security, health) and economic

--- a/src/components/locations/StarSystemGenerator.svelte
+++ b/src/components/locations/StarSystemGenerator.svelte
@@ -118,7 +118,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/star-system" theme="scifi" title="Star System Generator">
+<GeneratorPage toolPath="/star-system" title="Star System Generator">
   <RendererOverrideControls onchange={rebuildSystemPreviewImages} />
 
   <SeedControls bind:seed bind:lockSeed />

--- a/src/components/objects/DrugGenerator.svelte
+++ b/src/components/objects/DrugGenerator.svelte
@@ -26,7 +26,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/drug" theme="cyberpunk" title="Drug Generator">
+<GeneratorPage toolPath="/drug" title="Drug Generator">
   {#snippet description()}
     <p>I suppose you could also use this for any sci-fi setting, really.</p>
   {/snippet}

--- a/src/components/objects/EquipmentGenerator.svelte
+++ b/src/components/objects/EquipmentGenerator.svelte
@@ -59,7 +59,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/equipment-generator" theme="fantasy" title="Equipment Generator">
+<GeneratorPage toolPath="/fantasy/equipment-generator" title="Equipment Generator">
   {#snippet description()}
     <p>Generate random weapons and armor.</p>
     <p>"Refine" adds quality modifications to the items.</p>

--- a/src/components/objects/EquipmentPriceLists.svelte
+++ b/src/components/objects/EquipmentPriceLists.svelte
@@ -23,7 +23,7 @@
   }
 </script>
 
-<GeneratorPage toolPath="/fantasy/equipment" theme="fantasy" title="Fantasy Equipment Lists">
+<GeneratorPage toolPath="/fantasy/equipment" title="Fantasy Equipment Lists">
   {#snippet description()}
     <p>
       This page is meant to be a comprehensive list of equipment for fantasy games. It will be

--- a/src/components/objects/MerchantGenerator.svelte
+++ b/src/components/objects/MerchantGenerator.svelte
@@ -60,7 +60,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/merchant" theme="fantasy" title="Fantasy Merchant Generator">
+<GeneratorPage toolPath="/fantasy/merchant" title="Fantasy Merchant Generator">
   {#snippet description()}
     <p>
       Generate a fantasy merchant with a proprietor, shop or traveling venue, merchant mark, and

--- a/src/components/objects/PotionGenerator.svelte
+++ b/src/components/objects/PotionGenerator.svelte
@@ -38,7 +38,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/potion-generator" theme="fantasy" title="Potion Generator">
+<GeneratorPage toolPath="/fantasy/potion-generator" title="Potion Generator">
   {#snippet description()}
     <p>
       Generate magical potions, oils, and ointments with procedural sensory details and SRD-based

--- a/src/components/objects/SpookyShipGenerator.svelte
+++ b/src/components/objects/SpookyShipGenerator.svelte
@@ -28,7 +28,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/spooky-ship" theme="scifi" title="Spooky Ship Generator">
+<GeneratorPage toolPath="/spooky-ship" title="Spooky Ship Generator">
   {#snippet description()}
     <p>Generate a spooky ship description.</p>
   {/snippet}

--- a/src/components/objects/SwnStarshipGenerator.svelte
+++ b/src/components/objects/SwnStarshipGenerator.svelte
@@ -43,11 +43,7 @@
   });
 </script>
 
-<GeneratorPage
-  toolPath="/swn/starship"
-  theme="scifi"
-  title="Stars Without Number Starship Generator"
->
+<GeneratorPage toolPath="/swn/starship" title="Stars Without Number Starship Generator">
   <SeedControls bind:seed bind:lockSeed />
 
   <BaseButton onclick={generate}>Generate</BaseButton>

--- a/src/components/objects/TreasureHoardGenerator.svelte
+++ b/src/components/objects/TreasureHoardGenerator.svelte
@@ -155,7 +155,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/treasure-hoard" theme="fantasy" title="Treasure Hoard Generator">
+<GeneratorPage toolPath="/fantasy/treasure-hoard" title="Treasure Hoard Generator">
   {#snippet description()}
     <p>This generates a unique treasure hoard.</p>
   {/snippet}

--- a/src/components/objects/WeaponGenerator.svelte
+++ b/src/components/objects/WeaponGenerator.svelte
@@ -60,7 +60,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/weapon" theme="fantasy" title="Magic Weapon Generator">
+<GeneratorPage toolPath="/fantasy/weapon" title="Magic Weapon Generator">
   {#snippet description()}
     <p>This generates a unique magical weapon.</p>
   {/snippet}

--- a/src/components/utilities/LanguageGenerator.svelte
+++ b/src/components/utilities/LanguageGenerator.svelte
@@ -50,7 +50,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/language" theme="default" title="Language Generator">
+<GeneratorPage toolPath="/language" title="Language Generator">
   {#snippet description()}
     <p>This generates fictional languages. This is mostly useful for debugging.</p>
   {/snippet}

--- a/src/components/utilities/SpeciesStatsCalculator.svelte
+++ b/src/components/utilities/SpeciesStatsCalculator.svelte
@@ -42,7 +42,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/species-stats" theme="default" title="Species Stats Tool">
+<GeneratorPage toolPath="/species-stats" title="Species Stats Tool">
   {#snippet description()}
     <p>
       This tool helps in the construction of non-human species. I built it to help me input standard

--- a/src/lib/genre_skin/README.md
+++ b/src/lib/genre_skin/README.md
@@ -1,0 +1,54 @@
+# Genre skin
+
+Which genre the page is currently wearing, if any. One function, no state.
+
+The app ships three genre skins — `fantasy.css`, `scifi.css`, `cyberpunk.css`, with `horror` still
+to come — and each is keyed off a `data-genre` attribute. This library answers what that attribute's
+value should be; `src/routes/+layout.svelte` is the only place that writes it.
+
+See [the visual design system](../../../docs/visual-design.md), "Applying a skin", for the design.
+
+## The rule
+
+**A skin dresses the user's work, never the app's own voice.** Three surfaces are genre-neutral —
+the top bar, the sidebar, and a dialog — because those are the three places the app speaks for
+itself. A warning that dresses up as fantasy is a warning that reads as decoration.
+
+They do not opt out. They are never in a position to ask: the bar and the sidebar are _siblings_ of
+the page region in the shell grid rather than descendants of it, and a dialog opened with
+`showModal()` is in the top layer entirely. Neutrality is structural, so there is no opt-out list
+for anyone to maintain or forget.
+
+## Resolution order
+
+```
+the open project's genre
+  ?? the route's own genre, when the catalog gives exactly one
+  ?? nothing
+```
+
+**The project wins**, because it is the user's own answer to what they are working on and it is the
+more specific of the two. A fantasy tool opened inside a science-fiction project is being used
+_for_ that science-fiction project.
+
+**A tool with more than one genre gets no route skin.** `/spooky-ship` is `scifi` and `horror`, and
+picking the first entry is a coin toss dressed as a rule. Only reachable with no project genre.
+
+**Nothing is the base appearance**, not a fallback nobody looked at. The tokens, controls, panels
+and message family are all specified without reference to any genre; a skin is a permitted
+variation on top. A project with no genre is ordinary — `docs/workshop.md` is explicit that a
+project may be "a box of tools" that is neither a genre nor a system.
+
+## Why it is derived and never stored
+
+[Decision 7](../../../docs/workshop.md) promises that changing a project's genre invalidates
+nothing: no artifact records the genre it was saved under, and no payload changes shape. A skin
+that were persisted or cached would turn that promise into a lie in the one place nobody would
+look. Recomputed on every read, there is nothing to invalidate — and `onProjectsChanged` is what
+makes the page follow a change live rather than at the next load.
+
+## Why it is here and not in `$lib/projects`
+
+It reads a project _and_ the tool catalog. `project_types.ts` documents the dependency direction —
+`$lib/projects` knows about `$lib/tools`' vocabularies, and `$lib/tools` must never learn about
+projects — and a resolver living inside `$lib/projects` would drag the catalog in behind it.

--- a/src/lib/genre_skin/genre_skin.test.ts
+++ b/src/lib/genre_skin/genre_skin.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { GENRES, TOOL_CATALOG, toolGenres } from '$lib/tools';
+
+import { resolveGenreSkin } from './genre_skin';
+
+describe('resolveGenreSkin', () => {
+  it('takes the project genre over the route it is on', () => {
+    // The project is the user's own answer to what they are working on, and it is the more
+    // specific of the two: a fantasy tool opened inside a science-fiction project is being used
+    // *for* that science-fiction project.
+    expect(resolveGenreSkin('scifi', '/fantasy/potion-generator')).toBe('scifi');
+  });
+
+  it('falls back to the route when no project genre answers', () => {
+    expect(resolveGenreSkin(undefined, '/fantasy/potion-generator')).toBe('fantasy');
+  });
+
+  it('resolves to nothing when neither answers', () => {
+    // The base appearance, which is the design rather than a degraded mode.
+    expect(resolveGenreSkin(undefined, '/projects')).toBeUndefined();
+    expect(resolveGenreSkin(undefined, null)).toBeUndefined();
+    expect(resolveGenreSkin(undefined, undefined)).toBeUndefined();
+  });
+
+  it('gives a genre-neutral tool no skin', () => {
+    // `/environment`, `/language`, `/workshop` and `/word-generator-cheat-sheet` carry no genre,
+    // and docs/workshop.md is explicit that this is deliberate rather than an omission.
+    expect(resolveGenreSkin(undefined, '/environment')).toBeUndefined();
+    expect(resolveGenreSkin(undefined, '/language')).toBeUndefined();
+  });
+
+  it('gives a tool with two genres no skin from its route', () => {
+    // `/spooky-ship` is `scifi` and `horror`. Picking the first entry is a coin toss dressed as a
+    // rule — ambiguity is not a look. Before #118 the page hard-coded `theme="scifi"`, which is
+    // exactly that coin toss.
+    const spookyShip = TOOL_CATALOG.find((tool) => tool.path === '/spooky-ship');
+    expect(toolGenres(spookyShip!).length).toBeGreaterThan(1);
+
+    expect(resolveGenreSkin(undefined, '/spooky-ship')).toBeUndefined();
+  });
+
+  it('still skins a two-genre route when a project answers', () => {
+    // The ambiguity is in the route, not in the project.
+    expect(resolveGenreSkin('horror', '/spooky-ship')).toBe('horror');
+  });
+
+  it('answers for every genre, including one with no stylesheet yet', () => {
+    // `horror` is in GENRES and has no skin file until #122. It resolves like any other and
+    // renders as base, which is why this returns a genre rather than a stylesheet.
+    for (const genre of GENRES) {
+      expect(resolveGenreSkin(genre, null)).toBe(genre);
+    }
+  });
+
+  it('ignores a route that names no tool', () => {
+    expect(resolveGenreSkin(undefined, '/not-a-tool')).toBeUndefined();
+  });
+
+  it('agrees with the catalog for every single-genre tool', () => {
+    // The sweep that would have caught the four disagreements #118 found between the catalog and
+    // the hand-written `theme` prop it replaces.
+    for (const tool of TOOL_CATALOG) {
+      const genres = toolGenres(tool);
+      const expected = genres.length === 1 ? genres[0] : undefined;
+
+      expect(resolveGenreSkin(undefined, tool.path), tool.path).toBe(expected);
+    }
+  });
+});

--- a/src/lib/genre_skin/genre_skin.ts
+++ b/src/lib/genre_skin/genre_skin.ts
@@ -1,0 +1,57 @@
+import { findToolByPath, toolGenres, type Genre } from '$lib/tools';
+
+/**
+ * Which genre the page is currently wearing, if any.
+ *
+ * A skin dresses the user's work, never the app's own voice — so this answers for the page region
+ * and for nothing else. The top bar, the sidebar and a dialog never ask: they are siblings of the
+ * page region (or, for a dialog, in the top layer entirely), so they are neutral by position
+ * rather than by opting out of anything. See docs/visual-design.md, "Applying a skin".
+ *
+ * It holds no state, and that is deliberate rather than incidental. Decision 7 in
+ * docs/workshop.md promises that changing a project's genre invalidates nothing — no artifact
+ * records the genre it was saved under, no payload changes shape. A skin that were stored, cached
+ * or written into an artifact would turn that promise into a lie in the one place nobody would
+ * look for it. Derived on every read, there is nothing to invalidate.
+ */
+export function resolveGenreSkin(
+  projectGenre: Genre | undefined,
+  routeId: string | null | undefined,
+): Genre | undefined {
+  // The project wins. It is the user's own answer to what they are working on, and it is the more
+  // specific of the two: a fantasy tool opened inside a science-fiction project is being used
+  // *for* that science-fiction project. The route's genre is a statement about the page; the
+  // project's is a statement about the work, and the work is what a skin dresses.
+  if (projectGenre !== undefined) {
+    return projectGenre;
+  }
+  return routeGenre(routeId);
+}
+
+/**
+ * The genre a route declares for itself, from the tool catalog.
+ *
+ * The catalog is the only place a tool's genre is written down. Before #118 it was written twice —
+ * once here and once as a free-string `theme` prop on `GeneratorPage` — and the two disagreed in
+ * four places, including a tool the catalog calls `fantasy` that rendered unskinned because its
+ * prop said `"default"`, a class no stylesheet defines.
+ *
+ * `routeId` rather than a pathname: a catalog `path` *is* a route id, so the two compare exactly
+ * and neither has to know whether the app is served under a base path.
+ */
+function routeGenre(routeId: string | null | undefined): Genre | undefined {
+  if (routeId === null || routeId === undefined) {
+    return undefined;
+  }
+
+  const tool = findToolByPath(routeId);
+  if (tool === undefined) {
+    return undefined;
+  }
+
+  // A tool with more than one genre gets no skin from its route. `/spooky-ship` is `scifi` and
+  // `horror`, and taking the first entry is a coin toss dressed as a rule — ambiguity is not a
+  // look. Only reachable with no project genre, since a project outranks the route.
+  const genres = toolGenres(tool);
+  return genres.length === 1 ? genres[0] : undefined;
+}

--- a/src/lib/genre_skin/index.ts
+++ b/src/lib/genre_skin/index.ts
@@ -1,0 +1,1 @@
+export * from './genre_skin';

--- a/src/lib/styles/cyberpunk.css
+++ b/src/lib/styles/cyberpunk.css
@@ -26,7 +26,7 @@
   }
 }
 
-.cyberpunk {
+[data-genre='cyberpunk'] {
   & h1,
   & h2,
   & h3,

--- a/src/lib/styles/fantasy.css
+++ b/src/lib/styles/fantasy.css
@@ -7,7 +7,7 @@
   }
 }
 
-.fantasy {
+[data-genre='fantasy'] {
   & h1,
   & h2,
   & h3,

--- a/src/lib/styles/scifi.css
+++ b/src/lib/styles/scifi.css
@@ -10,7 +10,7 @@
   }
 }
 
-.scifi {
+[data-genre='scifi'] {
   & h1,
   & h2,
   & h3,

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -25,6 +25,8 @@ import { join, relative } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { GENRES } from '$lib/tools';
+
 const STYLES_DIR = join(process.cwd(), 'src/lib/styles');
 const COMPONENTS_DIR = join(process.cwd(), 'src/components');
 const BRAND_COLORS = join(STYLES_DIR, 'brand/colors.css');
@@ -77,6 +79,11 @@ function siteStylesheets(): { name: string; css: string }[] {
     name: relative(process.cwd(), path),
     css: readFileSync(path, 'utf8'),
   }));
+}
+
+/** Source with its CSS and HTML comments removed. A comment naming a thing is not a use of it. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/<!--[\s\S]*?-->/g, '');
 }
 
 /**
@@ -444,6 +451,66 @@ describe('the message family', () => {
     }
 
     expect(offenders, 'a literal hidden behind a var() fallback').toEqual([]);
+  });
+});
+
+describe('applying a skin', () => {
+  // docs/visual-design.md, "What applying a skin enforces". Each of these guards a rule that was
+  // broken before #118: the genre was written in thirty places, four of which disagreed with the
+  // tool catalog that already knew the answer.
+
+  const SKIN_FILES = ['fantasy.css', 'scifi.css', 'cyberpunk.css'];
+
+  it('writes the genre in one place', () => {
+    // One genre, one writer. `+layout.svelte` puts `data-genre` on the page region and nothing
+    // else touches it — which is the whole of the opt-out mechanism, since the top bar and the
+    // sidebar are that element's siblings rather than its descendants.
+    const offenders = siteStylesheets()
+      .filter(({ name }) => name.endsWith('.svelte'))
+      .filter(({ css }) => withoutComments(css).includes('data-genre'))
+      .map(({ name }) => name);
+
+    expect(offenders, 'a component writing data-genre of its own').toEqual([]);
+
+    const layout = readFileSync(join('src', 'routes', '+layout.svelte'), 'utf8');
+    expect(layout, 'the one writer stopped writing it').toContain('data-genre={genre}');
+  });
+
+  it('keeps skins in skin files, and leaves the old class name behind', () => {
+    // A `[data-genre=…]` rule outside a skin file is a skin leaking into the base system. A bare
+    // `.fantasy` inside one is the old selector surviving beside the new attribute, which is how
+    // both would end up half-working.
+    for (const { name, css } of siteStylesheets()) {
+      if (SKIN_FILES.some((skin) => name.endsWith(skin))) {
+        continue;
+      }
+      expect(withoutComments(css), `${name} declares a genre skin rule`).not.toMatch(
+        /\[data-genre/,
+      );
+    }
+
+    for (const name of SKIN_FILES) {
+      const css = readFileSync(join(STYLES_DIR, name), 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
+      const genre = name.replace('.css', '');
+
+      expect(css, `${name} still declares the old bare class`).not.toMatch(
+        new RegExp(`(^|[\\s,>+~])\\.${genre}\\b`),
+      );
+    }
+  });
+
+  it('keys every skin off a genre that exists', () => {
+    // A stylesheet keyed to a genre the app does not have is dead CSS that looks live, and it is
+    // exactly what a typo produces. `horror` is in GENRES with no file yet — that direction is
+    // fine, and is why the resolver returns a genre rather than a stylesheet.
+    const genres = new Set<string>(GENRES);
+
+    for (const name of SKIN_FILES) {
+      const css = readFileSync(join(STYLES_DIR, name), 'utf8');
+      for (const [, keyed] of css.matchAll(/\[data-genre='([^']*)'\]/g)) {
+        expect(genres, `${name} keys off a genre that is not in GENRES`).toContain(keyed);
+      }
+    }
   });
 });
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { onMount } from 'svelte';
 
+  import { page } from '$app/state';
   import '$lib/styles/main.css';
+  import { resolveGenreSkin } from '$lib/genre_skin';
+  import { getActiveProject, hydrateProjects, onProjectsChanged } from '$lib/projects';
+  import type { Genre } from '$lib/tools';
   import Footer from '$components/layout/Footer.svelte';
   import ModalHost from '$components/layout/ModalHost.svelte';
   import Sidebar from '$components/layout/Sidebar.svelte';
@@ -18,6 +22,26 @@
    * off-canvas; above that the sidebar is simply part of the grid and this is ignored.
    */
   let drawerOpen = $state(false);
+
+  /**
+   * The open project's genre, or `undefined` for none — held rather than read inline because
+   * `getActiveProject` is a synchronous read of an index that has to be hydrated first.
+   */
+  let projectGenre = $state<Genre | undefined>(undefined);
+
+  /**
+   * Which genre the page region is wearing. Derived on every read and stored nowhere: decision 7
+   * in docs/workshop.md promises that changing a project's genre invalidates nothing, and a
+   * cached skin would make that a lie in the one place nobody would look for it.
+   *
+   * `page.route.id` rather than a pathname, because a catalog `path` *is* a route id — the two
+   * compare exactly, and neither has to know whether the app is served under a base path.
+   */
+  const genre = $derived(resolveGenreSkin(projectGenre, page.route.id));
+
+  function refreshProjectGenre(): void {
+    projectGenre = getActiveProject()?.genre;
+  }
 
   function closeDrawer(): void {
     drawerOpen = false;
@@ -42,6 +66,20 @@
     };
     drawerWidth.addEventListener('change', sync);
     return () => drawerWidth.removeEventListener('change', sync);
+  });
+
+  // The skin follows the project live rather than at load: a project can be created, opened, or
+  // have its genre changed from the projects page, from the context bar, or from a generator in a
+  // panel saving its first culture, and none of those reload the page. `onProjectsChanged` is the
+  // same event `ProjectContextBar` keeps up with, for the same reason.
+  //
+  // The read is deferred until the index is hydrated, which the adoption pass below also does —
+  // this is what covers a load where that pass failed before it got that far.
+  onMount(() => onProjectsChanged(refreshProjectGenre));
+
+  onMount(async () => {
+    await hydrateProjects();
+    refreshProjectGenre();
   });
 
   // Heraldry, cultures, and religions saved under the old per-generator scopes are adopted into a
@@ -102,7 +140,17 @@
     stops taking focus, stops taking clicks, and disappears from the accessibility tree, so Tab
     cycles inside the drawer because there is nowhere else to go.
   -->
-  <main class="shell__page" inert={drawerOpen}>
+  <!-- The one place `data-genre` is written. The top bar and the sidebar are this element's
+       *siblings* in the shell grid, not its descendants, so they are genre-neutral by position and
+       there is no opt-out list for anyone to maintain. A dialog is neutral for the same kind of
+       reason: `ModalHost` is outside `.shell` and a modal renders in the top layer, so the
+       attribute cannot reach it however the selector is written — which is correct, and is not a
+       gap to close later. A skin dresses the user's work, never the app's own voice.
+
+       An attribute rather than a class: an element has exactly one `data-genre`, so "one genre on
+       screen" is structurally true rather than a rule somebody has to keep, and it cannot collide
+       with a component's own class names. See docs/visual-design.md, "Applying a skin". -->
+  <main class="shell__page" data-genre={genre} inert={drawerOpen}>
     {@render children?.()}
     <Footer />
   </main>


### PR DESCRIPTION
Implements #118, to the design merged in #140. **It also repairs the browser suite, which has been red on `main` since #139** — see the second section.

## The mechanism

The genre is written in **one place**: `data-genre` on the page region, in `+layout.svelte`.

- **An attribute, not a class.** An element has exactly one `data-genre`, so "one genre on screen" is structurally true rather than a rule someone keeps, and it cannot collide with a component's class names.
- **The page region, not the shell.** The top bar and sidebar are its _siblings_ in the grid, so they are genre-neutral **by position** — no opt-out list to maintain or forget. A dialog is neutral for a related reason: it renders in the top layer, outside `.shell`, so the attribute cannot reach it however the selector is written.
- **`$lib/genre_skin`** resolves project genre → route genre from the catalog when it gives exactly one → nothing. It holds no state, because decision 7 of `workshop.md` promises changing a genre invalidates nothing and a cached skin would quietly make that false.
- **Live, not at load.** `+layout.svelte` subscribes to `onProjectsChanged`, the same event `ProjectContextBar` uses.

`GeneratorPage`'s free-string `theme` prop is deleted along with its **thirty** call sites, plus `AdndCharacterBuilder`'s hand-written `class="fantasy main"`. The catalog already knew every tool's genre, and the two disagreed four times — including `/species-stats`, which the catalog calls `fantasy` and which rendered unskinned because its prop said `"default"`, a class no stylesheet defines.

The three skin files change selector (`.fantasy` → `[data-genre='fantasy']`) and nothing else; their contents are #119–#121's.

## The regression this fixes, and a correction

**`e2e.yaml` has been failing on `main` since #139 merged**, and #140 inherited it. I reported #117 as green and it was not — that report was wrong, and the cause is mine twice over:

1. **The bug.** Since #117 a dialog _is_ a panel, with the same classes and header plate. `LoadSnapshotDialog` is rendered by the heraldry tool from _inside_ its bench panel, so `.workshop-panel .panel__title` began matching "Load Saved Heraldry" as a third panel title — in the DOM whether or not the dialog is open. Several `workshop.spec.ts` bench tests fail as a result. `panelTitles` now matches the panel's own header by the child chain, and all 70 workshop tests pass.

2. **Why I missed it.** I ran `npm run verify:all 2>&1 | tail -50`. In a pipeline the exit status is `tail`'s, so the failure was discarded and I read the "428 passed" line without noticing the "1 failed" above it. **`verify:all` itself is not defective** — I said it was in-session and that was also wrong. The gate is fine; the invocation was not.

This branch's run captured each exit code separately instead: `verify` passes and the browser suite is **429 passed, none failed**.

The deeper fragility is worth its own issue rather than more work here: since a dialog is a panel, any `.panel …` descendant selector is ambiguous wherever a dialog is mounted inside a panel. #117's design already named the real fix — fold `LoadSnapshotDialog` into the shared `modalState` so the app has literally one `<dialog>`, outside `.shell` — and called it behaviour rather than look.

## Enforcement

Three sweeps in `tokens.test.ts`: one writer for `data-genre`; skins stay in skin files and the old bare class is gone; every genre a skin keys off is in `GENRES`. Plus an e2e test that the page region carries the attribute while the bar and sidebar do not, that it follows a genre change **without a reload**, and that clearing the genre returns the page to base.

`$lib/genre_skin` has 9 unit tests, including one asserting the resolver agrees with the catalog for every single-genre tool — the sweep that would have caught the four disagreements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQb8pv4eiBkyY7We7NPiaZ
