### PR TITLE
Gild the fantasy foot, for #156

### DIFF
--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -2103,7 +2103,8 @@ both visibly warm and no lighter than slate returns exactly one recipe, and it i
 | Property          | Value                                                             | Measured                                                                            |
 | ----------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `--panel-surface` | `color-mix(in srgb, var(--gold) 12%, var(--charcoal))`            | Warm; no lighter than slate                                                         |
-| `--panel-edge`    | `var(--border-strong)` — the tan keyline                          | —                                                                                   |
+| `--panel-edge`    | `var(--border-strong)` — the tan keyline                          | luminance 0.0823, in the register                                                   |
+| Gilt              | Gold corner pieces on the two cut corners, 24px arms              | Added by #156; 4%–7.5% of the perimeter, so a corner mark                           |
 | Heading colour    | `var(--accent-quiet)`, scoped to headings inside a panel          | 5.8:1, clears 4.5                                                                   |
 | `--accent-quiet`  | Unchanged. Gold is already the base's quiet accent                | —                                                                                   |
 | Corner            | A shield's foot — both bottom corners at `--s5`, square shoulders | Amended by #120; see [the four shapes](#the-four-shapes-and-why-each-is-its-genres) |
@@ -2115,6 +2116,32 @@ it alone and let the skins that wanted a different corner pay for it. What that 
 genre wants one — so the base's shape stops being fantasy's by inheritance and fantasy takes a
 shield's foot instead, leaving the cut as the app's own neutral plate. The mechanism and the two
 lines that do it are #120's.
+
+**The gilt is the device, and it is on the foot.** Added by
+[#156](https://github.com/ironarachne/ironarachne/issues/156), which closed the gap the four skin
+issues left: fantasy was converted first and so was written before either of the ideas that made the
+other two skins legible — sci-fi's texture and cyberpunk's corner marks — and it stayed a surface, a
+flat keyline and a sheen while they gained a device each.
+
+It uses the mechanism [#121 proved](#the-keyline-is-four-corner-marks-not-a-hairline) rather than a
+new one: `--panel-edge` is the background of the 1px ring, so a gold block placed at a corner is
+visible only where that ring is. **Placed at the two _cut_ corners**, which is what separates it from
+cyberpunk's brackets and is the whole point of the choice: the clip runs a diagonal through that
+corner, the liner covers everything but a pixel of it, and what is left of a 24px block is the mitre
+itself with a short run of gilt flanking it on each edge. A bound book's metal corners, and the one
+place this skin's shape and its keyline say the same thing — where cyberpunk marks the four corners
+its shape leaves square, fantasy gilds the two its shape cuts.
+
+Gold is luminance 0.40, which the register forbids on a keyline that runs the whole perimeter and
+[#121's area exemption](#a-corner-mark-is-not-a-keyline-and-the-register-knows-the-difference)
+permits on a mark: 24px arms at two corners are 4% of a wide panel's perimeter and 7.5% of a small
+one's, against a fifth. **No rule moves for this** — it is the first thing built on that exemption
+rather than the reason for it, which is the test of whether the exemption was drawn at the right
+size.
+
+The tan hairline stays continuous around the rest at 0.0823. The gilt is not a second keyline
+replacing it; it is the same edge, richer at the two corners the eye already goes to because the
+shape changes there.
 
 **The sheen is the shimmer, moved.** A gold gradient band crossing the panel surface on a long
 cycle, painted as a background layer on the liner rather than as an element, so it touches nothing
@@ -2145,10 +2172,12 @@ the skin is forbidden to touch. Three constraints on it:
   four depth properties it reads are the one exception — see [what the sci-fi skin
   enforces](#what-the-sci-fi-skin-enforces).)
 
-And one in the browser, because it is the whole point and cannot be read off the source: an e2e
-check that a fantasy panel's computed surface is **no lighter** than a base panel's. That is the
-rule above, and it is what a future skin — or a future tweak to this one — would otherwise break
-silently.
+And two in the browser, because neither can be read off the source: an e2e check that a fantasy
+panel's computed surface is **no lighter** than a base panel's — the rule above, and what a future
+skin or a future tweak to this one would otherwise break silently — and, since #156, that its gilt
+is a corner mark by the same measurement cyberpunk's marks answer to. Gold at luminance 0.40 is only
+allowed on a panel while it stays under a fifth of the perimeter, and a panel's perimeter is a thing
+only the browser knows.
 
 ## The sci-fi skin, and the corner every genre gets
 

--- a/e2e/genre_skin.spec.ts
+++ b/e2e/genre_skin.spec.ts
@@ -40,6 +40,59 @@ function luminance([r, g, b]: [number, number, number]): number {
   return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
 }
 
+/**
+ * What a skin paints into the 1px ring `--panel-edge` fills, measured against the box it painted on.
+ *
+ * docs/visual-design.md, "A corner mark is not a keyline, and the register knows the difference":
+ * a keyline running the whole perimeter is held to a luminance register, and a mark covering under a
+ * fifth of it may go to full palette brightness instead. Which of the two a skin has written is a
+ * relationship between its layers and the rendered size of the panel, so it is only answerable here.
+ *
+ * A layer at a corner paints along both edges that meet there, so its contribution is its width plus
+ * its height — 24 + 24 for a square gilt block, 18 + 1 for a bracket arm.
+ *
+ * Only the image-bearing layers count. `background: <gradient>, <gradient>, <colour>` is three
+ * layers, not two with a colour: the last one carries the fill and reports `none`, `repeat` and
+ * `auto auto`, and counting it would fail a skin for the hairline it wears everywhere the marks are
+ * not. Both skins that paint marks put their images first, which is the order this relies on.
+ */
+async function cornerMarks(
+  page: Page,
+): Promise<{ layers: number; repeats: string[]; painted: number; perimeter: number }> {
+  return page
+    .locator('.panel')
+    .first()
+    .evaluate((element) => {
+      const computed = getComputedStyle(element);
+      const { width, height } = element.getBoundingClientRect();
+      // Counted by gradient rather than by comma: each layer's own `rgb(…)` stops carry commas of
+      // their own, so splitting the string counts sixteen of eight.
+      const layers = (computed.backgroundImage.match(/linear-gradient\(/g) ?? []).length;
+
+      const painted = computed.backgroundSize
+        .split(',')
+        .slice(0, layers)
+        .map((size) =>
+          size
+            .trim()
+            .split(/\s+/)
+            .map(Number.parseFloat)
+            .reduce((total, side) => total + side, 0),
+        )
+        .reduce((total, layer) => total + layer, 0);
+
+      return {
+        layers,
+        repeats: computed.backgroundRepeat
+          .split(',')
+          .slice(0, layers)
+          .map((value) => value.trim()),
+        painted,
+        perimeter: 2 * (width + height),
+      };
+    });
+}
+
 /** A project with a panel on screen, and a genre that can be changed without a reload. */
 async function openProject(page: Page): Promise<void> {
   await visitRoute(page, '/projects', { title: 'Projects | Iron Arachne' });
@@ -105,6 +158,28 @@ test.describe('the fantasy skin', () => {
     expect(barPaint, 'the skin reached the top bar').toBe('none');
     await expect(page.locator('.top-bar')).not.toHaveAttribute('data-genre');
     await expect(page.locator('.sidebar')).not.toHaveAttribute('data-genre');
+  });
+
+  test('gilds the two corners its shape cuts, and stays a corner mark', async ({ page }) => {
+    // #156: the device fantasy went without while the other two skins gained one. Gold is luminance
+    // 0.40, which the register forbids on a keyline that runs the whole perimeter — so this is only
+    // permitted while it stays a mark, and that is a measurement against the rendered box.
+    await openProject(page);
+    await setGenre(page, 'fantasy');
+
+    const marks = await cornerMarks(page);
+
+    // Two blocks, at the two corners the shield's foot cuts. The tan hairline the rest of the
+    // perimeter wears is a background *colour*, so it is not one of these layers.
+    expect(marks.layers, 'the gilt is not painted at the corners').toBe(2);
+    expect(marks.repeats, 'the gilt repeats, which would make it a keyline').toEqual([
+      'no-repeat',
+      'no-repeat',
+    ]);
+
+    expect(marks.painted, 'the gilt covers more than a fifth of the perimeter').toBeLessThanOrEqual(
+      marks.perimeter / 5,
+    );
   });
 
   test('puts its one effect on the surface rather than on the type', async ({ page }) => {
@@ -211,45 +286,23 @@ test.describe('the cyberpunk skin', () => {
 
   test('earns its brightness by covering a fifth of the perimeter at most', async ({ page }) => {
     // The rule that lets this skin wear undiluted acid and magenta where the register would
-    // otherwise forbid them: a corner mark is not a keyline. Checked in the browser because it is a
-    // relationship between what the skin paints and how big the panel it painted on turned out to
-    // be — which no source sweep can see.
+    // otherwise forbid them: a corner mark is not a keyline.
     await openProject(page);
     await setGenre(page, 'cyberpunk');
 
-    const keyline = await page
-      .locator('.panel')
-      .first()
-      .evaluate((element) => {
-        const computed = getComputedStyle(element);
-        const { width, height } = element.getBoundingClientRect();
-        return {
-          // Counted by gradient rather than by comma: each layer's own `rgb(…)` stops carry
-          // commas of their own, so splitting the string counts sixteen of eight.
-          layers: (computed.backgroundImage.match(/linear-gradient\(/g) ?? []).length,
-          repeat: computed.backgroundRepeat,
-          sizes: computed.backgroundSize,
-          perimeter: 2 * (width + height),
-        };
-      });
+    const marks = await cornerMarks(page);
 
     // Eight layers: two arms at each of four corners.
-    expect(keyline.layers, 'the keyline is not painted as corner marks').toBe(8);
+    expect(marks.layers, 'the keyline is not painted as corner marks').toBe(8);
+
     // Every layer, not just some: one repeating layer would run an arm the length of the panel and
     // make the whole argument for full brightness untrue.
-    expect(
-      keyline.repeat.split(',').map((value) => value.trim()),
-      'a mark repeats, which would make it a hairline',
-    ).toEqual(Array.from({ length: 8 }, () => 'no-repeat'));
+    expect(marks.repeats, 'a mark repeats, which would make it a hairline').toEqual(
+      Array.from({ length: 8 }, () => 'no-repeat'),
+    );
 
-    // Every arm's long side, totalled, against the perimeter it sits on.
-    const arms = keyline.sizes
-      .split(',')
-      .map((size) => Math.max(...size.trim().split(/\s+/).map(Number.parseFloat)));
-    const painted = arms.reduce((total, arm) => total + arm, 0);
-
-    expect(painted, 'the marks cover more than a fifth of the perimeter').toBeLessThanOrEqual(
-      keyline.perimeter / 5,
+    expect(marks.painted, 'the marks cover more than a fifth of the perimeter').toBeLessThanOrEqual(
+      marks.perimeter / 5,
     );
   });
 

--- a/src/lib/styles/fantasy.css
+++ b/src/lib/styles/fantasy.css
@@ -33,9 +33,29 @@
      lets colour roles measure against it. */
   --panel-surface: color-mix(in srgb, var(--gold) 12%, var(--charcoal));
 
-  /* The tan keyline. `--border-strong` is already the base's stronger edge, so this is the skin
-     choosing between two roles the system has rather than introducing a colour. */
-  --panel-edge: var(--border-strong);
+  /* The tan keyline, gilded at the foot.
+
+     `--border-strong` is already the base's stronger edge, so the continuous part of this is the
+     skin choosing between two roles the system has rather than introducing a colour: luminance
+     0.0823, inside the register a keyline that runs the whole perimeter is held to.
+
+     The two gold layers are the device, and they use the mechanism #121 proved rather than a new
+     one. `--panel-edge` is painted as the background of the 1px ring the liner sits inside, so a
+     24px block at a corner is visible only where that ring is — and these are at the two corners
+     the shape *cuts*, where the clip runs a diagonal and the liner covers all but a pixel of it.
+     What is left of each block is the mitre itself with a short run of gilt flanking it on both
+     edges: a bound book's metal corners, and the one place this skin's shape and its keyline say
+     the same thing. Cyberpunk marks the four corners its shape leaves square; fantasy gilds the two
+     its shape takes.
+
+     Gold is luminance 0.40, which the register forbids on a continuous keyline and #121's area
+     exemption permits on a corner mark: two 24px corners are 4% of a wide panel's perimeter and
+     7.5% of a small one's, against a fifth. `e2e/genre_skin.spec.ts` measures that against the
+     rendered box, because a panel's perimeter is a thing only the browser knows. */
+  --panel-edge:
+    linear-gradient(var(--gold), var(--gold)) left bottom / 24px 24px no-repeat,
+    linear-gradient(var(--gold), var(--gold)) right bottom / 24px 24px no-repeat,
+    var(--border-strong);
 
   /* No `--accent` or `--accent-quiet` override: gold is already the base's quiet accent, so the
      fantasy chip, kicker and figure colour is the one the app has. A skin that changes nothing


### PR DESCRIPTION
Closes #156.

Fantasy was the first skin converted (#119), so it was written before either of the ideas that made the other two legible — sci-fi's texture and cyberpunk's corner marks. It satisfied every rule, including #120's distinct-shape rule, and was still a warm surface, a flat tan keyline and a sheen. This is the device it went without.

Design: [`docs/visual-design.md`, "The fantasy skin"](https://github.com/ironarachne/ironarachne/blob/issue-156-fantasy-device/docs/visual-design.md#the-fantasy-skin).

### Gild the foot

The gilt sits at the two corners the shield's foot **cuts**, and that placement is the whole idea rather than a detail. The clip runs a diagonal through those corners and the liner covers all but a pixel of it, so what survives of a 24px block is the mitre itself with a short run of gilt flanking it on each edge — a bound book's metal corners.

Where cyberpunk marks the four corners its shape leaves *square*, fantasy gilds the two its shape *takes*. Same mechanism, opposite relationship to the shape, which is what keeps the two from reading as one idea used twice. It is also the first time this skin's shape and its keyline say the same thing.

### No rule moves

Gold is luminance 0.40 — above the keyline register, and already permitted by [#121's area exemption](https://github.com/ironarachne/ironarachne/blob/issue-156-fantasy-device/docs/visual-design.md#a-corner-mark-is-not-a-keyline-and-the-register-knows-the-difference) on a mark covering under a fifth of the perimeter. Two 24px corners are 4% of a wide panel's perimeter and 7.5% of a small one's. The tan hairline stays continuous around the rest at 0.0823, inside the register.

This is the first thing built on that exemption rather than the reason for it, which is the useful test of whether it was drawn at the right size. It was.

### Checked on the page before it was asserted

The magnified corner shows the mitre in gold with the tan hairline resuming past the gilt — the shape the CSS predicts, confirmed rather than assumed.

The e2e measure is now shared by both skins that paint marks, with one correction it forced: **`background: <gradient>, <gradient>, <colour>` is three layers, not two with a colour.** The colour-bearing layer reports `none`, `repeat` and `auto auto`, and counting it failed fantasy for the hairline it wears everywhere the marks are not. A layer at a corner paints along both edges that meet there, so a layer's contribution is its width plus its height — 24 + 24 for a gilt block, 18 + 1 for a bracket arm.

### Out of scope, deliberately

The shape (`0/0/12/12` stays — this is the device it was waiting for), the surface, the sheen, and the accent. Fantasy remains the one skin that sets no accent of its own, because gold is already the base's quiet accent.

### Checks

`npm run verify:all` green — 4453 unit tests, 443 Playwright tests, `svelte-check` 0 errors, coverage gate 98/98 with no baselined debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2wzaP74ffGJjghzcabKeT