### PR TITLE
Set a dialog's words in --ink

### DIFF
--- a/e2e/modal_ink.spec.ts
+++ b/e2e/modal_ink.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+import { projectCard, projectsPage } from './projects';
+
+/**
+ * A dialog's words are readable.
+ *
+ * `docs/visual-design.md`, "The message family", says the tone is the edge and the wash and the
+ * words are always `--ink`. Nothing asserted the second half, and #117 broke it: rewriting
+ * `modal.css` dropped the `color: inherit` the old rule carried, and the user-agent stylesheet
+ * sets `dialog { color: CanvasText }`. The app declares no `color-scheme`, so `CanvasText` is
+ * black — black text on `--surface-raised`, in every dialog in the app.
+ *
+ * Checked as a computed style in a real browser, because it is exactly the kind of failure a
+ * source sweep cannot see: every rule involved is valid, and the one that mattered is one nobody
+ * wrote. A dialog inherits from `dialog` itself, so asserting the element's own colour covers the
+ * toned dialogs too — a tone sets `--panel-edge` and `--panel-surface` and never touches text.
+ */
+
+/**
+ * What `--ink` actually computes to, resolved in the page rather than written down here.
+ *
+ * A literal would have to be `color(srgb 0.955294 …)` today, because `--ink` is a `color-mix` and
+ * Chromium computes those to `color()` rather than to `rgb()`. Pinning that string would make the
+ * test a statement about a serialisation format instead of about the design, and it would fail the
+ * next time the palette moves for a reason that is not a bug.
+ */
+async function inkColor(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const probe = document.createElement('span');
+    probe.style.color = 'var(--ink)';
+    document.body.append(probe);
+    const resolved = getComputedStyle(probe).color;
+    probe.remove();
+    return resolved;
+  });
+}
+
+async function colorOf(page: Page, selector: string): Promise<string> {
+  return page
+    .locator(selector)
+    .first()
+    .evaluate((element) => getComputedStyle(element).color);
+}
+
+test.describe('a dialog is readable', () => {
+  test('sets its words in --ink rather than inheriting the user agent black', async ({ page }) => {
+    await visitRoute(page, '/projects', { title: 'Projects | Iron Arachne' });
+
+    await projectsPage(page).getByLabel('New project').fill('Ashfall');
+    await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+    await expect(projectCard(page, 'Ashfall')).toBeVisible();
+
+    // The delete confirmation is the ordinary dialog: a title, a message, two peer actions.
+    await projectCard(page, 'Ashfall').getByRole('button', { name: 'Delete' }).click();
+
+    const dialog = page.locator('dialog.modal-host');
+    await expect(dialog).toBeVisible();
+
+    const ink = await inkColor(page);
+
+    // Stated as well as compared: whatever `--ink` resolves to, it is not the user agent's black,
+    // which is the specific value this test exists to keep out.
+    expect(ink).not.toBe('rgb(0, 0, 0)');
+
+    // The element itself, so everything inheriting from it starts correct.
+    expect(await colorOf(page, 'dialog.modal-host')).toBe(ink);
+
+    // And the two things a reader actually reads.
+    expect(await colorOf(page, 'dialog.modal-host .panel__title')).toBe(ink);
+    expect(await colorOf(page, 'dialog.modal-host #modal-dialog-message')).toBe(ink);
+  });
+});

--- a/src/lib/styles/modal.css
+++ b/src/lib/styles/modal.css
@@ -30,8 +30,18 @@ dialog.panel::backdrop {
 
 /* A dialog is a column of prose the same width as every other column of prose in the app.
    `--measure` rather than the 40rem that was written here: they resolve to about the same number
-   today, and naming the token means a dialog follows the measure if it ever moves. */
+   today, and naming the token means a dialog follows the measure if it ever moves.
+
+   `--ink` is not decoration here, it is the rule. "The message family" says the tone is the edge
+   and the wash and the words are always `--ink`, and this is the declaration that makes that true
+   — a dialog does not inherit from the page, because the user-agent stylesheet sets
+   `dialog { color: CanvasText }` and the app declares no `color-scheme`, so `CanvasText` is
+   **black**. The rule this file carried before #117 said `color: inherit`; rewriting the file
+   dropped it and every dialog in the app went black on `--surface-raised`. `--ink` rather than
+   `inherit` because the design names the colour, and a dialog that says which colour it is cannot
+   be broken by whatever it happens to be nested inside. `e2e/modal_ink.spec.ts` holds it. */
 dialog.panel {
+  color: var(--ink);
   max-width: var(--measure);
   width: calc(100% - var(--s8));
 }


### PR DESCRIPTION
Every dialog in the app has been rendering **black text on a dark surface** since #117. Reported by @BenOvermyer.

## Cause

`modal.css` carried `color: inherit` on the dialog before #117. Rewriting that file dropped it and put nothing in its place. The user-agent stylesheet sets `dialog { color: CanvasText }`, and the app declares no `color-scheme` anywhere — so `CanvasText` resolves to literal black.

Confirmed in a browser before changing anything:

```
Expected: "rgb(243, 243, 244)"
Received: "rgb(0, 0, 0)"
```

It affected every dialog, not a subset: the confirm and alert dialogs, the storage-failure dialog, the heraldry persistence modal, and the snapshot dialog.

## Fix

```css
dialog.panel {
  color: var(--ink);
  …
}
```

`--ink` rather than `inherit`, because the design already names the colour — "the tone is the edge and the wash, and the words are always `--ink`" — and a dialog that states its own colour cannot be broken by whatever it is nested inside. The declaration sits on `dialog.panel`, so `LoadSnapshotDialog` is covered by the same rule as the modal host's.

## Why nothing caught it

Every rule involved was valid CSS. The token sweeps in `tokens.test.ts` check what is _written_, and the failure was a rule **nobody wrote** — there was nothing for a source sweep to find. Only a computed style in a real browser can see this class of bug.

`e2e/modal_ink.spec.ts` asserts the computed colour of the dialog element, its title and its message all equal `--ink`, and separately that `--ink` is not the user agent's black. The expected value is resolved from the token in the page rather than hard-coded: `--ink` is a `color-mix`, which Chromium computes to `color(srgb …)` rather than `rgb()`, so a literal would make the test a statement about a serialisation format instead of about the design.

## Verification

`npm run test:e2e` exits 0 — 430 browser tests, including the new one, which fails on `main` and passes here.

**`npm run verify` fails locally on this branch, and it is unrelated.** `src/lib/workshop/artifact_kind_catalog.test.ts` › "loads a codec for every registered kind" times out at the 5s default. Details, because the distinction matters:

- It reproduces **3/3** under `npm run verify`, which runs the suite with v8 coverage instrumentation.
- It passes under plain `npm run test` (4430/4430) and passes alone in 2.6s.
- The only `src` change on this branch is one CSS declaration, which vitest does not execute. The test file has not been touched since `aac17948`.
- CI passes it — every PR merged this session had `verify` green as the required check.

So it is a pre-existing marginal timeout on a test that awaits a dynamic import per registered kind, tripped by coverage overhead on a slower machine. It is not this branch's, and I have deliberately not bundled a fix for it here. Worth a small explicit timeout on that one test, since a local gate that goes red for an unrelated reason is the kind that stops being trusted.

## Related

Still open from #117: **#143**, giving the app one `<dialog>`. Unrelated to this bug, but the same rewrite is behind both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQb8pv4eiBkyY7We7NPiaZ
