### PR TITLE
Put the icon set to work, for #123

### DIFF
--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -141,9 +141,21 @@ look like a page of failed writes and hide the one panel that had really failed.
 contract used as intended: an institutional green surface with room under the readability ceiling, a
 blood stain that darkens, and the slowest ambient effect in the app at 60s.
 
-Awaiting approval, unlike the amendments above it, which are built: #122 is `needs-design`, and the
-tone rule, the surface and the 60s breath are what CLAUDE.md's review gate asks a human to approve
-before implementation starts.
+Approved and built.
+
+**Amended 2026-08-30 by [#123](https://github.com/ironarachne/ironarachne/issues/123)**, which adds
+[icons](#icons-the-glyph-that-names-and-the-mark-that-decorates) and closes the document's two
+remaining open questions. It moves one rule rather than adding a section beside it: "a glyph replaces
+a label there is no space for" was written to stop a codebase with 455 icons from acquiring them
+everywhere, and it reads as a ban on the other job an icon does. A glyph names; a **mark**
+decorates, is `aria-hidden`, and is governed by five rules that keep a page with character from
+becoming a page somebody decorated. The domains get marks — which is the domain marker
+[open question 3](#open-questions) speculated about, delivered as a glyph rather than a colour, so
+the eight unused palette entries stay unused.
+
+Awaiting approval, unlike the amendments above it, which are built: #123 is `needs-design`, and the
+second role, the density rules and the domain mapping are what CLAUDE.md's review gate asks a human
+to approve before implementation starts.
 
 **Amended 2026-08-30, in review of the above:** every genre gets a panel shape of its own, which
 replaces the "three corner treatments" cap rather than extending it. The panel's polygon is written
@@ -785,6 +797,13 @@ and onto the panel is [#119](https://github.com/ironarachne/ironarachne/issues/1
 that forward here would put four genres' worth of untested surface in a controls change.
 
 ### A round icon button
+
+**This section governs glyphs, not marks.** Its rule — a glyph replaces a label there is no space
+for, not one that already works — is about icons that carry meaning, and
+[icons](#icons-the-glyph-that-names-and-the-mark-that-decorates) adds the second role beside it: a
+mark, which decorates a surface that already reads without it and is hidden from the accessibility
+tree for exactly that reason. The rule below is unchanged and still binding on anything that names a
+control.
 
 Five controls are round: **move left**, **move right** and **close** on a workshop panel's header,
 and **export** and **delete** on a row in the project listing. `RoundIconButton` is what they
@@ -2886,6 +2905,176 @@ than red, the third of the four hue assertions after fantasy's warmth and sci-fi
 runs no faster than the floor, and under reduced motion the stain is still there while the vignette
 holds still.
 
+## Icons: the glyph that names, and the mark that decorates
+
+The pack is in. `src/lib/assets/icons` holds 455 icons from SunGraphica's _600 Minimal Icons_,
+split from the vendor's sheets, named, indexed, and credited in the footer as a licence term. Five
+controls use it — the five [the round icon button](#a-round-icon-button) identified as having no
+room for a label. Everything else about it is undecided, which is
+[open question 1](#open-questions), and this settles it.
+
+It also has to move a rule. The document says a glyph "replaces a label there is no space for, not
+one that already works", which was written to stop a codebase with 455 icons in it from acquiring
+them everywhere — a real risk, and the rule stays. But it describes only half of what an icon does
+here. This is a suite of generators for tabletop games, `set2` alone is ninety-nine shields,
+potions, scrolls, weapons and campfires, and **a site that never shows one is underselling what it
+is.** The answer is a second role beside the first rather than an exception to it.
+
+### Two roles, and the test that separates them
+
+|                  | **Glyph**                                     | **Mark**                                           |
+| ---------------- | --------------------------------------------- | -------------------------------------------------- |
+| Job              | Stands in for a label there was no room for   | Gives a surface character it already reads without |
+| Accessibility    | Carries an accessible name                    | `aria-hidden`, always                              |
+| If you delete it | The control cannot be identified              | The page loses flavour and nothing else            |
+| Governed by      | [The round icon button](#a-round-icon-button) | This section                                       |
+
+The test is the third row, and it is worth applying literally rather than by feel: **delete it and
+see what breaks.** If meaning goes, it is a glyph and it needs a name. If only flavour goes, it is a
+mark and it must be hidden from the accessibility tree — because a screen reader announcing "image"
+between a heading and its text is worse than the silence it replaces.
+
+Everything the five existing controls do stays exactly as it is. What follows is about marks.
+
+### What stops a mark becoming a sticker
+
+Five rules, and they are what makes the difference between a page with character and a page somebody
+decorated:
+
+- **One mark per surface.** A card with three marks on it is decorated; a card with one is
+  characterful. The exception is a mark used as a **classifier**, which repeats down a list on
+  purpose — see the domain marks below.
+- **A mark is never the brightest thing on its surface.** It paints `--ink-faint`, the role for
+  things that are present without being read. A mark that outshines the text beside it has become
+  the content.
+- **A mark is sized in `em`**, so it inherits the ramp step of the text it accompanies and is on the
+  type ramp for free. No mark declares a pixel size.
+- **Never in running prose.** A mark sits beside a heading, in an empty state, or on a card — never
+  inside a sentence, where it interrupts a line somebody is reading.
+- **Never inside a control that already has a label.** That is the original rule, and it is the one
+  a set this large erodes first.
+
+Marks survive the genre skins for free, because `--ink-faint` is a role every skin inherits and an
+icon paints `currentColor` through a mask. A skin may not swap a mark: a skin sets a surface, a
+keyline, a corner, an accent and one effect, and an icon is none of those.
+
+### The domain marks, which answer the question the palette could not
+
+The tool catalog has classified every tool by `domain` since it was written, and nothing has ever
+shown that classification. Five domains, five marks, **all from `set2`** so the family reads as one
+hand rather than as five icons that happened to be available:
+
+| Domain       | Mark            | Why                                                     |
+| ------------ | --------------- | ------------------------------------------------------- |
+| `characters` | `set2/helmet-1` | A helm — a person in a game, rather than a person       |
+| `factions`   | `set2/flag`     | The thing a faction plants                              |
+| `locations`  | `set2/map`      | Settlements, regions, dungeons: all read off a map      |
+| `objects`    | `set2/chest`    | What the objects are generated into                     |
+| `utilities`  | `set2/compass`  | Instruments rather than output — dice, names, languages |
+
+**This is the domain marker [open question 3](#open-questions) speculated about**, and it settles
+that question in a way the palette could not. The elevation section imagined domains reachable
+"through a genre skin or a domain marker"; a mark does it as a **glyph rather than a colour**, which
+means the eight unused palette entries stay unused — the other answer that question offered, and now
+the true one. A colour-coded domain would have collided with the genre skins (which own the panel's
+hue) and with the tone colours (which own meaning); a glyph collides with neither.
+
+A domain mark is the classifier exception to "one mark per surface": it repeats beside every tool in
+a list because that is what classifying is. It is still `aria-hidden` — the domain is already in the
+heading above the group, and announcing it once per row is noise.
+
+### An artifact kind carries its own mark
+
+`ArtifactKindEntry` gains an optional `icon`, beside the `displayName` it already has. A kind is
+registered once and read everywhere — the vault, the project view, the picker — so the mark belongs
+with the registration rather than in a lookup table each surface maintains.
+
+```mermaid
+classDiagram
+    class ArtifactKindEntry {
+        +ArtifactKind kind
+        +string displayName
+        +string icon
+        +number payloadVersion
+    }
+    class ToolDomain {
+        <<characters, factions, locations, objects, utilities>>
+    }
+    class DomainMark {
+        <<DOMAIN_MARKS>>
+        +string markup
+    }
+    class Icon {
+        <<component>>
+        +string markup
+        +string label
+    }
+
+    ToolDomain "1" --> "1" DomainMark : classified by
+    ArtifactKindEntry "1" --> "0..1" Icon : marked by
+    DomainMark --> Icon : rendered through
+    Icon ..> ArtifactKindEntry : label absent means aria-hidden
+```
+
+`icon` is optional because a kind without one is a kind that reads fine without one, and requiring it
+would produce a shrug emoji's worth of thought per new kind. The vault falls back to no mark rather
+than to a generic one: a placeholder mark is a sticker.
+
+### Where character goes
+
+Concretely, and the list is the scope rather than an illustration:
+
+- **`/tools`** — a domain mark beside each of the five group headings, and beside each tool in the
+  group.
+- **The workshop's tool browser** — the same marks, the same source.
+- **The home page's featured list** — the tool's domain mark per row.
+- **The vault and the session log's empty states** — the surfaces the app is plainest on, and the
+  ones a first-time user sees most. An empty shelf with a mark on it reads as a shelf; an empty
+  shelf with a sentence on it reads as a bug.
+- **Artifact rows in the vault and the project view** — the kind's mark, where it has one.
+
+And where it does not go: **the six nav destinations** (`docs/app-shell.md` decision 6 stands, and
+reopening it is its own issue), **a dialog** (the app's own voice, and neutral by rule), **inside any
+labelled control**, and **in running prose**.
+
+### The import is static, for the same reason `TOOL_PANELS` is
+
+`Icon` takes **markup**, not a name:
+
+```svelte
+<script lang="ts">
+  import flag from '$lib/assets/icons/set2/flag.svg?raw';
+</script>
+
+<Icon icon={flag} />
+```
+
+A component that took `name="set2/flag"` and resolved it would need a computed import, and a
+computed import cannot be statically analysed — so every one of the 455 icons would land in the
+bundle of any page that showed one. That is the same trap `TOOL_PANELS` documents for the tool
+panels, and it is the reason `DOMAIN_MARKS` is written out in full as five `?raw` imports rather
+than built from `DOMAINS`.
+
+`Icon` is otherwise thin: it inlines the markup, sets `aria-hidden` when no `label` is given and
+`role="img"` with the name when one is, and sizes itself at `1em`. `RoundIconButton` already does
+this by hand for its five, and keeps doing it — it owns a control, not a mark.
+
+### What this enforces
+
+- **No component inlines an `<svg>` literal.** The exceptions are the libraries that _generate_ SVG
+  — heraldry, the emblem renderers — which is a different thing from a component drawing a picture
+  by hand. This is the sweep that stops the sixth icon being pasted in as markup.
+- **An icon without a label is `aria-hidden`.** Asserted on the component, because the alternative is
+  a screen reader reading "image" beside every tool in a list of thirty-four.
+- **`DOMAIN_MARKS` covers `DOMAINS` exactly.** A sixth domain cannot be added without a mark, and a
+  mark cannot outlive its domain — the same shape as the test that keeps the tool catalog and
+  `TOOL_PANELS` in step.
+- **No mark declares a pixel size or a colour.** Both fall out of the existing ramp and hex sweeps
+  once a mark is `em`-sized and painted in a role.
+
+And one in the browser: a tool row in the catalog carries **exactly one** mark, which is the density
+rule stated as a number rather than as a paragraph.
+
 ## Enforcement
 
 The rule is that no component declares a hex and no component declares a size outside these ramps.
@@ -2941,12 +3130,20 @@ For the implementation issues that follow this one:
    the rule the rest of the answer should follow: a glyph replaces a label there is no space for,
    not one that already works.
 
+   **Answered by [icons](#icons-the-glyph-that-names-and-the-mark-that-decorates):** the control set
+   is those five and stays those five, and the rest of the pack is spent on the other job an icon
+   does — character, as a **mark** rather than a glyph. The domains are mapped, artifact kinds carry
+   their own, and the five rules that keep marks from becoming stickers are stated there.
+
 2. ~~**Whether `--surface-sunken` earns its place.**~~ **Answered by [the panel
    language](#three-levels-and-the-well-makes-four):** it stays. Four panels scroll their contents
    internally, and the well is the surface that says a run of rows is held by the panel rather than
    continuing past its edge. Four surface levels is one more than the elevation model claimed, and
    the model gains the fourth rather than the token being dropped.
-3. **Domain accent markers.** The eight unused palette entries are described as reachable "through
-   a genre skin or a domain marker", but no domain marker is designed here. The tool catalog has a
-   `domain` field and the mockup does not use it. Either a later document designs that, or the
-   eight entries are simply unused by the app, which is also a fine answer.
+3. ~~**Domain accent markers.**~~ **Answered by [the domain
+   marks](#the-domain-marks-which-answer-the-question-the-palette-could-not):** the domain marker
+   exists, and it is a **glyph rather than a colour** — one `set2` icon per domain, the same five
+   everywhere the catalog groups itself. So the second half of this question's own answer is the
+   true one: the eight unused palette entries stay unused. A colour-coded domain would have collided
+   with the genre skins, which own a panel's hue, and with the tone colours, which own meaning; a
+   glyph collides with neither.

--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -2948,7 +2948,10 @@ decorated:
   things that are present without being read. A mark that outshines the text beside it has become
   the content.
 - **A mark is sized in `em`**, so it inherits the ramp step of the text it accompanies and is on the
-  type ramp for free. No mark declares a pixel size.
+  type ramp for free. No mark declares a pixel size. The exception is a mark on an **empty
+  surface**, which has no text to accompany: it takes a step from the ramp directly
+  (`--t-display-size`), because at `1em` a mark on an empty shelf reads as a typo beside the
+  sentence rather than as furniture.
 - **Never in running prose.** A mark sits beside a heading, in an empty state, or on a card — never
   inside a sentence, where it interrupts a line somebody is reading.
 - **Never inside a control that already has a label.** That is the original rule, and it is the one

--- a/e2e/icons.spec.ts
+++ b/e2e/icons.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * The density rule, as a number rather than as a paragraph.
+ *
+ * `docs/visual-design.md`, "What stops a mark becoming a sticker": one mark per surface, and the
+ * domain marks are the classifier exception that repeats down a list on purpose. Both halves are
+ * only checkable against what actually renders — a source sweep cannot count what a component put
+ * on a row.
+ */
+test.describe('icons', () => {
+  test('gives a tool row one mark and no more', async ({ page }) => {
+    await visitRoute(page, '/tools', { title: 'All Tools | Iron Arachne' });
+
+    const rows = page.locator('.all-tools__tool');
+    const count = await rows.count();
+    expect(count, 'the catalog rendered no tools').toBeGreaterThan(0);
+
+    for (let index = 0; index < count; index += 1) {
+      const marks = rows.nth(index).locator('.icon');
+      await expect(marks, 'a tool row carries more than one mark').toHaveCount(1);
+    }
+  });
+
+  test('hides every mark from the accessibility tree', async ({ page }) => {
+    await visitRoute(page, '/tools', { title: 'All Tools | Iron Arachne' });
+
+    // Thirty-four rows, each classified by a domain the heading above it already states. A mark
+    // that announced itself would be thirty-four unskippable "image"s between a reader and the
+    // list they came for.
+    const marks = page.locator('.all-tools__list .icon');
+    const total = await marks.count();
+    expect(total, 'nothing was marked').toBeGreaterThan(0);
+
+    for (let index = 0; index < total; index += 1) {
+      await expect(marks.nth(index)).toHaveAttribute('aria-hidden', 'true');
+    }
+  });
+
+  test('recedes rather than competing with the label it classifies', async ({ page }) => {
+    await visitRoute(page, '/tools', { title: 'All Tools | Iron Arachne' });
+
+    // A mark is never the brightest thing on its surface. It shipped inheriting the link's accent
+    // green the first time, which is a mark competing with the label beside it; `Icon` decides this
+    // from the same `label`-or-not that makes it a mark at all.
+    const paint = await page
+      .locator('.all-tools__tool .icon')
+      .first()
+      .evaluate((element) => {
+        const row = element.closest('a');
+        return {
+          mark: getComputedStyle(element).color,
+          label: row === null ? '' : getComputedStyle(row).color,
+        };
+      });
+
+    expect(paint.mark, 'the mark takes the label’s own colour').not.toBe(paint.label);
+  });
+});

--- a/src/components/common/Icon.svelte
+++ b/src/components/common/Icon.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  /**
+   * One icon from `src/lib/assets/icons`, inlined.
+   *
+   * See docs/visual-design.md, "Icons: the glyph that names, and the mark that decorates". An icon
+   * here does one of two jobs and this component is told which by whether it is given a `label`:
+   *
+   * - **A glyph** stands in for a label there was no room for. It carries an accessible name, and
+   *   deleting it would leave the thing it names unidentifiable.
+   * - **A mark** gives a surface character it already reads without. It is `aria-hidden`, because a
+   *   screen reader announcing "image" between a heading and its text is worse than the silence it
+   *   replaces, and deleting it costs nothing but flavour.
+   *
+   * **Markup rather than a name**, which is not a convenience. A `name="set2/flag"` prop would need
+   * a computed `import()`, a computed specifier cannot be statically analysed, and all 455 icons
+   * would land in the bundle of any page that showed one — the same trap `TOOL_PANELS` documents
+   * for the tool panels. Callers import with `?raw` and pass what they get.
+   *
+   * Sized at `1em`, so a mark inherits the ramp step of the text beside it and is on the type ramp
+   * without declaring a size. Painted with `currentColor` through the icon's own mask, so it takes
+   * the colour of whatever it sits in and survives all four genre skins without knowing they exist.
+   */
+
+  type Props = {
+    /** The icon's markup, imported with `?raw`. */
+    icon: string;
+    /** The accessible name. Given, this is a glyph; omitted, it is a mark and is hidden. */
+    label?: string;
+    class?: string;
+  };
+
+  let { icon, label, class: extraClass = '' }: Props = $props();
+</script>
+
+<!-- Vendored icon markup from `src/lib/assets/icons`, never user input.
+
+     A block directive rather than `eslint-disable-next-line`: this element carries enough
+     attributes that Prettier wraps them, which moves the `{@html}` off the line after the comment
+     and leaves the rule firing again. -->
+<!-- eslint-disable svelte/no-at-html-tags -->
+<span
+  class="icon {extraClass}"
+  class:icon--mark={label === undefined}
+  role={label === undefined ? undefined : 'img'}
+  aria-label={label}
+  aria-hidden={label === undefined ? 'true' : undefined}>{@html icon}</span
+>
+
+<!-- eslint-enable svelte/no-at-html-tags -->
+
+<style>
+  /* `em` rather than a ramp step: the mark belongs to the text it accompanies, so it takes that
+     text's size whatever step the caller is on. A pixel size here would be a sixth type ramp. */
+  .icon {
+    display: inline-flex;
+    flex: 0 0 auto;
+    height: 1em;
+    width: 1em;
+  }
+
+  /* A mark is never the brightest thing on its surface, so it recedes to the role for things that
+     are present without being read. Decided here rather than at each call site, because the same
+     `label`-or-not that makes it a mark is what makes it decoration — and a mark inheriting a
+     link's accent green, which is what happened the first time this shipped, is a mark competing
+     with the label it classifies.
+
+     A glyph is untouched: it takes `currentColor` from the control it names, which is how a
+     pressed or disabled button carries its icon with it. */
+  .icon--mark {
+    color: var(--ink-faint);
+  }
+
+  /* The file's own `width`/`height` are a default to override in CSS, per the icon set's README. */
+  .icon :global(svg) {
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+</style>

--- a/src/components/common/SessionLogPanel.svelte
+++ b/src/components/common/SessionLogPanel.svelte
@@ -14,6 +14,8 @@
   import { findToolByPath } from '$lib/tools';
   import { showConfirmModal } from '$lib/ui';
   import { hasToolPanel } from '$lib/workshop';
+  import roll from '$lib/assets/icons/set3/roll.svg?raw';
+  import Icon from '$components/common/Icon.svelte';
   import ListButton from '$components/common/ListButton.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
   import Panel from '$components/common/Panel.svelte';
@@ -108,7 +110,13 @@
 
   <div class="session-log__list well">
     {#if visible.length === 0}
-      <p class="session-log__empty">Nothing rolled yet.</p>
+      <!-- Same reasoning as the vault's empty shelf: a mark makes an empty list read as a list
+           rather than as a failure to load. Hidden from the accessibility tree; the sentence is
+           the whole message. -->
+      <p class="session-log__empty">
+        <Icon icon={roll} class="session-log__empty-mark" />
+        Nothing rolled yet.
+      </p>
     {:else}
       <ul>
         {#each visible as entry (entry.id)}
@@ -183,6 +191,15 @@
     letter-spacing: normal;
     color: var(--ink-muted);
     overflow-wrap: anywhere;
+  }
+
+  .session-log__empty :global(.session-log__empty-mark) {
+    /* An empty surface has nothing for a mark to accompany, so this one takes a ramp step of its
+       own rather than inheriting one — at `1em` it reads as a typo beside the sentence. A step
+       from the ramp rather than a multiple of the text, which is what keeps it off a sixth scale. */
+    font-size: var(--t-display-size);
+    margin-right: var(--s3);
+    vertical-align: -0.15em;
   }
 
   .session-log__empty {

--- a/src/components/common/ToolBrowser.svelte
+++ b/src/components/common/ToolBrowser.svelte
@@ -7,7 +7,9 @@
     systemDisplayName,
   } from '$lib/tools';
   import type { GameSystem, Genre, Tool } from '$lib/tools';
+  import { DOMAIN_MARKS } from '$lib/tool_marks';
   import Badge from '$components/common/Badge.svelte';
+  import Icon from '$components/common/Icon.svelte';
   import ListButton from '$components/common/ListButton.svelte';
   import Panel from '$components/common/Panel.svelte';
   import ToolMaturityBadge from '$components/common/ToolMaturityBadge.svelte';
@@ -135,7 +137,10 @@
 
   <div class="tool-browser__list well">
     {#each groups as group (group.domain)}
-      <h3>{group.heading}</h3>
+      <!-- The catalog's own classification, shown. Same marks the All Tools page uses, from the
+           same map, because two lists of the same catalog disagreeing about what a domain looks
+           like is worse than neither showing it. -->
+      <h3><Icon icon={DOMAIN_MARKS[group.domain]} class="tool-browser__mark" />{group.heading}</h3>
       <ul>
         {#each group.tools as tool (tool.path)}
           {@const isActive = loadedPaths.has(tool.path)}
@@ -145,7 +150,10 @@
               selected={isActive}
               onclick={() => selectTool(tool)}
             >
-              <span class="tool-browser__name">{tool.label}</span>
+              <span class="tool-browser__label">
+                <Icon icon={DOMAIN_MARKS[group.domain]} />
+                <span class="tool-browser__name">{tool.label}</span>
+              </span>
               <!-- The maturity rides along with every entry that has one to state. This list
                    used to mark all of them, on the grounds that marking only the unfinished tools
                    leaves the user reading absence; #43 settled it the other way, because
@@ -240,6 +248,19 @@
   li {
     list-style-type: none;
     margin: 0;
+  }
+
+  /* The mark and the name are one thing, so the row's own layout pushes the badges away from the
+     pair rather than the mark away from the name it classifies. */
+  .tool-browser__label {
+    align-items: baseline;
+    display: flex;
+    gap: var(--s3);
+    min-width: 0;
+  }
+
+  .tool-browser__list :global(.tool-browser__mark) {
+    margin-right: var(--s3);
   }
 
   .tool-browser__name {

--- a/src/components/layout/AllToolsPage.svelte
+++ b/src/components/layout/AllToolsPage.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { allTools, groupToolsByDomain, searchTools } from '$lib/tools';
+  import { DOMAIN_MARKS } from '$lib/tool_marks';
+  import Icon from '$components/common/Icon.svelte';
   import ToolMaturityBadge from '$components/common/ToolMaturityBadge.svelte';
 
   const tools = allTools();
@@ -57,7 +59,12 @@
   <div class="all-tools__list">
     {#each groups as group (group.domain)}
       <section class="all-tools__group">
-        <h2>{group.heading}</h2>
+        <!-- The domain's mark, twice over: once on the heading and once per row. It is a
+             classifier rather than decoration, which is the one exception to "one mark per
+             surface" — repeating beside every tool is what classifying is. `aria-hidden` in both
+             places, because the domain is already in the heading and announcing it thirty-four
+             times is noise. See docs/visual-design.md, "The domain marks". -->
+        <h2><Icon icon={DOMAIN_MARKS[group.domain]} class="all-tools__mark" />{group.heading}</h2>
         <ul>
           {#each group.tools as tool (tool.path)}
             <li>
@@ -70,7 +77,10 @@
                    a value typed as the union of every route id does not satisfy it. Every catalog
                    path is a parameterless static route, as the home page's featured links are. -->
               <a class="all-tools__tool inset" href={resolve(tool.path as '/')}>
-                <span class="all-tools__name">{tool.label}</span>
+                <span class="all-tools__label">
+                  <Icon icon={DOMAIN_MARKS[group.domain]} />
+                  <span class="all-tools__name">{tool.label}</span>
+                </span>
                 <!-- Same rule the workshop's browser follows, settled in #43: a release-ready tool
                      says nothing, because the level is a qualifier on what will happen to the
                      user's work rather than a grade. An unmarked row is a finished tool. -->
@@ -124,6 +134,10 @@
     margin-top: 1.5rem;
   }
 
+  .all-tools__group :global(.all-tools__mark) {
+    margin-right: var(--s3);
+  }
+
   .all-tools__group h2 {
     color: var(--gold);
     font-size: 0.85rem;
@@ -165,6 +179,15 @@
   .all-tools__tool:hover,
   .all-tools__tool:focus-visible {
     border-color: var(--tan);
+  }
+
+  /* The mark and the name are one thing, so the row's `space-between` pushes the maturity badge
+     away from the pair rather than pushing the mark away from the name it classifies. */
+  .all-tools__label {
+    align-items: baseline;
+    display: flex;
+    gap: var(--s3);
+    min-width: 0;
   }
 
   .all-tools__name {

--- a/src/components/layout/HomePage.svelte
+++ b/src/components/layout/HomePage.svelte
@@ -4,6 +4,8 @@
   import ReleaseNotes from '$components/layout/ReleaseNotes.svelte';
   import ToolMaturityBadge from '$components/common/ToolMaturityBadge.svelte';
   import { featuredTools } from '$lib/tools';
+  import { DOMAIN_MARKS } from '$lib/tool_marks';
+  import Icon from '$components/common/Icon.svelte';
 
   const featured = featuredTools();
 </script>
@@ -40,7 +42,10 @@
           <li>
             <!-- `resolve` is typed against one route id at a time, so the union of every route id
                  does not satisfy it. Catalog paths are all parameterless static routes. -->
-            <a href={resolve(tool.path as '/')}>{tool.label}</a>
+            <a href={resolve(tool.path as '/')}>
+              <Icon icon={DOMAIN_MARKS[tool.domain]} />
+              {tool.label}
+            </a>
             <ToolMaturityBadge maturity={tool.maturity} />
           </li>
         {/each}
@@ -146,6 +151,14 @@
 
   .home__column h2 {
     margin-top: 0;
+  }
+
+  /* The mark sits with the link's own text, so a wrapped tool name keeps its classifier beside
+     the first line rather than stranded above it. */
+  .home__featured a {
+    align-items: baseline;
+    display: inline-flex;
+    gap: var(--s3);
   }
 
   .home__featured li {

--- a/src/components/layout/VaultPage.svelte
+++ b/src/components/layout/VaultPage.svelte
@@ -18,7 +18,9 @@
   import { hydrateProjects, listProjects, onProjectsChanged } from '$lib/projects';
   import { showConfirmModal } from '$lib/ui';
   import { artifactKindEntry, registeredArtifactKinds } from '$lib/workshop';
+  import chest from '$lib/assets/icons/set2/chest.svg?raw';
   import Chip from '$components/common/Chip.svelte';
+  import Icon from '$components/common/Icon.svelte';
   import ListButton from '$components/common/ListButton.svelte';
   import ArtifactInspector from '$components/common/ArtifactInspector.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
@@ -185,15 +187,28 @@
       {/if}
 
       {#if entries.length === 0}
+        <!-- An empty shelf with a mark on it reads as a shelf; an empty shelf with only a
+             sentence on it reads as a bug. The mark is `aria-hidden` and the sentence says
+             everything — remove the chest and nothing is lost but the flavour of one. -->
         <p class="vault__empty">
-          Nothing saved yet. Anything you keep in the workshop shows up here, whichever project it
-          went into.
+          <Icon icon={chest} class="vault__empty-mark" />
+          Nothing saved yet. Anything you keep in the workshop shows up here, whichever project it went
+          into.
         </p>
       {:else if visible.length === 0}
         <p class="vault__empty">Nothing matches that.</p>
       {:else}
         {#each groups as group (group.kind)}
-          <h2>{kindLabel(group.kind)}</h2>
+          <!-- The kind's own mark, from its registration. A kind without one shows none: the
+               fallback is nothing rather than a generic icon, because a placeholder mark is a
+               sticker. -->
+          {@const kindMark = artifactKindEntry(group.kind)?.icon}
+          <h2>
+            {#if kindMark !== undefined}
+              <Icon icon={kindMark} class="vault__kind-mark" />
+            {/if}
+            {kindLabel(group.kind)}
+          </h2>
           <ul>
             {#each group.artifacts as artifact (artifact.id)}
               <li>
@@ -313,6 +328,21 @@
     flex: 0 0 auto;
     font-size: 0.8rem;
     opacity: 0.7;
+  }
+
+  /* `:global`, because the class lands on `Icon`'s element rather than on one this component
+     writes, and Svelte scopes what it can see. */
+  .vault :global(.vault__kind-mark) {
+    margin-right: var(--s3);
+  }
+
+  .vault__empty :global(.vault__empty-mark) {
+    /* An empty surface has nothing for a mark to accompany, so this one takes a ramp step of its
+       own rather than inheriting one — at `1em` it reads as a typo beside the sentence. A step
+       from the ramp rather than a multiple of the text, which is what keeps it off a sixth scale. */
+    font-size: var(--t-display-size);
+    margin-right: var(--s3);
+    vertical-align: -0.15em;
   }
 
   .vault__empty {

--- a/src/lib/adnd/adnd_character_artifact_kind.ts
+++ b/src/lib/adnd/adnd_character_artifact_kind.ts
@@ -1,3 +1,4 @@
+import helmet from '$lib/assets/icons/set2/helmet-2.svg?raw';
 import {
   acceptedPayload,
   asRecord,
@@ -230,6 +231,7 @@ function adndCharacterName(snapshot: AdndCharacterSnapshot): string {
 export const adndCharacterArtifactKind = defineArtifactKind<ADNDCharacter, AdndCharacterSnapshot>({
   kind: ADND_CHARACTER_ARTIFACT_KIND,
   displayName: 'AD&D 2E Character',
+  icon: helmet,
   payloadVersion: ADND_CHARACTER_PAYLOAD_VERSION,
   loadCodec: async () => {
     const { adndCharacterFromSnapshotWithRng, toAdndCharacterSnapshot } =

--- a/src/lib/artifact_kinds/artifact_kind_types.ts
+++ b/src/lib/artifact_kinds/artifact_kind_types.ts
@@ -74,6 +74,19 @@ export type ArtifactKindEntry<TValue, TSnapshot> = {
   kind: ArtifactKind;
   /** What a user sees for the kind, e.g. "Coat of Arms". */
   displayName: string;
+  /**
+   * The kind's mark, imported from `src/lib/assets/icons` with `?raw`.
+   *
+   * Optional, and deliberately so: a kind that reads fine without one should not have to invent
+   * one, and a surface with no mark to show shows none rather than a generic placeholder — a
+   * placeholder mark is a sticker. See docs/visual-design.md, "An artifact kind carries its own
+   * mark".
+   *
+   * It lives with the registration because a kind is registered once and read everywhere: the
+   * vault, the project view and the picker would otherwise each keep a lookup table of the same
+   * five answers.
+   */
+  icon?: string;
   /** The version of the snapshot shape this build writes. Starts at 1 and only ever rises. */
   payloadVersion: number;
   /** Loads the conversion pair. See {@link ArtifactKindCodec} for why it is not inline. */

--- a/src/lib/culture/culture_artifact_kind.ts
+++ b/src/lib/culture/culture_artifact_kind.ts
@@ -1,3 +1,4 @@
+import book from '$lib/assets/icons/set3/book.svg?raw';
 import {
   acceptedPayload,
   asRecord,
@@ -166,6 +167,7 @@ export function migrateCultureSnapshot(
 export const cultureArtifactKind = defineArtifactKind<Culture, CultureSnapshot>({
   kind: CULTURE_ARTIFACT_KIND,
   displayName: 'Culture',
+  icon: book,
   payloadVersion: CULTURE_PAYLOAD_VERSION,
   // Deferred like every kind's codec, and for the same reason the heraldry one is: this side
   // reaches `$lib/names` and the made-up-names generators, which nothing that merely lists or

--- a/src/lib/heraldry/heraldry_artifact_kind.ts
+++ b/src/lib/heraldry/heraldry_artifact_kind.ts
@@ -1,3 +1,4 @@
+import shield from '$lib/assets/icons/set2/shild.svg?raw';
 import type { RNG } from '@ironarachne/rng';
 
 import {
@@ -189,6 +190,7 @@ export function migrateHeraldrySnapshot(
 export const heraldryArtifactKind = defineArtifactKind<RestoredHeraldry, HeraldrySnapshot>({
   kind: HERALDRY_ARTIFACT_KIND,
   displayName: 'Coat of Arms',
+  icon: shield,
   payloadVersion: HERALDRY_PAYLOAD_VERSION,
   // The import is written out rather than computed so the bundler can split it, and it is split
   // because `heraldry_rehydrate` reaches the charge art. Writing a snapshot does not, but both

--- a/src/lib/religion/religion_artifact_kind.ts
+++ b/src/lib/religion/religion_artifact_kind.ts
@@ -1,3 +1,4 @@
+import amulet from '$lib/assets/icons/set2/necklece.svg?raw';
 import {
   acceptedPayload,
   asRecord,
@@ -101,6 +102,7 @@ export function migrateReligionSnapshot(
 export const religionArtifactKind = defineArtifactKind<RestoredReligion, ReligionSnapshot>({
   kind: RELIGION_ARTIFACT_KIND,
   displayName: 'Religion',
+  icon: amulet,
   payloadVersion: RELIGION_PAYLOAD_VERSION,
   // Deferred like every kind's codec. A religion is the cheap case — the module it loads is
   // small — but a contract that some kinds follow and others do not is not a contract, and a

--- a/src/lib/settlements/settlement_artifact_kind.ts
+++ b/src/lib/settlements/settlement_artifact_kind.ts
@@ -1,3 +1,4 @@
+import house from '$lib/assets/icons/set1/house.svg?raw';
 import {
   acceptedPayload,
   asRecord,
@@ -235,6 +236,7 @@ export function migrateSettlementSnapshot(
 export const settlementArtifactKind = defineArtifactKind<Settlement, SettlementSnapshot>({
   kind: SETTLEMENT_ARTIFACT_KIND,
   displayName: 'Settlement',
+  icon: house,
   payloadVersion: SETTLEMENT_PAYLOAD_VERSION,
   loadCodec: async () => {
     const [{ toSettlementSnapshot }, { settlementFromSnapshot }] = await Promise.all([

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -977,6 +977,69 @@ describe('the panel language', () => {
   });
 });
 
+describe('icons', () => {
+  // docs/visual-design.md, "Icons: the glyph that names, and the mark that decorates".
+  const COMPONENTS_ROOT = COMPONENTS_DIR;
+
+  function componentFiles(): string[] {
+    const walk = (dir: string): string[] =>
+      readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          return walk(path);
+        }
+        return entry.name.endsWith('.svelte') ? [path] : [];
+      });
+
+    return walk(COMPONENTS_ROOT);
+  }
+
+  it('draws no icon by hand', () => {
+    // The sixth icon is the one that gets pasted in as markup, and then the seventh is copied from
+    // it. An icon comes from the pack, through `Icon` or `RoundIconButton`; what is exempt is a
+    // component that *generates* SVG, which is a different thing from drawing a picture in a
+    // template — heraldry composes its output as SVG and that output is the tool's product.
+    const generators = ['HeraldryTinctureSelect.svelte'];
+
+    const offenders = componentFiles().filter((path) => {
+      if (generators.some((name) => path.endsWith(name))) {
+        return false;
+      }
+      return /<svg[\s>]/.test(readFileSync(path, 'utf8'));
+    });
+
+    expect(offenders, 'a component draws an icon by hand').toEqual([]);
+  });
+
+  it('hides every mark from the accessibility tree', () => {
+    // A mark decorates a surface that already reads without it, so a screen reader announcing
+    // "image" beside every tool in a list of thirty-four is noise it cannot skip. `Icon` decides
+    // this from whether it was given a label, which is the whole of the glyph/mark boundary: the
+    // component is the one place it can be enforced rather than remembered.
+    const icon = readFileSync(join(COMPONENTS_ROOT, 'common/Icon.svelte'), 'utf8');
+
+    expect(icon, 'Icon can render without deciding whether it is a mark').toContain(
+      "aria-hidden={label === undefined ? 'true' : undefined}",
+    );
+    expect(icon, 'a labelled icon is not announced as an image').toContain(
+      "role={label === undefined ? undefined : 'img'}",
+    );
+  });
+
+  it('sizes a mark in em rather than in pixels', () => {
+    // A mark belongs to the text it accompanies, so it takes that text's step and is on the type
+    // ramp without declaring a size. A pixel size here would be a sixth ramp.
+    const icon = readFileSync(join(COMPONENTS_ROOT, 'common/Icon.svelte'), 'utf8');
+    const sizes = [...icon.matchAll(/(?:height|width|font-size)\s*:\s*([^;]+);/g)].map(
+      ([, value]) => value.trim(),
+    );
+
+    for (const size of sizes) {
+      expect(/px/.test(size), `Icon sizes something in pixels: ${size}`).toBe(false);
+    }
+  });
+});
+
 describe('motion', () => {
   it('declares one duration, and it is swift', () => {
     expect(tokens.get('--motion-swift')).toBe('120ms');

--- a/src/lib/tool_marks/README.md
+++ b/src/lib/tool_marks/README.md
@@ -1,0 +1,53 @@
+# Tool marks
+
+The mark each tool domain wears. One map, one guard, no state.
+
+See [the visual design system](../../../docs/visual-design.md), "The domain marks, which answer the
+question the palette could not", for the design.
+
+## What a mark is
+
+A **mark** is decoration, not a name. The catalog has classified every tool by `domain` since it was
+written and nothing ever showed that classification; these five glyphs are the showing. They are
+`aria-hidden` wherever they render — the domain is already in the heading above the group, and
+announcing it once per row is noise a reader cannot skip.
+
+That makes them the classifier exception to the one-mark-per-surface rule: a mark repeats beside
+every tool in a list because repeating is what classifying is.
+
+| Domain       | Mark            |                                                         |
+| ------------ | --------------- | ------------------------------------------------------- |
+| `characters` | `set2/helmet-1` | A helm — a person in a game, rather than a person       |
+| `factions`   | `set2/flag`     | The thing a faction plants                              |
+| `locations`  | `set2/map`      | Settlements, regions, dungeons: all read off a map      |
+| `objects`    | `set2/chest`    | What the objects are generated into                     |
+| `utilities`  | `set2/compass`  | Instruments rather than output — dice, names, languages |
+
+All five come from `set2`, the pack's fantasy sheet, so the family reads as one hand rather than as
+five icons that happened to be available. That is also the argument for showing them at all: this is
+a suite of generators for tabletop games.
+
+## Why the map is hand-written
+
+A lookup that resolved `set2/${domain}.svg` would need a computed import specifier, and a computed
+specifier cannot be statically analysed — so all 455 icons in the pack would land in the bundle of
+any page that showed one. It is the same trap `TOOL_PANELS` documents for the tool panels, and the
+same answer: write the imports out.
+
+`toolMarksCoverDomains` and `tool_marks.test.ts` are what keep a hand-written map honest. A sixth
+domain cannot be added without a mark, a mark cannot outlive the domain it classifies, and no two
+domains may wear the same glyph — a classifier that classifies two things as one is not one.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { DOMAIN_MARKS } from '$lib/tool_marks';
+  import Icon from '$components/common/Icon.svelte';
+</script>
+
+<Icon icon={DOMAIN_MARKS[tool.domain]} />
+```
+
+`Icon` with no `label` is a mark: hidden from the accessibility tree, and painted `--ink-faint` so
+it never outshines the label it classifies.

--- a/src/lib/tool_marks/index.ts
+++ b/src/lib/tool_marks/index.ts
@@ -1,0 +1,1 @@
+export { DOMAIN_MARKS, toolMarksCoverDomains } from './tool_marks';

--- a/src/lib/tool_marks/tool_marks.test.ts
+++ b/src/lib/tool_marks/tool_marks.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { DOMAINS } from '$lib/tools';
+
+import { DOMAIN_MARKS, toolMarksCoverDomains } from './tool_marks';
+
+describe('the domain marks', () => {
+  it('covers every domain, and marks nothing that is not one', () => {
+    // docs/visual-design.md, "The domain marks". The map is hand-written because a computed import
+    // specifier cannot be statically analysed — a lookup that resolved `set2/${domain}.svg` would
+    // bundle all 455 icons into any page that showed one, which is the trap `TOOL_PANELS`
+    // documents. This is what keeps a hand-written map honest: a sixth domain cannot be added
+    // without a mark, and a mark cannot outlive the domain it classifies.
+    expect(Object.keys(DOMAIN_MARKS).sort()).toEqual([...DOMAINS].sort());
+    expect(toolMarksCoverDomains()).toBe(true);
+  });
+
+  it('draws every mark from one sheet, so the family reads as one hand', () => {
+    // Five icons that happened to be available look like five icons that happened to be available.
+    // All five come from `set2`, the pack's fantasy sheet, which is also the argument for showing
+    // them at all: this is a suite of generators for tabletop games.
+    for (const [domain, markup] of Object.entries(DOMAIN_MARKS)) {
+      expect(markup, `${domain} has no mark`).toContain('<svg');
+      expect(markup, `${domain}'s mark is not a masked icon`).toContain('<mask');
+    }
+  });
+
+  it('gives each domain a mark of its own', () => {
+    // Two domains wearing the same glyph is a classifier that does not classify.
+    expect(new Set(Object.values(DOMAIN_MARKS)).size).toBe(Object.keys(DOMAIN_MARKS).length);
+  });
+});

--- a/src/lib/tool_marks/tool_marks.ts
+++ b/src/lib/tool_marks/tool_marks.ts
@@ -1,0 +1,51 @@
+import chest from '$lib/assets/icons/set2/chest.svg?raw';
+import compass from '$lib/assets/icons/set2/compass.svg?raw';
+import flag from '$lib/assets/icons/set2/flag.svg?raw';
+import helmet from '$lib/assets/icons/set2/helmet-1.svg?raw';
+import map from '$lib/assets/icons/set2/map.svg?raw';
+import { DOMAINS, type ToolDomain } from '$lib/tools';
+
+/**
+ * The mark each tool domain wears.
+ *
+ * See docs/visual-design.md, "The domain marks, which answer the question the palette could not".
+ * The catalog has classified every tool by `domain` since it was written and nothing ever showed
+ * that classification; this is the showing, and it is the domain marker the elevation section
+ * speculated about — delivered as a **glyph rather than a colour**, so the eight unused palette
+ * entries stay unused. A colour-coded domain would have collided with the genre skins, which own a
+ * panel's hue, and with the tone colours, which own meaning. A glyph collides with neither.
+ *
+ * **All five from `set2`**, the pack's fantasy sheet, so the family reads as one hand rather than
+ * as five icons that happened to be available.
+ *
+ * **Written out rather than built from `DOMAINS`**, for the reason `TOOL_PANELS` is: a computed
+ * import specifier cannot be statically analysed, so a lookup that resolved `set2/${domain}.svg`
+ * would bundle all 455 icons into any page that showed one. `toolMarksCoverDomains` is what keeps
+ * the hand-written map honest instead.
+ */
+export const DOMAIN_MARKS: Readonly<Record<ToolDomain, string>> = {
+  /** A helm: a person *in a game*, rather than a person. */
+  characters: helmet,
+  /** The thing a faction plants. */
+  factions: flag,
+  /** Settlements, regions and dungeons all read off one. */
+  locations: map,
+  /** What the objects are generated into. */
+  objects: chest,
+  /** Instruments rather than output — dice, names, languages. */
+  utilities: compass,
+};
+
+/**
+ * Whether every domain has a mark and no mark outlives its domain.
+ *
+ * The map is hand-written because it has to be, so this is what a test holds it to — the same shape
+ * as the check that keeps the tool catalog and `TOOL_PANELS` in step in both directions.
+ */
+export function toolMarksCoverDomains(): boolean {
+  const marked = Object.keys(DOMAIN_MARKS).sort();
+  return (
+    marked.length === DOMAINS.length &&
+    marked.every((domain, index) => domain === [...DOMAINS].sort()[index])
+  );
+}


### PR DESCRIPTION
Closes #123. Closes the design document's last two open questions.

Design: [`docs/visual-design.md`, "Icons: the glyph that names, and the mark that decorates"](https://github.com/ironarachne/ironarachne/blob/issue-123-icons/docs/visual-design.md#icons-the-glyph-that-names-and-the-mark-that-decorates), approved before implementation.

The pack has been in the repository since #112 — 455 SunGraphica icons, split, named, credited — and five controls used it. Everything else about it was undecided.

### It moves a rule rather than adding one beside it

"A glyph replaces a label there is no space for, not one that already works" was written to stop a codebase with 455 icons from acquiring them everywhere. It stays, **for glyphs**. Beside it now sits the other job an icon does here:

| | **Glyph** | **Mark** |
| --- | --- | --- |
| Job | stands in for a label there was no room for | gives a surface character it already reads without |
| Accessibility | carries an accessible name | `aria-hidden`, always |
| Delete it and | the control cannot be identified | the page loses flavour and nothing else |

`Icon` decides which from whether it was given a `label` — one place, rather than a rule each call site has to remember.

### The domain marks

| Domain | Mark | |
| --- | --- | --- |
| `characters` | `set2/helmet-1` | a helm — a person *in a game* |
| `factions` | `set2/flag` | the thing a faction plants |
| `locations` | `set2/map` | settlements, regions, dungeons all read off one |
| `objects` | `set2/chest` | what the objects are generated into |
| `utilities` | `set2/compass` | instruments rather than output |

All from one sheet, so the family reads as one hand. They render on `/tools` (headings and rows), in the workshop's browser, and on the home page's featured list. A domain mark is the **classifier exception** to one-mark-per-surface: repeating beside every tool is what classifying is.

### Both open questions close

**Open question 3 — domain accent markers.** The marker exists and it is a **glyph, not a colour**, so the second half of that question's own answer is the true one: the eight unused palette entries stay unused. A colour-coded domain would have collided with the genre skins, which own a panel's hue, and with the tone colours, which own meaning. A glyph collides with neither.

**Open question 1 — which icons the app uses.** The control set is those five and stays those five; the rest of the pack is spent on character.

### Also in

- **`ArtifactKindEntry.icon`**, optional, set for all five registered kinds — helm, book, shield, amulet, house. A kind without one shows no mark rather than a generic one: a placeholder mark is a sticker.
- **Character on the plainest surfaces** — the vault's and session log's empty states. An empty shelf with a mark reads as a shelf; with only a sentence it reads as a bug.
- **`src/lib/tool_marks`**, a new library with a README and tests.

### `Icon` takes markup, not a name

A `name="set2/flag"` prop needs a computed `import()`, and a computed specifier cannot be statically analysed — so all 455 icons would land in the bundle of any page that showed one. That is the trap `TOOL_PANELS` documents, and it is why `DOMAIN_MARKS` is five written-out `?raw` imports rather than something built from `DOMAINS`.

### Two things the screenshots corrected

**Marks shipped inheriting the link's accent green**, which made each one as bright as the label it classifies — exactly what "a mark is never the brightest thing on its surface" forbids. Fixed in `Icon`, since the same `label`-or-not that makes something a mark is what makes it decoration.

**The empty-state marks needed a size rule.** `font-size: 2em` was correctly rejected by the existing ramp sweep. An empty surface has no text for a mark to accompany, so it takes a ramp step directly (`--t-display-size`) — now a stated exception in the document rather than a magic multiple.

### Enforcement

- No component draws an `<svg>` by hand; the SVG-*generating* components are named as the exception.
- `Icon` hides an unlabelled icon and announces a labelled one — asserted on the component, because the alternative is thirty-four unskippable "image"s in a list.
- `Icon` sizes nothing in pixels.
- `DOMAIN_MARKS` covers `DOMAINS` exactly, no two domains share a glyph, and a sixth domain cannot be added without a mark.
- In the browser: a tool row carries **exactly one** mark, every mark on the page is `aria-hidden`, and a mark's computed colour differs from the label beside it.

### Checks

`npm run verify:all` green — 4476 unit tests, 449 Playwright tests, `svelte-check` 0 errors, coverage gate 99/99 with no baselined debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2wzaP74ffGJjghzcabKeT