### PR TITLE
Let a skin's surface layers only darken, for #158

### DIFF
--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -2092,6 +2092,30 @@ Because ink is light and surfaces are dark, that reduces to a check anyone can m
 surface may shift hue freely, but its luminance may not rise above `--surface-raised`'s.** A skin
 that only re-hues cannot make text less readable, and it never has to argue about a floor.
 
+**Amended by [#158](https://github.com/ironarachne/ironarachne/issues/158), which found the hole in
+it.** The rule says `--panel-surface` and says nothing about what a skin paints _on top_ of that
+surface — and both skins that painted anything did so by lightening. `--ink-faint`'s 4.5:1 floor
+puts the ceiling for any pixel under text at luminance 0.0303; the fantasy sheen peaked at 0.0365
+and measured 4.18:1, the sci-fi scan at 0.0399 and 4.02:1, and the sci-fi scanlines — static, and on
+every panel — at 0.0343 and 4.29:1. Both surfaces sit at 0.0277 and 0.0276, so they hold 0.0026 of
+headroom and **no** lightening layer fits in it. A 2% gold sheen measures 4.49:1.
+
+The same shape as [`--ink-faint`'s first failure](#ink-faint-did-not-meet-its-own-target-on-any-panel-and-now-does),
+one layer up: a true figure about the wrong surface. So the rule gains a second half, and it is
+stated as a place rather than as a number:
+
+> **Anything a skin paints where text can sit may only darken.**
+
+The keyline is not that place. The corner marks in [#121](#the-keyline-is-four-corner-marks-not-a-hairline)
+and [#156](#the-fantasy-skin) live in the 1px ring, which is exactly where no text goes, and they
+answer to the luminance register and its area exemption instead. This half is about the layers on
+`.panel__field`, which is where a label sits.
+
+Darkening on a dark ground cannot cost contrast, so this is satisfiable forever rather than a figure
+every future skin re-measures — and it is the more accurate description of both effects anyway. A
+CRT scanline **is** the dark gap between phosphor rows, and a rolling bar is dark. What a plate does
+under a moving light is show a shadow crossing it.
+
 This has a consequence worth stating plainly, because it is the opposite of the obvious approach.
 **A warm panel is charcoal warmed toward gold, not slate warmed toward gold.** Warming slate
 lightens it, and every ink role pays; warming charcoal by the same amount lands at the same
@@ -2108,7 +2132,7 @@ both visibly warm and no lighter than slate returns exactly one recipe, and it i
 | Heading colour    | `var(--accent-quiet)`, scoped to headings inside a panel          | 5.8:1, clears 4.5                                                                   |
 | `--accent-quiet`  | Unchanged. Gold is already the base's quiet accent                | —                                                                                   |
 | Corner            | A shield's foot — both bottom corners at `--s5`, square shoulders | Amended by #120; see [the four shapes](#the-four-shapes-and-why-each-is-its-genres) |
-| Ambient effect    | A slow gold sheen across the panel surface                        | —                                                                                   |
+| Ambient effect    | A slow shadow crossing the panel surface, `black 14%`             | 0.0211; `--ink-faint` 5.08:1                                                        |
 
 The corner line read **"unchanged"** until #120, and the reasoning was sound as far as it went: the
 9px cut in [elevation](#elevation) was drawn for this genre, so fantasy's contribution was to leave
@@ -2153,7 +2177,11 @@ the skin is forbidden to touch. Three constraints on it:
 - **Not on a bare panel.** The main tool panel has `--panel-surface: none`, so a sheen there would be
   a gradient floating on the page. It is scoped to `.panel:not(.panel--bare)`.
 - **Off under `prefers-reduced-motion: reduce`**, with the surface still reading correctly static —
-  the effect is a moving highlight on a fill, not the fill itself.
+  the effect is a moving shadow on a fill, not the fill itself.
+- **It darkens.** Until #158 it was a gold gleam at 6%, which took `--ink-faint` to 4.18:1 against a
+  4.5:1 floor wherever the band crossed a label. It is `black 14%` now — luminance 0.0211 and
+  `--ink-faint` at 5.08:1 — and reads as the shadow of something passing over the plate rather than
+  a highlight on it. The surface is untouched.
 
 ### What the fantasy skin enforces
 
@@ -2379,15 +2407,19 @@ what makes that true rather than merely stated.
 
 Two layers on the liner's `background-image`, and only one of them moves:
 
-- **The texture is static.** Horizontal scanlines — a `repeating-linear-gradient` of cyan at 4%,
-  one pixel on a five-pixel pitch. Decision 2 lists texture under _surface_, not under _motion_, and
+- **The texture is static, and it is dark.** Horizontal scanlines — a `repeating-linear-gradient` of
+  `black 15%`, one pixel on a five-pixel pitch. It was cyan at 4% until
+  [#158](https://github.com/ironarachne/ironarachne/issues/158), which is a _lightening_ layer on
+  every sci-fi panel at all times and took `--ink-faint` to 4.29:1 under every label. Dark is both
+  the fix and the better description: a scanline is the gap between phosphor rows, not a row. Decision 2 lists texture under _surface_, not under _motion_, and
   this is the whole reason to spend it here: it says "screen" without animating, so the sci-fi panel
   is still visibly sci-fi when everything that moves is switched off. Pitch and mix are stated
   because a tighter, stronger grid moirés against a scrolling panel, which is a shimmer nobody asked
   for and the one failure mode this layer has.
-- **The motion is a single scan.** A faint cyan band drifting down the surface on a 45s cycle — the
+- **The motion is a single scan.** A `black 12%` band drifting down the surface on a 45s cycle — the
   vertical counterpart of fantasy's sheen, one `@keyframes`, one `animation`, slower than fantasy's
-  40s because a band that crosses the short axis of a panel is on screen more of the time.
+  40s because a band that crosses the short axis of a panel is on screen more of the time. Dark for
+  #158's reason, and a rolling bar on a CRT is dark in any case.
 - **Reduced motion drops the band and keeps the lines.** This is a better reduced-motion state than
   fantasy's rather than a different one: fantasy's surface falls back to a flat warm fill because
   its effect _is_ the highlight, where sci-fi keeps its texture and loses only the travel.
@@ -2405,8 +2437,8 @@ surface, and a scanline grid floating on the page is what a wider selector would
 | `--accent`        | `var(--cyan)`                                                 | 7.5:1; the halo follows the hue        |
 | `--accent-quiet`  | **Unchanged.** Gold is the message tone, not the genre's      | —                                      |
 | Heading colour    | `var(--accent)`, scoped to headings inside a panel            | 7.5:1, clears 4.5                      |
-| Texture           | Cyan 4%, 1px on a 5px pitch, static                           | —                                      |
-| Ambient effect    | A cyan scan band drifting down the surface, 45s               | —                                      |
+| Texture           | `black 15%`, 1px on a 5px pitch, static                       | 0.0206; `--ink-faint` 5.12:1           |
+| Ambient effect    | A `black 12%` scan band drifting down the surface, 45s        | 0.0219; `--ink-faint` 5.03:1           |
 
 Seven declarations and one keyframe. The contract's table said six, and the seventh is the corner —
 which was always in [decision 2](#2-genre-skins-are-a-permitted-subset-not-a-second-look)'s list of

--- a/src/lib/styles/fantasy.css
+++ b/src/lib/styles/fantasy.css
@@ -11,8 +11,14 @@
  * the notch, the liner, the halo, `--lift`, and a badge's shape.
  */
 
-/* The one ambient effect. A gold band crossing the panel surface, painted as a background layer
-   rather than as an element so it touches nothing the skin is forbidden to touch. */
+/* The one ambient effect. A shadow crossing the panel surface, painted as a background layer rather
+   than as an element so it touches nothing the skin is forbidden to touch.
+
+   It was a gold gleam until #158, and a gleam is a *lightening* layer: at 6% it took `--ink-faint`
+   to 4.18:1 wherever the band crossed a label, against a 4.5:1 floor. The surface sits 0.0026 below
+   the readability ceiling, which is not room for any highlight at all — so what moves is the shadow
+   of something passing over the plate rather than the light on it. Anything a skin paints where
+   text can sit may only darken. */
 @keyframes fantasy-sheen {
   from {
     background-position: -150% 0;
@@ -90,7 +96,7 @@
    `background-color`, so the fill is still `--panel-surface` and the effect is a highlight moving
    across it rather than the fill itself.
 
-   40s and a 6% mix: a bench holds several panels and every one of them wears this, so the effect
+   40s and a 14% mix: a bench holds several panels and every one of them wears this, so the effect
    has to survive being on screen five times at once without becoming a strobe. The heading shimmer
    it replaces ran an 8s cycle over text somebody was reading. */
 [data-genre='fantasy'] .panel:not(.panel--bare) > .panel__field {
@@ -98,7 +104,7 @@
   background-image: linear-gradient(
     100deg,
     transparent 35%,
-    color-mix(in srgb, var(--gold) 6%, transparent) 50%,
+    color-mix(in srgb, black 14%, transparent) 50%,
     transparent 65%
   );
   background-repeat: no-repeat;

--- a/src/lib/styles/scifi.css
+++ b/src/lib/styles/scifi.css
@@ -90,8 +90,14 @@
    The scanlines are *texture*, which decision 2 lists under surface rather than under motion, and
    that is the whole reason to spend a layer on them: they say "screen" without animating, so a
    sci-fi panel is still visibly sci-fi when everything that moves is switched off. 1px on a 5px
-   pitch at 4%, both stated because a tighter or stronger grid moirés against a scrolling panel,
-   which is a shimmer nobody asked for.
+   pitch, stated because a tighter or stronger grid moirés against a scrolling panel, which is a
+   shimmer nobody asked for.
+
+   **Both layers darken**, which #158 made a rule and which is the better description besides: a
+   scanline is the gap between phosphor rows rather than a row, and a rolling bar on a CRT is dark.
+   They were cyan tints until then — 4% static and 7% moving — and a lightening layer on a surface
+   sitting 0.0026 below the readability ceiling took `--ink-faint` to 4.29:1 under every label on
+   every sci-fi panel. Dark costs nothing on a dark ground: 5.12:1 and 5.03:1 now.
 
    45s for the scan, where fantasy's sheen runs 40s: a band crossing the short axis of a panel is
    on screen more of the time, and a bench holds several panels all wearing this. */
@@ -101,12 +107,12 @@
     linear-gradient(
       180deg,
       transparent 40%,
-      color-mix(in srgb, var(--cyan) 7%, transparent) 50%,
+      color-mix(in srgb, black 12%, transparent) 50%,
       transparent 60%
     ),
     repeating-linear-gradient(
       180deg,
-      color-mix(in srgb, var(--cyan) 4%, transparent) 0 1px,
+      color-mix(in srgb, black 15%, transparent) 0 1px,
       transparent 1px 5px
     );
   background-repeat: no-repeat, repeat;
@@ -124,7 +130,7 @@
     animation: none;
     background-image: repeating-linear-gradient(
       180deg,
-      color-mix(in srgb, var(--cyan) 4%, transparent) 0 1px,
+      color-mix(in srgb, black 15%, transparent) 0 1px,
       transparent 1px 5px
     );
     background-repeat: repeat;

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -897,6 +897,35 @@ describe('the panel language', () => {
     );
   });
 
+  it.each(CONVERTED_SKINS)('paints nothing under text that lightens it in %s', (name) => {
+    // docs/visual-design.md, "A skin's surface is never lighter than the base's", second half.
+    // The rule held `--panel-surface` to `--surface-raised` and said nothing about the layers a skin
+    // paints on top of it — and every layer that existed lightened. `--ink-faint`'s floor puts the
+    // ceiling for a pixel under text at luminance 0.0303, both surfaces sit at 0.0277 and 0.0276,
+    // and a 2% gold sheen measures 4.49:1. There is no headroom for a highlight, so a skin's surface
+    // layers may only darken.
+    //
+    // The keyline is deliberately not swept here. A corner mark lives in the 1px ring where no text
+    // goes, and answers to the luminance register and its area exemption instead — which is why
+    // this reads the rules that paint `.panel__field` rather than every gradient in the file.
+    const css = withoutComments(readFileSync(join(STYLES_DIR, name), 'utf8'));
+
+    // `var(--x)` comes out first: a nested paren would otherwise end a match early and report a stop
+    // that had been cut in half, which is a test failing on the wrong thing.
+    const flattened = css.replace(/var\([^)]*\)/g, 'TOKEN');
+    const surfaceRules = [...flattened.matchAll(/\.panel__field[^{]*\{([^}]*)\}/g)].map(
+      ([, body]) => body,
+    );
+
+    for (const body of surfaceRules) {
+      for (const [stop] of body.matchAll(/color-mix\([^)]*\)/g)) {
+        expect(stop.includes('black'), `${name} paints ${stop} under text, which lightens it`).toBe(
+          true,
+        );
+      }
+    }
+  });
+
   it('gives every genre a shape of its own', () => {
     // "A shape is a genre's, or it is furniture." The cap on corner treatments used to be three;
     // #120 replaced it with one shape per genre, and this is the half of that rule no source sweep


### PR DESCRIPTION
Closes #158. Found while designing the horror skin (#122), which this blocks.

### The hole in the rule

[A skin's surface is never lighter than the base's](https://github.com/ironarachne/ironarachne/blob/issue-158-layers-may-only-darken/docs/visual-design.md#a-skins-surface-is-never-lighter-than-the-bases) holds `--panel-surface` at or below `--surface-raised`, which is what lets [colour roles](https://github.com/ironarachne/ironarachne/blob/issue-158-layers-may-only-darken/docs/visual-design.md#colour-roles) state every ink ratio against one surface and call it the worst case. **It says nothing about what a skin paints on top of that surface** — and both skins that painted anything did so by lightening.

`--ink-faint`'s 4.5:1 floor puts the ceiling for any pixel under text at luminance **0.0303**:

| Layer | Peak luminance | `--ink-faint` there |
| --- | --- | --- |
| Ceiling | 0.0303 | 4.50:1 |
| `--surface-raised`, for reference | 0.0281 | 4.65:1 |
| Fantasy sheen — gold 6% | 0.0365 | **4.18:1** |
| Sci-fi scan — cyan 7% | 0.0399 | **4.02:1** |
| Sci-fi scanlines — cyan 4%, static, every panel | 0.0343 | **4.29:1** |

Both surfaces were drawn to sit just under slate — 0.0277 and 0.0276 — so they hold **0.0026** of headroom, and no lightening layer fits in it. Even a 2% gold sheen measures 4.49:1. The scanlines are the worst of the three because they are static and cover every sci-fi panel, so a `--t-micro` label there was below the floor all of the time rather than as a band passed.

Same shape as #149 one layer up: a true figure measured against the wrong thing.

### The rule

> **Anything a skin paints where text can sit may only darken.**

Stated as a place rather than a number. The keyline is not that place — the corner marks from #121 and #156 live in the 1px ring, which is exactly where no text goes, and answer to the luminance register and its area exemption instead. This half governs the layers on `.panel__field`, which is where a label sits.

Darkening on a dark ground cannot cost contrast, so it is satisfiable forever rather than a figure every future skin re-measures.

### What changed

| Layer | Was | Now | `--ink-faint` |
| --- | --- | --- | --- |
| Fantasy sheen | gold 6% | `black 14%`, L 0.0211 | 4.18 → **5.08:1** |
| Sci-fi scan | cyan 7% | `black 12%`, L 0.0219 | 4.02 → **5.03:1** |
| Sci-fi scanlines | cyan 4% | `black 15%`, L 0.0206 | 4.29 → **5.12:1** |

**Neither surface moves.** Keeping both plates exactly as they are is the reason to prefer this over lowering them to buy headroom — and it is the more accurate description of both effects anyway: a scanline is the dark gap between phosphor rows rather than a row, a rolling bar on a CRT is dark, and what a plate does under a moving light is show a shadow crossing it.

**This does not constrain a genre's colour.** `--panel-surface`, `--panel-edge`, the corner marks, `--accent` and the heading colour are all untouched, and even an overlay may carry hue as long as it lands darker than the surface — a `color-mix` toward `black` off a palette entry passes. The constraint is on the lightness of what covers text, not on a palette.

### Enforcement

A sweep over the rules that paint `.panel__field` in every skin file: a colour stop there names no palette hue except through `black`. Checked by putting a lightening stop back and confirming the test fails, rather than trusting that it would. `var()` is flattened before matching, because a nested paren otherwise truncates a stop and fails the test on the wrong thing.

### Checks

`npm run verify:all` green — 4456 unit tests, 443 Playwright tests, `svelte-check` 0 errors, coverage gate 98/98 with no baselined debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2wzaP74ffGJjghzcabKeT