### PR TITLE
Add the horror skin, for #122

### DIFF
--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -123,9 +123,27 @@ techniques the contract refuses, listed where they are refused rather than dropp
 revises #120's reserved shape for this genre from a 12px slash to four square corners: a cut corner
 truncates the bracket that is meant to sit in it.
 
-Awaiting approval, unlike the amendments above it, which are built: #121 is `needs-design`, and the
-motion floor, the corrected register and the surface that spends its own separation are what
-CLAUDE.md's review gate asks a human to approve before implementation starts.
+Approved and built.
+
+**Amended 2026-08-30 by [#158](https://github.com/ironarachne/ironarachne/issues/158)**, which is a
+correction rather than a section: the surface rule governed `--panel-surface` and said nothing about
+the layers painted on it, and every layer that existed lightened — taking `--ink-faint` to 4.18:1,
+4.02:1 and 4.29:1 against its 4.5:1 floor. Anything a skin paints where text can sit may only darken
+now, which is stated in [the surface rule](#a-skins-surface-is-never-lighter-than-the-bases) and
+swept. No surface moved.
+
+**Amended 2026-08-30 by [#122](https://github.com/ironarachne/ironarachne/issues/122)**, which adds
+[the horror skin, and the discipline of not startling anyone](#the-horror-skin-and-the-discipline-of-not-startling-anyone)
+— the fourth genre, the only one with no file to rewrite, and the first written under the whole
+contract rather than converted into it. It adds one rule: **a skin may not paint a tone's colour as
+its keyline**, because neat crimson is `--danger`, and a genre wearing it would make a horror project
+look like a page of failed writes and hide the one panel that had really failed. The rest is the
+contract used as intended: an institutional green surface with room under the readability ceiling, a
+blood stain that darkens, and the slowest ambient effect in the app at 60s.
+
+Awaiting approval, unlike the amendments above it, which are built: #122 is `needs-design`, and the
+tone rule, the surface and the 60s breath are what CLAUDE.md's review gate asks a human to approve
+before implementation starts.
 
 **Amended 2026-08-30, in review of the above:** every genre gets a panel shape of its own, which
 replaces the "three corner treatments" cap rather than extending it. The panel's polygon is written
@@ -2272,13 +2290,13 @@ and to the skin above it, and the control and nav treatments are untouched by an
 
 ### The four shapes, and why each is its genre's
 
-| Genre         | tl  | tr   | br   | bl   | Reads as                                                                                    |
-| ------------- | --- | ---- | ---- | ---- | ------------------------------------------------------------------------------------------- |
-| _Base_        | 0   | 9px  | 0    | 9px  | The app's own plate. Neutral, and what a projectless page keeps                             |
-| **Fantasy**   | 0   | 0    | 12px | 12px | A shield's foot: square shoulders, both bottom corners taken deep                           |
-| **Sci-fi**    | 9px | 9px  | 9px  | 9px  | A machined plate, chamfered on every edge by the same amount                                |
-| **Cyberpunk** | 0   | 0    | 0    | 0    | Four knife edges. Revised from a 12px slash by #121; its corner marks sit where the cut was |
-| **Horror**    | 3px | 11px | 5px  | 8px  | Nothing agrees with anything. Wrong in a way the eye catches and cannot name                |
+| Genre         | tl  | tr   | br   | bl   | Reads as                                                                                        |
+| ------------- | --- | ---- | ---- | ---- | ----------------------------------------------------------------------------------------------- |
+| _Base_        | 0   | 9px  | 0    | 9px  | The app's own plate. Neutral, and what a projectless page keeps                                 |
+| **Fantasy**   | 0   | 0    | 12px | 12px | A shield's foot: square shoulders, both bottom corners taken deep                               |
+| **Sci-fi**    | 9px | 9px  | 9px  | 9px  | A machined plate, chamfered on every edge by the same amount                                    |
+| **Cyberpunk** | 0   | 0    | 0    | 0    | Four knife edges. Revised from a 12px slash by #121; its corner marks sit where the cut was     |
+| **Horror**    | 3px | 11px | 5px  | 8px  | Nothing agrees with anything. Wrong in a way the eye catches and cannot name. Confirmed by #122 |
 
 Sci-fi's is the one this issue builds, and it is the plainest of the four on purpose: the genre's
 argument is made by a cool plate, a plasma keyline and a scan, and a corner that shouted over them
@@ -2711,6 +2729,162 @@ And two in the browser, because both are computed:
   present and non-zero. The fill separation is gone by design; this is the assertion that says what
   is carrying the affordance instead, and it is the one thing about this skin a later change could
   quietly break.
+
+## The horror skin, and the discipline of not startling anyone
+
+[#122](https://github.com/ironarachne/ironarachne/issues/122) is the fourth genre and the only one
+with nothing to rewrite: `GENRES` has held `horror` since before this document existed, two tools are
+tagged with it, and a project set to horror gets the base appearance by omission rather than by
+decision. It is also the first skin written under the whole contract rather than converted into it,
+and the first with three finished siblings to be distinct **from** — a surface, a keyline, a shape, a
+device and an effect each have to miss three occupied positions.
+
+Drawn against [horror aesthetics in
+UX](https://medium.com/@yfxpdbw/designing-for-nightmares-the-role-of-horror-aesthetics-in-user-experience-1499b307de8a)
+and the genre's own reference points — Resident Evil's institutional corridors, Diablo's near-black
+grounds and dried blood.
+
+### What horror may not do in a tool somebody keeps open
+
+The reference's devices are mostly events: "a bright flash of red in an otherwise dark environment
+can create a sudden shock", glitch displacement, sudden visual change. **None of them ships**, and
+the reason is the same one that killed the cyberpunk flicker in
+[#121](#the-flicker-does-not-survive-and-that-is-the-point): a generator is open for an afternoon,
+and a thing that startles you at minute ninety is a thing you turn off — taking the genre with it.
+
+The reference is direct about that limit itself, warning against designs that "cross ethical
+boundaries", and it names its most-emphasised technique as sound. **Sound was already refused
+here**, by [decision 4](#4-sound-on-press-does-not-ship), for a different reason and before any of
+this was written. That the horror reference's first tool is the one the design had already declined
+is worth noting rather than quietly working around.
+
+What is left is the half that works in software people use: **dread rather than shock**. The genre
+comes from the surface being wrong — the wrong green, a stain that was there when you arrived, a
+shape whose corners do not agree — and never from something happening. The one moving thing in this
+skin is slower than anything else in the app.
+
+### The surface is the morgue, not the blood
+
+Red is the obvious horror colour and it is the wrong one for the plate: everything a panel holds
+sits on this, and a red field under a page of generated text is a page nobody reads. The
+institutional green-grey of a room designed to be hosed down is the horror surface, and the blood
+goes on it.
+
+`color-mix(in srgb, var(--emerald) 14%, var(--charcoal))` — `rgb(30 41 42)`, luminance 0.0201:
+
+| Measured against the horror surface | Figure | On a base panel |
+| ----------------------------------- | ------ | --------------- |
+| `--ink`                             | 13.6:1 | 12.2:1          |
+| `--ink-muted`                       | 7.1:1  | 6.3:1           |
+| `--ink-faint`                       | 5.15:1 | 4.65:1          |
+
+It is also **the first surface designed after [#158](#a-skins-surface-is-never-lighter-than-the-bases)**,
+and it shows: at 0.0201 it holds 0.0102 of headroom under the readability ceiling where fantasy and
+sci-fi hold 0.0026. Those two were drawn as close to the ceiling as the old rule allowed, which is
+what left them no room for the layers they went on to paint. This one is drawn with the layers in
+mind.
+
+### The keyline is old blood, and deliberately not `--danger`
+
+Neat crimson is luminance 0.0882, comfortably inside the register — so the rule would allow it, and
+it must not be used, because **crimson _is_ `--danger`**. [A toned
+panel](#four-tones-and-two-of-them-cannot-be-said-in-words) sets `--panel-edge: var(--danger)` to say
+a write failed, and a genre painting that same edge on every panel would make a horror project look
+like a page of failures — and would make the one panel that really had failed indistinguishable from
+its neighbours.
+
+> **A skin may not paint a tone's colour as its keyline.** `--danger` and `--success` mean something
+> the app says about an event; a genre means nothing about any event at all.
+
+So `color-mix(in srgb, var(--crimson) 50%, var(--granite))` — `rgb(100 63 69)`, luminance 0.0661,
+inside the register and a step off the tone. Old blood rather than fresh, which is the more horror
+answer in any case.
+
+### The stain, and the fourth device
+
+Three device positions are taken: sci-fi rules the surface with lines, fantasy gilds two corners of
+the ring, cyberpunk marks four. Horror takes the one shape none of them is — **a blot** — and puts
+it on the surface rather than in the ring: a bloom of dried blood in the bottom-right corner, soaked
+into the plate, there before you arrived and never explained.
+
+`color-mix(in srgb, var(--crimson) 45%, black)` laid over the surface at 35% — `rgb(41 36 36)`,
+luminance 0.0185, `--ink-faint` 5.28:1 across it. It **darkens**, which is #158's rule and which is
+also what a stain does: blood on a green floor is a dark patch, not a bright one. This is the first
+device built under that rule rather than corrected into it.
+
+Bottom-right because it is the corner a reader reaches last, and because the panel's own furniture —
+the header plate, the first line of text — all live at the top left. The stain is in the part of the
+panel you see without looking at.
+
+### The effect is a breath, and it is the slowest thing in the app
+
+One effect, and it is the article's tension-and-relief cycle rather than its shocks: a **vignette
+that closes and recedes on a 60s cycle**, darkening the surface toward its edges and easing back.
+Something in the room is breathing, and it is never doing anything else.
+
+| Skin       | Cycle   |
+| ---------- | ------- |
+| Cyberpunk  | 24s     |
+| Fantasy    | 40s     |
+| Sci-fi     | 45s     |
+| **Horror** | **60s** |
+
+Sixty seconds is three times [#121's floor](#what-the-cyberpunk-skin-enforces) and slow enough that a
+reader never catches it moving — they notice only that the panel is not quite as it was. That is the
+uncanny the reference asks for, at a rate that cannot startle anyone. It darkens in both directions,
+so it can never cost contrast, and under `prefers-reduced-motion: reduce` the vignette holds at its
+open state with the stain untouched: the genre survives the switch, as it does in the other three.
+
+### The shape nothing agrees with
+
+`3px / 11px / 5px / 8px`, reserved by [#120](#the-four-shapes-and-why-each-is-its-genres) and
+confirmed here. Every other genre's shape states a rule — the base cuts a diagonal pair, sci-fi
+chamfers all four, fantasy takes its foot, cyberpunk refuses to cut at all. This one states no rule:
+four different depths, none matching another, in a system whose whole argument is that the ramps
+agree with each other.
+
+**It is the one genre that can carry that**, which is why it was reserved rather than assigned. An
+uneven shape reads as a mistake anywhere else; here the mistake is the point, and it is legible only
+because three siblings are regular. Every depth is inside `--s5`, so it costs nothing but the
+disagreement.
+
+### The horror skin
+
+| Property          | Value                                                     | Measured                              |
+| ----------------- | --------------------------------------------------------- | ------------------------------------- |
+| `--panel-surface` | `color-mix(in srgb, var(--emerald) 14%, var(--charcoal))` | `rgb(30 41 42)`, luminance 0.0201     |
+| `--panel-edge`    | `color-mix(in srgb, var(--crimson) 50%, var(--granite))`  | 0.0661, in the register, off the tone |
+| Corner depths     | `3px` / `11px` / `5px` / `8px`                            | Nothing agrees; all inside `--s5`     |
+| `--accent`        | `color-mix(in srgb, var(--crimson) 45%, var(--ink))`      | `rgb(197 160 160)`, 6.35:1            |
+| `--accent-quiet`  | **Unchanged.** Gold is the message tone                   | —                                     |
+| Heading colour    | `var(--accent)`, scoped to headings inside a panel        | 6.35:1, clears 4.5                    |
+| Static device     | A crimson-into-black bloom in the bottom-right corner     | 0.0185; `--ink-faint` 5.28:1          |
+| Ambient effect    | A vignette breathing on a 60s cycle, darkening only       | The slowest cycle in the app          |
+
+**The accent is blood on bone, because crimson cannot be text.** Crimson is 2.2:1 on charcoal and is
+never a text colour — [colour roles](#colour-roles) has said so since it was written — so a genre
+whose colour is blood has to lighten it to say anything in words. Crimson 45% into `--ink` is
+`rgb(197 160 160)` at 6.35:1: a blanched, drained red that is legible at label size and reads as
+old rather than fresh. It is the fourth distinct accent, after gold, cyan and magenta, and the halo
+follows it as [sci-fi settled](#the-accent-moves-and-the-halo-follows-it) that it may.
+
+### What the horror skin enforces
+
+- **`horror.css` joins `CONVERTED_SKINS`, and the set is complete.** Four genres, four skin files,
+  every sweep applying to all of them: the hex sweep, the type-ramp sweep, the one-effect cap, the
+  20s motion floor, the depth cap, the darkening rule and the distinctness rule. `GENRES` and the
+  skin directory finally hold the same four names.
+- **No skin paints a tone's colour as its keyline.** `--panel-edge` in a skin file resolves to
+  neither `var(--danger)` nor `var(--success)`. This is the rule this issue adds, and it is the one
+  a future genre reaching for red would break first — the check costs nothing and the failure it
+  prevents is a horror project that looks like a page of failed writes.
+- **The distinctness sweep covers four shapes**, which is the number it was written for and the
+  first time it has had them.
+
+And in the browser: the surface is no lighter than a base panel's and reads **green** — more green
+than red, the third of the four hue assertions after fantasy's warmth and sci-fi's cool — the breath
+runs no faster than the floor, and under reduced motion the stain is still there while the vignette
+holds still.
 
 ## Enforcement
 

--- a/e2e/genre_skin.spec.ts
+++ b/e2e/genre_skin.spec.ts
@@ -344,3 +344,82 @@ test.describe('the cyberpunk skin', () => {
     expect(paint.image, 'the corner marks went with the fault').toContain('linear-gradient');
   });
 });
+
+test.describe('the horror skin', () => {
+  test('goes green and keeps its stain when motion is switched off', async ({ page }) => {
+    await openProject(page);
+    const base = await panelShape(page);
+
+    await setGenre(page, 'horror');
+    const horror = await panelShape(page);
+
+    expect(horror.surface, 'the skin did not reach the panel surface').not.toEqual(base.surface);
+
+    // The morgue, not the blood: red is the obvious horror colour and the wrong one for a plate
+    // that holds a page of generated text. This is the third of the four hue assertions, after
+    // fantasy's warmth and sci-fi's cool. docs/visual-design.md, "The surface is the morgue".
+    expect(horror.surface[1], 'the horror surface is not green').toBeGreaterThan(horror.surface[0]);
+
+    expect(
+      luminance(horror.surface),
+      'a horror panel is lighter than a base panel',
+    ).toBeLessThanOrEqual(luminance(base.surface));
+
+    // Four depths that agree with nothing, which is the one shape a genre states no rule with.
+    expect(horror.clip, 'the skin did not reach the corner').not.toEqual(base.clip);
+    expect(horror.box, 'a skinned panel is not the size of a base panel').toEqual(base.box);
+  });
+
+  test('breathes slower than anything else, and never on the type', async ({ page }) => {
+    await openProject(page);
+    await setGenre(page, 'horror');
+
+    const paint = await page
+      .locator('.panel__field')
+      .first()
+      .evaluate((element) => {
+        const computed = getComputedStyle(element);
+        return {
+          duration: computed.animationDuration,
+          image: computed.backgroundImage,
+        };
+      });
+
+    // Three times #121's floor. The reference's devices are events — a flash, a glitch, a sudden
+    // change — and the whole argument of this skin is that none of them ships: a generator is open
+    // for an afternoon, and what startles you at minute ninety is what you turn off.
+    expect(
+      Number.parseFloat(paint.duration),
+      'the breath is faster than 20s',
+    ).toBeGreaterThanOrEqual(20);
+
+    // The stain and the vignette, both on the surface rather than on anything being read.
+    expect(paint.image, 'the stain is not on the panel surface').toContain('radial-gradient');
+
+    const headingPaint = await page
+      .locator('h1')
+      .first()
+      .evaluate((element) => getComputedStyle(element).backgroundImage);
+
+    expect(headingPaint, 'the skin is painting the type').toBe('none');
+  });
+
+  test('keeps the stain when the breathing stops', async ({ page }) => {
+    // Same standard the other three are held to: what reduced motion removes is the movement, not
+    // the genre. The vignette holds at its open state and the stain is untouched.
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await openProject(page);
+    await setGenre(page, 'horror');
+
+    const paint = await page
+      .locator('.panel__field')
+      .first()
+      .evaluate((element) => ({
+        animation: getComputedStyle(element).animationName,
+        image: getComputedStyle(element).backgroundImage,
+      }));
+
+    expect(paint.animation, 'the breath still runs under reduced motion').toBe('none');
+    expect(paint.image, 'the stain went with the breath').toContain('radial-gradient');
+  });
+});

--- a/src/lib/genre_skin/README.md
+++ b/src/lib/genre_skin/README.md
@@ -2,8 +2,8 @@
 
 Which genre the page is currently wearing, if any. One function, no state.
 
-The app ships three genre skins — `fantasy.css`, `scifi.css`, `cyberpunk.css`, with `horror` still
-to come — and each is keyed off a `data-genre` attribute. This library answers what that attribute's
+The app ships a skin per genre — `fantasy.css`, `scifi.css`, `cyberpunk.css` and `horror.css` — and
+each is keyed off a `data-genre` attribute. This library answers what that attribute's
 value should be; `src/routes/+layout.svelte` is the only place that writes it.
 
 See [the visual design system](../../../docs/visual-design.md), "Applying a skin", for the design.

--- a/src/lib/styles/README.md
+++ b/src/lib/styles/README.md
@@ -11,9 +11,10 @@ brand/          # Vendored from the brand repo: the colour palette, as --ia-* to
 tokens.css      # Custom properties — colour roles, the type and space ramps, elevation, motion
 fonts.css       # The @font-face declarations
 modal.css       # The shared modal system's styles
-fantasy.css     # Genre themes, applied to generated output
+fantasy.css     # Genre skins, applied to the panels of a project's genre
 scifi.css
 cyberpunk.css
+horror.css
 ```
 
 ## Usage

--- a/src/lib/styles/horror.css
+++ b/src/lib/styles/horror.css
@@ -1,0 +1,138 @@
+/* The horror skin: a panel skin over the base system, and nothing more.
+ *
+ * See docs/visual-design.md, "The horror skin, and the discipline of not startling anyone". This is
+ * the fourth genre and the only one with nothing to rewrite — `GENRES` has held `horror` since
+ * before that document existed, and a project set to it got the base appearance by omission rather
+ * than by decision. It is also the first skin written under the whole contract rather than
+ * converted into it, and the first with three finished siblings to be distinct *from*.
+ *
+ * What this file may not touch: the typeface, the type scale, the space ramp, control geometry, the
+ * liner, the halo, `--lift`, and a badge's shape.
+ *
+ * The reference's devices are mostly events — a bright flash of red in a dark field, a glitch, a
+ * sudden change — and none of them is here. A generator is open for an afternoon, and a thing that
+ * startles you at minute ninety is a thing you turn off, taking the genre with it. What this skin
+ * has is dread: the surface is wrong, and nothing ever happens.
+ */
+
+/* The one ambient effect: a breath. The vignette closes and eases back on a 60s cycle — three times
+   #121's motion floor and the slowest thing in the app, against cyberpunk's 24s, fantasy's 40s and
+   sci-fi's 45s. Slow enough that nobody catches it moving; they notice only that the panel is not
+   quite as it was.
+
+   It darkens in both directions, so it can never cost contrast — #158's rule, and the reason a
+   vignette is the right shape for this effect rather than a compromise. */
+@keyframes horror-breath {
+  from {
+    background-size:
+      auto,
+      170% 170%;
+  }
+  to {
+    background-size:
+      auto,
+      120% 120%;
+  }
+}
+
+[data-genre='horror'] {
+  /* The morgue, not the blood. Red is the obvious horror colour and the wrong one for a plate:
+     everything a panel holds sits on this, and a red field under a page of generated text is a page
+     nobody reads. Institutional green-grey — a room designed to be hosed down — and the blood goes
+     on top of it.
+
+     `rgb(30 41 42)` at luminance 0.0201, which puts every ink role ahead of a base panel: 13.6:1,
+     7.1:1 and 5.15:1 against 12.2, 6.3 and 4.6. It is also the first surface drawn after #158, and
+     it shows — 0.0102 of headroom under the readability ceiling where fantasy and sci-fi have
+     0.0026, because those two were drawn as close to the old ceiling as the rule then allowed and
+     had nothing left for the layers they went on to paint. */
+  --panel-surface: color-mix(in srgb, var(--emerald) 14%, var(--charcoal));
+
+  /* Old blood, and deliberately not `--danger`.
+
+     Neat crimson is luminance 0.0882, comfortably inside the register — so the rules as they stood
+     would have allowed it, and it must not be used: crimson *is* `--danger`. A toned panel sets
+     `--panel-edge: var(--danger)` to say a write failed, so a genre painting that same edge would
+     make a horror project look like a page of failures and hide the one panel that had really
+     failed among them. A skin may not paint a tone's colour as its keyline.
+
+     50% into granite is 0.0661: inside the register, a step off the tone, and old blood rather than
+     fresh — which is the more horror answer in any case. */
+  --panel-edge: color-mix(in srgb, var(--crimson) 50%, var(--granite));
+
+  /* The shape nothing agrees with. Every other genre's shape states a rule — the base cuts a
+     diagonal pair, sci-fi chamfers all four, fantasy takes its foot, cyberpunk refuses to cut at
+     all. This one states none: four different depths, none matching another, in a system whose
+     whole argument is that the ramps agree with each other.
+
+     Horror is the only genre that can carry that, which is why #120 reserved it rather than
+     assigning it. An uneven shape reads as a mistake anywhere else; here the mistake is the point,
+     and it is legible only because three siblings are regular. */
+  --panel-corner-tl: 3px;
+  --panel-corner-tr: 11px;
+  --panel-corner-br: 5px;
+  --panel-corner-bl: 8px;
+
+  /* Blood on bone. Crimson is 2.2:1 on charcoal and is never a text colour — "Colour roles" has
+     said so since it was written — so a genre whose colour is blood has to lighten it to say
+     anything in words. 45% into `--ink` is `rgb(197 160 160)` at 6.35:1 on the surface above: a
+     blanched, drained red, legible at label size and old rather than fresh.
+
+     The halo follows the hue, as sci-fi settled that it may. No `--accent-quiet` override, for the
+     fourth time and the same reason: gold is the message tone, and a tone outranks a genre. */
+  --accent: color-mix(in srgb, var(--crimson) 45%, var(--ink));
+}
+
+/* The display ink. Drained red inside a panel, at 6.35:1 on the surface above — a colour, which a
+   skin may set, and not a size or a face, which it may not. Scoped to the panel because that is
+   what a skin dresses: a heading on the bare page belongs to the type ramp. */
+[data-genre='horror'] .panel .panel__title,
+[data-genre='horror'] .panel h2,
+[data-genre='horror'] .panel h3,
+[data-genre='horror'] .panel h4 {
+  color: var(--accent);
+}
+
+/* Two layers on the liner, and only the vignette moves.
+
+   The stain is the fourth device. Sci-fi rules the surface with lines, fantasy gilds two corners of
+   the ring and cyberpunk marks four, so horror takes the shape none of them is — a blot — and puts
+   it on the surface rather than in the ring: a bloom of dried blood soaked into the plate, there
+   before you arrived and never explained. Bottom-right, because that is the corner a reader reaches
+   last and the panel's own furniture is all at the top left; it is in the part of the panel you see
+   without looking at.
+
+   Both layers darken, which is #158's rule and also what these things do: blood on a green floor is
+   a dark patch, not a bright one, and a room's corners go dark before its middle does. The stain
+   measures 0.0185 with `--ink-faint` at 5.28:1 across it. */
+[data-genre='horror'] .panel:not(.panel--bare) > .panel__field {
+  animation: horror-breath 60s ease-in-out infinite alternate;
+  background-image:
+    radial-gradient(
+      ellipse 55% 45% at 88% 92%,
+      color-mix(in srgb, color-mix(in srgb, var(--crimson) 45%, black) 35%, transparent) 0%,
+      transparent 70%
+    ),
+    radial-gradient(
+      ellipse at center,
+      transparent 35%,
+      color-mix(in srgb, black 30%, transparent) 100%
+    );
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+  background-size:
+    auto,
+    150% 150%;
+}
+
+/* Decision 2 caps ambient motion at one effect per skin and turns it off here. The stain stays and
+   the vignette holds at its open state — the genre survives the switch, as it does in the other
+   three, because what is switched off is only the breathing. */
+@media (prefers-reduced-motion: reduce) {
+  [data-genre='horror'] .panel:not(.panel--bare) > .panel__field {
+    animation: none;
+    background-size:
+      auto,
+      170% 170%;
+  }
+}

--- a/src/lib/styles/main.css
+++ b/src/lib/styles/main.css
@@ -5,6 +5,7 @@
 @import './fantasy.css';
 @import './scifi.css';
 @import './cyberpunk.css';
+@import './horror.css';
 @import './modal.css';
 
 /* No `max-width` here on purpose. Capping the document was what kept the site inside 70ch of a

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -402,7 +402,7 @@ describe('the control system', () => {
     ).toEqual([]);
   });
 
-  it.each(['fantasy.css', 'scifi.css', 'cyberpunk.css'])(
+  it.each(['fantasy.css', 'scifi.css', 'cyberpunk.css', 'horror.css'])(
     'leaves control geometry alone in %s',
     (name) => {
       // Decision 2: a skin may set a surface, a keyline, a corner, an accent hue and one ambient
@@ -575,7 +575,7 @@ describe('applying a skin', () => {
   // broken before #118: the genre was written in thirty places, four of which disagreed with the
   // tool catalog that already knew the answer.
 
-  const SKIN_FILES = ['fantasy.css', 'scifi.css', 'cyberpunk.css'];
+  const SKIN_FILES = ['fantasy.css', 'scifi.css', 'cyberpunk.css', 'horror.css'];
 
   it('writes the genre in one place', () => {
     // One genre, one writer. `+layout.svelte` puts `data-genre` on the page region and nothing
@@ -590,6 +590,23 @@ describe('applying a skin', () => {
 
     const layout = readFileSync(join('src', 'routes', '+layout.svelte'), 'utf8');
     expect(layout, 'the one writer stopped writing it').toContain('data-genre={genre}');
+  });
+
+  it('gives every genre a skin, now that horror has one', () => {
+    // The other direction, which only became assertable with #122. `horror` sat in GENRES with no
+    // file from before this document existed until then, and a project set to it got the base
+    // appearance by omission rather than by decision — the resolver returns a genre rather than a
+    // stylesheet precisely so that gap could exist. It does not any more, and this is what keeps a
+    // fifth genre from being added without one.
+    const skinned = new Set(
+      SKIN_FILES.flatMap((name) =>
+        [...readFileSync(join(STYLES_DIR, name), 'utf8').matchAll(/\[data-genre='([^']*)'\]/g)].map(
+          ([, genre]) => genre,
+        ),
+      ),
+    );
+
+    expect([...skinned].sort(), 'a genre has no skin file').toEqual([...GENRES].sort());
   });
 
   it('keeps skins in skin files, and leaves the old class name behind', () => {
@@ -617,8 +634,7 @@ describe('applying a skin', () => {
 
   it('keys every skin off a genre that exists', () => {
     // A stylesheet keyed to a genre the app does not have is dead CSS that looks live, and it is
-    // exactly what a typo produces. `horror` is in GENRES with no file yet — that direction is
-    // fine, and is why the resolver returns a genre rather than a stylesheet.
+    // exactly what a typo produces.
     const genres = new Set<string>(GENRES);
 
     for (const name of SKIN_FILES) {
@@ -751,7 +767,7 @@ describe('the panel language', () => {
     }
   });
 
-  it.each(['fantasy.css', 'scifi.css', 'cyberpunk.css'])(
+  it.each(['fantasy.css', 'scifi.css', 'cyberpunk.css', 'horror.css'])(
     'leaves panel and badge geometry alone in %s',
     (name) => {
       // Decision 2 again, for the surfaces: a skin may set `--panel-edge` and `--panel-surface`
@@ -786,10 +802,11 @@ describe('the panel language', () => {
     },
   );
 
-  // Every skin the app has. The list was created because the skins converted one issue at a time
-  // and the ones that had not were exempt from the sweeps; #121 is the last of them, so there is
-  // nothing carried and nothing left to exempt.
-  const CONVERTED_SKINS = ['fantasy.css', 'scifi.css', 'cyberpunk.css'];
+  // Every skin the app has, and now every genre it has: #122 adds the fourth file, so `GENRES` and
+  // this directory finally hold the same four names. The list was created because the skins
+  // converted one issue at a time and the ones that had not were exempt from the sweeps; nothing is
+  // carried and there is nothing left to exempt.
+  const CONVERTED_SKINS = ['fantasy.css', 'scifi.css', 'cyberpunk.css', 'horror.css'];
 
   it.each(CONVERTED_SKINS)('writes no colour value of its own in %s', (name) => {
     // The exemption granted when the controls landed — "their heading effects are full of hexes and
@@ -923,6 +940,24 @@ describe('the panel language', () => {
           true,
         );
       }
+    }
+  });
+
+  it.each(CONVERTED_SKINS)('leaves the tones their own colours in %s', (name) => {
+    // docs/visual-design.md, "The keyline is old blood, and deliberately not `--danger`". Neat
+    // crimson is luminance 0.0882 and sits inside the keyline register, so the rules as they stood
+    // permitted it — and crimson *is* `--danger`. A toned panel sets `--panel-edge: var(--danger)`
+    // to say a write failed, so a genre wearing that edge would make a whole project look like a
+    // page of failures and hide the one panel that had really failed among them.
+    //
+    // A skin may mix a tone's palette entry with something else — horror's keyline is half crimson
+    // — but it may not paint the role itself, because that is the value the tone sets.
+    const css = withoutComments(readFileSync(join(STYLES_DIR, name), 'utf8'));
+
+    for (const tone of ['--danger', '--success']) {
+      expect(css, `${name} paints ${tone}, which is a tone's to say and not a genre's`).not.toMatch(
+        new RegExp(`--panel-edge\\s*:\\s*var\\(${tone}\\)`),
+      );
     }
   });
 


### PR DESCRIPTION
Closes #122. The fourth genre, and the last skin in the redesign.

Design: [`docs/visual-design.md`, "The horror skin, and the discipline of not startling anyone"](https://github.com/ironarachne/ironarachne/blob/issue-122-horror-skin/docs/visual-design.md#the-horror-skin-and-the-discipline-of-not-startling-anyone), approved before implementation. Drawn against [horror aesthetics in UX](https://medium.com/@yfxpdbw/designing-for-nightmares-the-role-of-horror-aesthetics-in-user-experience-1499b307de8a), Resident Evil's corridors and Diablo's near-black grounds.

This one had nothing to rewrite: `horror` has been in `GENRES` since before the design document existed and a project set to it got the base appearance by omission rather than by decision. It is also the first skin written under the whole contract rather than converted into it, and the first with three finished siblings its surface, keyline, shape, device and effect all had to miss.

### What ships

| Property | Value | Measured |
| --- | --- | --- |
| `--panel-surface` | `--emerald` 14% into `--charcoal` | `rgb(30 41 42)`, L 0.0201 — ink 13.6 / 7.1 / 5.15, all ahead of a base panel |
| `--panel-edge` | `--crimson` 50% into `--granite` | 0.0661, inside the register and a step off the tone |
| Corner depths | `3 / 11 / 5 / 8` | the shape #120 reserved |
| `--accent` | `--crimson` 45% into `--ink` | `rgb(197 160 160)`, 6.35:1 |
| Static device | a crimson-into-black bloom, bottom-right | 0.0185; `--ink-faint` 5.28:1 across it |
| Ambient effect | a vignette breathing on 60s, darkening only | the slowest cycle in the app |

### None of the reference's devices ship

"A bright flash of red in an otherwise dark environment", glitch displacement, sudden visual change — all events, and the same reasoning that killed the cyberpunk flicker applies: a generator is open for an afternoon, and what startles you at minute ninety is what you turn off, taking the genre with it. What ships is **dread rather than shock** — the surface is wrong, and nothing ever happens. The reference's most-emphasised technique is sound, which [decision 4](https://github.com/ironarachne/ironarachne/blob/issue-122-horror-skin/docs/visual-design.md#4-sound-on-press-does-not-ship) had already refused for its own reasons.

Sixty seconds is three times #121's motion floor. Slow enough that nobody catches it moving — they notice only that the panel is not quite as it was.

### The surface is the morgue, not the blood

Red is the obvious horror colour and the wrong one for a plate: everything a panel holds sits on it, and a red field under a page of generated text is a page nobody reads. Institutional green-grey, with the blood on top.

It is also the first surface drawn after #158, and it shows: 0.0102 of headroom under the readability ceiling where fantasy and sci-fi have 0.0026, because those two were drawn as close to the old ceiling as the rule then allowed and had nothing left for the layers they went on to paint.

### One new rule: a skin may not paint a tone's colour as its keyline

Neat crimson is luminance 0.0882 — inside the keyline register, so the rules as they stood permitted it. But crimson **is** `--danger`, and a toned panel sets `--panel-edge: var(--danger)` to say a write failed. A genre wearing that edge would make a horror project look like a page of failures, and would hide the one panel that had really failed among them. Old blood at 50% into granite instead — and the sweep now forbids a skin painting either tone role directly.

### The stain is the fourth device

Sci-fi rules the surface with lines, fantasy gilds two corners of the ring, cyberpunk marks four — so horror takes the shape none of them is, a blot, and puts it on the surface. Bottom-right, because that is the corner a reader reaches last and the panel's furniture is all top-left: it is in the part of the panel you see without looking at. It darkens, per #158, which is also what a stain does — blood on a green floor is a dark patch, not a bright one.

### Checked on the page

A screenshot confirms the green plate, the drained-red heading, the stain blushing at the bottom-right and the uneven corners — the 11px top-right reads against the 3px top-left, which is the whole point of a shape that agrees with nothing.

### Enforcement

`horror.css` joins `CONVERTED_SKINS` and **the set is complete**: four genres, four files, every sweep applying to all of them — hex, type ramp, one effect, the 20s floor, the depth cap, the darkening rule, distinctness and now tones — with nothing carried and nothing exempt. Plus one assertion that only became possible with this file: **every genre has a skin**. The existing test checked that no stylesheet keys off a genre that does not exist; its comment noted `horror` was the gap in the other direction, and that gap is closed.

In the browser: the surface reads green (the third of four hue assertions, after fantasy's warmth and sci-fi's cool), is no lighter than a base panel's, the corner differs while the box does not, the breath is no faster than the floor, and under reduced motion the stain is still there while the vignette holds still.

### Checks

`npm run verify:all` green — 4470 unit tests, 446 Playwright tests, `svelte-check` 0 errors, coverage gate 98/98 with no baselined debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2wzaP74ffGJjghzcabKeT