### PR TITLE
Give the modal host's dialog a name, and stop sampling the tool count

### DIFF
--- a/e2e/all_tools.spec.ts
+++ b/e2e/all_tools.spec.ts
@@ -17,9 +17,14 @@ test.describe('the tool index', () => {
     // reading its constants, so a test cannot pass by agreeing with a catalog that failed to
     // render. The bar reads the catalog's length on every page, so "the index lists as many tools
     // as the shell says exist" is the whole claim — a tool added without an anchor fails here.
-    const declared = Number(
-      await page.locator('.top-bar .top-bar__stat--tools dd').first().innerText(),
-    );
+    // Waited for rather than sampled. The bar renders `—` until its hydration resolves, and
+    // `Number('—')` is `NaN` — so reading the text once is a race that a slow machine loses. It
+    // lost it on CI three merges running while passing locally every time, which is exactly the
+    // shape of bug a snapshot read produces.
+    const toolCount = page.locator('.top-bar .top-bar__stat--tools dd').first();
+    await expect(toolCount).toHaveText(/^\d+$/);
+
+    const declared = Number(await toolCount.innerText());
 
     expect(declared).toBeGreaterThan(0);
     await expect(toolLinks(page)).toHaveCount(declared);

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -86,7 +86,7 @@ test.describe('the projects page', () => {
   test('asks before deleting, and says how much goes with it', async ({ page }) => {
     await create(page, 'Ashfall');
 
-    const dialog = page.locator('dialog.panel');
+    const dialog = page.locator('dialog.modal-host');
 
     // The `[open]` trap, and the reason it is checked in a browser rather than by a source sweep.
     // A `<dialog>` is `display: none` until it is opened, by a user-agent rule about `display` —

--- a/e2e/vault.spec.ts
+++ b/e2e/vault.spec.ts
@@ -166,7 +166,7 @@ test.describe('the result vault', () => {
     await row(page, 'The Emberfolk').click();
     await inspector(page).getByRole('button', { name: 'Delete' }).click();
 
-    const dialog = page.locator('dialog.panel');
+    const dialog = page.locator('dialog.modal-host');
     await expect(dialog).toContainText('no copy anywhere else');
     await dialog.getByRole('button', { name: 'Delete', exact: true }).click();
 

--- a/e2e/workshop.spec.ts
+++ b/e2e/workshop.spec.ts
@@ -266,7 +266,7 @@ test.describe('the workshop bench', () => {
 
     // The dialog element is always in the DOM; ModalHost opens and closes it, so "not asked"
     // is hidden rather than absent.
-    await expect(page.locator('dialog.panel')).toBeHidden();
+    await expect(page.locator('dialog.modal-host')).toBeHidden();
     await expect(panelTitles(page)).toHaveText([/Heraldry/]);
   });
 
@@ -282,7 +282,7 @@ test.describe('the workshop bench', () => {
 
     await mountTool(page, /^Heraldry/);
 
-    const dialog = page.locator('dialog.panel');
+    const dialog = page.locator('dialog.modal-host');
     await expect(dialog).toContainText('you have not saved');
 
     // Refusing leaves the bench exactly as it was.
@@ -302,7 +302,7 @@ test.describe('the workshop bench', () => {
 
     // The dialog element is always in the DOM; ModalHost opens and closes it, so "not asked"
     // is hidden rather than absent.
-    await expect(page.locator('dialog.panel')).toBeHidden();
+    await expect(page.locator('dialog.modal-host')).toBeHidden();
     await expect(panelTitles(page)).toHaveText([/Heraldry/]);
   });
 
@@ -478,7 +478,7 @@ test.describe('the session log', () => {
     await mountTool(page, /^Culture/);
     await expect(logEntries(page)).toHaveCount(1);
 
-    const dialog = page.locator('dialog.panel');
+    const dialog = page.locator('dialog.modal-host');
 
     await sessionLog(page).getByRole('button', { name: 'Clear' }).click();
     await dialog.getByRole('button', { name: 'Cancel' }).click();
@@ -634,7 +634,7 @@ test.describe('saving what a tool made', () => {
  */
 test.describe('building one artifact from another', () => {
   const artifactPanel = (page: Page) => page.locator('.artifact-panel');
-  const confirmDialog = (page: Page) => page.locator('dialog.panel');
+  const confirmDialog = (page: Page) => page.locator('dialog.modal-host');
 
   test.beforeEach(async ({ page }) => {
     await openEmptyWorkshop(page);
@@ -843,7 +843,7 @@ test.describe('building one artifact from another', () => {
  */
 test.describe('editing a saved artifact', () => {
   const artifactPanel = (page: Page) => page.locator('.artifact-panel');
-  const confirmDialog = (page: Page) => page.locator('dialog.panel');
+  const confirmDialog = (page: Page) => page.locator('dialog.modal-host');
 
   /** A project with one saved artifact of the named tool in it, open in a panel of its own. */
   async function openASavedArtifact(
@@ -1617,7 +1617,7 @@ test.describe('vault export and import', () => {
   // Export is the storage panel's primary action; what is left in the transfer controls is the way
   // back in. See docs/storage-panel.md.
   const storagePanel = (page: Page) => page.locator('section.storage');
-  const confirmDialog = (page: Page) => page.locator('dialog.panel');
+  const confirmDialog = (page: Page) => page.locator('dialog.modal-host');
 
   test.beforeEach(async ({ page }) => {
     await openEmptyWorkshop(page);
@@ -1771,7 +1771,7 @@ test.describe('vault export and import', () => {
  * installed before the app boots so the app's own code path is what meets it.
  */
 test.describe('when the browser has no room to save', () => {
-  const storageDialog = (page: Page) => page.locator('dialog.panel .storage-failure');
+  const storageDialog = (page: Page) => page.locator('dialog.modal-host .storage-failure');
 
   /** Refuses writes to the artifact stores, leaving projects and reads alone. */
   async function fillTheDisk(page: Page): Promise<void> {

--- a/src/components/layout/ModalHost.svelte
+++ b/src/components/layout/ModalHost.svelte
@@ -92,10 +92,15 @@
      and padding ramp as every other surface. It wears the panel classes directly rather than
      holding a `Panel`, because a `<dialog>` is already a labelled thing with its own
      `aria-labelledby` — a `<section aria-label>` inside it would give one object two accessible
-     names and two landmarks, and a screen reader would read the wrapper before the message. -->
+     names and two landmarks, and a screen reader would read the wrapper before the message.
+
+     `modal-host` carries no styling and exists to name *which* dialog this is. Every dialog in the
+     app is a `.panel` now, and `LoadSnapshotDialog` is a second one rendered from inside a bench
+     panel — so `.panel` identifies a look and cannot identify this element. The suites address it
+     by this class. -->
 <dialog
   bind:this={dialogEl}
-  class="panel {TONE_CLASS[tone]}"
+  class="panel modal-host {TONE_CLASS[tone]}"
   role={isAlertDialog ? 'alertdialog' : 'dialog'}
   aria-labelledby={modalState.current?.kind === 'heraldry' ||
   modalState.current?.kind === 'storage' ||


### PR DESCRIPTION
**Repairs the browser suite, which has been red on `main` since #139 and stayed red through #141.** Two distinct causes, both from #117.

## 1. `.panel` is a look, not a name

Since #117 a dialog _is_ a panel — same classes, same header plate — so **every** dialog in the app is a `.panel`. That issue nonetheless replaced `dialog.ironarachne-modal` with `dialog.panel` in ten e2e selectors, which threw away the only thing identifying the element.

`LoadSnapshotDialog` is a second `dialog.panel`, and the heraldry tool renders it from _inside_ its bench panel. Whenever that tool is mounted:

```
strict mode violation: locator('dialog.panel') resolved to 2 elements:
  1) <dialog class="panel">…</dialog>  aka getByRole('region', { name: 'Heraldry panel' }).locator('dialog')
  2) <dialog role="dialog" class="panel " aria-describedby="modal-dialog-message">…</dialog>
```

`ModalHost`'s dialog now carries a `modal-host` class that styles nothing and exists to say _which_ dialog it is; the suites address it by that. My #141 fix to `panelTitles` was the same bug in a different selector — necessary, but I only fixed the instance I could see rather than the class of problem.

## 2. A sampled value that needed to be an assertion

`all_tools.spec.ts` read the top bar's tool count once and converted it:

```ts
const declared = Number(await page.locator("… dd").first().innerText());
expect(declared).toBeGreaterThan(0); // Received: NaN
```

The bar renders `—` until its hydration resolves, and `Number('—')` is `NaN`. Reading the text once is a sample, not an assertion, so a slow machine loses the race. It passed **12/12 locally** while failing on CI three merges running — which is the shape this bug always has. It now waits for `/^\d+$/` before reading.

## Verification

Run with each exit code captured separately, because trusting a piped summary line is how cause 1 got past me twice:

```
=== VERIFY exit=0 ===
=== E2E exit=0 ===
```

4430 unit tests, **429 browser tests**, coverage gate passed on 98 libraries.

## Still open

The structural fix is not here. `LoadSnapshotDialog` should move into the shared `modalState` so the app has literally one `<dialog>`, outside `.shell` — #117's design named this and scoped it as behaviour rather than look. Until it happens, any `.panel …` descendant selector is ambiguous wherever a dialog sits inside a panel, and this PR only removes the two places that ambiguity was actually biting. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQb8pv4eiBkyY7We7NPiaZ
