### PR TITLE
Rewrite the sci-fi skin as a panel skin, for #120

### DIFF
--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -85,9 +85,28 @@ measured against the page and a label lives on a panel. Fixed in
 [#149](https://github.com/ironarachne/ironarachne/issues/149), which moved both `--ink-faint` and
 `--ink-muted` and restated the whole table against `--surface-raised`.
 
-Awaiting approval, unlike the five amendments above it: #119 is still `needs-design`, and the rule
-and the finding are what CLAUDE.md's review gate asks a human to approve before implementation
-starts.
+**Amended 2026-08-30 by [#120](https://github.com/ironarachne/ironarachne/issues/120)**, which adds
+[the sci-fi skin, and the corner every genre gets](#the-sci-fi-skin-and-the-corner-every-genre-gets).
+The skin itself is the contract filled in a second time; the corner is not. Decision 2 has always let
+a skin set one and [elevation](#elevation) has always named three treatments, but only the cut exists
+as a polygon and no skin has a way to ask for another — fantasy could decline the question and #120
+and #121 cannot. So the panel's polygon is written once with a depth at each corner, a skin sets the
+four depths, and the "three treatments" cap is replaced by a bound with a reason behind it: one shape
+per genre, capped at `--s5`, no two alike. It adds one measured band — a skin's keyline
+between 1.3:1 and 2.2:1 on its own surface — and settles that a skin setting `--accent` moves the
+halo's hue with it, which is permitted because the halo's geometry, its opacity and the `--focus`
+ring are all untouched.
+
+Awaiting approval, unlike the amendments above it, which are built: #120 is `needs-design`, and the
+corner mechanism, the keyline band and the halo consequence are what CLAUDE.md's review gate asks a
+human to approve before implementation starts.
+
+**Amended 2026-08-30, in review of the above:** every genre gets a panel shape of its own, which
+replaces the "three corner treatments" cap rather than extending it. The panel's polygon is written
+once with a depth at each corner, a skin sets the four depths, and the bound is `GENRES` — one shape
+per genre, none deeper than `--s5`, no two alike. Fantasy's "corner: unchanged" is reversed by it:
+the base's cut goes back to being the app's own neutral plate and fantasy takes a shield's foot,
+which is two lines in a file #119 already shipped.
 
 Written against the rough-cut mockup published from the [design
 canvas](https://claude.ai/code/artifact/c2f18fd6-1a76-46bd-9044-c8cfc888befb) — five artboards:
@@ -353,11 +372,14 @@ Supporting tokens:
   this.
 - `--edge` — `inset 0 1px 0 rgb(255 255 255 / 7%)`, the top highlight that makes a plate a plate.
 - `--lift` — `0 1px 0 rgb(0 0 0 / 60%), 0 6px 14px rgb(0 0 0 / 35%)`, the one shadow in the system.
-- `--notch` — the corner vocabulary: a 9px cut on the top-right and bottom-left, as a `clip-path`
-  polygon. Controls use a 7px cut of the same shape (`--corner-control`), and a nav item a 7px cut
-  of both corners on one edge (`--corner-nav`, added by [the shell](#the-nav-corner-is-a-third-treatment)).
-  **These are the only three corner treatments**; a skin picks between cut, bevelled and square
-  from this vocabulary rather than inventing one.
+- `--panel-corner` — the panel's clip, a polygon with a depth at each of its four corners,
+  defaulting to a 9px cut on the top-right and bottom-left. Controls use a 7px cut of that shape
+  (`--corner-control`), and a nav item a 7px cut of both corners on one edge (`--corner-nav`, added
+  by [the shell](#the-nav-corner-is-a-third-treatment)). Those two are fixed. The panel's four
+  depths are the one piece of geometry a genre may move, capped at `--s5` and unique per genre —
+  see [a skin sets four depths](#a-skin-sets-four-depths-and-the-polygon-stays-in-the-base), which
+  replaces the "three treatments" cap this section carried until #120. It was named `--notch`, and
+  still is the notch on any panel no skin has reached.
 
 **Density.** A panel differs from the page by surface, keyline and notch — not by padding, which
 is `--s5` everywhere. The bench differs from a panel by having no surface at all: it is the page,
@@ -1942,14 +1964,17 @@ type.
 
 ### What a skin file contains
 
-Six declarations and one keyframe. That is the whole shape, and a skin file that wants a seventh is
-asking for something the system has not agreed to give it.
+Six declarations and one keyframe. That is the whole shape, and a skin file that wants one the table
+does not list is asking for something the system has not agreed to give it. (The corner row is
+[#120](https://github.com/ironarachne/ironarachne/issues/120)'s, which is where a genre gets a shape
+of its own; it counts as one line however many of the four depths a genre moves.)
 
 | Line                                    | Sets                                                |
 | --------------------------------------- | --------------------------------------------------- |
 | `--panel-edge`                          | The keyline colour on every panel                   |
 | `--panel-surface`                       | The fill inside the liner                           |
 | `--accent` / `--accent-quiet`           | The hue for chips, kickers and figures              |
+| Four corner depths                      | How deep the panel's clip is cut at each corner     |
 | A heading colour, scoped to the panel   | The display ink, and nothing about its size or face |
 | A background layer on the panel surface | The one ambient effect                              |
 | A `prefers-reduced-motion` block        | Which turns that effect off                         |
@@ -2049,18 +2074,21 @@ both visibly warm and no lighter than slate returns exactly one recipe, and it i
 
 ### The fantasy skin
 
-| Property          | Value                                                     | Measured                    |
-| ----------------- | --------------------------------------------------------- | --------------------------- |
-| `--panel-surface` | `color-mix(in srgb, var(--gold) 12%, var(--charcoal))`    | Warm; no lighter than slate |
-| `--panel-edge`    | `var(--border-strong)` — the tan keyline                  | —                           |
-| Heading colour    | `var(--accent-quiet)`, scoped to headings inside a panel  | 5.8:1, clears 4.5           |
-| `--accent-quiet`  | Unchanged. Gold is already the base's quiet accent        | —                           |
-| Corner            | **Unchanged.** Fantasy is the genre the cut was drawn for | —                           |
-| Ambient effect    | A slow gold sheen across the panel surface                | —                           |
+| Property          | Value                                                             | Measured                                                                            |
+| ----------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `--panel-surface` | `color-mix(in srgb, var(--gold) 12%, var(--charcoal))`            | Warm; no lighter than slate                                                         |
+| `--panel-edge`    | `var(--border-strong)` — the tan keyline                          | —                                                                                   |
+| Heading colour    | `var(--accent-quiet)`, scoped to headings inside a panel          | 5.8:1, clears 4.5                                                                   |
+| `--accent-quiet`  | Unchanged. Gold is already the base's quiet accent                | —                                                                                   |
+| Corner            | A shield's foot — both bottom corners at `--s5`, square shoulders | Amended by #120; see [the four shapes](#the-four-shapes-and-why-each-is-its-genres) |
+| Ambient effect    | A slow gold sheen across the panel surface                        | —                                                                                   |
 
-The corner line is not an omission. The vocabulary offers cut, bevelled and square, and the 9px cut
-in [elevation](#elevation) was designed for exactly this genre — so fantasy's contribution is to
-leave it alone, and the skins that want a different corner are the ones that pay for it.
+The corner line read **"unchanged"** until #120, and the reasoning was sound as far as it went: the
+9px cut in [elevation](#elevation) was drawn for this genre, so fantasy's contribution was to leave
+it alone and let the skins that wanted a different corner pay for it. What that missed is that every
+genre wants one — so the base's shape stops being fantasy's by inheritance and fantasy takes a
+shield's foot instead, leaving the cut as the app's own neutral plate. The mechanism and the two
+lines that do it are #120's.
 
 **The sheen is the shimmer, moved.** A gold gradient band crossing the panel surface on a long
 cycle, painted as a background layer on the liner rather than as an element, so it touches nothing
@@ -2087,12 +2115,260 @@ the skin is forbidden to touch. Three constraints on it:
 - **A skin declares at most one `@keyframes` and one `animation`**, and declares a
   `prefers-reduced-motion` block if it declares either. One effect per skin, stated as a test.
 - **No skin file mentions `--notch`, `--halo`, `--lift`, a `font-` property, or a spacing step.**
-  The "may not touch" list, swept.
+  The "may not touch" list, swept. (`--notch` is `--panel-corner` after #120's rename, and the
+  four depth properties it reads are the one exception — see [what the sci-fi skin
+  enforces](#what-the-sci-fi-skin-enforces).)
 
 And one in the browser, because it is the whole point and cannot be read off the source: an e2e
 check that a fantasy panel's computed surface is **no lighter** than a base panel's. That is the
 rule above, and it is what a future skin — or a future tweak to this one — would otherwise break
 silently.
+
+## The sci-fi skin, and the corner every genre gets
+
+[The skin contract](#the-skin-contract-and-the-fantasy-skin) settled the shape of a skin file and
+fantasy filled it in. This settles [#120](https://github.com/ironarachne/ironarachne/issues/120),
+and it has to settle one thing fantasy was able to walk past: **the corner**. Decision 2 lists a
+corner among the five things a skin may set, [elevation](#elevation) says a skin picks between cut,
+bevelled and square "from this vocabulary", and the vocabulary contains no bevel, no square, and no
+way for a skin to name one. Fantasy's contribution was to leave the corner alone, which was an
+answer for the genre the cut was drawn for and no answer at all for the three genres after it —
+#120 wants a bevel and #121 wants hard corners. **Every genre gets a shape**, which is a firmer
+answer than the document had, and it is why the section below replaces a cap rather than filling a
+gap in one.
+
+### A skin sets four depths, and the polygon stays in the base
+
+Two sentences of the approved document point in opposite directions. Decision 2 says a skin may set
+the corner; [what the panel language leaves to the skins](#what-this-leaves-to-the-skins-1) says a
+skin may not touch the notch geometry. Both survive, because the thing a genre needs to move is not
+the geometry:
+
+> The panel's polygon is written once, in the base, with a depth at each of its four corners. A skin
+> sets **the four depths**. It never writes a `polygon()`, and there is no shape it can make that is
+> not a panel.
+
+`--notch` and `--notch-inner` are renamed `--panel-corner` and `--panel-corner-inner` and become that
+one formula, read at each corner from `--panel-corner-tl` / `-tr` / `-br` / `-bl`, which default to
+`0` / `9px` / `0` / `9px` — the cut the app has today, unchanged on an unskinned panel. Substitution
+is lazy, so the depths resolve against the element the clip is applied to: the formula lives on
+`:root` and a skin's depths, set on the page region, reach every panel below it. The liner's polygon
+is the same four depths a pixel shallower, `max(0px, d - 1px)`, so the two outlines stay parallel at
+whatever depth a genre picks — which is what `--notch-inner` was hand-written to do at one depth.
+`.panel--bare`'s own `clip-path: none` still outranks all of it. Every other `--notch` in this
+document — [panel anatomy](#panel-anatomy), the two-layer table, the shell's nav-corner argument — is
+this same token under its old name, and the rename is the only thing that happens to them: a
+component still picks one of `--panel-corner`, `--corner-control` and `--corner-nav`, and three is
+still the cap on what a **component** may pick from. What #120 opens is the panel's depths, and only
+to a skin.
+
+Two rules bound what a skin can do with the four numbers:
+
+- **No depth exceeds `--s5`.** 12px is the panel's padding, and a corner cut deeper than the padding
+  stops shaping the plate and starts eating the first character of the first line inside it.
+- **No two genres wear the same four.** A shape is a genre's, or it is furniture.
+
+This replaces the cap in [elevation](#elevation), which said three treatments and named cut,
+bevelled and square. That cap was the right instinct pointed at the wrong quantity: it bounded the
+number of _shapes_, when what needs bounding is who may make one. **One shape per genre, plus the
+base's, and `GENRES` is what closes the list** — four genres, four shapes, and a fifth arrives only
+when a fifth genre does. A component still picks nothing: the corner belongs to the panel language
+and to the skin above it, and the control and nav treatments are untouched by any of this.
+
+### The four shapes, and why each is its genre's
+
+| Genre         | tl   | tr   | br   | bl   | Reads as                                                                     |
+| ------------- | ---- | ---- | ---- | ---- | ---------------------------------------------------------------------------- |
+| _Base_        | 0    | 9px  | 0    | 9px  | The app's own plate. Neutral, and what a projectless page keeps              |
+| **Fantasy**   | 0    | 0    | 12px | 12px | A shield's foot: square shoulders, both bottom corners taken deep            |
+| **Sci-fi**    | 9px  | 9px  | 9px  | 9px  | A machined plate, chamfered on every edge by the same amount                 |
+| **Cyberpunk** | 12px | 0    | 0    | 0    | Three hard corners and one deliberate slash — signage, cut once              |
+| **Horror**    | 3px  | 11px | 5px  | 8px  | Nothing agrees with anything. Wrong in a way the eye catches and cannot name |
+
+Sci-fi's is the one this issue builds, and it is the plainest of the four on purpose: the genre's
+argument is made by a cool plate, a plasma keyline and a scan, and a corner that shouted over them
+would be a second statement of the same thing.
+
+The other three are **reserved rather than settled**. #121 and #122 own their skins and may move
+their own four numbers, and the shapes above are what those issues start from rather than what they
+inherit. What they may not do is take a shape another genre is already wearing, or go past `--s5`.
+
+Fantasy's row is a reversal, and worth naming as one. [The fantasy skin](#the-fantasy-skin) says the
+corner is "unchanged" because the 9px cut was drawn for that genre — true, and beside the point once
+every genre has a shape: a fantasy panel that keeps the base's corner is the one skinned panel
+shaped like an unskinned one. The shield foot is two lines in `fantasy.css` and ships with this
+issue rather than reopening #119, because the mechanism it needs does not exist until now.
+
+```mermaid
+classDiagram
+    class PanelCorner {
+        <<tokens.css>>
+        +panel-corner : polygon of four depths
+        +panel-corner-inner : the same, less 1px
+        +panel-corner-tl, -tr, -br, -bl : 0, 9px, 0, 9px
+    }
+    class Panel {
+        <<main.css>>
+        +clip-path = var(panel-corner)
+        +field.clip-path = var(panel-corner-inner)
+    }
+    class Skin {
+        <<fantasy, scifi, cyberpunk, horror>>
+        +panel-surface
+        +panel-edge
+        +four corner depths, each <= s5
+        +accent
+        +one ambient effect
+    }
+    class BarePanel {
+        <<panel--bare>>
+        +clip-path : none, declared on itself
+    }
+
+    PanelCorner --> Panel : supplies the one polygon
+    Skin --> Panel : sets depths, on an ancestor
+    Skin ..> PanelCorner : moves the numbers, never the shape
+    BarePanel --> Panel : outranks both
+```
+
+Nothing about this changes a panel's box. A `clip-path` paints; it does not lay out. A bevelled panel
+and a base panel beside each other are the same height, the same width and the same padding, which is
+the property [decision 2](#2-genre-skins-are-a-permitted-subset-not-a-second-look) actually protects
+when it forbids a skin the geometry — and the depth cap is what keeps the clip off the content the
+padding is holding.
+
+### The surface is charcoal cooled, for the same reason fantasy's is charcoal warmed
+
+The rule from #119 — a skin's surface may shift hue freely but never rise above `--surface-raised`'s
+luminance — settles the recipe before any taste is involved. Cooling slate lightens it and every ink
+role pays; cooling charcoal by more lands at the same luminance and reads cool.
+
+| Surface                                                  | `--ink` | `--ink-muted` | `--ink-faint` |  Cyan |
+| -------------------------------------------------------- | ------: | ------------: | ------------: | ----: |
+| `--surface-raised`, the floor every ratio is measured to |  12.2:1 |         6.3:1 |         4.6:1 | 7.5:1 |
+| **Charcoal cooled 16% toward plasma blue** — sci-fi      |  12.3:1 |         6.4:1 |         4.7:1 | 7.5:1 |
+| Slate cooled 16% toward plasma blue                      |  11.5:1 |         6.0:1 |         4.4:1 | 7.1:1 |
+
+`color-mix(in srgb, var(--plasma-blue) 16%, var(--charcoal))` computes to `rgb(33 47 69)` at a
+relative luminance of 0.0276, against slate's 0.0281. Every ink role is a tenth of a point _better_
+than it is on a base panel, which is what the rule promises and is why no skin after this one has to
+re-measure the table.
+
+**Plasma blue is the fill and cyan is the ink**, and that split is forced rather than chosen. Plasma
+blue measures 3.8:1 on the surface it makes — the same class of colour as crimson and emerald in
+[colour roles](#colour-roles), which are an edge and a fill and never a sentence. Cyan measures
+7.5:1 there. So the genre's two hues divide by what they can legibly do: the darker one is the plate
+and the keyline, the brighter one is every word the skin colours.
+
+### The keyline is louder than the base's, and stays in the same register
+
+A panel is identified by its keyline, so a genre's keyline is the loudest thing it can honestly
+change — and the temptation is to make it a glow. Measured against the surface it sits on:
+
+| Keyline                                         |  Ratio |
+| ----------------------------------------------- | -----: |
+| Base — `--border`, granite on slate             | 1.35:1 |
+| Fantasy — `--border-strong`, tan on its surface | 1.70:1 |
+| **Sci-fi — plasma blue 40% into granite**       | 2.07:1 |
+| Plasma blue undiluted on the same surface       | 3.83:1 |
+
+The last row is what "plasma keyline" reads like as an instruction and it is the wrong answer: at
+2.8× the base's contrast the keyline stops identifying a plate and starts outlining a box, and a
+bench of six panels becomes a wireframe. `color-mix(in srgb, var(--plasma-blue) 40%, var(--granite))`
+is unmistakably a blue keyline in the register the other panels on the page are drawn in.
+
+That gives the skins a band rather than a taste: **a skin's keyline measures between 1.3:1 and
+2.2:1 against its own surface.** #121's "acid keyline with a magenta edge" now has a number to hit
+instead of an argument to have.
+
+### The accent moves, and the halo follows it
+
+Sci-fi is the first skin to set `--accent`, which fantasy did not need to: gold was already the
+base's quiet accent, and green is not a science-fiction hue. `--accent: var(--cyan)` colours the
+chips, the kickers, the figures and the selected list row inside the page region, and it is the
+heading colour on a panel at 7.5:1.
+
+It has one consequence the document should own rather than discover: **`--halo` is mixed from
+`--accent`, so under this skin the focus halo is cyan.** That is permitted, and the rule it looks
+like it breaks is intact. A skin may not touch `--halo` — its spread, its opacity, its two layers
+and the fact that there is exactly one on screen are all unchanged, and the ring that carries the
+meaning is `--focus`, which is acid green in every genre. What moved is a hue the skin is entitled
+to move. The alternative — pinning the halo to green while everything it surrounds is cyan — would
+be a skin leaking _out_ of the accent role rather than staying inside it.
+
+`--accent-quiet` is deliberately not set. It is the message tone's gold ([the message
+family](#the-message-family)), and a notice inside a science-fiction project is still the app
+saying something went a certain way. A tone outranks a genre; leaving the quiet accent alone is
+what makes that true rather than merely stated.
+
+### One effect, and a texture that survives without it
+
+Two layers on the liner's `background-image`, and only one of them moves:
+
+- **The texture is static.** Horizontal scanlines — a `repeating-linear-gradient` of cyan at 4%,
+  one pixel on a five-pixel pitch. Decision 2 lists texture under _surface_, not under _motion_, and
+  this is the whole reason to spend it here: it says "screen" without animating, so the sci-fi panel
+  is still visibly sci-fi when everything that moves is switched off. Pitch and mix are stated
+  because a tighter, stronger grid moirés against a scrolling panel, which is a shimmer nobody asked
+  for and the one failure mode this layer has.
+- **The motion is a single scan.** A faint cyan band drifting down the surface on a 45s cycle — the
+  vertical counterpart of fantasy's sheen, one `@keyframes`, one `animation`, slower than fantasy's
+  40s because a band that crosses the short axis of a panel is on screen more of the time.
+- **Reduced motion drops the band and keeps the lines.** This is a better reduced-motion state than
+  fantasy's rather than a different one: fantasy's surface falls back to a flat warm fill because
+  its effect _is_ the highlight, where sci-fi keeps its texture and loses only the travel.
+
+`.panel:not(.panel--bare) > .panel__field`, exactly as fantasy scopes it: the main tool panel has no
+surface, and a scanline grid floating on the page is what a wider selector would produce.
+
+### The sci-fi skin
+
+| Property          | Value                                                         | Measured                               |
+| ----------------- | ------------------------------------------------------------- | -------------------------------------- |
+| `--panel-surface` | `color-mix(in srgb, var(--plasma-blue) 16%, var(--charcoal))` | `rgb(33 47 69)`; no lighter than slate |
+| `--panel-edge`    | `color-mix(in srgb, var(--plasma-blue) 40%, var(--granite))`  | 2.07:1 on that surface                 |
+| Corner depths     | `9px` at all four corners                                     | A machined plate; none past `--s5`     |
+| `--accent`        | `var(--cyan)`                                                 | 7.5:1; the halo follows the hue        |
+| `--accent-quiet`  | **Unchanged.** Gold is the message tone, not the genre's      | —                                      |
+| Heading colour    | `var(--accent)`, scoped to headings inside a panel            | 7.5:1, clears 4.5                      |
+| Texture           | Cyan 4%, 1px on a 5px pitch, static                           | —                                      |
+| Ambient effect    | A cyan scan band drifting down the surface, 45s               | —                                      |
+
+Seven declarations and one keyframe. The contract's table said six, and the seventh is the corner —
+which was always in [decision 2](#2-genre-skins-are-a-permitted-subset-not-a-second-look)'s list of
+what a skin may set and was missing from the file shape only because the mechanism did not exist yet.
+The table in [what a skin file contains](#what-a-skin-file-contains) gains a corner-depths row, and
+every skin file now carries it, fantasy's included.
+
+### What the sci-fi skin enforces
+
+`tokens.test.ts` grows, and the deferred list shrinks again:
+
+- **`scifi.css` joins `CONVERTED_SKINS`**, which is the hex sweep, the type-ramp sweep and the
+  one-effect cap in one move. `cyberpunk.css` is the last file left on the exemption.
+- **A skin's corner is four numbers, not a polygon.** A skin file may set
+  `--panel-corner-tl` / `-tr` / `-br` / `-bl`; it may not contain `polygon(` or `clip-path`, and it
+  may not declare `--panel-corner` or `--panel-corner-inner` themselves. That is the line between
+  moving the depths and redrawing the panel, and without it the geometry sweep would pass on a skin
+  that redrew it.
+- **No depth exceeds `--s5`**, swept as a number across every skin file. 12px is the padding, and
+  past the padding the clip is taking the content.
+- **No two skins declare the same four depths**, and none matches the base's `0 / 9px / 0 / 9px`.
+  "A shape is a genre's, or it is furniture" is a rule a test can hold, and it is the one that would
+  otherwise erode a genre at a time as skins are tuned. It reads the skin files rather than a list,
+  so a fifth genre is covered on the day its file appears.
+- **A skin declares at most one `@keyframes`**, unchanged — the texture is a second background
+  layer, not a second effect, and the test measures effects.
+
+And two in the browser, because both are computed relationships:
+
+- `e2e/genre_skin.spec.ts` gains a sci-fi case beside the fantasy one — the skin reaches the panel,
+  the surface reads **cool** (more blue than red, the mirror of fantasy's warmth assertion), and its
+  luminance is no higher than a base panel's.
+- **A bevelled panel and a base panel are the same size.** Computed `clip-path` differs; the
+  bounding box does not. That is the corner rule's whole claim, it is invisible to a source sweep,
+  and it is what a future skin reaching for geometry would break. The same assertion covers the
+  fantasy shield, since both are the same two lines of mechanism.
 
 ## Enforcement
 

--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -92,7 +92,9 @@ a skin set one and [elevation](#elevation) has always named three treatments, bu
 as a polygon and no skin has a way to ask for another — fantasy could decline the question and #120
 and #121 cannot. So the panel's polygon is written once with a depth at each corner, a skin sets the
 four depths, and the "three treatments" cap is replaced by a bound with a reason behind it: one shape
-per genre, capped at `--s5`, no two alike. It adds one measured band — a skin's keyline
+per genre, capped at `--s5`, no two alike. The formula sits on the clipping elements rather than on
+`:root`, because a `var()` inside a custom property resolves where it is declared — a correction this
+document earned in a browser rather than reasoned out. It adds one measured band — a skin's keyline
 between 1.3:1 and 2.2:1 on its own surface — and settles that a skin setting `--accent` moves the
 halo's hue with it, which is permitted because the halo's geometry, its opacity and the `--focus`
 ring are all untouched.
@@ -2150,12 +2152,24 @@ the geometry:
 
 `--notch` and `--notch-inner` are renamed `--panel-corner` and `--panel-corner-inner` and become that
 one formula, read at each corner from `--panel-corner-tl` / `-tr` / `-br` / `-bl`, which default to
-`0` / `9px` / `0` / `9px` — the cut the app has today, unchanged on an unskinned panel. Substitution
-is lazy, so the depths resolve against the element the clip is applied to: the formula lives on
-`:root` and a skin's depths, set on the page region, reach every panel below it. The liner's polygon
-is the same four depths a pixel shallower, `max(0px, d - 1px)`, so the two outlines stay parallel at
-whatever depth a genre picks — which is what `--notch-inner` was hand-written to do at one depth.
-`.panel--bare`'s own `clip-path: none` still outranks all of it. Every other `--notch` in this
+`0` / `9px` / `0` / `9px` — the cut the app has today, unchanged on an unskinned panel. The liner's
+polygon is the same four depths a pixel shallower, `max(0px, d - 1px)`, so the two outlines stay
+parallel at whatever depth a genre picks — which is what `--notch-inner` was hand-written to do at
+one depth.
+
+**The formula is declared on `.panel` and `.panel__header`, not on `:root`, and that is not a
+stylistic choice.** A `var()` inside a custom property is substituted where that property is
+_declared_, not where it is used: a `--panel-corner` on `:root` resolves its four depths against
+`:root` and hands every panel the base cut however a skin sets them. This document said the opposite
+until it was measured — the first implementation put the formula on `:root`, and
+`e2e/genre_skin.spec.ts` failed with a sci-fi panel wearing the base's corner and the right surface,
+which is exactly the shape of the #119 bug that put `--panel-surface` on `.panel` and made the skin
+inert. Declared on the elements that clip, the depths resolve against what those elements inherited,
+and the liners inherit the finished polygon from their own parent. It is still written once each.
+`.panel--bare`'s own `clip-path: none` still outranks all of it, and `.panel__header` sets the four
+depths back to the base cut on itself: a genre shapes the plate, not the furniture inside it, and a
+fantasy header would otherwise carry the shield's deep bottom cuts halfway up the panel's own face.
+Every other `--notch` in this
 document — [panel anatomy](#panel-anatomy), the two-layer table, the shell's nav-corner argument — is
 this same token under its old name, and the rename is the only thing that happens to them: a
 component still picks one of `--panel-corner`, `--corner-control` and `--corner-nav`, and three is

--- a/e2e/genre_skin.spec.ts
+++ b/e2e/genre_skin.spec.ts
@@ -55,6 +55,22 @@ async function setGenre(page: Page, genre: string): Promise<void> {
   await expect(page.locator('main.shell__page')).toHaveAttribute('data-genre', genre);
 }
 
+/** The rendered surface, clip and box of the first panel liner on the page. */
+async function panelShape(
+  page: Page,
+): Promise<{ surface: [number, number, number]; clip: string; box: string }> {
+  const surface = await panelSurface(page);
+  const rest = await page
+    .locator('.panel')
+    .first()
+    .evaluate((element) => {
+      const { width, height } = element.getBoundingClientRect();
+      return { clip: getComputedStyle(element).clipPath, box: `${width}x${height}` };
+    });
+
+  return { surface, ...rest };
+}
+
 test.describe('the fantasy skin', () => {
   test('reaches the panel, warms it, and never lightens it', async ({ page }) => {
     await openProject(page);
@@ -112,5 +128,55 @@ test.describe('the fantasy skin', () => {
       .evaluate((element) => getComputedStyle(element).backgroundImage);
 
     expect(headingPaint, 'the skin is still painting the type').toBe('none');
+  });
+});
+
+test.describe('the sci-fi skin', () => {
+  test('cools the panel without lightening it, and takes a shape of its own', async ({ page }) => {
+    await openProject(page);
+    const base = await panelShape(page);
+
+    await setGenre(page, 'scifi');
+    const scifi = await panelShape(page);
+
+    expect(scifi.surface, 'the skin did not reach the panel surface').not.toEqual(base.surface);
+
+    // It reads cool: more blue than red, the mirror of the fantasy assertion. Without it, "no
+    // lighter" could be satisfied by a skin that simply went darker and dressed nothing.
+    expect(scifi.surface[2], 'the sci-fi surface is not cool').toBeGreaterThan(scifi.surface[0]);
+
+    expect(
+      luminance(scifi.surface),
+      'a sci-fi panel is lighter than a base panel',
+    ).toBeLessThanOrEqual(luminance(base.surface));
+
+    // The corner: a machined plate, chamfered on all four rather than the base's diagonal pair.
+    // docs/visual-design.md, "The four shapes, and why each is its genre's".
+    expect(scifi.clip, 'the skin did not reach the corner').not.toEqual(base.clip);
+
+    // And the whole claim the corner rests on: a `clip-path` paints, it does not lay out. Two
+    // panels wearing different shapes are the same box, which is what decision 2 protects when it
+    // keeps geometry away from a skin — and what a skin reaching past the four depths would break.
+    expect(scifi.box, 'a skinned panel is not the size of a base panel').toEqual(base.box);
+  });
+
+  test('keeps its texture when motion is switched off', async ({ page }) => {
+    // The sci-fi surface carries two layers and only one of them moves: the scan is the ambient
+    // effect and goes under reduced motion, where the scanlines are *texture* and stay. This is
+    // the assertion that the genre survives the switch rather than falling back to a plain fill.
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await openProject(page);
+    await setGenre(page, 'scifi');
+
+    const paint = await page
+      .locator('.panel__field')
+      .first()
+      .evaluate((element) => ({
+        image: getComputedStyle(element).backgroundImage,
+        animation: getComputedStyle(element).animationName,
+      }));
+
+    expect(paint.animation, 'the scan still runs under reduced motion').toBe('none');
+    expect(paint.image, 'the scanlines went with the scan').toContain('repeating-linear-gradient');
   });
 });

--- a/src/components/common/Panel.svelte
+++ b/src/components/common/Panel.svelte
@@ -4,7 +4,7 @@
   /**
    * The site's panel, in the one markup that can draw its own keyline.
    *
-   * A panel is cut at two corners (`--notch`), and a `clip-path` cuts everything the element
+   * A panel is cut at two corners (`--panel-corner`), and a `clip-path` cuts everything the element
    * paints — a `border` included. On the two diagonal edges the keyline is therefore sliced off,
    * at exactly the corners the treatment exists to make visible. That is why this component
    * exists, and it is the same reason `BaseButton` does: the outer element paints the edge colour

--- a/src/components/layout/Sidebar.svelte
+++ b/src/components/layout/Sidebar.svelte
@@ -38,7 +38,7 @@
 <style>
   /* The sidebar is flush to the left edge of the screen and square on that side: the items run
      edge to edge and carry their own inset padding, which is why the inline padding here is zero
-     at every width. No notch on the outer edge — `--notch` cuts a corner off a plate that sits on
+     at every width. No notch on the outer edge — `--panel-corner` cuts a corner off a plate that sits on
      a surface, and a cut on an edge with nothing beyond it reads as damage rather than as a cut.
      See docs/visual-design.md, "The shell". */
   .sidebar {

--- a/src/lib/styles/fantasy.css
+++ b/src/lib/styles/fantasy.css
@@ -41,8 +41,16 @@
      fantasy chip, kicker and figure colour is the one the app has. A skin that changes nothing
      here is a skin agreeing with the base, not a skin that forgot.
 
-     No corner override either. The vocabulary offers cut, bevelled and square, and the 9px cut in
-     "Elevation" was drawn for exactly this genre — fantasy's contribution is to leave it alone. */
+     The corner is a shield's foot: square shoulders, both bottom corners taken to `--s5`. This
+     line reverses #119, which left the corner alone on the grounds that the base's 9px cut was
+     drawn for this genre. True, and beside the point once every genre has a shape of its own — a
+     fantasy panel wearing the base's corner is the one skinned panel shaped like an unskinned one,
+     so the cut goes back to being the app's own neutral plate. See docs/visual-design.md, "The
+     four shapes, and why each is its genre's". */
+  --panel-corner-tl: 0px;
+  --panel-corner-tr: 0px;
+  --panel-corner-br: 12px;
+  --panel-corner-bl: 12px;
 }
 
 /* The display ink. Gold headings inside a panel, at 5.8:1 on the surface above — a colour, which a

--- a/src/lib/styles/main.css
+++ b/src/lib/styles/main.css
@@ -536,7 +536,7 @@ label {
      rather than replacing it — and so the halo can be set by a state without restating either. */
   --panel-halo: 0 0 rgb(0 0 0 / 0%);
 
-  /* The edge, painted across the whole box. `--notch` is a `clip-path`, a `clip-path` cuts
+  /* The edge, painted across the whole box. `--panel-corner` is a `clip-path`, a `clip-path` cuts
      everything the element paints, and a `border` is something the element paints — so a panel
      carrying the corner treatment loses its keyline along both diagonals, at exactly the two
      corners the treatment exists to make visible. The liner below covers all of this but a pixel,
@@ -544,7 +544,7 @@ label {
   background: var(--panel-edge, var(--border));
   box-shadow: var(--lift), var(--panel-halo);
   box-sizing: border-box;
-  clip-path: var(--notch);
+  clip-path: var(--panel-corner);
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -559,7 +559,7 @@ label {
   background: var(--panel-surface, var(--surface-raised));
   box-shadow: var(--edge);
   box-sizing: border-box;
-  clip-path: var(--notch-inner);
+  clip-path: var(--panel-corner-inner);
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
@@ -598,9 +598,18 @@ label {
    running full-bleed to the keyline — one offset in both forms, so the same furniture looks the
    same on a framed panel as it does on a bare one. */
 .panel__header {
+  /* The base cut, restated rather than inherited. A genre skin sets the four corner depths on the
+     page region and every panel below it takes the shape; the header is a plate *inside* one, and
+     furniture that changed shape with the genre would put a fantasy panel's deep bottom cuts
+     halfway up its own face. The skin dresses the plate, not the parts of it. */
+  --panel-corner-tl: 0px;
+  --panel-corner-tr: 9px;
+  --panel-corner-br: 0px;
+  --panel-corner-bl: 9px;
+
   background: var(--border-strong);
   box-sizing: border-box;
-  clip-path: var(--notch);
+  clip-path: var(--panel-corner);
   padding: 1px;
 }
 
@@ -609,7 +618,7 @@ label {
   background: var(--plate);
   box-shadow: var(--edge);
   box-sizing: border-box;
-  clip-path: var(--notch-inner);
+  clip-path: var(--panel-corner-inner);
   display: flex;
   gap: var(--s4);
   justify-content: space-between;

--- a/src/lib/styles/main.css
+++ b/src/lib/styles/main.css
@@ -521,6 +521,45 @@ label {
    notice were all the same box at the same height, and nothing was emphasised by being a panel
    because everything was one. */
 
+/* The panel's two polygons, on the two elements that clip: a panel, and the header plate inside
+   it. Written here rather than in `tokens.css` because a `var()` inside a custom property is
+   substituted where that property is declared — on `:root` these would resolve their depths
+   against `:root` and every panel would wear the base cut whatever a skin set. Declared on the
+   clipping element, they resolve against the depths that element inherited, which is how a genre's
+   corner reaches a panel at all. The liners inherit them from their own parent.
+
+   The shape is the base's at whatever depth is in force: a skin sets the four depths on the page
+   region and never a polygon, so there is no value it can give them that is not a panel. See
+   docs/visual-design.md, "A skin sets four depths, and the polygon stays in the base". */
+.panel,
+.panel__header {
+  --panel-corner: polygon(
+    var(--panel-corner-tl) 0,
+    calc(100% - var(--panel-corner-tr)) 0,
+    100% var(--panel-corner-tr),
+    100% calc(100% - var(--panel-corner-br)),
+    calc(100% - var(--panel-corner-br)) 100%,
+    var(--panel-corner-bl) 100%,
+    0 calc(100% - var(--panel-corner-bl)),
+    0 var(--panel-corner-tl)
+  );
+
+  /* The same four depths a pixel shallower, for the liner that paints inside the keyline: it sits
+     a pixel inside on every edge, so its cut is a pixel shallower and the two outlines run
+     parallel instead of converging. `max()` because a square corner has nothing to take a pixel
+     off — 0px - 1px is -1px, and a negative coordinate would pull the outline outside the box. */
+  --panel-corner-inner: polygon(
+    max(0px, calc(var(--panel-corner-tl) - 1px)) 0,
+    calc(100% - max(0px, calc(var(--panel-corner-tr) - 1px))) 0,
+    100% max(0px, calc(var(--panel-corner-tr) - 1px)),
+    100% calc(100% - max(0px, calc(var(--panel-corner-br) - 1px))),
+    calc(100% - max(0px, calc(var(--panel-corner-br) - 1px))) 100%,
+    max(0px, calc(var(--panel-corner-bl) - 1px)) 100%,
+    0 calc(100% - max(0px, calc(var(--panel-corner-bl) - 1px))),
+    0 max(0px, calc(var(--panel-corner-tl) - 1px))
+  );
+}
+
 .panel {
   /* The two colours a level, a state and a genre skin each set are *not* declared here, and that
      is the whole reason a skin works. A declaration on the element beats an inherited one, so

--- a/src/lib/styles/scifi.css
+++ b/src/lib/styles/scifi.css
@@ -1,29 +1,133 @@
-@keyframes pulse-glow {
-  0% {
-    text-shadow: 0 0 6px var(--cyan);
+/* The sci-fi skin: a panel skin over the base system, and nothing more.
+ *
+ * Seven declarations and one keyframe, which is the whole shape a skin file is allowed — see
+ * docs/visual-design.md, "The sci-fi skin, and the corner every genre gets". Before #120 this file
+ * styled `h1`-`h6` and only `h1`-`h6`: a cyan glow pulsing on a 3s loop, over the type, written in
+ * a hex no token named. A heading that pulses is a heading being animated while it is being read,
+ * and the display face already carries the brand — so the genre moved off the type and onto the
+ * panel.
+ *
+ * What this file may not touch: the typeface, the type scale, the space ramp, control geometry,
+ * the liner, the halo, `--lift`, and a badge's shape. It may set four corner depths, and the
+ * panel's polygon stays in `tokens.css` where a skin cannot reach it.
+ */
+
+/* The one ambient effect. A scan crossing the panel surface, painted as a background layer rather
+   than as an element so it touches nothing the skin is forbidden to touch. Vertical, where
+   fantasy's sheen runs across: a scan travels down a screen. */
+@keyframes scifi-scan {
+  from {
+    background-position:
+      0 -60%,
+      0 0;
   }
-  50% {
-    text-shadow: 0 0 14px var(--cyan);
-  }
-  100% {
-    text-shadow: 0 0 6px var(--cyan);
+  to {
+    background-position:
+      0 160%,
+      0 0;
   }
 }
 
 [data-genre='scifi'] {
-  & h1,
-  & h2,
-  & h3,
-  & h4,
-  & h5,
-  & h6 {
-    animation: pulse-glow 3s infinite ease-in-out;
-    color: #a2d4ff;
-    text-shadow: 0 0 6px var(--cyan);
-  }
+  /* Charcoal cooled toward plasma blue, and deliberately not slate cooled toward plasma blue.
 
-  /* No `button` rule. A skin may set a surface, a keyline, a corner, an accent hue and one
-     ambient effect; control geometry is not on that list, and a skin's copy of the old gradient
-     would outrank the control system wherever a genre is applied. See docs/visual-design.md,
-     decision 2 and "What this leaves to the skins". */
+     Cooling slate lightens it and every ink role pays: `--ink-faint` measures 4.4:1 on slate
+     cooled 16%, against a 4.5:1 floor. Cooling charcoal by the same amount lands a hair *under*
+     slate's luminance while reading cool, so nothing pays — `rgb(33 47 69)` at 0.0276 against
+     slate's 0.0281, which puts every ink role a tenth of a point better here than on a base panel.
+     That is the skin rule from #119 stated in one declaration: a skin may shift its surface's hue
+     but never raise its luminance above `--surface-raised`. */
+  --panel-surface: color-mix(in srgb, var(--plasma-blue) 16%, var(--charcoal));
+
+  /* The plasma keyline, diluted into granite rather than used neat. Undiluted plasma blue measures
+     3.83:1 on the surface above — 2.8x the base keyline's 1.35:1 — and at that contrast the
+     keyline stops identifying a plate and starts outlining a box, which turns a bench of six
+     panels into a wireframe. At 40% it is 2.07:1: unmistakably a blue keyline, in the register the
+     rest of the app's panels are drawn in. A skin's keyline belongs between 1.3:1 and 2.2:1 on its
+     own surface. */
+  --panel-edge: color-mix(in srgb, var(--plasma-blue) 40%, var(--granite));
+
+  /* A machined plate: the base's 9px cut taken to all four corners rather than the diagonal pair.
+     The plainest of the four genre shapes on purpose — the cool plate, the keyline and the scan
+     are already making the argument, and a corner that shouted over them would say it twice. */
+  --panel-corner-tl: 9px;
+  --panel-corner-tr: 9px;
+  --panel-corner-br: 9px;
+  --panel-corner-bl: 9px;
+
+  /* Cyan is the genre's ink and plasma blue is its fill, and the split is forced rather than
+     chosen: plasma blue measures 3.8:1 on the surface it makes, which is the same class of colour
+     as crimson and emerald in "Colour roles" — an edge and a fill, never a sentence. Cyan is
+     7.5:1 there, so it takes the chips, the kickers, the figures and the selected row.
+
+     `--halo` is mixed from `--accent`, so the focus halo is cyan under this skin. That is a hue
+     the skin is entitled to move: the halo's spread, its opacity and the fact that there is one on
+     screen are untouched, and the ring that carries the meaning is `--focus`, acid green in every
+     genre. Pinning the halo to green while everything it surrounds is cyan would be the skin
+     leaking out of the accent role rather than staying inside it.
+
+     No `--accent-quiet` override. Gold is the message tone, and a notice inside a science-fiction
+     project is still the app saying how something went; a tone outranks a genre. */
+  --accent: var(--cyan);
+}
+
+/* The display ink. Cyan headings inside a panel, at 7.5:1 on the surface above — a colour, which a
+   skin may set, and not a size or a face, which it may not. Scoped to the panel because that is
+   what a skin dresses: a heading on the bare page belongs to the type ramp. */
+[data-genre='scifi'] .panel .panel__title,
+[data-genre='scifi'] .panel h2,
+[data-genre='scifi'] .panel h3,
+[data-genre='scifi'] .panel h4 {
+  color: var(--accent);
+}
+
+/* Two layers on the liner that paints the surface, and only the first of them moves.
+
+   `.panel:not(.panel--bare)` because the main tool panel has no surface of its own — a scanline
+   grid there would be a texture floating on the page. `background-image` over the liner's own
+   `background-color`, so the fill is still `--panel-surface`.
+
+   The scanlines are *texture*, which decision 2 lists under surface rather than under motion, and
+   that is the whole reason to spend a layer on them: they say "screen" without animating, so a
+   sci-fi panel is still visibly sci-fi when everything that moves is switched off. 1px on a 5px
+   pitch at 4%, both stated because a tighter or stronger grid moirés against a scrolling panel,
+   which is a shimmer nobody asked for.
+
+   45s for the scan, where fantasy's sheen runs 40s: a band crossing the short axis of a panel is
+   on screen more of the time, and a bench holds several panels all wearing this. */
+[data-genre='scifi'] .panel:not(.panel--bare) > .panel__field {
+  animation: scifi-scan 45s linear infinite;
+  background-image:
+    linear-gradient(
+      180deg,
+      transparent 40%,
+      color-mix(in srgb, var(--cyan) 7%, transparent) 50%,
+      transparent 60%
+    ),
+    repeating-linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--cyan) 4%, transparent) 0 1px,
+      transparent 1px 5px
+    );
+  background-repeat: no-repeat, repeat;
+  background-size:
+    100% 60%,
+    100% 5px;
+}
+
+/* Decision 2 caps ambient motion at one effect per skin and turns it off here. The scan goes; the
+   scanlines stay, because they are surface rather than motion — which makes this a better reduced
+   state than fantasy's rather than a different one: the genre survives the switch intact and loses
+   only the travel. */
+@media (prefers-reduced-motion: reduce) {
+  [data-genre='scifi'] .panel:not(.panel--bare) > .panel__field {
+    animation: none;
+    background-image: repeating-linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--cyan) 4%, transparent) 0 1px,
+      transparent 1px 5px
+    );
+    background-repeat: repeat;
+    background-size: 100% 5px;
+  }
 }

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -195,28 +195,58 @@
     0 0 20px color-mix(in srgb, var(--accent) 14%, transparent);
 
   /* ---- Corners -------------------------------------------------------------------------
-     Three treatments, and three is a cap. A component picks one of these, and a skin picks
-     between cut, bevelled and square from this vocabulary; inventing a fourth is what the rule
-     exists to make awkward.
+     A control picks `--corner-control` and a nav item `--corner-nav`; both are fixed. The panel's
+     corner is not, because a genre skin sets it — and it is the one piece of geometry a skin may
+     move. See docs/visual-design.md, "A skin sets four depths, and the polygon stays in the base".
+
+     The panel's polygon is written *once*, here, with a depth at each of its four corners. A skin
+     sets the four depths and never the shape, so there is no value a skin can give them that is
+     not a panel. This replaces the "three treatments" cap: what needed bounding was never the
+     number of shapes but who may make one, which is now one shape per genre and nobody else.
+
+     Two rules on the depths, and both are swept by `tokens.test.ts`: none exceeds `--s5`, because
+     12px is the panel's padding and a deeper cut starts taking the first character of the first
+     line inside it; and no two genres wear the same four.
 
      A `clip-path` cuts everything the element paints, borders included — so an edge marker on a
      clipped element is an inset shadow, not a border, or the clip shaves it at both ends. */
 
-  /* A panel: 9px off the top-right and bottom-left. */
-  --notch: polygon(0 0, calc(100% - 9px) 0, 100% 9px, 100% 100%, 9px 100%, 0 calc(100% - 9px));
+  /* The base cut: 9px off the top-right and bottom-left, and square at the other two. This is the
+     app's own plate — an unskinned panel, and every plate *inside* a panel, which is why
+     `.panel__header` sets these back to these values rather than wearing the genre. */
+  --panel-corner-tl: 0px;
+  --panel-corner-tr: 9px;
+  --panel-corner-br: 0px;
+  --panel-corner-bl: 9px;
 
-  /* The panel treatment again, for the liner a panel draws its keyline with. Same story as
-     `--corner-control-inner` below, at the panel's scale: the liner sits a pixel inside on every
-     edge, so its cut is a pixel shallower — 8px against the notch's 9px — and the two diagonals
-     run parallel instead of converging. Not a fourth treatment; the panel's own, drawn a pixel
-     in. */
-  --notch-inner: polygon(
-    0 0,
-    calc(100% - 8px) 0,
-    100% 8px,
-    100% 100%,
-    8px 100%,
-    0 calc(100% - 8px)
+  --panel-corner: polygon(
+    var(--panel-corner-tl) 0,
+    calc(100% - var(--panel-corner-tr)) 0,
+    100% var(--panel-corner-tr),
+    100% calc(100% - var(--panel-corner-br)),
+    calc(100% - var(--panel-corner-br)) 100%,
+    var(--panel-corner-bl) 100%,
+    0 calc(100% - var(--panel-corner-bl)),
+    0 var(--panel-corner-tl)
+  );
+
+  /* The same four depths a pixel shallower, for the liner a panel draws its keyline with. Same
+     story as `--corner-control-inner` below, at the panel's scale: the liner sits a pixel inside
+     on every edge, so its cut is a pixel shallower and the two outlines run parallel instead of
+     converging. `max()` because a square corner has nothing to take a pixel off — 0px - 1px is
+     -1px, and a negative coordinate would pull the outline outside the box.
+
+     Not a second treatment; the panel's own, drawn a pixel in — and it follows a skin's depths for
+     free, where `--notch-inner` was hand-written at the one depth the app used to have. */
+  --panel-corner-inner: polygon(
+    max(0px, calc(var(--panel-corner-tl) - 1px)) 0,
+    calc(100% - max(0px, calc(var(--panel-corner-tr) - 1px))) 0,
+    100% max(0px, calc(var(--panel-corner-tr) - 1px)),
+    100% calc(100% - max(0px, calc(var(--panel-corner-br) - 1px))),
+    calc(100% - max(0px, calc(var(--panel-corner-br) - 1px))) 100%,
+    max(0px, calc(var(--panel-corner-bl) - 1px)) 100%,
+    0 calc(100% - max(0px, calc(var(--panel-corner-bl) - 1px))),
+    0 max(0px, calc(var(--panel-corner-tl) - 1px))
   );
 
   /* A control: the same diagonal shape at 7px, because a control is not the size of a panel. */

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -219,35 +219,15 @@
   --panel-corner-br: 0px;
   --panel-corner-bl: 9px;
 
-  --panel-corner: polygon(
-    var(--panel-corner-tl) 0,
-    calc(100% - var(--panel-corner-tr)) 0,
-    100% var(--panel-corner-tr),
-    100% calc(100% - var(--panel-corner-br)),
-    calc(100% - var(--panel-corner-br)) 100%,
-    var(--panel-corner-bl) 100%,
-    0 calc(100% - var(--panel-corner-bl)),
-    0 var(--panel-corner-tl)
-  );
+  /* The polygon these four feed is **not here**, and it cannot be. A `var()` inside a custom
+     property is substituted where that property is *declared*, not where it is used — so a
+     `--panel-corner` declared on `:root` would resolve its depths against `:root` and hand every
+     panel the base cut however a skin set them. Measured in a browser rather than reasoned about:
+     the first cut of #120 did exactly that, and `e2e/genre_skin.spec.ts` caught it.
 
-  /* The same four depths a pixel shallower, for the liner a panel draws its keyline with. Same
-     story as `--corner-control-inner` below, at the panel's scale: the liner sits a pixel inside
-     on every edge, so its cut is a pixel shallower and the two outlines run parallel instead of
-     converging. `max()` because a square corner has nothing to take a pixel off — 0px - 1px is
-     -1px, and a negative coordinate would pull the outline outside the box.
-
-     Not a second treatment; the panel's own, drawn a pixel in — and it follows a skin's depths for
-     free, where `--notch-inner` was hand-written at the one depth the app used to have. */
-  --panel-corner-inner: polygon(
-    max(0px, calc(var(--panel-corner-tl) - 1px)) 0,
-    calc(100% - max(0px, calc(var(--panel-corner-tr) - 1px))) 0,
-    100% max(0px, calc(var(--panel-corner-tr) - 1px)),
-    100% calc(100% - max(0px, calc(var(--panel-corner-br) - 1px))),
-    calc(100% - max(0px, calc(var(--panel-corner-br) - 1px))) 100%,
-    max(0px, calc(var(--panel-corner-bl) - 1px)) 100%,
-    0 calc(100% - max(0px, calc(var(--panel-corner-bl) - 1px))),
-    0 max(0px, calc(var(--panel-corner-tl) - 1px))
-  );
+     The two polygons are therefore declared on the elements that clip — `.panel` and
+     `.panel__header` in `main.css` — where the depths a skin sets on the page region are visible.
+     They are still written once each. */
 
   /* A control: the same diagonal shape at 7px, because a control is not the size of a panel. */
   --corner-control: polygon(

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -293,38 +293,77 @@ describe('elevation and corners', () => {
   });
 
   it('holds exactly three corner treatments', () => {
-    // Three is a cap, not a count. A component picks from these and a skin picks between cut,
-    // bevelled and square from the same vocabulary; a fourth is what the rule exists to prevent.
-    const corners = ['--notch', '--corner-control', '--corner-nav'];
+    // Three is a cap on what a *component* may pick from, and #120 left it there while opening the
+    // panel's own corner to a skin: the shape is still one polygon, and what a genre moves is the
+    // depth at each of its four corners.
+    const corners = ['--panel-corner', '--corner-control', '--corner-nav'];
 
     for (const corner of corners) {
       expect(tokens.get(corner), `${corner} is a clip-path polygon`).toMatch(/^polygon\(/);
     }
 
-    // `--corner-control-inner` and `--notch-inner` are those treatments a second time, not two
-    // more treatments: a clipped border is shaved at the diagonals, so a button and a panel each
-    // paint their edge as a box and cover all but a pixel of it with a liner cut to the same
+    // `--corner-control-inner` and `--panel-corner-inner` are those treatments a second time, not
+    // two more treatments: a clipped border is shaved at the diagonals, so a button and a panel
+    // each paint their edge as a box and cover all but a pixel of it with a liner cut to the same
     // shape. The cap counts treatments, and there are still three; a genuinely new shape would
     // not be named after one of these.
     const declared = [...tokens.keys()].filter(
-      (name) => name.startsWith('--notch') || name.startsWith('--corner-'),
+      (name) => name.startsWith('--panel-corner') || name.startsWith('--corner-'),
     );
-    expect(declared.sort()).toEqual([...corners, '--corner-control-inner', '--notch-inner'].sort());
+    expect(declared.sort()).toEqual(
+      [
+        ...corners,
+        '--corner-control-inner',
+        '--panel-corner-inner',
+        '--panel-corner-tl',
+        '--panel-corner-tr',
+        '--panel-corner-br',
+        '--panel-corner-bl',
+      ].sort(),
+    );
+  });
+
+  it('writes the panel polygon once, from four depths', () => {
+    // docs/visual-design.md, "A skin sets four depths, and the polygon stays in the base". The
+    // whole mechanism is that a skin has numbers to move and no shape to write, which only holds
+    // while the shape is built from the depths rather than beside them.
+    const depths = {
+      '--panel-corner-tl': '0px',
+      '--panel-corner-tr': '9px',
+      '--panel-corner-br': '0px',
+      '--panel-corner-bl': '9px',
+    };
+
+    for (const [name, value] of Object.entries(depths)) {
+      expect(tokens.get(name), `${name} is not the base cut`).toBe(value);
+      expect(tokens.get('--panel-corner'), `${name} is not read by the polygon`).toContain(
+        `var(${name})`,
+      );
+      // The liner is the same four depths a pixel shallower, so the two outlines stay parallel at
+      // whatever depth a genre picks. `max()` because 0px - 1px is -1px, and a negative coordinate
+      // would pull the liner's outline outside the box it is meant to sit inside.
+      expect(tokens.get('--panel-corner-inner'), `${name} is not read by the liner`).toContain(
+        `max(0px, calc(var(${name}) - 1px))`,
+      );
+    }
   });
 
   it('cuts the nav corner on one edge and the other two diagonally', () => {
     // The three shapes are easy to confuse and impossible to tell apart by name. The nav item is
     // square on its flush edge and cut at both corners of the inner one; the notch and the
     // control cut diagonally opposite corners, at 9px and 7px respectively.
-    expect(tokens.get('--notch')).toContain('9px');
+    expect(tokens.get('--panel-corner-tr')).toBe('9px');
     expect(tokens.get('--corner-control')).toContain('7px');
     // A liner sits 1px inside on every edge, so its cut is 1px shallower — that is what keeps the
-    // two diagonals parallel instead of converging. Both liners, at both scales.
+    // two diagonals parallel instead of converging. The panel's is arithmetic now rather than a
+    // second polygon, so only the control's is a literal.
     expect(tokens.get('--corner-control-inner')).toContain('6px');
-    expect(tokens.get('--notch-inner')).toContain('8px');
 
     expect(tokens.get('--corner-nav')).toContain('100% calc(100% - 7px)');
-    expect(tokens.get('--notch')).not.toContain('100% calc(100% - 9px)');
+    // The base panel is square at the two corners the notch does not take, which is what makes it
+    // a diagonal pair rather than a bevel.
+    expect(tokens.get('--panel-corner-tl')).toBe('0px');
+    expect(tokens.get('--panel-corner-br')).toBe('0px');
   });
 });
 
@@ -723,13 +762,20 @@ describe('the panel language', () => {
       expect(css).not.toMatch(/\.(badge|chip)(--)?[\w-]*\s*\{/);
       expect(css).not.toContain('--halo');
       expect(css).not.toContain('--lift');
-      expect(css).not.toContain('--notch');
+
+      // The corner is the one geometry a skin may move, and it moves it as four numbers. The
+      // polygon itself, and the liner's, stay in `tokens.css` where a skin cannot reach them —
+      // which is the line between setting a depth and redrawing the panel.
+      expect(css, `${name} redeclares the panel polygon`).not.toMatch(
+        /--panel-corner(-inner)?\s*:/,
+      );
+      expect(css, `${name} draws a shape of its own`).not.toContain('polygon(');
     },
   );
 
-  // The skins converted so far. `scifi.css` and `cyberpunk.css` join as #120 and #121 land; the
-  // list is meant only to grow, and a skin that is on it is held to the whole contract.
-  const CONVERTED_SKINS = ['fantasy.css'];
+  // The skins converted so far. `cyberpunk.css` joins as #121 lands; the list is meant only to
+  // grow, and a skin that is on it is held to the whole contract.
+  const CONVERTED_SKINS = ['fantasy.css', 'scifi.css'];
 
   it.each(CONVERTED_SKINS)('writes no colour value of its own in %s', (name) => {
     // The exemption granted when the controls landed — "their heading effects are full of hexes and
@@ -780,6 +826,48 @@ describe('the panel language', () => {
         'prefers-reduced-motion: reduce',
       );
     }
+  });
+
+  /** The four corner depths a skin file declares, in `tl tr br bl` order, or `[]` if it sets none. */
+  function cornerDepths(name: string): string[] {
+    const css = withoutComments(readFileSync(join(STYLES_DIR, name), 'utf8'));
+    const corners = ['tl', 'tr', 'br', 'bl'];
+
+    return corners
+      .map((corner) => new RegExp(`--panel-corner-${corner}\\s*:\\s*([^;]+);`).exec(css)?.[1])
+      .filter((depth): depth is string => depth !== undefined)
+      .map((depth) => depth.trim());
+  }
+
+  it.each(CONVERTED_SKINS)('cuts no corner deeper than the padding in %s', (name) => {
+    // `--s5` is 12px and it is the panel's padding. A corner cut deeper than the padding stops
+    // shaping the plate and starts taking the first character of the first line inside it, which
+    // is the one way a corner can cost something the design refuses to spend.
+    const depths = cornerDepths(name);
+    expect(depths, `${name} sets some corners and not others`).toHaveLength(4);
+
+    for (const depth of depths) {
+      const pixels = Number.parseFloat(depth);
+      expect(Number.isNaN(pixels), `${name} writes a corner depth that is not a length`).toBe(
+        false,
+      );
+      expect(pixels, `${name} cuts deeper than --s5`).toBeLessThanOrEqual(12);
+    }
+  });
+
+  it('gives every genre a shape of its own', () => {
+    // "A shape is a genre's, or it is furniture." The cap on corner treatments used to be three;
+    // #120 replaced it with one shape per genre, and this is the half of that rule no source sweep
+    // of a single file could catch — it is a statement about the skins as a set. Reading the files
+    // rather than a list is what covers a fifth genre on the day its file appears.
+    const base = ['0px', '9px', '0px', '9px'];
+    const shapes = new Map(CONVERTED_SKINS.map((name) => [name, cornerDepths(name).join(' ')]));
+
+    for (const [name, shape] of shapes) {
+      expect(shape, `${name} wears the base's own corner`).not.toBe(base.join(' '));
+    }
+
+    expect(new Set(shapes.values()).size, 'two genres wear the same shape').toBe(shapes.size);
   });
 });
 

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -296,11 +296,17 @@ describe('elevation and corners', () => {
     // Three is a cap on what a *component* may pick from, and #120 left it there while opening the
     // panel's own corner to a skin: the shape is still one polygon, and what a genre moves is the
     // depth at each of its four corners.
-    const corners = ['--panel-corner', '--corner-control', '--corner-nav'];
+    const corners = ['--corner-control', '--corner-nav'];
 
     for (const corner of corners) {
       expect(tokens.get(corner), `${corner} is a clip-path polygon`).toMatch(/^polygon\(/);
     }
+
+    // The panel's is the third, and it is the one that is not here: a `var()` inside a custom
+    // property resolves where the property is declared, so a `--panel-corner` on `:root` would
+    // hand every panel the base depths however a skin set them. It is declared on `.panel` and
+    // `.panel__header` in `main.css` instead — see the test below, and tokens.css's own comment.
+    expect(tokens.get('--panel-corner'), 'the panel polygon is back on :root').toBeUndefined();
 
     // `--corner-control-inner` and `--panel-corner-inner` are those treatments a second time, not
     // two more treatments: a clipped border is shaved at the diagonals, so a button and a panel
@@ -314,7 +320,6 @@ describe('elevation and corners', () => {
       [
         ...corners,
         '--corner-control-inner',
-        '--panel-corner-inner',
         '--panel-corner-tl',
         '--panel-corner-tr',
         '--panel-corner-br',
@@ -334,18 +339,26 @@ describe('elevation and corners', () => {
       '--panel-corner-bl': '9px',
     };
 
+    const panels = readFileSync(join(STYLES_DIR, 'main.css'), 'utf8');
+    const polygon = /--panel-corner:\s*polygon\(([^;]+)\);/.exec(panels)?.[1] ?? '';
+    const liner = /--panel-corner-inner:\s*polygon\(([^;]+)\);/.exec(panels)?.[1] ?? '';
+
     for (const [name, value] of Object.entries(depths)) {
       expect(tokens.get(name), `${name} is not the base cut`).toBe(value);
-      expect(tokens.get('--panel-corner'), `${name} is not read by the polygon`).toContain(
-        `var(${name})`,
-      );
+      expect(polygon, `${name} is not read by the polygon`).toContain(`var(${name})`);
       // The liner is the same four depths a pixel shallower, so the two outlines stay parallel at
       // whatever depth a genre picks. `max()` because 0px - 1px is -1px, and a negative coordinate
       // would pull the liner's outline outside the box it is meant to sit inside.
-      expect(tokens.get('--panel-corner-inner'), `${name} is not read by the liner`).toContain(
+      expect(liner, `${name} is not read by the liner`).toContain(
         `max(0px, calc(var(${name}) - 1px))`,
       );
     }
+
+    // Declared on the elements that clip, and only those — anywhere higher and the depths resolve
+    // against that ancestor rather than against the panel, which is the bug this test exists for.
+    expect(panels, 'the panel polygon moved off the clipping elements').toContain(
+      '.panel,\n.panel__header {',
+    );
   });
 
   it('cuts the nav corner on one edge and the other two diagonally', () => {


### PR DESCRIPTION
Closes #120.

The genre moves off the type and onto the panel. `scifi.css` styled `h1`–`h6` and only `h1`–`h6` — a cyan glow pulsing on a 3s loop over text somebody was reading, in a hex no token named. It is now a panel skin: a cool plate, a plasma keyline, cyan ink and one scan.

Design: [`docs/visual-design.md`, "The sci-fi skin, and the corner every genre gets"](https://github.com/ironarachne/ironarachne/blob/issue-120-scifi-skin/docs/visual-design.md#the-sci-fi-skin-and-the-corner-every-genre-gets), approved before implementation.

### The skin, measured

| | Value | Measured |
| --- | --- | --- |
| `--panel-surface` | charcoal cooled 16% toward plasma blue | `rgb(33 47 69)`, luminance 0.0276 against slate's 0.0281 — every ink role a tenth better than on a base panel |
| `--panel-edge` | plasma blue 40% into granite | 2.07:1 on that surface; undiluted plasma is 3.83:1 and outlines a box rather than identifying a plate |
| `--accent`, headings | `var(--cyan)` | 7.5:1 |

Plasma blue is 3.8:1 on the surface it makes, so it is a fill and an edge and never a sentence — the same class of colour as crimson and emerald. That forces the split: the darker hue is the plate, the brighter one is every word the skin colours. `--accent-quiet` stays gold, because that is the message tone and a tone outranks a genre.

`--halo` is mixed from `--accent`, so the focus halo is cyan under this skin. Permitted: its spread, its opacity and the `--focus` ring are untouched, and pinning the halo to green while everything it surrounds is cyan would be the skin leaking out of the accent role rather than staying inside it.

### The corner, which is the part that is not just another skin

Decision 2 has always let a skin set a corner and elevation has always named three treatments, but only the cut existed as a polygon and no skin had a way to ask for another. **Every genre now gets a shape**, so the panel's polygon is written once from a depth at each of its four corners and a skin sets the four depths. That replaces the "three treatments" cap with a bound that has a reason behind it: one shape per genre, none deeper than `--s5` (the padding — deeper starts taking the first character of the first line), no two alike.

| Genre | tl / tr / br / bl | Reads as |
| --- | --- | --- |
| Base | 0 / 9 / 0 / 9 | the app's neutral plate |
| Fantasy | 0 / 0 / 12 / 12 | a shield's foot |
| Sci-fi | 9 / 9 / 9 / 9 | a machined plate |
| Cyberpunk, horror | — | reserved for #121 and #122 |

Two consequences worth review attention:

- **Fantasy takes a shield's foot**, reversing #119's "corner: unchanged". Defensible while it was the only skin; with four, it is the one skinned panel shaped like an unskinned one.
- **`.panel__header` sets the depths back to the base cut**, so a genre shapes the plate and not the furniture inside it.

### The bug the browser suite caught

The first cut declared the formula on `:root`, and a sci-fi panel came out with the right surface and the base's corner. A `var()` inside a custom property is substituted where that property is **declared**, not where it is used — the same shape as the #119 bug that put `--panel-surface` on `.panel` and made the fantasy skin inert. The polygons now live on `.panel, .panel__header`, where the depths a skin sets on the page region are visible. The design document said substitution was lazy; it is corrected, and the correction is recorded as measured rather than reasoned.

### Enforcement

`tokens.test.ts`: `scifi.css` joins the hex, type-ramp and one-effect sweeps, leaving `cyberpunk.css` as the last exemption. New: a skin may not declare `--panel-corner`/`-inner` or contain `polygon(`; no depth exceeds `--s5`; and **no two genres wear the same four depths**, read from the files rather than a list, so a fifth genre is covered the day its file appears.

`e2e/genre_skin.spec.ts`: a sci-fi case beside the fantasy one — the skin reaches the panel, the surface reads cool, its luminance is no higher than a base panel's, the clip differs and **the bounding box does not**. Plus a reduced-motion case: the scan stops, the scanlines stay, so the genre survives the switch instead of falling back to a plain fill.

### Checks

`npm run verify:all` green — 4443 unit tests, 438 Playwright tests, `svelte-check` 0 errors, coverage gate 98/98 with no baselined debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2wzaP74ffGJjghzcabKeT