### PR TITLE
Tell the browser the app is dark

### DIFF
--- a/src/lib/styles/main.css
+++ b/src/lib/styles/main.css
@@ -11,7 +11,22 @@
    2560px display, and the shell in docs/app-shell.md needs the viewport. The measure moved to the
    wrappers that actually hold prose — see `--measure` in tokens.css and `section.main` below. */
 html {
+  /* The app is dark-only — decision 1 in docs/visual-design.md — and this is where it says so to
+     the browser rather than only to itself.
+
+     Everything the user agent draws for us reads this: form control chrome, spinner buttons, the
+     scrollbars, and the `Canvas` / `CanvasText` system colours that back the defaults on elements
+     the app has not styled. Without it every one of those is computed for a light page and drawn
+     onto `--charcoal`.
+
+     That is not hypothetical. It is what made every dialog in the app render black text on a dark
+     surface between #117 and #144: the user-agent rule is `dialog { color: CanvasText }`, and with
+     no declared scheme `CanvasText` is black. Naming the colour on the dialog fixed that instance;
+     this is the reason the instance existed, and it closes the rest of the class — the next
+     element with a system-colour default gets a readable one without anyone noticing it needed
+     one. */
   background: var(--charcoal);
+  color-scheme: dark;
   color: color-mix(in srgb, var(--charcoal) 5%, white 95%);
   font-family: 'Inclusive Sans', system-ui, Helvetica, sans-serif;
   font-size: clamp(1em, 0.909em + 0.45vmin, 1.25em);

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -408,6 +408,38 @@ describe('the control system', () => {
   });
 });
 
+describe('dark is the only mode', () => {
+  // Decision 1 in docs/visual-design.md, stated to the browser rather than only to ourselves.
+  it('declares the document colour scheme', () => {
+    const css = readFileSync(join(STYLES_DIR, 'main.css'), 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
+
+    // Everything the user agent draws reads this: control chrome, scrollbars, and the `Canvas` /
+    // `CanvasText` system colours behind the defaults on anything the app has not styled. Without
+    // it they are all computed for a light page and drawn onto `--charcoal`, which is how every
+    // dialog came to have black text between #117 and #144.
+    expect(css, 'the document does not declare a colour scheme').toMatch(
+      /color-scheme:\s*dark\s*;/,
+    );
+  });
+
+  it('declares no light-scheme alternative', () => {
+    // The palette carries no light-surface pair for the brand green — `brand/colors.css` measures
+    // it at 1.57:1 on white — so a light mode could not use the brand's own accent. Decision 1
+    // settles that there is one mode, and a `light dark` pair or a `prefers-color-scheme: light`
+    // block would be the start of a second one.
+    for (const { name, css } of siteStylesheets()) {
+      const stripped = withoutComments(css);
+
+      expect(stripped, `${name} offers a light colour scheme`).not.toMatch(
+        /color-scheme:[^;]*\blight\b/,
+      );
+      expect(stripped, `${name} branches on a light preference`).not.toMatch(
+        /prefers-color-scheme:\s*light/,
+      );
+    }
+  });
+});
+
 describe('the message family', () => {
   // docs/visual-design.md, "What the message family enforces". Each of these guards a rule that
   // was broken before #117: three implementations of one idea, one of them painting a grey that


### PR DESCRIPTION
Decision 1 in `docs/visual-design.md` says dark is the only mode. The document never said so to the **browser** — only to itself.

## What that cost

Everything the user agent draws was computed for a light page and painted onto `--charcoal`: form control chrome, spinner buttons, scrollbars, and the `Canvas` / `CanvasText` system colours behind the defaults on any element the app has not styled.

That is not hypothetical — it is the root cause of the bug fixed in #144. The user-agent rule is `dialog { color: CanvasText }`, and with no declared scheme `CanvasText` is **black**, which is why every dialog in the app had black text on a dark surface between #117 and #144. Naming the colour on the dialog fixed that instance. This closes the class: the next element with a system-colour default gets a readable one without anyone having to notice it needed one.

## Looked at, not assumed

Native checkboxes and radios are the visible change — `main.css` deliberately excludes them from its input styling (`input:not([type='checkbox'], [type='radio'])`), so they are the controls the user agent still draws. Their boxes go from white to dark, which is what "a checkbox keeps its native box" should have looked like on a dark page all along.

The checked state does **not** move: `accent-color: var(--accent)` already makes it brand green, exactly as the control vocabulary specifies. Selects and scrollbars follow the scheme.

Confirmed with screenshots of the religion generator (six checkboxes, two selects, a seed field) and the projects page (two selects, a text input) before committing.

## Guards

- `main.css` declares `color-scheme: dark`.
- **No stylesheet offers a light scheme** or branches on `prefers-color-scheme: light`. The palette carries no light-surface pair for the brand green — `brand/colors.css` measures it at 1.57:1 on white and records "never set green text on white" — so a light branch would be the start of a second system rather than a variation on this one.

## One thing kept deliberately

The explicit `color: var(--ink)` on the dialog stays. `CanvasText` is white now and would be readable, but the design names the colour and `modal_ink.spec.ts` asserts equality with `--ink` specifically — so it enforces the design rather than mere readability.

## Verification

Exit codes captured separately:

```
=== VERIFY exit=0 ===
=== E2E exit=0 ===
```

Browser suite clean including the golden images and every width in `MOBILE_VIEWPORTS`, which is the check that matters for a change this broad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQb8pv4eiBkyY7We7NPiaZ
