### PR TITLE
Give the codec test a timeout it can meet

### DIFF
--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -39,13 +39,29 @@ describe('artifact kind catalog', () => {
     expect(artifactKindEntry('character.swn')).toBeUndefined();
   });
 
+  // Given its own timeout, because the default five seconds is not a budget this test can be held
+  // to honestly. It dynamically imports every registered kind's codec, and those are exactly the
+  // deep module graphs the comment on `buildArtifactKindRegistry` is about — settlement alone
+  // reaches `$lib/organizations`, the heraldry generator and the charge library. Under
+  // `coverage:check`, which is what `npm run verify` runs, every one of those modules is
+  // transformed and instrumented on the way in.
+  //
+  // It passes in ~2.6s alone and in the plain `npm run test` run, and it timed out 3/3 under
+  // coverage on a developer machine while staying green on CI — so the failure tracks how busy the
+  // machine is rather than anything about the code. A local gate that goes red for a reason
+  // unrelated to the change in front of you is the kind that stops being trusted, which is the one
+  // thing CLAUDE.md asks of this suite.
+  //
+  // The number is deliberately generous: nothing here is waiting on a timer, so a larger ceiling
+  // costs nothing on a run that passes and only changes whether a slow machine reports a failure
+  // it does not have.
   it('loads a codec for every registered kind', async () => {
     for (const entry of registeredArtifactKinds()) {
       const codec = await entry.loadCodec();
       expect(typeof codec.toSnapshot).toBe('function');
       expect(typeof codec.fromSnapshot).toBe('function');
     }
-  });
+  }, 30_000);
 
   it('quarantines a payload whose kind came from a newer build', () => {
     const result = readRegisteredArtifactPayload('character.swn', { name: 'Vex' }, 1);


### PR DESCRIPTION
`npm run verify` has been failing locally on a test that is not broken.

## The test

`artifact_kind_catalog.test.ts` › "loads a codec for every registered kind" dynamically imports all five kinds' codecs. Those are precisely the deep module graphs the comment on `buildArtifactKindRegistry` exists to warn about — settlement alone reaches `$lib/organizations`, and from there the heraldry generator and the charge library. Under `coverage:check`, which is what `verify` runs, every one of those modules is transformed and v8-instrumented on the way in.

Five seconds is not a budget that work can honestly be held to.

## Why it is the machine, not the code

| Run                                          | Result            |
| -------------------------------------------- | ----------------- |
| The test alone                               | passes, 2.6s      |
| `npm run test` (no coverage)                 | passes, 4430/4430 |
| `npm run verify` (coverage) on a dev machine | **timed out 3/3** |
| CI                                           | has never failed  |

Nothing in the test waits on a timer, so the duration tracks how busy the machine is.

## The change

An explicit 30s timeout on that one test, with a comment saying why. Deliberately generous: a larger ceiling costs nothing on a passing run, and only changes whether a slow machine reports a failure it does not have.

CLAUDE.md asks that this suite be the definition of done. A gate that goes red for a reason unrelated to the change in front of you is exactly the kind that stops being trusted — and I hit that directly last change, where a real regression had to be separated by hand from this noise.

`npm run verify` exits 0 with this applied, checked by exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQb8pv4eiBkyY7We7NPiaZ
