### PR TITLE
Rewrite the fantasy skin as a panel skin, for #119

### DIFF
--- a/e2e/genre_skin.spec.ts
+++ b/e2e/genre_skin.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+import { editingCard, projectCard, projectsPage } from './projects';
+
+/**
+ * A skin dresses a panel without making it less readable.
+ *
+ * `docs/visual-design.md`, "A skin's surface is never lighter than the base's": a skin may shift
+ * its panel surface's hue freely, but its luminance may not rise above `--surface-raised`'s. That
+ * rule is why colour roles can measure every ink ratio against `--surface-raised` and treat it as
+ * the worst case for the whole app — so this file is what that table rests on.
+ *
+ * **Everything here reads the rendered panel, not the recipe.** The first version of this suite
+ * compared the two token expressions to each other and passed while the skin was reaching nothing
+ * at all: `.panel` declared `--panel-surface` on itself, and an element's own declaration beats an
+ * inherited one, so every fantasy panel painted slate. That is the same mistake #149 was about —
+ * measuring the right idea against the wrong thing — and the fix is to ask the panel.
+ */
+
+/** The rendered background of the first panel liner on the page, as sRGB 0-255. */
+async function panelSurface(page: Page): Promise<[number, number, number]> {
+  return page
+    .locator('.panel__field')
+    .first()
+    .evaluate((element) => {
+      const computed = getComputedStyle(element).backgroundColor;
+      const parts = (computed.match(/[\d.]+/g) ?? []).slice(0, 3).map(Number);
+      // `rgb()` is 0-255; `color(srgb …)`, which a `color-mix` computes to, is 0-1.
+      const scaled = computed.startsWith('color(') ? parts.map((c) => c * 255) : parts;
+      return [scaled[0], scaled[1], scaled[2]] as [number, number, number];
+    });
+}
+
+function luminance([r, g, b]: [number, number, number]): number {
+  const [lr, lg, lb] = [r, g, b].map((channel) => {
+    const c = channel / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+}
+
+/** A project with a panel on screen, and a genre that can be changed without a reload. */
+async function openProject(page: Page): Promise<void> {
+  await visitRoute(page, '/projects', { title: 'Projects | Iron Arachne' });
+  await projectsPage(page).getByLabel('New project').fill('Ashfall');
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectCard(page, 'Ashfall')).toBeVisible();
+}
+
+async function setGenre(page: Page, genre: string): Promise<void> {
+  await projectCard(page, 'Ashfall').getByRole('button', { name: 'Rename' }).click();
+  await editingCard(page).getByLabel('Genre').selectOption(genre);
+  await editingCard(page).getByRole('button', { name: 'Save' }).click();
+  await expect(page.locator('main.shell__page')).toHaveAttribute('data-genre', genre);
+}
+
+test.describe('the fantasy skin', () => {
+  test('reaches the panel, warms it, and never lightens it', async ({ page }) => {
+    await openProject(page);
+    const base = await panelSurface(page);
+
+    await setGenre(page, 'fantasy');
+    const fantasy = await panelSurface(page);
+
+    // It reaches the panel at all. This is the assertion the first version of this file lacked,
+    // and the skin was inert without it.
+    expect(fantasy, 'the skin did not reach the panel surface').not.toEqual(base);
+
+    // It reads warm: more red than blue. Without this, "no lighter" could be satisfied by a skin
+    // that simply went darker and dressed nothing.
+    expect(fantasy[0], 'the fantasy surface is not warm').toBeGreaterThan(fantasy[2]);
+
+    // And it costs no contrast, which is the rule the colour-roles table depends on.
+    expect(luminance(fantasy), 'a fantasy panel is lighter than a base panel').toBeLessThanOrEqual(
+      luminance(base),
+    );
+  });
+
+  test('dresses the work and leaves the app’s own voice alone', async ({ page }) => {
+    await openProject(page);
+    await setGenre(page, 'fantasy');
+
+    // The bar and the sidebar are the page region's siblings, so the genre cannot reach them.
+    const barPaint = await page
+      .locator('.top-bar')
+      .evaluate((element) => getComputedStyle(element).backgroundImage);
+
+    expect(barPaint, 'the skin reached the top bar').toBe('none');
+    await expect(page.locator('.top-bar')).not.toHaveAttribute('data-genre');
+    await expect(page.locator('.sidebar')).not.toHaveAttribute('data-genre');
+  });
+
+  test('puts its one effect on the surface rather than on the type', async ({ page }) => {
+    await openProject(page);
+    await setGenre(page, 'fantasy');
+
+    // The genre moved off the type and onto the panel: the sheen is a background layer on the
+    // liner, and the heading it used to animate is a flat colour.
+    const panelPaint = await page
+      .locator('.panel__field')
+      .first()
+      .evaluate((element) => getComputedStyle(element).backgroundImage);
+
+    expect(panelPaint, 'the ambient effect is not on the panel surface').toContain('gradient');
+
+    // The page title is the element the old skin painted hardest: a gold foil gradient clipped to
+    // the text, animated on an 8s loop. It is flat ink now, and it is outside a panel besides.
+    const headingPaint = await page
+      .locator('h1')
+      .first()
+      .evaluate((element) => getComputedStyle(element).backgroundImage);
+
+    expect(headingPaint, 'the skin is still painting the type').toBe('none');
+  });
+});

--- a/src/lib/styles/fantasy.css
+++ b/src/lib/styles/fantasy.css
@@ -1,42 +1,87 @@
-@keyframes shimmering-gold {
-  0% {
-    background-position: -200% center;
+/* The fantasy skin: a panel skin over the base system, and nothing more.
+ *
+ * Six declarations and one keyframe, which is the whole shape a skin file is allowed —
+ * see docs/visual-design.md, "The skin contract, and the fantasy skin". Before #119 this file
+ * styled `h1`-`h6` and only `h1`-`h6`: a shimmering gold foil, animated, over the type, written in
+ * hexes no token named. A heading that shimmers is a heading being animated while it is being
+ * read, and the display face already carries the brand — so the genre moved off the type and onto
+ * the panel.
+ *
+ * What this file may not touch: the typeface, the type scale, the space ramp, control geometry,
+ * the notch, the liner, the halo, `--lift`, and a badge's shape.
+ */
+
+/* The one ambient effect. A gold band crossing the panel surface, painted as a background layer
+   rather than as an element so it touches nothing the skin is forbidden to touch. */
+@keyframes fantasy-sheen {
+  from {
+    background-position: -150% 0;
   }
-  100% {
-    background-position: 200% center;
+  to {
+    background-position: 250% 0;
   }
 }
 
 [data-genre='fantasy'] {
-  & h1,
-  & h2,
-  & h3,
-  & h4,
-  & h5,
-  & h6 {
-    /* Create a metallic/shimmering gold foil effect instead of a flat color or glow */
-    background: linear-gradient(
-      120deg,
-      var(--gold) 20%,
-      #ffe169 40%,
-      #fffae6 50%,
-      #ffe169 60%,
-      var(--gold) 80%
-    );
-    background-size: 200% auto;
-    color: transparent;
-    -webkit-background-clip: text;
-    background-clip: text;
+  /* Charcoal warmed toward gold, and deliberately not slate warmed toward gold.
 
-    /* Keep the crimson shadow but use drop-shadow since the text color is transparent */
-    filter: drop-shadow(0 2px 2px var(--crimson));
+     Warming slate lightens it, and every ink role pays: `--ink-faint` measures 3.4:1 on slate
+     warmed 8% toward gold, against a 4.5:1 floor. Warming charcoal by more lands at the same
+     luminance as slate while reading warm, so nothing pays. That is the skin rule stated in one
+     declaration — a skin may shift its surface's hue but never raise its luminance above
+     `--surface-raised`, which is what makes that surface the worst case for the whole app and
+     lets colour roles measure against it. */
+  --panel-surface: color-mix(in srgb, var(--gold) 12%, var(--charcoal));
 
-    /* Animate the metallic shine slowly over the surface */
-    animation: shimmering-gold 8s linear infinite;
+  /* The tan keyline. `--border-strong` is already the base's stronger edge, so this is the skin
+     choosing between two roles the system has rather than introducing a colour. */
+  --panel-edge: var(--border-strong);
+
+  /* No `--accent` or `--accent-quiet` override: gold is already the base's quiet accent, so the
+     fantasy chip, kicker and figure colour is the one the app has. A skin that changes nothing
+     here is a skin agreeing with the base, not a skin that forgot.
+
+     No corner override either. The vocabulary offers cut, bevelled and square, and the 9px cut in
+     "Elevation" was drawn for exactly this genre — fantasy's contribution is to leave it alone. */
+}
+
+/* The display ink. Gold headings inside a panel, at 5.8:1 on the surface above — a colour, which a
+   skin may set, and not a size or a face, which it may not. Scoped to the panel because that is
+   what a skin dresses: a heading on the bare page belongs to the type ramp. */
+[data-genre='fantasy'] .panel .panel__title,
+[data-genre='fantasy'] .panel h2,
+[data-genre='fantasy'] .panel h3,
+[data-genre='fantasy'] .panel h4 {
+  color: var(--accent-quiet);
+}
+
+/* The sheen, on the liner that paints the surface.
+
+   `.panel:not(.panel--bare)` because the main tool panel has no surface of its own — a sheen there
+   would be a gradient floating on the page. `background-image` over the liner's own
+   `background-color`, so the fill is still `--panel-surface` and the effect is a highlight moving
+   across it rather than the fill itself.
+
+   40s and a 6% mix: a bench holds several panels and every one of them wears this, so the effect
+   has to survive being on screen five times at once without becoming a strobe. The heading shimmer
+   it replaces ran an 8s cycle over text somebody was reading. */
+[data-genre='fantasy'] .panel:not(.panel--bare) > .panel__field {
+  animation: fantasy-sheen 40s linear infinite;
+  background-image: linear-gradient(
+    100deg,
+    transparent 35%,
+    color-mix(in srgb, var(--gold) 6%, transparent) 50%,
+    transparent 65%
+  );
+  background-repeat: no-repeat;
+  background-size: 200% 100%;
+}
+
+/* Decision 2 caps ambient motion at one effect per skin and turns it off here. The surface still
+   reads correctly without it: the sheen is a moving highlight on a fill, not the fill. */
+@media (prefers-reduced-motion: reduce) {
+  [data-genre='fantasy'] .panel:not(.panel--bare) > .panel__field {
+    animation: none;
+    background-image: none;
   }
-
-  /* No `button` rule. A skin may set a surface, a keyline, a corner, an accent hue and one
-     ambient effect; control geometry is not on that list, and a skin's copy of the old gradient
-     would outrank the control system wherever a genre is applied. See docs/visual-design.md,
-     decision 2 and "What this leaves to the skins". */
 }

--- a/src/lib/styles/main.css
+++ b/src/lib/styles/main.css
@@ -522,8 +522,16 @@ label {
    because everything was one. */
 
 .panel {
-  --panel-edge: var(--border);
-  --panel-surface: var(--surface-raised);
+  /* The two colours a level, a state and a genre skin each set are *not* declared here, and that
+     is the whole reason a skin works. A declaration on the element beats an inherited one, so
+     `--panel-surface: var(--surface-raised)` written here would silently outrank the value a
+     genre sets on the page region — which is exactly what it did until #119 measured a fantasy
+     panel and found it painting slate.
+
+     Written as fallbacks instead: an ancestor's value wins if there is one, the base value applies
+     if there is not, and a tone or `--panel--bare` still outranks a skin by declaring on the
+     element itself. That precedence is the one the design describes — a tone says how something
+     went and outranks a genre, which is decoration. */
   /* Composed the way `--btn-ring` is, so a panel that takes the halo keeps its lift underneath
      rather than replacing it — and so the halo can be set by a state without restating either. */
   --panel-halo: 0 0 rgb(0 0 0 / 0%);
@@ -533,7 +541,7 @@ label {
      carrying the corner treatment loses its keyline along both diagonals, at exactly the two
      corners the treatment exists to make visible. The liner below covers all of this but a pixel,
      and that pixel is the keyline. `padding: 1px` is its width. */
-  background: var(--panel-edge);
+  background: var(--panel-edge, var(--border));
   box-shadow: var(--lift), var(--panel-halo);
   box-sizing: border-box;
   clip-path: var(--notch);
@@ -548,7 +556,7 @@ label {
    parallel. `--s5` of padding and `--s6` between the blocks it holds: a panel holds sections, and
    `--s5` twice reads as one column. */
 .panel__field {
-  background: var(--panel-surface);
+  background: var(--panel-surface, var(--surface-raised));
   box-shadow: var(--edge);
   box-sizing: border-box;
   clip-path: var(--notch-inner);

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -705,13 +705,82 @@ describe('the panel language', () => {
       // Decision 2 again, for the surfaces: a skin may set `--panel-edge` and `--panel-surface`
       // and put its one ambient effect on the panel, and may not touch the notch, the liner, the
       // padding or the halo.
-      const css = readFileSync(join(STYLES_DIR, name), 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
+      //
+      // Checked as *properties* rather than as selectors. This forbade a `.panel` selector outright
+      // until #119, which is stricter than the design: putting the ambient effect on the panel
+      // surface means selecting the liner that paints it. What a skin may not do is change the
+      // shape of what it selects.
+      const css = withoutComments(readFileSync(join(STYLES_DIR, name), 'utf8'));
 
-      expect(css).not.toMatch(/\.panel(__|--)?[\w-]*\s*\{/);
+      const geometry =
+        /(?:^|[;{])\s*(padding|margin|gap|clip-path|border-radius|border-width|box-shadow|width|height|inset)\s*:/g;
+
+      expect(
+        [...css.matchAll(geometry)].map(([, property]) => property),
+        `${name} changes the shape of what it dresses`,
+      ).toEqual([]);
+
       expect(css).not.toMatch(/\.(badge|chip)(--)?[\w-]*\s*\{/);
       expect(css).not.toContain('--halo');
+      expect(css).not.toContain('--lift');
+      expect(css).not.toContain('--notch');
     },
   );
+
+  // The skins converted so far. `scifi.css` and `cyberpunk.css` join as #120 and #121 land; the
+  // list is meant only to grow, and a skin that is on it is held to the whole contract.
+  const CONVERTED_SKINS = ['fantasy.css'];
+
+  it.each(CONVERTED_SKINS)('writes no colour value of its own in %s', (name) => {
+    // The exemption granted when the controls landed — "their heading effects are full of hexes and
+    // belong to #119–#121" — ends for a skin the moment its issue does.
+    const css = withoutComments(readFileSync(join(STYLES_DIR, name), 'utf8'));
+
+    expect(css.match(/#[0-9a-fA-F]{3,8}\b/g) ?? [], `${name} declares a hex`).toEqual([]);
+    expect(css.match(/rgba?\(\s*\d+\s*,/g) ?? [], `${name} declares a literal colour`).toEqual([]);
+  });
+
+  it.each(CONVERTED_SKINS)('leaves the type ramp alone in %s', (name) => {
+    // The genre moved off the type and onto the panel. Every skin styled `h1`-`h6` and only
+    // `h1`-`h6` before its rewrite, which is a heading being animated while it is being read.
+    // A heading *colour* inside a panel is permitted and is not this: what is forbidden is a rule
+    // that reaches the elements the type ramp owns, and any font property at all.
+    const css = withoutComments(readFileSync(join(STYLES_DIR, name), 'utf8'));
+
+    // Every heading rule is scoped to a panel. A skin dresses panels, and a heading colour on one
+    // is permitted — what is forbidden is the old form, `[data-genre='fantasy'] h1, h2, …`, which
+    // reached every heading on the page including the page title the type ramp owns.
+    const selectors = css.match(/[^{}]+(?=\{)/g) ?? [];
+    const unscopedHeadings = selectors
+      .map((selector) => selector.trim())
+      .filter((selector) => /(?:^|[\s,>+~])h[1-6](?![\w-])/.test(selector))
+      .filter((selector) =>
+        selector
+          .split(',')
+          .some((part) => /(?:^|[\s,>+~])h[1-6](?![\w-])/.test(part) && !part.includes('.panel')),
+      );
+
+    expect(unscopedHeadings, `${name} restyles a heading outside a panel`).toEqual([]);
+    expect(css, `${name} sets a font property`).not.toMatch(
+      /(?:^|[;{])\s*(?:font|font-[\w-]+|letter-spacing|line-height|text-transform)\s*:/,
+    );
+  });
+
+  it.each(CONVERTED_SKINS)('caps ambient motion at one effect in %s', (name) => {
+    // "At most one ambient effect, off under reduced motion" is decision 2's, and it is the line
+    // the old skins broke hardest: cyberpunk ran two animations at once on the type.
+    const css = withoutComments(readFileSync(join(STYLES_DIR, name), 'utf8'));
+
+    const keyframes = css.match(/@keyframes\s/g) ?? [];
+    expect(keyframes.length, `${name} declares more than one effect`).toBeLessThanOrEqual(1);
+
+    const animated = /(?:^|[;{])\s*animation\s*:\s*(?!none)/.test(css);
+    if (animated) {
+      expect(css, `${name} animates without a reduced-motion escape`).toContain(
+        'prefers-reduced-motion: reduce',
+      );
+    }
+  });
 });
 
 describe('motion', () => {


### PR DESCRIPTION
Closes #119. Implements the design merged in #148.

## The genre moves off the type and onto the panel

`fantasy.css` styled `h1`–`h6` and only `h1`–`h6`: a gold foil gradient clipped to the text, animated on an 8s loop, in hexes no token named. A heading that shimmers is a heading being animated while it is being read.

It is now the six declarations and one keyframe a skin file is allowed:

|                   |                                                                                               |
| ----------------- | --------------------------------------------------------------------------------------------- |
| `--panel-surface` | `color-mix(in srgb, var(--gold) 12%, var(--charcoal))`                                        |
| `--panel-edge`    | `var(--border-strong)` — the tan keyline                                                      |
| Heading colour    | `var(--accent-quiet)`, scoped inside a panel, 5.8:1                                           |
| Accent, corner    | unchanged — gold is already the base's quiet accent, and the 9px cut was drawn for this genre |
| Ambient           | one 40s sheen on the panel surface, off under reduced motion, not on a bare panel             |

Charcoal warmed toward gold, **not** slate warmed toward gold: warming slate lightens it and every ink role pays, while warming charcoal by more lands at the same luminance and reads warm. That is the skin rule in one declaration, and it is what lets colour roles treat `--surface-raised` as the worst case for the whole app.

## Two things the work found

**1. The skin was inert, and the first version of my test passed anyway.**

`main.css` declared `--panel-edge` and `--panel-surface` **on `.panel` itself**, and an element's own declaration beats an inherited one — so the values a genre sets on the page region never reached a panel. Measured: base and fantasy both computed to `rgb(42, 47, 56)`, identically.

They are fallbacks now — `var(--panel-surface, var(--surface-raised))` — which also makes the panel language's own claim true for the first time: _"a level, a state and a genre skin each set two colours and none of them mentions the markup."_ A tone and `.panel--bare` still outrank a skin by declaring on the element, which is exactly the precedence #118's design describes.

The test that should have caught this compared the two **token expressions** to each other rather than reading the rendered panel. That is the same mistake #149 was about — measuring the right idea against the wrong thing. The suite now reads what actually paints, and its first assertion is that the skin reached the panel at all.

**2. One existing sweep contradicted the design.** It forbade any `.panel` selector in a skin file, but putting the ambient effect on the panel surface means selecting the liner that paints it. It checks **properties** now: a skin may paint what it selects, and may not reshape it.

## Enforcement

Four sweeps, each verified to bite by reintroducing the old skin's exact mistakes — an unscoped `h1, h2`, a hex, a `font-size`, a `padding`, a second `@keyframes` — which produced four failures, then reverted:

- no hex or literal colour in a converted skin
- no rule reaching a heading **outside** a panel, and no font property at all
- at most one `@keyframes`, and a `prefers-reduced-motion` block if anything animates
- no geometry property, no `--halo`, `--lift` or `--notch`

`fantasy.css` comes off the hex exemption granted in #115. `scifi.css` and `cyberpunk.css` stay on it until #120 and #121 — the list is meant only to grow.

Plus `e2e/genre_skin.spec.ts`: the skin reaches the panel, warms it, never lightens it, leaves the bar and sidebar alone, and puts its effect on the surface rather than on the type.

## Verification

```
=== VERIFY exit=0 ===
=== E2E exit=0 ===
```

4436 unit tests, 98 libraries past the coverage gate, browser suite clean. Screenshotted before and after: warm panels, tan keylines, gold panel titles, shell untouched, page headings still base ink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQb8pv4eiBkyY7We7NPiaZ
