### PR TITLE
Measure the ink roles against the surface they sit on

### DIFF
--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -79,11 +79,11 @@ may shift hue freely but its luminance may not rise above `--surface-raised`'s, 
 every ink role at least as readable on a skinned panel as on a base one without measuring four skins
 separately.
 
-It also records a failure in the approved taxonomy that this issue is what measured.
-**`--ink-faint` does not meet its 4.5:1 target on any panel** — it is 3.9:1 on `--surface-raised`,
-because the 4.8:1 in [colour roles](#colour-roles) is measured against the page and a label lives on
-a panel. Not fantasy's doing and not fantasy's to fix; see the section for why the fix moves two
-roles rather than one.
+It also found a failure in the approved taxonomy. **`--ink-faint` did not meet its 4.5:1 target on
+any panel** — 3.9:1 on `--surface-raised`, because the figure in [colour roles](#colour-roles) was
+measured against the page and a label lives on a panel. Fixed in
+[#149](https://github.com/ironarachne/ironarachne/issues/149), which moved both `--ink-faint` and
+`--ink-muted` and restated the whole table against `--surface-raised`.
 
 Awaiting approval, unlike the five amendments above it: #119 is still `needs-design`, and the rule
 and the finding are what CLAUDE.md's review gate asks a human to approve before implementation
@@ -258,7 +258,18 @@ no vocabulary for.
 ### Colour roles
 
 Thirteen roles. The middle column is the expression that goes in `tokens.css` — never a hex, so
-`tokens.test.ts` keeps holding. The ratio is measured against `--surface-page`.
+`tokens.test.ts` keeps holding.
+
+**The ratio is measured against `--surface-raised`, not against the page**, and that choice is
+load-bearing. A panel is the lightest surface any text in this app sits on, and
+[the skin contract](#a-skins-surface-is-never-lighter-than-the-bases) holds it there — a skin may
+shift its surface's hue but never raise its luminance above this one. So `--surface-raised` is the
+worst case for every ink role, in every present and future genre, and a role that clears its floor
+here clears it everywhere.
+
+This table measured against the page until [#149](https://github.com/ironarachne/ironarachne/issues/149),
+and that is precisely how `--ink-faint` came to sit below its own floor for as long as it did: it
+read 4.8:1 against the page, 3.9:1 against a panel, and a label is never on the page.
 
 | Role               | Resolves to                                      | Contrast | Used for                                  |
 | ------------------ | ------------------------------------------------ | -------: | ----------------------------------------- |
@@ -268,25 +279,36 @@ Thirteen roles. The middle column is the expression that goes in `tokens.css` �
 | `--surface-sunken` | `color-mix(in srgb, var(--charcoal) 60%, black)` |        — | Scroll wells behind an inset run          |
 | `--border`         | `var(--granite)`                                 |        — | Every neutral keyline                     |
 | `--border-strong`  | `var(--tan)`                                     |        — | Control edges, base skin keyline          |
-| `--ink`            | `color-mix(in srgb, white 95%, var(--charcoal))` |   15.2:1 | Body text, headings, control labels       |
-| `--ink-muted`      | `color-mix(in srgb, white 60%, var(--charcoal))` |    6.8:1 | Sublines, list detail, secondary values   |
-| `--ink-faint`      | `color-mix(in srgb, white 48%, var(--charcoal))` |    4.8:1 | Labels and kickers only, never a sentence |
-| `--accent`         | `var(--iron-arachne-green)`                      |   10.6:1 | Links, the active nav marker              |
-| `--accent-quiet`   | `var(--gold)`                                    |    7.1:1 | Kickers, primary control edge             |
-| `--danger`         | `var(--crimson)`                                 |    2.2:1 | Fills and edges — **never text**          |
-| `--success`        | `var(--emerald)`                                 |   2.65:1 | Fills and edges — **never text**          |
-| `--focus`          | `var(--acid-green)`                              |   13.4:1 | The focus ring, and nothing else          |
+| `--ink`            | `color-mix(in srgb, white 95%, var(--charcoal))` |   12.2:1 | Body text, headings, control labels       |
+| `--ink-muted`      | `color-mix(in srgb, white 66%, var(--charcoal))` |    6.3:1 | Sublines, list detail, secondary values   |
+| `--ink-faint`      | `color-mix(in srgb, white 54%, var(--charcoal))` |    4.6:1 | Labels and kickers only, never a sentence |
+| `--accent`         | `var(--iron-arachne-green)`                      |    8.6:1 | Links, the active nav marker              |
+| `--accent-quiet`   | `var(--gold)`                                    |    5.8:1 | Kickers, primary control edge             |
+| `--danger`         | `var(--crimson)`                                 |    1.8:1 | Fills and edges — **never text**          |
+| `--success`        | `var(--emerald)`                                 |    2.1:1 | Fills and edges — **never text**          |
+| `--focus`          | `var(--acid-green)`                              |   10.8:1 | The focus ring, and nothing else          |
 
-Three corrections to the mockup, all of them in this table:
+This table has been corrected twice, and both times for the same reason: a ratio that was
+believed rather than measured.
 
-- **`--ink-faint` was `#7b7f88`, which measures 4.16:1** — below the 4.5:1 it is held to, despite
-  the mockup labelling it 4.6. It is raised to a 48% mix, measuring **4.8:1**. This is the one
-  token where the mockup would have shipped a failure.
-- `--ink-muted` measures **6.8:1**, not 7.1.
-- `--accent-quiet` measures **7.1:1**, not 8.0.
+**Against the mockup**, which mislabelled three values. `--ink-faint` was `#7b7f88` at 4.16:1
+against the page, below the 4.5:1 it is held to, despite the mockup labelling it 4.6; `--ink-muted`
+measured 6.8:1 against the page and not 7.1; `--accent-quiet` 7.1:1 and not 8.0.
+
+**Against the wrong surface**, which is [#149](https://github.com/ironarachne/ironarachne/issues/149)
+and is the more instructive of the two. The first correction moved `--ink-faint` to a 48% mix and
+recorded 4.8:1 — a true number about `--surface-page`, and the wrong question, because a label is
+never on the page. On a panel that same token measured **3.9:1**, so the role went on failing its
+floor while the table said it passed. Both ink roles moved to fix it: `--ink-faint` to 54% and
+`--ink-muted` to 66%, together, because raising the first alone would have left the two 1.17:1
+apart and a three-step ink ramp reading as two.
+
+The lesson is in the reference surface rather than in either number. A ratio is a fact about a
+foreground **and a background**, and half of it was missing here.
 
 `--danger` and `--success` are listed with their ratios precisely so nobody uses either as a text
-colour later: crimson on charcoal is 2.2:1 and emerald is 2.65:1, and neither is readable.
+colour later: crimson is 1.8:1 on a panel and emerald 2.1:1, and neither is readable anywhere —
+2.2:1 and 2.65:1 even against the page, which is the most forgiving surface in the app.
 Destructive intent is carried by a crimson **edge and fill** under `--ink`-coloured text, and a
 successful outcome by an emerald one. **This is the single fact the [message
 family](#the-message-family) is built on** — two of the three tones a message can take cannot be
@@ -1984,27 +2006,28 @@ Measured, rather than assumed:
 
 | Surface                            | `--ink` | `--ink-muted` | `--ink-faint` | Gold heading |
 | ---------------------------------- | ------: | ------------: | ------------: | -----------: |
-| `--surface-page`, as documented    |  15.2:1 |         6.8:1 |         4.8:1 |        7.1:1 |
-| `--surface-raised` — **any panel** |  12.2:1 |         5.5:1 |     **3.9:1** |        5.8:1 |
-| Slate warmed 8% toward gold        |  10.7:1 |         4.8:1 |     **3.4:1** |        5.0:1 |
-| Charcoal warmed 12% toward gold    |  11.6:1 |         5.5:1 |     **3.9:1** |        5.8:1 |
+| `--surface-page`                   |  15.2:1 |         7.9:1 |         5.8:1 |        7.1:1 |
+| `--surface-raised` — **any panel** |  12.2:1 |         6.3:1 |         4.6:1 |        5.8:1 |
+| Slate warmed 8% toward gold        |  10.7:1 |         5.5:1 |         4.1:1 |        5.0:1 |
+| Charcoal warmed 12% toward gold    |  12.3:1 |         6.4:1 |         4.7:1 |        5.8:1 |
 
 Two things fall out of that table, and they are the substance of this design.
 
-### `--ink-faint` does not meet its own target on any panel, skin or no skin
+### `--ink-faint` did not meet its own target on any panel, and now does
 
-**It measures 3.9:1 on `--surface-raised`, against a 4.5:1 floor.** The 4.8:1 the document records
-is real and is measured against the page — but `--ink-faint` is for "labels and kickers", and a
-label lives on a panel. The role has been failing on the surface it is actually used on since it was
-defined.
+Designing this skin is what measured it. `--ink-faint` was 3.9:1 on `--surface-raised` against a
+4.5:1 floor — the 4.8:1 the document recorded was a true number about `--surface-page`, and a label
+is never on the page, so the role had been failing on the surface it is actually used on since it
+was defined.
 
-This is not the fantasy skin's doing and it is not the fantasy skin's to fix. It is recorded here
-because this issue is what measured it, and because the fix is a taxonomy change rather than a
-nudge: raising the mix from 48% to **54%** clears 4.5:1 on a base panel, and **58%** would be needed
-on a warmed one — but `--ink-muted` is 60%, so a faint role at 58% is a muted role with a different
-name. Fixing it properly means moving both, which is #113's table and wants its own issue.
+Fixed in [#149](https://github.com/ironarachne/ironarachne/issues/149) rather than here, and it took
+**two** roles rather than one: `--ink-faint` to 54% and `--ink-muted` to 66%, together, because
+raising the first alone would have left the pair 1.17:1 apart and a three-step ink ramp reading as
+two. [Colour roles](#colour-roles) now states its ratios against `--surface-raised` for the same
+reason this section exists — that is the surface the text is on.
 
-**What #119 owes here is only that it does not make it worse**, which the rule below guarantees.
+**What #119 owed here was only that it did not make things worse**, which the rule below
+guarantees; the base failure was never a skin's to carry.
 
 ### A skin's surface is never lighter than the base's
 

--- a/e2e/ink_contrast.spec.ts
+++ b/e2e/ink_contrast.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Every ink role clears its contrast floor on the surface it is actually used on.
+ *
+ * `--ink-faint` sat below 4.5:1 on a panel from the day it was defined until #149, while the
+ * document recorded 4.8:1 — a true number about `--surface-page`, and the wrong question, because
+ * a label is never on the page. A ratio is a fact about a foreground *and* a background, and half
+ * of it was missing.
+ *
+ * Computed in a browser rather than from the source: the roles are `color-mix()` expressions, so
+ * what they resolve to is the browser's answer and not something a test should reimplement. This
+ * reads what actually renders.
+ *
+ * `--surface-raised` is the worst case for the whole app, and that is guaranteed rather than
+ * assumed — a skin may shift its panel surface's hue but never raise its luminance above this one
+ * (docs/visual-design.md, "A skin's surface is never lighter than the base's"), and every other
+ * surface in the app is darker. A role that clears its floor here clears it everywhere, in every
+ * present and future genre.
+ */
+
+/** Text that has to be readable, and the floor each is held to. */
+const INK_ROLES = [
+  { token: '--ink', floor: 4.5 },
+  { token: '--ink-muted', floor: 4.5 },
+  { token: '--ink-faint', floor: 4.5 },
+] as const;
+
+/**
+ * Resolve a custom property to an actual colour by letting the browser paint it, then read the
+ * relative luminance back. `getPropertyValue` would hand back the unresolved `color-mix(...)`.
+ */
+async function contrast(page: Page, foreground: string, background: string): Promise<number> {
+  return page.evaluate(
+    ([fg, bg]) => {
+      const resolve = (value: string): [number, number, number] => {
+        const probe = document.createElement('span');
+        probe.style.color = value;
+        document.body.append(probe);
+        const computed = getComputedStyle(probe).color;
+        probe.remove();
+
+        const parts = computed.match(/[\d.]+/g);
+        if (parts === null) {
+          throw new Error(`could not read a colour from ${value} (got ${computed})`);
+        }
+        // `rgb()` gives 0-255; `color(srgb ...)`, which is what a `color-mix` computes to, gives
+        // 0-1. Both are sRGB, so the only difference is the scale.
+        const channels = parts.slice(0, 3).map(Number);
+        const scaled = computed.startsWith('color(') ? channels.map((c) => c * 255) : channels;
+        return [scaled[0], scaled[1], scaled[2]];
+      };
+
+      const luminance = (rgb: [number, number, number]): number => {
+        const [r, g, b] = rgb.map((channel) => {
+          const c = channel / 255;
+          return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+        });
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+      };
+
+      const a = luminance(resolve(fg));
+      const b = luminance(resolve(bg));
+      const [lighter, darker] = a > b ? [a, b] : [b, a];
+      return (lighter + 0.05) / (darker + 0.05);
+    },
+    [foreground, background],
+  );
+}
+
+test.describe('the ink roles are readable', () => {
+  test('every ink role clears 4.5:1 on a panel', async ({ page }) => {
+    await visitRoute(page, '/projects', { title: 'Projects | Iron Arachne' });
+
+    for (const { token, floor } of INK_ROLES) {
+      const ratio = await contrast(page, `var(${token})`, 'var(--surface-raised)');
+
+      expect(ratio, `${token} on --surface-raised`).toBeGreaterThanOrEqual(floor);
+    }
+  });
+
+  test('the ink ramp keeps three distinguishable steps', async ({ page }) => {
+    await visitRoute(page, '/projects', { title: 'Projects | Iron Arachne' });
+
+    // Raising `--ink-faint` alone would have cleared the floor and left the pair 1.17:1 apart,
+    // which is a three-step ramp reading as two. Both roles moved together so this stays true.
+    const faintToMuted = await contrast(page, 'var(--ink-faint)', 'var(--ink-muted)');
+    const mutedToInk = await contrast(page, 'var(--ink-muted)', 'var(--ink)');
+
+    expect(faintToMuted, '--ink-faint against --ink-muted').toBeGreaterThanOrEqual(1.3);
+    expect(mutedToInk, '--ink-muted against --ink').toBeGreaterThanOrEqual(1.3);
+  });
+
+  test('the page is the forgiving surface, not the one that matters', async ({ page }) => {
+    await visitRoute(page, '/projects', { title: 'Projects | Iron Arachne' });
+
+    // The premise behind measuring against `--surface-raised`: the page flatters every role, so a
+    // ratio taken there says nothing about a label on a panel. If this ever inverts, the reference
+    // surface in docs/visual-design.md is wrong and this suite should say so.
+    const onPage = await contrast(page, 'var(--ink-faint)', 'var(--surface-page)');
+    const onPanel = await contrast(page, 'var(--ink-faint)', 'var(--surface-raised)');
+
+    expect(onPage, 'the page is more forgiving than a panel').toBeGreaterThan(onPanel);
+  });
+});

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -52,9 +52,18 @@
   --border-strong: var(--tan);
 
   --ink: color-mix(in srgb, white 95%, var(--charcoal)); /* 15.2:1 */
-  --ink-muted: color-mix(in srgb, white 60%, var(--charcoal)); /* 6.8:1 */
-  /* 4.8:1 — labels and kickers only, never a sentence. */
-  --ink-faint: color-mix(in srgb, white 48%, var(--charcoal));
+  /* Ratios below are against `--surface-raised`, not `--surface-page`. A panel is the lightest
+     surface any text in this app sits on, and #119's skin rule holds it there — a skin may shift
+     its surface's hue but never raise its luminance above this one — so it is the worst case for
+     every ink role, in every present and future genre. Measuring against the page is what hid a
+     failure here until #149: these two read 7.9:1 and 5.8:1 on the page, and a label is never on
+     the page. */
+  --ink-muted: color-mix(in srgb, white 66%, var(--charcoal)); /* 6.3:1 on a panel */
+  /* 4.6:1 on a panel — labels and kickers only, never a sentence. Was 48%, which is 3.9:1 there
+     and below the 4.5:1 floor this role is held to. Raising it alone would have left it 1.17:1
+     from `--ink-muted`, so the pair moved together and the ramp kept its three distinguishable
+     steps. */
+  --ink-faint: color-mix(in srgb, white 54%, var(--charcoal));
 
   --accent: var(--iron-arachne-green); /* 10.6:1 */
   --accent-quiet: var(--gold); /* 7.1:1 */

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -122,7 +122,10 @@ describe('brand colour tokens', () => {
   });
 
   it('is the only place a colour value is written down', () => {
-    const hexes = tokensSource.match(/#[0-9a-fA-F]{3,8}\b/g) ?? [];
+    // Comments first. This file cites issue numbers, and `#149` is a hex as far as a regex is
+    // concerned — the sweep over `main.css` and `modal.css` has stripped comments since #115 for
+    // exactly this reason, and this one did not, so it failed twice on prose that named an issue.
+    const hexes = withoutComments(tokensSource).match(/#[0-9a-fA-F]{3,8}\b/g) ?? [];
     expect(hexes).toEqual([]);
   });
 


### PR DESCRIPTION
Closes #149.

## The bug is the reference surface, not the value

`--ink-faint` has been below its 4.5:1 floor on **every panel in the app** since it was defined — **3.9:1** on `--surface-raised`. The 4.8:1 the document recorded is a true number about `--surface-page`, and a label is never on the page.

[Colour roles] said "the ratio is measured against `--surface-page`". That is the most forgiving surface in the app and the one most text is _not_ on, so a role could sit below its floor while the table said it passed. A ratio is a fact about a foreground **and** a background, and half of it was missing.

The table now states its ratios against `--surface-raised`. That is safe to treat as the worst case for the whole app, and the guarantee comes from #119's skin rule: a skin may shift its panel surface's hue but never raise its luminance above that one, and every other surface — inset, sunken, the page — is darker. **Clear the floor there and it is cleared everywhere, in every present and future genre.**

## Two roles move, not one

| Option                     | faint on a panel | muted on a panel | faint vs muted |
| -------------------------- | ---------------: | ---------------: | -------------: |
| today (48 / 60)            |       **3.88 ✗** |             5.45 |           1.40 |
| raise faint only (54 / 60) |           4.64 ✓ |             5.45 |       **1.17** |
| raise faint only (56 / 60) |           4.90 ✓ |             5.45 |       **1.11** |
| **this PR (54 / 66)**      |       **4.64 ✓** |         **6.34** |       **1.37** |

`--ink-muted` does not fail and is moved only to keep the ramp a ramp: at 54/60 the two roles land 1.17:1 apart against 1.40:1 today, which is a three-step ink ramp reading as two, and the point of three named roles is that they are distinguishable.

## The guard

`e2e/ink_contrast.spec.ts` computes the ratios **in a browser** rather than reimplementing `color-mix` — what these roles resolve to is the browser's answer, not something a test should duplicate. It asserts three things:

- every ink role clears 4.5:1 against `--surface-raised`
- the ramp keeps three distinguishable steps
- the page is more forgiving than a panel — so if that ever inverts, the reference surface is wrong and the suite says so

Checked that it bites: reverting the token to 48% fails it, restoring it passes.

## A sweep that was hiding this class of thing

`tokens.css` cites issue numbers, and the hex sweep read `#149` as a colour — exactly as it read `#117` two changes ago, where I reworded the comment instead. The sweeps over `main.css` and `modal.css` have stripped comments since #115; this one never did. Fixed at the source, and verified it still catches a real hex by planting `--probe-hex: #abcdef` and watching it fail.

## Verification

```
=== VERIFY exit=0 ===
=== E2E exit=0 ===
```

4433 unit tests, 98 libraries past the coverage gate, browser suite clean.

## Sequencing

Worth taking before #119's implementation and before #124's route walk — the skins inherit these values, and the walk would otherwise flag this on every page at once.

[colour roles]: ../blob/main/docs/visual-design.md#colour-roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQb8pv4eiBkyY7We7NPiaZ
