### PR TITLE
Rewrite the cyberpunk skin as a panel skin, for #121

### DIFF
--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -99,9 +99,33 @@ between 1.3:1 and 2.2:1 on its own surface — and settles that a skin setting `
 halo's hue with it, which is permitted because the halo's geometry, its opacity and the `--focus`
 ring are all untouched.
 
-Awaiting approval, unlike the amendments above it, which are built: #120 is `needs-design`, and the
-corner mechanism, the keyline band and the halo consequence are what CLAUDE.md's review gate asks a
-human to approve before implementation starts.
+Approved and built. One claim in it was wrong and is corrected where it stands: the formula was
+put on `:root`, where a `var()` inside a custom property resolves against `:root` rather than against
+the panel, and the browser suite caught a sci-fi panel wearing the right surface and the base's
+corner.
+
+**Amended 2026-08-30 by [#121](https://github.com/ironarachne/ironarachne/issues/121)**, which adds
+[the cyberpunk skin, and what a keyline is measured against](#the-cyberpunk-skin-and-what-a-keyline-is-measured-against).
+Two things in it are not another skin. The **flicker does not survive**: `cyberpunk.css` runs two
+animations at once on type, with hard cuts 40ms apart, and it is the only thing in the app that goes
+near WCAG 2.3.1's three flashes per second — so the genre keeps the idea at 0.04Hz on a hairline, and
+the document gains a floor on how fast a skin may animate at all. And the **keyline band is
+corrected**: #120 measured one surface and stated the rule as a ratio against a surface the skin
+itself sets, which asks a near-black genre to wear a grey keyline. It is a register in the keyline's
+own luminance now, 0.055 to 0.111, and every existing skin is already inside it — with one exception
+the same section adds, on area rather than taste: a **corner mark** covering under a fifth of the
+perimeter may go to full brightness, which is what lets this genre wear undiluted acid and magenta
+without putting a bright wire around every panel on the bench.
+
+Drawn against [Cyberpunk 2077's screen language](https://designbycurio.com/learn/cyberpunk-2077-screen),
+which supplies the L-bracket corner mark, the near-black ground and the knife-edge corner — and three
+techniques the contract refuses, listed where they are refused rather than dropped silently. It also
+revises #120's reserved shape for this genre from a 12px slash to four square corners: a cut corner
+truncates the bracket that is meant to sit in it.
+
+Awaiting approval, unlike the amendments above it, which are built: #121 is `needs-design`, and the
+motion floor, the corrected register and the surface that spends its own separation are what
+CLAUDE.md's review gate asks a human to approve before implementation starts.
 
 **Amended 2026-08-30, in review of the above:** every genre gets a panel shape of its own, which
 replaces the "three corner treatments" cap rather than extending it. The panel's polygon is written
@@ -2191,13 +2215,13 @@ and to the skin above it, and the control and nav treatments are untouched by an
 
 ### The four shapes, and why each is its genre's
 
-| Genre         | tl   | tr   | br   | bl   | Reads as                                                                     |
-| ------------- | ---- | ---- | ---- | ---- | ---------------------------------------------------------------------------- |
-| _Base_        | 0    | 9px  | 0    | 9px  | The app's own plate. Neutral, and what a projectless page keeps              |
-| **Fantasy**   | 0    | 0    | 12px | 12px | A shield's foot: square shoulders, both bottom corners taken deep            |
-| **Sci-fi**    | 9px  | 9px  | 9px  | 9px  | A machined plate, chamfered on every edge by the same amount                 |
-| **Cyberpunk** | 12px | 0    | 0    | 0    | Three hard corners and one deliberate slash — signage, cut once              |
-| **Horror**    | 3px  | 11px | 5px  | 8px  | Nothing agrees with anything. Wrong in a way the eye catches and cannot name |
+| Genre         | tl  | tr   | br   | bl   | Reads as                                                                                    |
+| ------------- | --- | ---- | ---- | ---- | ------------------------------------------------------------------------------------------- |
+| _Base_        | 0   | 9px  | 0    | 9px  | The app's own plate. Neutral, and what a projectless page keeps                             |
+| **Fantasy**   | 0   | 0    | 12px | 12px | A shield's foot: square shoulders, both bottom corners taken deep                           |
+| **Sci-fi**    | 9px | 9px  | 9px  | 9px  | A machined plate, chamfered on every edge by the same amount                                |
+| **Cyberpunk** | 0   | 0    | 0    | 0    | Four knife edges. Revised from a 12px slash by #121; its corner marks sit where the cut was |
+| **Horror**    | 3px | 11px | 5px  | 8px  | Nothing agrees with anything. Wrong in a way the eye catches and cannot name                |
 
 Sci-fi's is the one this issue builds, and it is the plainest of the four on purpose: the genre's
 argument is made by a cool plate, a plasma keyline and a scan, and a corner that shouted over them
@@ -2295,6 +2319,13 @@ That gives the skins a band rather than a taste: **a skin's keyline measures bet
 2.2:1 against its own surface.** #121's "acid keyline with a magenta edge" now has a number to hit
 instead of an argument to have.
 
+**Corrected by [#121](#the-band-was-measured-on-one-surface-and-it-does-not-generalise):** that band
+is measured against a surface the skin itself sets, so it punishes a dark genre for being dark. The
+rule is now a register in the keyline's own luminance — 0.055 to 0.111, `--border`'s to roughly twice
+it — and 1.3:1 to 2.2:1 is what that register produces _on a slate-luminance surface_, which is what
+made it look like the rule. Sci-fi's keyline is unchanged either way: 0.1107, at the top of the
+register.
+
 ### The accent moves, and the halo follows it
 
 Sci-fi is the first skin to set `--accent`, which fantasy did not need to: gold was already the
@@ -2340,7 +2371,7 @@ surface, and a scanline grid floating on the page is what a wider selector would
 | Property          | Value                                                         | Measured                               |
 | ----------------- | ------------------------------------------------------------- | -------------------------------------- |
 | `--panel-surface` | `color-mix(in srgb, var(--plasma-blue) 16%, var(--charcoal))` | `rgb(33 47 69)`; no lighter than slate |
-| `--panel-edge`    | `color-mix(in srgb, var(--plasma-blue) 40%, var(--granite))`  | 2.07:1 on that surface                 |
+| `--panel-edge`    | `color-mix(in srgb, var(--plasma-blue) 40%, var(--granite))`  | luminance 0.1107, top of the register  |
 | Corner depths     | `9px` at all four corners                                     | A machined plate; none past `--s5`     |
 | `--accent`        | `var(--cyan)`                                                 | 7.5:1; the halo follows the hue        |
 | `--accent-quiet`  | **Unchanged.** Gold is the message tone, not the genre's      | —                                      |
@@ -2383,6 +2414,242 @@ And two in the browser, because both are computed relationships:
   bounding box does not. That is the corner rule's whole claim, it is invisible to a source sweep,
   and it is what a future skin reaching for geometry would break. The same assertion covers the
   fantasy shield, since both are the same two lines of mechanism.
+
+## The cyberpunk skin, and what a keyline is measured against
+
+[#121](https://github.com/ironarachne/ironarachne/issues/121) is the third skin and the last file on
+the hex exemption, so it should be the cheap one: the contract is settled, the corner mechanism
+exists, and two skins have filled the shape in. It is not, for two reasons. Its ambient effect is the
+one animation in this app that could plausibly hurt somebody, and its stated look — an inset black
+surface under an acid keyline — is the case that breaks the keyline rule #120 wrote after measuring
+exactly one surface.
+
+### The flicker does not survive, and that is the point
+
+`cyberpunk.css` runs **two** animations at once on `h1`–`h6`: `rapid-pulse-neon`, a 1.5s neon
+drop-shadow pulse, and `defective-led`, a 4s background jump with hard cuts at 10%, 11%, 40%, 41%,
+43% of the cycle. Both are on type. Decision 2 caps a skin at one ambient effect, so at least one of
+them was always going; what the numbers say is that neither survives in that form.
+
+The hard cuts in `defective-led` land in pairs 40ms apart — four transitions inside one 4s loop,
+with two of them separated by a single percent of the cycle. That is a **strobe on text somebody is
+reading**, and it is the only thing in the app that goes anywhere near
+[WCAG 2.3.1](https://www.w3.org/WAI/WCAG22/Understanding/three-flashes-or-below-threshold)'s three
+flashes per second. Removing it is a fix rather than a loss, and it is worth saying plainly in the
+document that this genre's charm was implemented as an accessibility hazard.
+
+**The idea survives; the rate does not.** A sign with a failing ballast is a legitimate thing for
+this genre to say, and it can be said once every twenty-four seconds instead of twice a second:
+
+- **One dip per 24s cycle**, lasting about 250ms — 0.04Hz where the threshold is 3Hz, and the
+  document states the figure so the next person changing it knows what the number is for.
+- **On a hairline, not on a field.** The thing that dips is a 1px lit edge on the panel surface, far
+  under the 25%-of-viewport area the general flash threshold is about, and nowhere near the type.
+- **Off under `prefers-reduced-motion: reduce`,** where the lit edge stays and only the dip goes —
+  the standard sci-fi set, and the reason the genre survives the switch.
+
+### The surface gives up its separation, and the keyline takes it over
+
+"Inset black" is the instruction, and taken literally it is measurable. The skin's surface is the
+app's own sunken fill given a violet cast — `color-mix(in srgb, var(--amethyst) 10%, var(--surface-inset))`,
+`rgb(30 26 45)`:
+
+| Measured against the cyberpunk surface | Figure | On a base panel |
+| -------------------------------------- | ------ | --------------- |
+| `--ink`                                | 15.3:1 | 12.2:1          |
+| `--ink-muted`                          | 8.0:1  | 6.3:1           |
+| `--ink-faint`                          | 5.8:1  | 4.6:1           |
+| `--magenta`, the accent                | 5.9:1  | —               |
+
+Every ink role is better here than anywhere else in the app, which is what going dark buys. What it
+costs is separation, and the cost is specific rather than vague:
+
+- **Against the page.** The surface is luminance 0.0121 where `--surface-page` is 0.0129 — 1.01:1.
+  A cyberpunk panel is not a plate raised off the page; it is a rectangle cut into it, told apart by
+  hue, by `--lift` and by its keyline rather than by being lighter.
+- **Against a control.** `--surface-inset` is 0.0091, so a text field's fill is 1.05:1 against the
+  panel it sits on where on a base panel it is 1.32:1. The fill stops doing the work.
+
+Neither is a reason to refuse the look, because neither was ever the mechanism. [The control
+vocabulary](#inputs-selects-and-checkboxes) says a control is raised off its surface by `--edge` or
+sunk into it by `--sink`, and both are shadows a skin may not touch; a panel is identified by its
+keyline and its corner, not by its fill. **What this genre does is spend those affordances rather
+than duplicate them** — which is exactly why its keyline has to be allowed to be louder than the
+one the other two skins wear.
+
+### The band was measured on one surface, and it does not generalise
+
+[#120](#the-keyline-is-louder-than-the-bases-and-stays-in-the-same-register) states the rule as
+**1.3:1 to 2.2:1 against a skin's own surface**. That was measured on a surface at slate's
+luminance, where it is correct and where it says the right thing. On this surface it says something
+absurd: to hit 2.2:1 against `rgb(30 26 45)`, an "acid" keyline has to be diluted to
+`rgb(70 86 81)` — a grey with a hint of green in it, no brighter than the base's granite, on the one
+genre whose entire visual argument is a lit edge.
+
+The rule was right about the thing it was protecting and wrong about the quantity, for the second
+time in this document — the same shape as [`--ink-faint`](#ink-faint-did-not-meet-its-own-target-on-any-panel-and-now-does),
+which was a true figure about the wrong surface. **A ratio against the skin's own surface is a
+measurement a skin can move by changing the surface**, so it punishes a dark genre for being dark
+and lets a light one off. Restated against something a skin does not control:
+
+> A keyline's own relative luminance sits between `--border`'s and roughly twice it — **0.055 to
+> 0.111** — which is the register every keyline in the app already occupies.
+
+| Keyline                                  | Luminance | On its own surface |
+| ---------------------------------------- | --------- | ------------------ |
+| Base — `--border`, granite               | 0.0555    | 1.35:1 on slate    |
+| Fantasy — `--border-strong`, tan         | 0.0823    | 1.70:1             |
+| Sci-fi — plasma blue 40% into granite    | 0.1107    | 2.07:1             |
+| **Cyberpunk — acid 15% into granite**    | 0.1031    | 2.46:1             |
+| **Cyberpunk — magenta 35% into granite** | 0.1067    | 2.52:1             |
+| Acid green, undiluted                    | 0.7954    | 13.6:1             |
+
+The 1.3–2.2:1 band becomes what it always was: the figure this register produces _on a
+slate-luminance surface_, useful as a sanity check and not as the rule. Cyberpunk's keyline is
+2.5:1 on its own surface and is **no brighter than sci-fi's** — it looks louder because the thing
+behind it is darker, which is the genre working as designed rather than a skin overreaching.
+
+Undiluted acid green stays out, and the register is why: at 0.795 it is fourteen times its own
+panel, on every panel on the bench at once. A neon hairline at that contrast is halation, not
+signage.
+
+### The keyline is four corner marks, not a hairline
+
+"Acid keyline with a magenta edge" reads like two keylines. It is neither, and the reference this
+skin was drawn against ([Cyberpunk 2077's screen
+language](https://designbycurio.com/learn/cyberpunk-2077-screen)) is what settles the shape: its
+signature compositional device is the **L-bracket corner mark** — partial borders at the corners
+rather than a continuous rectangle, borrowed from targeting reticles and satellite overlays, so a
+panel reads as monitored rather than merely framed. A full rectangle is reserved there for inputs and
+table cells, which is the app's own division stated in someone else's words: `--sink` and a border
+say "control", a keyline says "plate".
+
+The panel language already built the mechanism without meaning to. `--panel-edge` is painted as the
+**background** of the box the liner sits a pixel inside, so it takes layered gradients exactly as
+well as it takes a colour, and that 1px ring is where they land. Eight no-repeat layers — two arms at
+each corner, 18px along and 1px thick — leave the runs between them unpainted, and what shows through
+is the page.
+
+**Each mark is one acid arm and one magenta arm**: horizontals acid green, verticals magenta. That is
+the issue's "acid keyline with a magenta edge" as one device rather than two, and it fixes the two
+hues in a relationship instead of blending them into a third that is neither.
+
+### A corner mark is not a keyline, and the register knows the difference
+
+Undiluted acid green is luminance 0.795 — fourteen times its own panel — and the register above
+exists to keep exactly that off a panel. It is on this one, and the rule bends on area rather than on
+taste:
+
+> A keyline that runs the **whole perimeter** stays in the register, 0.055 to 0.111. A **corner
+> mark**, covering no more than a fifth of it, may go to full palette brightness.
+
+Both halves come from the same reasoning. Halation is a property of a long bright line and a
+wireframe is a property of a closed one; eight 18px arms are neither, and what the register protects
+is not at risk from them. On a 400px panel the marks total about 12% of the perimeter, and the fifth
+is a cap rather than a target.
+
+**Anything that declares `--panel-edge` on itself opts out of the marks**, and that is the existing
+precedence rather than a new rule: a tone, a `.panel--bare`, and the open project's own
+`.project-card--active` all set that property on the element, which beats a genre's inherited value.
+What is new is how visible it is. Under fantasy or sci-fi being outranked changed a keyline's
+colour; here it changes the device, so a toned notice and the open project's card wear a continuous
+edge among bracketed panels. Checked on the page rather than assumed, and it reads as the right
+answer: the one card that is not decoration is the one that is not bracketed.
+
+It is also what pays for the surface giving up its separation. A panel at 1.01:1 against the page has
+to state its boundary somewhere, and stating it brightly at four corners is a stronger signal than
+stating it dimly all the way round — the trade this genre is making, rather than the same rule being
+bent twice in the same direction.
+
+### Acid green is spoken for, so the accent is magenta
+
+The obvious accent for this genre is acid green, and it is the one hue the skin may not take.
+`--focus` **is** acid green — [decision 3](#3-focus-and-contrast-are-targets-not-assumptions) gives
+it to the focus ring and to nothing else — and `--halo` is mixed from `--accent`. A skin setting
+`--accent: var(--acid-green)` would produce a panel whose focus halo, focus ring and chips are all
+the same colour, which is the one place in the system where telling two things apart carries meaning.
+
+So `--accent: var(--magenta)`, at 5.9:1 on this surface, for the chips, the kickers, the figures and
+the panel headings; the halo follows the hue as [sci-fi settled](#the-accent-moves-and-the-halo-follows-it)
+that it may; and acid green appears in the keyline gradient and in the focus ring, where it means
+"the app is speaking" rather than "this is a cyberpunk project".
+
+`--accent-quiet` is unchanged, for the third time and the same reason: gold is the message tone, and
+a tone outranks a genre.
+
+### Three things in the reference a skin may not take
+
+The reference is a whole interface and this is a skin over somebody else's, so most of what makes
+that screen work is out of reach here — and naming which parts is more useful than quietly dropping
+them.
+
+- **Glow-based elevation.** It replaces the shadow ladder with emitted light: brighter means nearer.
+  The app's ladder is `--lift` and `--halo`, both fixed across genres precisely so two panels beside
+  each other sit at the same height, and a skin may touch neither. The genre gets its light in the
+  corner marks instead, which are a keyline and not an elevation.
+- **The typography.** A condensed all-caps display face over monospace data, uppercase by default and
+  tracked out. That is the type ramp, which is the first thing on the list a skin may never touch —
+  and it is the same instinct that put a shimmer on `h1`–`h6` in the first place.
+- **Density-first layout.** "Cyberpunk interfaces do not breathe." This one breathes: the space ramp
+  is one ramp so that two panels are the same height side by side, and a genre that tightened its
+  gutters would be a genre that changed the app's shape under the user.
+
+What survives the filter is exactly the three things decision 2 hands a skin — a surface, a keyline
+and one effect — which is a reasonable check that the contract is drawn in the right place. The
+genre is still legible without the other three, because the surface is nearly black, the marks are
+bright, and the corners are square.
+
+### The cyberpunk skin
+
+| Property          | Value                                                                   | Measured                             |
+| ----------------- | ----------------------------------------------------------------------- | ------------------------------------ |
+| `--panel-surface` | `color-mix(in srgb, var(--amethyst) 10%, var(--surface-inset))`         | `rgb(30 26 45)`, luminance 0.0121    |
+| `--panel-edge`    | Eight corner-mark arms: horizontals acid, verticals magenta, 18px × 1px | ~12% of the perimeter, so unmixed    |
+| Corner depths     | `0` / `0` / `0` / `0`                                                   | Four knife edges; the marks carry it |
+| `--accent`        | `var(--magenta)`                                                        | 5.9:1; acid is `--focus`'s           |
+| `--accent-quiet`  | **Unchanged.** Gold is the message tone                                 | —                                    |
+| Heading colour    | `var(--accent)`, scoped to headings inside a panel                      | 5.9:1, clears 4.5                    |
+| Ambient effect    | The marks dip for 250ms, once every 24s                                 | 0.04Hz against a 3Hz threshold       |
+
+**The corner revises what [#120 reserved](#the-four-shapes-and-why-each-is-its-genres)**, which was a
+single 12px slash at the top-left. The reference is unambiguous — "zero border radius throughout,
+every corner is a knife edge" — and a cut corner truncates the bracket that is meant to sit in it, so
+the two devices were fighting. Four square corners is still nobody else's shape, the base being
+`0/9/0/9`, and this is the one genre whose shape is an _absence_ of the app's cut: the marks say
+where the panel ends, so the corner does not have to.
+
+The ambient effect moves onto the marks with it, which is better than the lit edge it replaces — the
+thing that dips is the genre's signature element rather than a line invented to have something to
+dim. A bad ballast in the sign, once every twenty-four seconds.
+
+### What the cyberpunk skin enforces
+
+- **`cyberpunk.css` joins `CONVERTED_SKINS`, and the exemption list empties.** The hex sweep, the
+  type-ramp sweep, the one-effect cap, the depth cap and the distinctness rule all apply to every
+  skin file the app has, with nothing carried. That list was created to shrink and this is the last
+  entry.
+- **No skin animates faster than 20s.** This is the assertion #121 exists to leave behind: the cap on
+  the _number_ of effects never said anything about their rate, and a single 1.5s strobe would have
+  passed every check in this document. A genre's ambient motion is ambient — measured in tens of
+  seconds, like fantasy's 40s and sci-fi's 45s — and anything quicker is a state change, which is
+  `--motion-swift`'s business and not a skin's.
+- **`--focus`'s hue is not an accent.** No skin sets `--accent` to `var(--acid-green)`, swept across
+  the skin files. The focus ring and the thing being focused inside cannot be the same colour. Acid
+  in a corner mark is not that: a mark is at the panel's corner and a ring is around the control, so
+  the two are never the same object.
+
+And two in the browser, because both are computed:
+
+- **Every continuous keyline's luminance is inside the register**, read off the rendered panel for
+  each genre in turn — the only place a `color-mix()` resolves — replacing a rule that could
+  otherwise only be checked by hand. Cyberpunk answers the other half of it: its keyline layers are
+  `no-repeat` and their arms total under a fifth of the rendered perimeter, which is what earns them
+  full brightness. A skin that painted a bright edge all the way round would fail one test or the
+  other, whichever way it was written.
+- **An input on a cyberpunk panel still reads as sunken.** Its `--sink` shadow and its border are
+  present and non-zero. The fill separation is gone by design; this is the assertion that says what
+  is carrying the affordance instead, and it is the one thing about this skin a later change could
+  quietly break.
 
 ## Enforcement
 

--- a/e2e/genre_skin.spec.ts
+++ b/e2e/genre_skin.spec.ts
@@ -180,3 +180,114 @@ test.describe('the sci-fi skin', () => {
     expect(paint.image, 'the scanlines went with the scan').toContain('repeating-linear-gradient');
   });
 });
+
+test.describe('the cyberpunk skin', () => {
+  test('marks the corners rather than outlining the panel', async ({ page }) => {
+    await openProject(page);
+    const base = await panelShape(page);
+
+    await setGenre(page, 'cyberpunk');
+    const cyberpunk = await panelShape(page);
+
+    expect(cyberpunk.surface, 'the skin did not reach the panel surface').not.toEqual(base.surface);
+
+    // Darker than a base panel, which the skin rule requires, and darker than the page, which is
+    // what "inset black" means: this genre's panels are cut into the page rather than raised off
+    // it. docs/visual-design.md, "The surface gives up its separation".
+    expect(
+      luminance(cyberpunk.surface),
+      'a cyberpunk panel is lighter than a base panel',
+    ).toBeLessThanOrEqual(luminance(base.surface));
+
+    // Four knife edges, which is the shape it revised #120's reserved slash into. The clip is
+    // still a polygon — at zero depth it is the panel's own rectangle, so every coordinate is a
+    // corner of the box and nothing is cut off.
+    expect(cyberpunk.clip, 'the skin did not reach the corner').not.toEqual(base.clip);
+    expect(cyberpunk.clip, 'the corner is not square').toMatch(
+      /^polygon\((?:\s*(?:0px|100%) (?:0px|100%),?)+\)$/,
+    );
+    expect(cyberpunk.box, 'a skinned panel is not the size of a base panel').toEqual(base.box);
+  });
+
+  test('earns its brightness by covering a fifth of the perimeter at most', async ({ page }) => {
+    // The rule that lets this skin wear undiluted acid and magenta where the register would
+    // otherwise forbid them: a corner mark is not a keyline. Checked in the browser because it is a
+    // relationship between what the skin paints and how big the panel it painted on turned out to
+    // be — which no source sweep can see.
+    await openProject(page);
+    await setGenre(page, 'cyberpunk');
+
+    const keyline = await page
+      .locator('.panel')
+      .first()
+      .evaluate((element) => {
+        const computed = getComputedStyle(element);
+        const { width, height } = element.getBoundingClientRect();
+        return {
+          // Counted by gradient rather than by comma: each layer's own `rgb(…)` stops carry
+          // commas of their own, so splitting the string counts sixteen of eight.
+          layers: (computed.backgroundImage.match(/linear-gradient\(/g) ?? []).length,
+          repeat: computed.backgroundRepeat,
+          sizes: computed.backgroundSize,
+          perimeter: 2 * (width + height),
+        };
+      });
+
+    // Eight layers: two arms at each of four corners.
+    expect(keyline.layers, 'the keyline is not painted as corner marks').toBe(8);
+    // Every layer, not just some: one repeating layer would run an arm the length of the panel and
+    // make the whole argument for full brightness untrue.
+    expect(
+      keyline.repeat.split(',').map((value) => value.trim()),
+      'a mark repeats, which would make it a hairline',
+    ).toEqual(Array.from({ length: 8 }, () => 'no-repeat'));
+
+    // Every arm's long side, totalled, against the perimeter it sits on.
+    const arms = keyline.sizes
+      .split(',')
+      .map((size) => Math.max(...size.trim().split(/\s+/).map(Number.parseFloat)));
+    const painted = arms.reduce((total, arm) => total + arm, 0);
+
+    expect(painted, 'the marks cover more than a fifth of the perimeter').toBeLessThanOrEqual(
+      keyline.perimeter / 5,
+    );
+  });
+
+  test('keeps a control readable on a surface that gave up its fill', async ({ page }) => {
+    // The one thing about this skin a later change could quietly break. A cyberpunk panel is 1.05:1
+    // against `--surface-inset`, so a control's fill no longer separates it from the panel — what
+    // says "sunken" is `--sink` and the border, both base-system and both untouchable by a skin.
+    await openProject(page);
+    await setGenre(page, 'cyberpunk');
+    await projectCard(page, 'Ashfall').getByRole('button', { name: 'Rename' }).click();
+
+    const field = await editingCard(page)
+      .getByLabel('Genre')
+      .evaluate((element) => {
+        const computed = getComputedStyle(element);
+        return { shadow: computed.boxShadow, border: computed.borderTopWidth };
+      });
+
+    expect(field.shadow, 'the control lost the shadow that says it is sunken').not.toBe('none');
+    expect(Number.parseFloat(field.border), 'the control lost its border').toBeGreaterThan(0);
+  });
+
+  test('keeps its marks when motion is switched off', async ({ page }) => {
+    // The flicker is the whole reason #121 needed deciding, and the reduced-motion state is where
+    // that decision shows: the fault goes, the marks stay, and the genre survives the switch.
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await openProject(page);
+    await setGenre(page, 'cyberpunk');
+
+    const paint = await page
+      .locator('.panel')
+      .first()
+      .evaluate((element) => ({
+        animation: getComputedStyle(element).animationName,
+        image: getComputedStyle(element).backgroundImage,
+      }));
+
+    expect(paint.animation, 'the ballast still runs under reduced motion').toBe('none');
+    expect(paint.image, 'the corner marks went with the fault').toContain('linear-gradient');
+  });
+});

--- a/src/lib/styles/cyberpunk.css
+++ b/src/lib/styles/cyberpunk.css
@@ -1,71 +1,126 @@
-@keyframes rapid-pulse-neon {
-  0%,
-  100% {
-    filter: drop-shadow(0 0 5px var(--acid-green)) drop-shadow(0 0 10px var(--acid-green));
-  }
-  50% {
-    filter: drop-shadow(0 0 2px var(--acid-green)) drop-shadow(0 0 4px var(--acid-green));
-  }
-}
+/* The cyberpunk skin: a panel skin over the base system, and nothing more.
+ *
+ * See docs/visual-design.md, "The cyberpunk skin, and what a keyline is measured against". Before
+ * #121 this file styled `h1`-`h6` and only `h1`-`h6`, with *two* animations at once: a 1.5s neon
+ * pulse and a 4s LED fault whose hard cuts landed 40ms apart. That was a strobe on text somebody
+ * was reading, and the only thing in the app that went anywhere near WCAG 2.3.1's three flashes
+ * per second. The genre keeps the idea and loses the rate.
+ *
+ * Drawn against Cyberpunk 2077's screen language, which supplies the L-bracket corner mark, the
+ * near-black ground and the knife-edge corner. Three of its devices are refused because the
+ * contract refuses them — glow-based elevation is `--lift` and `--halo`, the condensed-caps-over-
+ * monospace type is the type ramp, and density-first layout is the space ramp. What is left is a
+ * surface, a keyline and one effect, which is exactly what decision 2 hands a skin.
+ */
 
-@keyframes defective-led {
+/* The one ambient effect: a bad ballast in the sign. Every mark drops out together for 250ms once
+   in twenty-four seconds — 0.04Hz, against a 3Hz threshold, on eight hairlines rather than a field.
+   The size list is the eight layers of `--panel-edge` below, in the same order, which is what makes
+   this a dip in the marks rather than a change to them. */
+@keyframes cyberpunk-ballast {
   0%,
-  10%,
-  12%,
-  40%,
-  42%,
-  44%,
-  80%,
-  100% {
-    background-position: 0% 0%;
+  96.9%,
+  99.9% {
+    background-size:
+      18px 1px,
+      1px 18px,
+      18px 1px,
+      1px 18px,
+      18px 1px,
+      1px 18px,
+      18px 1px,
+      1px 18px;
   }
-  11%,
-  41%,
-  43% {
-    background-position: 100% 0%;
+  97%,
+  99.8% {
+    background-size:
+      0 0,
+      0 0,
+      0 0,
+      0 0,
+      0 0,
+      0 0,
+      0 0,
+      0 0;
   }
 }
 
 [data-genre='cyberpunk'] {
-  & h1,
-  & h2,
-  & h3,
-  & h4,
-  & h5,
-  & h6 {
-    /* Base broken/dim state for dark letters */
-    color: transparent;
+  /* The app's own sunken fill, given a violet cast. "Inset black" is the instruction and this is as
+     black as the palette goes: `brand/colors.css` says pure #000 is never used, so the genre gets
+     charcoal-into-black rather than black.
 
-    /* Active bright neon linear gradient map with "dead" spots */
-    background-image: linear-gradient(
-      90deg,
-      #d8f6b0 0%,
-      #d8f6b0 15%,
-      rgba(216, 246, 176, 0.2) 15%,
-      rgba(216, 246, 176, 0.2) 20%,
-      #d8f6b0 20%,
-      #d8f6b0 45%,
-      rgba(216, 246, 176, 0.2) 45%,
-      rgba(216, 246, 176, 0.2) 50%,
-      #d8f6b0 50%,
-      #d8f6b0 75%,
-      rgba(216, 246, 176, 0.2) 75%,
-      rgba(216, 246, 176, 0.2) 85%,
-      #d8f6b0 85%,
-      #d8f6b0 100%
-    );
-    background-size: 200% 100%;
-    -webkit-background-clip: text;
-    background-clip: text;
+     Every ink role is better here than anywhere else in the app — 15.3:1, 8.0:1 and 5.8:1 against
+     12.2, 6.3 and 4.6 on a base panel — which is what going dark buys. What it costs is separation:
+     1.01:1 against the page and 1.05:1 against a control's own fill, where a base panel is 1.32:1.
+     Neither was ever the mechanism. A control is raised by `--edge` or sunk by `--sink`, and a panel
+     is identified by its keyline and its corner; this genre spends those affordances rather than
+     duplicating them, which is why its keyline is allowed to be the loudest in the app. */
+  --panel-surface: color-mix(in srgb, var(--amethyst) 10%, var(--surface-inset));
 
-    /* Rapid pulsing glow + shifting background for broken letters */
-    animation:
-      rapid-pulse-neon 1.5s infinite ease-in-out,
-      defective-led 4s infinite;
+  /* Four L-bracket corner marks, not a hairline. `--panel-edge` is painted as the *background* of
+     the box the liner sits a pixel inside, so it takes layered gradients as well as it takes a
+     colour, and that 1px ring is where they land. Eight no-repeat layers — two arms per corner,
+     18px along and 1px thick — leave the runs between them unpainted, and what shows through is the
+     page.
+
+     Horizontals acid, verticals magenta: the issue's "acid keyline with a magenta edge" as one
+     device rather than two. Undiluted, which the register above a panel would otherwise forbid at
+     luminance 0.795 — a corner mark covering under a fifth of the perimeter is exempt, because
+     halation is a property of a long bright line and a wireframe of a closed one, and eight 18px
+     arms are neither. On a 400px panel they total about 12%. */
+  --panel-edge:
+    linear-gradient(var(--acid-green), var(--acid-green)) left top / 18px 1px no-repeat,
+    linear-gradient(var(--magenta), var(--magenta)) left top / 1px 18px no-repeat,
+    linear-gradient(var(--acid-green), var(--acid-green)) right top / 18px 1px no-repeat,
+    linear-gradient(var(--magenta), var(--magenta)) right top / 1px 18px no-repeat,
+    linear-gradient(var(--acid-green), var(--acid-green)) right bottom / 18px 1px no-repeat,
+    linear-gradient(var(--magenta), var(--magenta)) right bottom / 1px 18px no-repeat,
+    linear-gradient(var(--acid-green), var(--acid-green)) left bottom / 18px 1px no-repeat,
+    linear-gradient(var(--magenta), var(--magenta)) left bottom / 1px 18px no-repeat;
+
+  /* Four knife edges. This revises the 12px slash #120 reserved for the genre: a cut corner
+     truncates the bracket that is meant to sit in it, so the two devices were fighting. Square is
+     still nobody else's shape — the base is 0/9/0/9 — and it is the one genre whose shape is an
+     absence of the app's cut, because the marks say where the panel ends. */
+  --panel-corner-tl: 0px;
+  --panel-corner-tr: 0px;
+  --panel-corner-br: 0px;
+  --panel-corner-bl: 0px;
+
+  /* Magenta, at 5.9:1 on the surface above, and **not** acid green. `--focus` is acid green and
+     `--halo` is mixed from `--accent`, so a skin taking acid for its accent would hand a panel a
+     focus halo, a focus ring and a set of chips in one colour — in the one place in the system
+     where telling two things apart carries meaning. Acid appears in the corner marks instead, where
+     it is a keyline at the panel's corner and never a ring around a control.
+
+     No `--accent-quiet` override, for the third time and the same reason: gold is the message tone,
+     and a tone outranks a genre. */
+  --accent: var(--magenta);
+}
+
+/* The display ink. Magenta headings inside a panel, at 5.9:1 on the surface above — a colour, which
+   a skin may set, and not a size or a face, which it may not. Scoped to the panel because that is
+   what a skin dresses: a heading on the bare page belongs to the type ramp. */
+[data-genre='cyberpunk'] .panel .panel__title,
+[data-genre='cyberpunk'] .panel h2,
+[data-genre='cyberpunk'] .panel h3,
+[data-genre='cyberpunk'] .panel h4 {
+  color: var(--accent);
+}
+
+/* The dip, on the element that paints the marks. `.panel:not(.panel--bare)` because a bare panel
+   sets `--panel-edge: none` and has no marks to dim — an animation there would be a keyframe
+   running against nothing. */
+[data-genre='cyberpunk'] .panel:not(.panel--bare) {
+  animation: cyberpunk-ballast 24s steps(1, end) infinite;
+}
+
+/* Decision 2 caps ambient motion at one effect per skin and turns it off here. The marks stay and
+   only the fault goes, which is the same standard the sci-fi scanlines set: the genre survives the
+   switch rather than falling back to a plain fill. */
+@media (prefers-reduced-motion: reduce) {
+  [data-genre='cyberpunk'] .panel:not(.panel--bare) {
+    animation: none;
   }
-
-  /* No `button` rule. A skin may set a surface, a keyline, a corner, an accent hue and one
-     ambient effect; control geometry is not on that list, and a skin's copy of the old gradient
-     would outrank the control system wherever a genre is applied. See docs/visual-design.md,
-     decision 2 and "What this leaves to the skins". */
 }

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -786,9 +786,10 @@ describe('the panel language', () => {
     },
   );
 
-  // The skins converted so far. `cyberpunk.css` joins as #121 lands; the list is meant only to
-  // grow, and a skin that is on it is held to the whole contract.
-  const CONVERTED_SKINS = ['fantasy.css', 'scifi.css'];
+  // Every skin the app has. The list was created because the skins converted one issue at a time
+  // and the ones that had not were exempt from the sweeps; #121 is the last of them, so there is
+  // nothing carried and nothing left to exempt.
+  const CONVERTED_SKINS = ['fantasy.css', 'scifi.css', 'cyberpunk.css'];
 
   it.each(CONVERTED_SKINS)('writes no colour value of its own in %s', (name) => {
     // The exemption granted when the controls landed — "their heading effects are full of hexes and
@@ -866,6 +867,34 @@ describe('the panel language', () => {
       );
       expect(pixels, `${name} cuts deeper than --s5`).toBeLessThanOrEqual(12);
     }
+  });
+
+  it.each(CONVERTED_SKINS)('animates slowly enough to be ambient in %s', (name) => {
+    // The assertion #121 exists to leave behind. The cap on the *number* of effects never said
+    // anything about their rate, and `cyberpunk.css` used to run a 1.5s pulse and a 4s LED fault
+    // whose hard cuts landed 40ms apart — a strobe on text, and the only thing in the app that went
+    // near WCAG 2.3.1's three flashes per second. Ambient motion is measured in tens of seconds;
+    // anything quicker is a state change, which is `--motion-swift`'s business and not a skin's.
+    const css = withoutComments(readFileSync(join(STYLES_DIR, name), 'utf8'));
+    const durations = [...css.matchAll(/(?:^|[;{])\s*animation\s*:\s*[^;]*?([\d.]+)s/g)];
+
+    for (const [, seconds] of durations) {
+      expect(Number.parseFloat(seconds), `${name} animates faster than 20s`).toBeGreaterThanOrEqual(
+        20,
+      );
+    }
+  });
+
+  it.each(CONVERTED_SKINS)('leaves the focus hue to the focus ring in %s', (name) => {
+    // `--focus` is acid green and `--halo` is mixed from `--accent`, so a skin taking acid for its
+    // accent would give a panel a focus halo, a focus ring and a set of chips in one colour — in
+    // the one place in the system where telling two things apart carries meaning. A corner mark in
+    // acid is not this: a mark is at the panel's corner, a ring is around the control.
+    const css = withoutComments(readFileSync(join(STYLES_DIR, name), 'utf8'));
+
+    expect(css, `${name} takes the focus ring's hue for its accent`).not.toMatch(
+      /--accent\s*:\s*var\(--acid-green\)/,
+    );
   });
 
   it('gives every genre a shape of its own', () => {


### PR DESCRIPTION
Closes #121. Third of the four skins, and the last file on the hex exemption — that list is now empty.

Design: [`docs/visual-design.md`, "The cyberpunk skin, and what a keyline is measured against"](https://github.com/ironarachne/ironarachne/blob/issue-121-cyberpunk-skin/docs/visual-design.md#the-cyberpunk-skin-and-what-a-keyline-is-measured-against), approved before implementation. Drawn against [Cyberpunk 2077's screen language](https://designbycurio.com/learn/cyberpunk-2077-screen).

### The flicker does not survive, and that is the point

`cyberpunk.css` ran **two** animations at once on `h1`–`h6`: a 1.5s neon pulse and a 4s LED fault whose hard cuts landed 40ms apart. That is a strobe on text being read, and the only thing in the app that went anywhere near [WCAG 2.3.1](https://www.w3.org/WAI/WCAG22/Understanding/three-flashes-or-below-threshold)'s three flashes per second. Removing it is a fix, not a loss.

The idea survives at a rate that cannot hurt anyone: every corner mark drops out together for 250ms **once every 24s** — 0.04Hz, on eight hairlines rather than a field, off entirely under `prefers-reduced-motion`. The document and a sweep now hold every skin to **no animation faster than 20s**, because the cap on the *number* of effects never said anything about their rate and a single 1.5s strobe would have passed every existing check.

### The keyline is four corner marks

The reference's signature device is the L-bracket corner mark — partial borders from targeting reticles, with full rectangles reserved for inputs and table cells, which is the app's own division in someone else's words. `--panel-edge` is painted as the *background* of the ring the liner sits inside, so it already took layered gradients: eight `no-repeat` layers, two 18px × 1px arms per corner, runs left unpainted so the page shows through. Horizontals acid, verticals magenta — the issue's "acid keyline with a magenta edge" as one device rather than two.

That needed an exemption from #120's keyline register, granted on **area rather than taste**: a keyline running the whole perimeter stays in 0.055–0.111; a corner mark covering under a fifth of it may go to full brightness. Halation is a property of a long bright line and a wireframe of a closed one; eight arms are neither, and on a 400px panel they total about 12%. It is also what pays for the surface — a panel at 1.01:1 against the page has to state its boundary somewhere, and stating it brightly at four corners beats stating it dimly all the way round.

### The rest

| | Value | Measured |
| --- | --- | --- |
| `--panel-surface` | `--amethyst` 10% into `--surface-inset` | `rgb(30 26 45)`; ink 15.3 / 8.0 / 5.8 — the best in the app |
| Corner depths | `0 / 0 / 0 / 0` | four knife edges, revising the slash #120 reserved |
| `--accent` | `var(--magenta)` | 5.9:1 |

**The corner revises what #120 reserved.** "Zero border radius throughout, every corner is a knife edge" — and a cut corner truncates the bracket meant to sit in it, so the two devices were fighting. Square is still nobody else's shape, and it is the one genre whose shape is an absence of the app's cut.

**The surface spends its separation.** 1.01:1 against the page and 1.05:1 against a control's fill, where a base panel is 1.32:1. Neither was ever the mechanism — `--sink`, `--edge` and the keyline carry those, all base-system — so the genre spends those affordances rather than duplicating them. An e2e case asserts a control on a cyberpunk panel still has its sink shadow and border, which is the one thing here a later change could quietly break.

**Acid green is `--focus`'s, so the accent is magenta.** `--halo` is mixed from `--accent`, and a panel whose halo, focus ring and chips are one colour loses the single distinction that carries meaning. Acid appears in the marks, where it is at the panel's corner and never a ring around a control.

### Three techniques from the reference the contract refuses

Named in the document where they are refused rather than dropped silently: **glow-based elevation** (that is `--lift` and `--halo`, fixed across genres so panels sit at the same height), the **condensed-caps-over-monospace typography** (the type ramp — the same instinct that put a shimmer on `h1`–`h6` in the first place), and **density-first layout** (the space ramp). What survives the filter is exactly the surface, keyline and one effect decision 2 hands a skin, which is a fair check that the contract is drawn in the right place.

### Checked on the page, not only in assertions

A screenshot confirmed the marks paint where the computed styles said they would. It also turned up something worth recording: **anything declaring `--panel-edge` on itself opts out of the marks** — a tone, `.panel--bare`, and the open project's `.project-card--active`. That is the existing precedence, but under fantasy or sci-fi being outranked changed a colour where here it changes the device, so the open project's card wears a continuous edge among bracketed panels. It reads as the right answer: the one card that is not decoration is the one that is not bracketed.

### Enforcement

`cyberpunk.css` joins `CONVERTED_SKINS`, so the hex sweep, type-ramp sweep, one-effect cap, depth cap and distinctness rule now apply to every skin the app has with nothing carried. New: **no skin animates faster than 20s**, and **no skin takes `--focus`'s hue for its accent**. In the browser: the marks are eight `no-repeat` layers totalling under a fifth of the rendered perimeter, the corner is the box's own rectangle, a control on the surface keeps `--sink` and its border, and reduced motion keeps the marks while the fault goes.

### Checks

`npm run verify:all` green — 4453 unit tests, 442 Playwright tests, `svelte-check` 0 errors, coverage gate 98/98 with no baselined debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2wzaP74ffGJjghzcabKeT