### PR TITLE
Walk every route and empty the exemption list, for #124

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ crash.log
 .claude/worktrees/
 # Per-machine tool permissions, not shared settings.
 .claude/settings.local.json
+capture/

--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -3180,6 +3180,43 @@ fixed, what became a test, and what was pushed back to this document as needing 
 than settled in a walk. An issue that needed a new rule is an issue this walk does not get to
 answer — the same boundary every skin issue was held to.
 
+### What the walk found
+
+Recorded here rather than only on the issue, because three of these are facts about the system
+rather than about one page.
+
+**Deleting the exemption made two more sweeps fire.** Clearing the nine files was expected to be
+twelve hexes and sixty-five sizes. It was also four hand-rolled panels and eight corners outside the
+vocabulary, which no one had seen because the list had been hiding those sweeps from those files
+too. An exemption is never as narrow as the sentence that grants it.
+
+**An exemption cannot state its own expiry.** The list's guard checked that a deferred file still
+existed, which is a check that a _file_ is alive, not that a _reason_ is. #119–#121 closed without
+touching any of the nine, and nothing failed. Where a future exemption is unavoidable, the thing to
+assert is the reason — the issue is open, the other suite exists — and where that cannot be
+asserted, the exemption should not be granted.
+
+**`fullPage` screenshots do not work on this app, and that is the shell working correctly.** The
+shell is a `100dvh` grid and scrolling happens inside the page region, so the document is always
+exactly one viewport tall and a full-page capture is a viewport capture. The capture harness grows
+the viewport to the page region's own scroll height instead. Anything else that reasons about page
+height — a future visual-diff tool, a PDF export, a crawler — meets the same wall.
+
+**Generated content carries its own colours, and the sweeps must not follow it there.** A species
+badge and an archetype badge are painted from `$lib/display_colors`, seeded from the name they
+belong to; heraldry composes SVG the same way. Those hues are the _product_, not the interface, and
+a sweep that widened to cover them would be enforcing the design system over a user's generated
+output. The line is the same one [icons](#what-this-enforces-4) draws for the SVG-generating
+components: a component that _draws_ is not a component that _decorates_.
+
+**Two findings needed a decision this walk does not get to make.** Tables
+([#154](https://github.com/ironarachne/ironarachne/issues/154)) are still styled in `main.css` with
+literal `black`, and three components have each invented their own rather than use that; stat
+blocks ([#153](https://github.com/ironarachne/ironarachne/issues/153)) are `<strong>Label:</strong>`
+229 times across 19 components. Both are the same gap, and it is worth naming: **this document
+settles the frame and says nothing about the content inside a panel.** Everything #77 converted was
+furniture. Those two issues are now in #77's scope, after this one.
+
 ## Enforcement
 
 The rule is that no component declares a hex and no component declares a size outside these ramps.

--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -153,9 +153,21 @@ becoming a page somebody decorated. The domains get marks — which is the domai
 [open question 3](#open-questions) speculated about, delivered as a glyph rather than a colour, so
 the eight unused palette entries stay unused.
 
-Awaiting approval, unlike the amendments above it, which are built: #123 is `needs-design`, and the
-second role, the density rules and the domain mapping are what CLAUDE.md's review gate asks a human
-to approve before implementation starts.
+Approved and built.
+
+**Amended 2026-08-30 by [#124](https://github.com/ironarachne/ironarachne/issues/124)**, which adds
+[walking it](#walking-it-and-what-a-walk-should-leave-behind) and is the issue that closes #77. It
+corrects that issue's own premise: there is no "before" to walk, because the redesign landed over
+ten issues and `main` has been the after since #113 — so the comparison is against this document
+rather than against a screenshot, and a pixel diff against the old look would report the work as one
+enormous regression. It states what a walk is for: **a walk that ends in an album has to be repeated,
+and a walk that ends in sweeps is done once.** It also names debt that needs no walking to find —
+nine components still exempted from the hex and ramp sweeps for three issues that have since closed
+without touching them.
+
+Awaiting approval, unlike the amendments above it, which are built: #124 is `needs-design`, and the
+corrected premise, the findings-become-sweeps rule and the capture-is-not-a-gate decision are what
+CLAUDE.md's review gate asks a human to approve before implementation starts.
 
 **Amended 2026-08-30, in review of the above:** every genre gets a panel shape of its own, which
 replaces the "three corner treatments" cap rather than extending it. The panel's polygon is written
@@ -3077,6 +3089,96 @@ this by hand for its five, and keeps doing it — it owns a control, not a mark.
 
 And one in the browser: a tool row in the catalog carries **exactly one** mark, which is the density
 rule stated as a number rather than as a paragraph.
+
+## Walking it, and what a walk should leave behind
+
+[#124](https://github.com/ironarachne/ironarachne/issues/124) is the issue that closes #77, and it
+says every route is walked "before and after". **There is no before.** The redesign landed over ten
+issues and `main` has been the after since #113; the only before is in git history, and recovering
+it would answer a question nobody asked. The whole point was to change how the site looks, so a
+pixel diff between then and now reports the work as one enormous regression.
+
+What the walk is actually for is finding what the conversion **missed** — and that is a different
+comparison, made against this document rather than against a screenshot.
+
+### A walk that ends in an album has to be repeated
+
+The temptation is to produce forty-one screenshots, look at them, and tick the issue off. That
+records that somebody looked once. Every finding this walk produces should leave behind one of two
+things:
+
+1. **A fix**, where the page disagrees with this document.
+2. **A sweep**, where the disagreement is of a kind a test can see.
+
+The second is the deliverable. `tokens.test.ts` exists because [the
+controls](#what-is-enforced) turned "no component declares a hex" from a style guide into a test, and
+every issue since has grown it. The walk's job is to convert what it finds into that same shape, so
+that closing #77 leaves the system defended rather than merely inspected.
+
+### The debt is already known, and it does not need a walk to find
+
+`tokens.test.ts` carries a `DEFERRED` list of nine components exempted from the hex and ramp sweeps.
+The comment on it says why: they are "surfaces that hold generated output, which is what a genre skin
+dresses", deferred to #119–#121. **Those three issues are closed and none of them touched these
+files.** The exemption has outlived its reason, which is exactly the failure the list's own guard
+test was written against — and that guard cannot see it, because it only checks that a deferred file
+still exists.
+
+Measured rather than assumed, and it is small:
+
+| File                       | Hexes | Off-ramp sizes |
+| -------------------------- | ----: | -------------: |
+| `AdndCharacterBuilder`     |     0 |             12 |
+| `EquipmentGenerator`       |     8 |             10 |
+| `ReligionArtifactEditor`   |     0 |              8 |
+| `SettlementArtifactEditor` |     0 |              8 |
+| `MerchantGenerator`        |     4 |              7 |
+| `CultureArtifactEditor`    |     0 |              6 |
+| `EncounterGenerator`       |     0 |              6 |
+| `HeraldryArtifactView`     |     0 |              4 |
+| `PotionGenerator`          |     0 |              4 |
+
+Twelve hexes and sixty-five off-ramp values across nine files. **Clearing them and deleting the list
+is the first half of #124**, and it is the half that needs no judgement at all: the sweeps already
+know what is wrong, they have simply been told not to look. A list that shrinks to nothing is the
+only honest end state for it — the same standard the skin exemption list was held to when
+[#122](#the-horror-skin-and-the-discipline-of-not-startling-anyone) emptied it.
+
+### What the walk covers that no sweep can
+
+The rest is judgement, and it is worth being precise about what kind. Three questions per route, at
+desktop width and at 320px:
+
+- **Does the same furniture look the same here as elsewhere?** A panel, a heading, a badge and a
+  control row appear on most of these forty-one pages. Two pages disagreeing about what a panel
+  looks like is the thing this whole document exists to prevent, and no test can see it because
+  each page passes its own assertions.
+- **Is anything unconverted?** A page that never got its ramp step, a box that is still a box rather
+  than a panel, a control that kept a bespoke style. These read as "not quite finished" and are
+  invisible to a per-file sweep that only checks the values a file _does_ declare.
+- **Does the page still work?** `e2e/pages.smoke.spec.ts` already walks all forty-one at desktop for
+  chrome and content, and `e2e/pages.mobile.spec.ts` walks them at five widths for overflow and
+  off-screen controls. Those are the mechanical half, they are green, and the walk does not repeat
+  them by eye.
+
+### The capture is a tool, not a gate
+
+A dispatch-only Playwright project that screenshots every manifest route at desktop and at the five
+mobile widths, written to a directory for the reviewer. Modelled on `goldens.yaml`, which renders
+baselines and gates nothing — for the same reason: an image comparison that fails a build on a
+deliberate visual change trains everyone to ignore it.
+
+It is not a golden-image suite and this document is not asking for one. Pixel baselines for
+forty-one routes would need regenerating on every deliberate change to any shared component, which
+is most changes, and the cost of that is paid every week to catch a class of bug the sweeps already
+catch by construction.
+
+### What this leaves behind
+
+The acceptance for #124 is the walk's **result**, recorded on the issue: what was found, what was
+fixed, what became a test, and what was pushed back to this document as needing a decision rather
+than settled in a walk. An issue that needed a new rule is an issue this walk does not get to
+answer — the same boundary every skin issue was held to.
 
 ## Enforcement
 

--- a/e2e/capture.spec.ts
+++ b/e2e/capture.spec.ts
@@ -1,0 +1,81 @@
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { test } from '@playwright/test';
+
+import { GENERATE_TEST_PAGES, PAGE_MANIFEST } from './page_manifest';
+import { clickGenerateButton, visitRoute } from './helpers';
+
+/**
+ * Screenshots every route in the manifest, for a human to look at.
+ *
+ * `docs/visual-design.md`, "The capture is a tool, not a gate". This suite asserts **nothing**. It
+ * is excluded from every default project and runs only when it is asked for by name:
+ *
+ * ```
+ * CAPTURE=1 npx playwright test --project=capture
+ * CAPTURE=1 npx playwright test --project=capture-360
+ * ```
+ *
+ * The env var is what makes it dispatch-only. A Playwright project with no filter runs on a bare
+ * `playwright test` — `testMatch` chooses which files a project runs, not whether the project runs
+ * — so the first version of this put two hundred and forty screenshots into `verify:all`.
+ *
+ * **It is deliberately not a golden-image suite.** Pixel baselines for forty-one routes would need
+ * regenerating on every deliberate change to a shared component — which is most changes — to catch
+ * a class of bug the sweeps in `src/lib/styles/tokens.test.ts` already catch by construction, and
+ * an image comparison that fails a build on an intended change trains everyone to ignore it.
+ * `goldens.yaml` makes the same trade for the renderers: it renders baselines, pushes them for
+ * review, and gates nothing.
+ *
+ * A pinned seed, so two captures of the same route differ only where the design differs and not
+ * because a generator rolled differently.
+ */
+const CAPTURE_DIR = process.env.CAPTURE_DIR ?? 'capture';
+
+test.describe.configure({ mode: 'parallel' });
+
+for (const entry of PAGE_MANIFEST) {
+  test(`capture: ${entry.path}`, async ({ page }, testInfo) => {
+    test.setTimeout(entry.webgl ? 90_000 : 30_000);
+    await visitRoute(page, entry.path, { title: entry.title, webgl: entry.webgl });
+
+    // Generated, where there is something to generate. An empty generator page shows its controls
+    // and nothing else, and the surfaces this walk is looking hardest at — the result cards, the
+    // stat blocks, the tables — only exist once a tool has run. Failures are swallowed on purpose:
+    // this suite reports nothing, and `pages.generate.spec.ts` is what asserts a tool still works.
+    const generates = GENERATE_TEST_PAGES.find((candidate) => candidate.path === entry.path);
+    if (generates !== undefined && generates.kind !== 'reference') {
+      try {
+        await clickGenerateButton(
+          page,
+          generates.generateButton,
+          entry.webgl ? 30_000 : 15_000,
+          Boolean(entry.webgl),
+        );
+      } catch {
+        // A tool that will not run is a finding for `pages.generate.spec.ts`, not for a capture.
+      }
+    }
+
+    // The project name is the width, so one directory holds one width's worth of the site and the
+    // reviewer compares across directories rather than across filenames.
+    const directory = join(CAPTURE_DIR, testInfo.project.name);
+    await mkdir(directory, { recursive: true });
+
+    // `fullPage` captures nothing extra here, and that is a property of the shell rather than a
+    // quirk of Playwright: `.shell` is a `100dvh` grid and scrolling happens *inside* the page
+    // region, so the document is always exactly one viewport tall. Grow the viewport to the page
+    // region's own scroll height instead, capped so a reference page with two hundred rows does
+    // not produce an image nobody can open.
+    const tall = await page.evaluate(() => {
+      const region = document.querySelector('main.shell__page');
+      return region === null ? 0 : region.scrollHeight;
+    });
+    const width = page.viewportSize()?.width ?? 1280;
+    await page.setViewportSize({ width, height: Math.min(Math.max(tall + 64, 720), 4000) });
+
+    const name = entry.path === '/' ? 'home' : entry.path.replaceAll('/', '_').replace(/^_/, '');
+    await page.screenshot({ path: join(directory, `${name}.png`) });
+  });
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,24 @@ const mobileUse = (width: number, height: number) => ({
   screen: { width, height },
 });
 
+/**
+ * Screenshot capture, off unless asked for. See `e2e/capture.spec.ts`.
+ */
+const captureProjects = process.env.CAPTURE
+  ? [
+      {
+        name: 'capture',
+        use: { ...devices['Desktop Chrome'] },
+        testMatch: /capture\.spec\.ts/,
+      },
+      ...MOBILE_VIEWPORTS.map(({ name, width, height }) => ({
+        name: `capture-${name}`,
+        use: mobileUse(width, height),
+        testMatch: /capture\.spec\.ts/,
+      })),
+    ]
+  : [];
+
 export default defineConfig({
   testDir: 'e2e',
   fullyParallel: true,
@@ -32,13 +50,22 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
-      testIgnore: /pages\.mobile\.spec\.ts/,
+      testIgnore: [/pages\.mobile\.spec\.ts/, /capture\.spec\.ts/],
     },
     ...MOBILE_VIEWPORTS.map(({ name, width, height }) => ({
       name: `mobile-${name}`,
       use: mobileUse(width, height),
       testMatch: /pages\.mobile\.spec\.ts/,
     })),
+
+    /* The capture projects, behind an env var because a project with no filter still runs on a
+       bare `playwright test` — `testMatch` chooses a project's files, not whether the project
+       runs at all, and adding these unguarded put two hundred and forty screenshot "tests" into
+       `verify:all`. `CAPTURE=1 npx playwright test --project=capture` is the whole interface.
+
+       See docs/visual-design.md, "The capture is a tool, not a gate": this is for a reviewer to
+       look at and it asserts nothing, so it must not be able to fail a build or pad a suite. */
+    ...captureProjects,
   ],
   webServer: {
     command: `npm run build && npm run preview -- --host ${previewHost} --port ${previewPort}`,

--- a/src/components/characters/AdndCharacterBuilder.svelte
+++ b/src/components/characters/AdndCharacterBuilder.svelte
@@ -1205,7 +1205,7 @@
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    gap: 1rem;
+    gap: var(--s6);
   }
 
   .builder-header h1 {
@@ -1213,35 +1213,35 @@
   }
 
   .builder-maturity {
-    margin: 0.5rem 0 0.75rem;
+    margin: var(--s4) 0 var(--s5);
   }
 
   .spell-pick-slots {
     display: flex;
     flex-wrap: wrap;
-    gap: 1rem;
+    gap: var(--s6);
     align-items: flex-end;
-    margin-bottom: 1rem;
+    margin-bottom: var(--s6);
   }
 
   .spell-pick-slots label {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: var(--s2);
   }
 
   .thief-skill-grid {
     display: flex;
     flex-wrap: wrap;
-    gap: 1rem;
+    gap: var(--s6);
     align-items: flex-end;
-    margin-bottom: 1rem;
+    margin-bottom: var(--s6);
   }
 
   .thief-skill-grid label {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: var(--s2);
     min-width: 12rem;
   }
 
@@ -1252,14 +1252,14 @@
   .wealth-inputs {
     display: flex;
     flex-wrap: wrap;
-    gap: 1rem;
+    gap: var(--s6);
     align-items: flex-end;
   }
 
   .wealth-inputs label {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: var(--s2);
   }
 
   .equipment-list {
@@ -1268,8 +1268,8 @@
   }
 
   .builder-result {
-    margin-top: 2rem;
-    padding-top: 1.5rem;
+    margin-top: var(--s8);
+    padding-top: var(--s7);
     border-top: 1px solid var(--border-strong);
   }
 </style>

--- a/src/components/factions/CultureArtifactEditor.svelte
+++ b/src/components/factions/CultureArtifactEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
   import {
     addCultureTaboo,
@@ -71,10 +72,10 @@
 </script>
 
 {#if culture === undefined}
-  <p class="culture-editor__problem" role="alert">
+  <Notice tone="danger">
     These contents are stored as a culture but do not read as one, so there is nothing safe to edit
     here. {accepted.ok ? '' : accepted.message}
-  </p>
+  </Notice>
 {:else}
   <div class="culture-editor">
     <div class="input-group input-group--inline">
@@ -224,26 +225,28 @@
   .culture-editor {
     display: flex;
     flex-direction: column;
-    gap: 0.6rem;
+    gap: var(--s4);
     min-width: 0;
   }
 
   .culture-editor fieldset {
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
+    gap: var(--s3);
     align-items: flex-start;
     margin: 0;
-    padding: 0.5rem 0.6rem;
-    border: 1px solid var(--tan);
-    border-radius: 4px;
+    /* No border and no radius. A fieldset inside an editor panel was a box inside a box, which
+       is what "the problem is nineteen copies of a box" is about: when everything is a box,
+       being one emphasises nothing. The legend and the spacing group these fields; the panel
+       around them is the only keyline in sight. */
+    padding: var(--s4) 0;
     min-width: 0;
   }
 
   .culture-editor legend {
-    padding: 0 0.3rem;
+    padding: 0 var(--s3);
     color: var(--gold);
-    font-size: 0.75rem;
+    font-size: var(--t-micro-size);
     letter-spacing: 0.04em;
     text-transform: uppercase;
   }
@@ -270,11 +273,9 @@
     width: 100%;
   }
 
-  .culture-editor__note,
-  .culture-editor__problem {
-    margin: 0;
-    font-size: 0.9rem;
+  .culture-editor__note {
+    font-size: var(--t-small-size);
     font-style: italic;
-    opacity: 0.9;
+    margin: 0;
   }
 </style>

--- a/src/components/factions/EncounterGenerator.svelte
+++ b/src/components/factions/EncounterGenerator.svelte
@@ -86,9 +86,14 @@
   <BaseButton onclick={generate}>Generate</BaseButton>
 
   {#if encounter}
-    <div class="stat-block">
-      <div class="encounter-header">
-        <h2>{encounter.name}</h2>
+    <!-- A result surface is a panel, not a box with a border on it: the two layers,
+         and the keyline, corner and padding are the system's. It wrote its own
+         border, radius and padding until #124. -->
+    <div class="stat-block panel">
+      <div class="panel__field">
+        <div class="encounter-header">
+          <h2>{encounter.name}</h2>
+        </div>
       </div>
 
       {#each encounter.groups as group}
@@ -120,12 +125,10 @@
 </GeneratorPage>
 
 <style>
+  /* The keyline, the corner, the padding and the fill are the panel's now — the fill was a
+     40% mix of slate, which is a fourth surface level invented in one component. */
   .stat-block {
-    margin-top: 2rem;
-    padding: 1rem;
-    border: 1px solid var(--granite);
-    border-radius: 4px;
-    background: color-mix(in srgb, var(--slate) 40%, transparent);
+    margin-top: var(--s8);
   }
 
   .stat-block h2 {
@@ -134,7 +137,7 @@
   }
 
   .group-section {
-    margin-top: 1.5rem;
+    margin-top: var(--s7);
   }
 
   .group-section ul {
@@ -145,17 +148,17 @@
 
   .group-section li {
     margin-left: 0;
-    margin-bottom: 0.5rem;
-    padding: 0.5rem;
-    border: 1px solid var(--granite);
-    border-radius: 3px;
-    background: color-mix(in srgb, var(--charcoal) 85%, white 15%);
+    margin-bottom: var(--s4);
+    /* A row in a list inside a panel, which the panel language says is a row rather than a
+       third box: the well the list sits in already says the rows are held. The fill was a mix of
+       charcoal and white invented here, and the radius was outside the vocabulary. */
+    padding: var(--s4);
   }
 
   .mob-row {
     display: flex;
     align-items: center;
-    gap: 0.35rem;
+    gap: var(--s3);
     flex-wrap: wrap;
   }
 

--- a/src/components/factions/ReligionArtifactEditor.svelte
+++ b/src/components/factions/ReligionArtifactEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
   import {
     ALL_RELIGION_DIMENSION_IDS,
@@ -88,10 +89,10 @@
 </script>
 
 {#if religion === undefined}
-  <p class="religion-editor__problem" role="alert">
+  <Notice tone="danger">
     These contents are stored as a religion but do not read as one, so there is nothing safe to edit
     here. {accepted.ok ? '' : accepted.message}
-  </p>
+  </Notice>
 {:else}
   <div class="religion-editor">
     <div class="input-group input-group--inline">
@@ -372,26 +373,28 @@
   .religion-editor {
     display: flex;
     flex-direction: column;
-    gap: 0.6rem;
+    gap: var(--s4);
     min-width: 0;
   }
 
   .religion-editor fieldset {
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
+    gap: var(--s3);
     align-items: flex-start;
     margin: 0;
-    padding: 0.5rem 0.6rem;
-    border: 1px solid var(--tan);
-    border-radius: 4px;
+    /* No border and no radius. A fieldset inside an editor panel was a box inside a box, which
+       is what "the problem is nineteen copies of a box" is about: when everything is a box,
+       being one emphasises nothing. The legend and the spacing group these fields; the panel
+       around them is the only keyline in sight. */
+    padding: var(--s4) 0;
     min-width: 0;
   }
 
   .religion-editor legend {
-    padding: 0 0.3rem;
+    padding: 0 var(--s3);
     color: var(--gold);
-    font-size: 0.75rem;
+    font-size: var(--t-micro-size);
     letter-spacing: 0.04em;
     text-transform: uppercase;
   }
@@ -423,18 +426,19 @@
   .religion-editor__deity {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: var(--s3);
     width: 100%;
     min-width: 0;
-    padding: 0.4rem 0;
-    border-top: 1px solid var(--tan);
+    padding: var(--s3) 0;
+    /* A divider between rows, not a keyline around a box: `--border` rather than
+       `--border-strong`, which is the plate's edge and says more than a separator has
+       to. */
+    border-top: 1px solid var(--border);
   }
 
-  .religion-editor__note,
-  .religion-editor__problem {
-    margin: 0;
-    font-size: 0.9rem;
+  .religion-editor__note {
+    font-size: var(--t-small-size);
     font-style: italic;
-    opacity: 0.9;
+    margin: 0;
   }
 </style>

--- a/src/components/heraldry/HeraldryArtifactView.svelte
+++ b/src/components/heraldry/HeraldryArtifactView.svelte
@@ -10,6 +10,7 @@
     validateHeraldrySnapshot,
   } from '$lib/heraldry';
   import type { ArtifactViewerProps } from '$lib/workshop';
+  import Notice from '$components/common/Notice.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
 
   const { snapshot }: ArtifactViewerProps = $props();
@@ -88,10 +89,10 @@
 
 <div class="heraldry-artifact">
   {#if restored === undefined}
-    <p class="heraldry-artifact__problem" role="alert">
+    <Notice tone="danger">
       These arms were written in a shape this version cannot draw. They are still stored, and still
       travel in an export.
-    </p>
+    </Notice>
   {:else}
     <!-- The blazon is the arms in words, and it is what a user reads out at the table. It is
          above the image because it is the part that can be searched, quoted, and copied. -->
@@ -107,7 +108,7 @@
       <BaseButton onclick={() => void downloadPng()}>Download PNG</BaseButton>
     </div>
     {#if error !== null}
-      <p class="heraldry-artifact__problem" role="alert">{error}</p>
+      <Notice tone="danger">{error}</Notice>
     {/if}
   {/if}
 </div>
@@ -116,7 +117,7 @@
   .heraldry-artifact {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: var(--s4);
   }
 
   .heraldry-artifact__blazon {
@@ -139,14 +140,6 @@
   .heraldry-artifact__actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-
-  .heraldry-artifact__problem {
-    margin: 0;
-    padding: 0.5rem 0.6rem;
-    border: 1px solid var(--tan);
-    border-radius: 4px;
-    font-size: 0.9rem;
+    gap: var(--s4);
   }
 </style>

--- a/src/components/locations/SettlementArtifactEditor.svelte
+++ b/src/components/locations/SettlementArtifactEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
   import {
     addSettlementProblem,
@@ -97,10 +98,10 @@
 </script>
 
 {#if settlement === undefined}
-  <p class="settlement-editor__problem" role="alert">
+  <Notice tone="danger">
     These contents are stored as a settlement but do not read as one, so there is nothing safe to
     edit here. {accepted.ok ? '' : accepted.message}
-  </p>
+  </Notice>
 {:else}
   <div class="settlement-editor">
     <div class="input-group input-group--inline">
@@ -463,26 +464,28 @@
   .settlement-editor {
     display: flex;
     flex-direction: column;
-    gap: 0.6rem;
+    gap: var(--s4);
     min-width: 0;
   }
 
   .settlement-editor fieldset {
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
+    gap: var(--s3);
     align-items: flex-start;
     margin: 0;
-    padding: 0.5rem 0.6rem;
-    border: 1px solid var(--tan);
-    border-radius: 4px;
+    /* No border and no radius. A fieldset inside an editor panel was a box inside a box, which
+       is what "the problem is nineteen copies of a box" is about: when everything is a box,
+       being one emphasises nothing. The legend and the spacing group these fields; the panel
+       around them is the only keyline in sight. */
+    padding: var(--s4) 0;
     min-width: 0;
   }
 
   .settlement-editor legend {
-    padding: 0 0.3rem;
+    padding: 0 var(--s3);
     color: var(--gold);
-    font-size: 0.75rem;
+    font-size: var(--t-micro-size);
     letter-spacing: 0.04em;
     text-transform: uppercase;
   }
@@ -492,11 +495,14 @@
   .settlement-editor__row {
     display: flex;
     flex-direction: column;
-    gap: 0.3rem;
+    gap: var(--s3);
     width: 100%;
     min-width: 0;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid var(--tan);
+    padding-bottom: var(--s4);
+    /* A divider between rows, not a keyline around a box: `--border` rather than
+       `--border-strong`, which is the plate's edge and says more than a separator has
+       to. */
+    border-bottom: 1px solid var(--border);
   }
 
   /* The row layout is `.input-group--inline`'s now — this file used to hand-roll it, as eight
@@ -523,11 +529,9 @@
     width: 100%;
   }
 
-  .settlement-editor__note,
-  .settlement-editor__problem {
-    margin: 0;
-    font-size: 0.9rem;
+  .settlement-editor__note {
+    font-size: var(--t-small-size);
     font-style: italic;
-    opacity: 0.9;
+    margin: 0;
   }
 </style>

--- a/src/components/objects/EquipmentGenerator.svelte
+++ b/src/components/objects/EquipmentGenerator.svelte
@@ -17,6 +17,7 @@
   import SelectField from '$components/common/SelectField.svelte';
   import NumberField from '$components/common/NumberField.svelte';
   import CheckboxField from '$components/common/CheckboxField.svelte';
+  import Badge from '$components/common/Badge.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
 
   const rng = new RNG.RNG(Date.now().toString());
@@ -104,51 +105,55 @@
 
   <div class="results">
     {#each generatedItems as item}
-      <div class="item-card">
-        <h3>{item.name}</h3>
-        <p class="description">{item.description}</p>
-        <div class="stats">
-          <span class="tag type">{item.itemMajorType}</span>
-          {#if item.itemMajorType === 'weapon'}
-            {@const weapon = item as Weapon}
-            {#if displaySystem === 'dnd5e' && weapon.actions && weapon.actions.length > 0}
-              <span class="tag damage"
-                >Damage: {convertPowerToDice(weapon.actions[0].baseDamage || 0)} ({weapon.actions[0]
-                  .damageType})</span
-              >
-              {#if weapon.actions[0].bonusDamage && weapon.actions[0].bonusDamage.length > 0}
-                {#each weapon.actions[0].bonusDamage as bonus}
-                  <span class="tag damage extra"
-                    >+ {convertPowerToDice(bonus.power)} ({bonus.type})</span
-                  >
-                {/each}
+      <!-- A card is a panel: the two layers, with the `li` painting the keyline across its box
+           and the field covering all but a pixel of it. See docs/visual-design.md, "Cards are
+           panels". This card wrote its own border, radius, fill and padding until #124. -->
+      <div class="item-card panel">
+        <div class="panel__field">
+          <h3>{item.name}</h3>
+          <p class="description">{item.description}</p>
+          <div class="stats">
+            <Badge>{item.itemMajorType}</Badge>
+            {#if item.itemMajorType === 'weapon'}
+              {@const weapon = item as Weapon}
+              {#if displaySystem === 'dnd5e' && weapon.actions && weapon.actions.length > 0}
+                <Badge
+                  >Damage: {convertPowerToDice(weapon.actions[0].baseDamage || 0)} ({weapon
+                    .actions[0].damageType})</Badge
+                >
+                {#if weapon.actions[0].bonusDamage && weapon.actions[0].bonusDamage.length > 0}
+                  {#each weapon.actions[0].bonusDamage as bonus}
+                    <Badge>+ {convertPowerToDice(bonus.power)} ({bonus.type})</Badge>
+                  {/each}
+                {/if}
+              {:else}
+                <Badge
+                  >Damage: {weapon.actions[0].baseDamage || 0} ({weapon.actions[0]
+                    .damageType})</Badge
+                >
               {/if}
-            {:else}
-              <span class="tag damage"
-                >Damage: {weapon.actions[0].baseDamage || 0} ({weapon.actions[0].damageType})</span
-              >
             {/if}
-          {/if}
-          {#if item.itemMajorType === 'armor'}
-            {@const armor = item as Armor}
-            {#if displaySystem === 'dnd5e'}
-              <span class="tag defense"
-                >AC: {convertToDnDArmorClass(armor.combatProfile.defense)}</span
-              >
-            {:else}
-              <span class="tag defense">Defense: {armor.combatProfile.defense}</span>
+            {#if item.itemMajorType === 'armor'}
+              {@const armor = item as Armor}
+              {#if displaySystem === 'dnd5e'}
+                <Badge>AC: {convertToDnDArmorClass(armor.combatProfile.defense)}</Badge>
+              {:else}
+                <Badge>Defense: {armor.combatProfile.defense}</Badge>
+              {/if}
             {/if}
-          {/if}
-          <span class="tag value">Value: {valueToString(item.value, COMMON_FANTASY)}</span>
-          <span class="tag weight">Weight: {kgToPounds(item.weight).toFixed(1)} lbs</span>
-        </div>
-        {#if item.properties && item.properties.length > 0}
-          <div class="tags">
-            {#each item.properties as tag}
-              <span class="property-tag">{tag}</span>
-            {/each}
+            <Badge>Value: {valueToString(item.value, COMMON_FANTASY)}</Badge>
+            <Badge>Weight: {kgToPounds(item.weight).toFixed(1)} lbs</Badge>
           </div>
-        {/if}
+          {#if item.properties && item.properties.length > 0}
+            <div class="tags">
+              {#each item.properties as tag}
+                <!-- `plain` because a card can carry a dozen of these: bordered pills stop
+                     annotating the item and start shouting over it. -->
+                <Badge plain>{tag}</Badge>
+              {/each}
+            </div>
+          {/if}
+        </div>
       </div>
     {/each}
   </div>
@@ -157,63 +162,30 @@
 <style>
   .results {
     display: grid;
+    gap: var(--s6);
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 1rem;
   }
 
-  .item-card {
-    border: 1px solid #ccc;
-    padding: 1rem;
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.05);
+  /* What is left after #124: the card's own border, radius, fill and padding are the panel's now,
+     and the three tag colours are gone. A hue meaning "damage", another meaning "defense" and a
+     third meaning "value" was a fourth colour system beside the roles, the tones and the genres —
+     the label already says which is which. */
+  .item-card .description {
+    color: var(--ink-muted);
+    font-style: italic;
+  }
 
-    h3 {
-      margin-top: 0;
-      text-transform: capitalize;
-    }
+  .item-card .stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--s4);
+    margin: var(--s4) 0;
+  }
 
-    .description {
-      font-style: italic;
-      color: #aaa;
-    }
-
-    .stats {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      margin: 0.5rem 0;
-    }
-
-    .tag {
-      background: #333;
-      padding: 0.2rem 0.5rem;
-      border-radius: 4px;
-      font-size: 0.8rem;
-
-      &.damage {
-        color: #ff9999;
-      }
-      &.defense {
-        color: #9999ff;
-      }
-      &.value {
-        color: #ffff99;
-      }
-    }
-
-    .tags {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.3rem;
-      margin-top: 0.5rem;
-    }
-
-    .property-tag {
-      background: #444;
-      padding: 0.1rem 0.4rem;
-      border-radius: 3px;
-      font-size: 0.7rem;
-      color: #ddd;
-    }
+  .item-card .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--s3);
+    margin-top: var(--s4);
   }
 </style>

--- a/src/components/objects/MerchantGenerator.svelte
+++ b/src/components/objects/MerchantGenerator.svelte
@@ -146,86 +146,90 @@
   </ControlsPanel>
 
   {#if merchant}
-    <article class="merchant-result">
-      <header class="merchant-header">
-        <div class="merchant-heading">
-          <h2>{merchant.shop.name}</h2>
-          <p class="shop-meta">
-            {merchant.shop.shopTypeLabel} · {merchant.shop.venueTypeLabel}
-          </p>
-        </div>
-        {#if merchant.mark}
-          <div class="merchant-mark" aria-hidden="true">
-            <!-- Renders app-generated markup (no external or user-supplied input). -->
-            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-            {@html renderMerchantMarkSvg(merchant.mark, 120, 120)}
+    <!-- A result surface is a panel, not a box with a border on it: the two layers,
+         and the keyline, corner and padding are the system's. It wrote its own
+         border, radius and padding until #124. -->
+    <article class="merchant-result panel">
+      <div class="panel__field">
+        <header class="merchant-header">
+          <div class="merchant-heading">
+            <h2>{merchant.shop.name}</h2>
+            <p class="shop-meta">
+              {merchant.shop.shopTypeLabel} · {merchant.shop.venueTypeLabel}
+            </p>
           </div>
+          {#if merchant.mark}
+            <div class="merchant-mark" aria-hidden="true">
+              <!-- Renders app-generated markup (no external or user-supplied input). -->
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html renderMerchantMarkSvg(merchant.mark, 120, 120)}
+            </div>
+          {/if}
+        </header>
+
+        <p class="location">{merchant.shop.locationBlurb}</p>
+        <p>{merchant.shop.description}</p>
+
+        <h3>Proprietor</h3>
+        <p><strong>{merchant.proprietor.fullName}</strong></p>
+        <p>{merchant.proprietor.description}</p>
+        {#if merchant.proprietor.personalityTraits.length > 0}
+          <p><strong>Temperament:</strong> {merchant.proprietor.personalityTraits.join(', ')}</p>
         {/if}
-      </header>
 
-      <p class="location">{merchant.shop.locationBlurb}</p>
-      <p>{merchant.shop.description}</p>
+        <h3>Trading Character</h3>
+        <ul class="trading-notes">
+          <li><strong>Honesty:</strong> {merchant.honesty}</li>
+          <li><strong>Price level:</strong> {merchant.priceLevel}</li>
+          <li>
+            <strong>Price modifier:</strong>
+            {formatModifier(merchant.priceModifier)} of catalog value
+          </li>
+          <li>{merchant.honestyNotes}</li>
+          <li>{merchant.hagglingAdvice}</li>
+        </ul>
 
-      <h3>Proprietor</h3>
-      <p><strong>{merchant.proprietor.fullName}</strong></p>
-      <p>{merchant.proprietor.description}</p>
-      {#if merchant.proprietor.personalityTraits.length > 0}
-        <p><strong>Temperament:</strong> {merchant.proprietor.personalityTraits.join(', ')}</p>
-      {/if}
-
-      <h3>Trading Character</h3>
-      <ul class="trading-notes">
-        <li><strong>Honesty:</strong> {merchant.honesty}</li>
-        <li><strong>Price level:</strong> {merchant.priceLevel}</li>
-        <li>
-          <strong>Price modifier:</strong>
-          {formatModifier(merchant.priceModifier)} of catalog value
-        </li>
-        <li>{merchant.honestyNotes}</li>
-        <li>{merchant.hagglingAdvice}</li>
-      </ul>
-
-      <h3>Stock</h3>
-      <div class="stock-table-scroll">
-        <table class="stock-table">
-          <thead>
-            <tr>
-              <th>Item</th>
-              <th>Qty</th>
-              <th>Catalog</th>
-              <th>Ask Price</th>
-              <th>Note</th>
-            </tr>
-          </thead>
-          <tbody>
-            {#each merchant.stock as item}
+        <h3>Stock</h3>
+        <div class="stock-table-scroll">
+          <table class="stock-table">
+            <thead>
               <tr>
-                <td>{item.name}</td>
-                <td>{item.quantity}</td>
-                <td>{formatPrice(item.baseCost)}</td>
-                <td>{formatPrice(item.price)}</td>
-                <td>{item.note ?? ''}</td>
+                <th>Item</th>
+                <th>Qty</th>
+                <th>Catalog</th>
+                <th>Ask Price</th>
+                <th>Note</th>
               </tr>
-            {/each}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {#each merchant.stock as item}
+                <tr>
+                  <td>{item.name}</td>
+                  <td>{item.quantity}</td>
+                  <td>{formatPrice(item.baseCost)}</td>
+                  <td>{formatPrice(item.price)}</td>
+                  <td>{item.note ?? ''}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
       </div>
     </article>
   {/if}
 </GeneratorPage>
 
 <style>
+  /* The keyline, the corner and the padding are the panel's now. What is left is where the
+     result sits on the page. */
   .merchant-result {
-    margin-top: 1.5rem;
-    padding: 1rem;
-    border: 1px solid var(--border);
-    border-radius: 8px;
+    margin-top: var(--s7);
   }
 
   .merchant-header {
     display: flex;
     justify-content: space-between;
-    gap: 1rem;
+    gap: var(--s6);
     align-items: flex-start;
     /* A long shop name plus the 120px mark does not fit a phone on one line. */
     flex-wrap: wrap;
@@ -241,24 +245,26 @@
   }
 
   .shop-meta {
-    color: #aaa;
-    margin-top: 0.25rem;
+    color: var(--ink-muted);
+    margin-top: var(--s1);
   }
 
+  /* The mark is generated artwork rather than furniture, so it keeps a plain keyline and loses
+     the radius: 4px is outside the corner vocabulary, which offers a pill and the round icon
+     button and nothing between them. */
   .merchant-mark {
+    border: 1px solid var(--border);
     flex-shrink: 0;
-    border: 1px solid #ccc;
-    border-radius: 4px;
     overflow: hidden;
   }
 
   .location {
+    color: var(--ink-muted);
     font-style: italic;
-    color: #bbb;
   }
 
   .trading-notes {
-    padding-left: 1.25rem;
+    padding-left: var(--s6);
   }
 
   /* Five columns cannot compress to phone width without the item names turning
@@ -267,21 +273,24 @@
     overflow-x: auto;
   }
 
+  /* One of the three bespoke tables #154 will collapse into a shared one. What #124 does here is
+     take the literals out — the borders were `#555` and the header a raw `rgba` — and leave the
+     structure for that issue to settle rather than inventing a fourth table language in a walk. */
   .stock-table {
-    width: 100%;
-    min-width: 30rem;
     border-collapse: collapse;
-    margin-top: 0.5rem;
+    margin-top: var(--s4);
+    min-width: 30rem;
+    width: 100%;
   }
 
   .stock-table th,
   .stock-table td {
-    border: 1px solid #555;
-    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--border);
+    padding: var(--s3) var(--s4);
     text-align: left;
   }
 
   .stock-table th {
-    background: rgba(0, 0, 0, 0.2);
+    background: var(--surface-inset);
   }
 </style>

--- a/src/components/objects/PotionGenerator.svelte
+++ b/src/components/objects/PotionGenerator.svelte
@@ -58,66 +58,70 @@
   <BaseButton onclick={generate}>Generate</BaseButton>
 
   {#if potion}
-    <article class="potion-result">
-      <h2>{potion.displayName}</h2>
+    <!-- A result surface is a panel, not a box with a border on it: the two layers,
+         and the keyline, corner and padding are the system's. It wrote its own
+         border, radius and padding until #124. -->
+    <article class="potion-result panel">
+      <div class="panel__field">
+        <h2>{potion.displayName}</h2>
 
-      {#if potion.modifications.length > 0}
+        {#if potion.modifications.length > 0}
+          <p>
+            <strong>Modifications:</strong>
+            {potion.modifications.map((mod) => mod.kind).join(', ')}
+          </p>
+        {/if}
+
+        {#if potion.canonicalName && potion.canonicalName !== potion.displayName}
+          <p><strong>Base formula:</strong> {potion.canonicalName}</p>
+        {/if}
+        <p><strong>Rarity:</strong> {potion.liquid.rarity}</p>
+        <p><strong>Value:</strong> {valueToString(potion.liquid.value, COMMON_FANTASY)}</p>
         <p>
-          <strong>Modifications:</strong>
-          {potion.modifications.map((mod) => mod.kind).join(', ')}
+          <strong>Form:</strong>
+          {potion.liquid.properties.includes('oil')
+            ? 'oil'
+            : potion.liquid.properties.includes('ointment')
+              ? 'ointment'
+              : 'drink'}
         </p>
-      {/if}
 
-      {#if potion.canonicalName && potion.canonicalName !== potion.displayName}
-        <p><strong>Base formula:</strong> {potion.canonicalName}</p>
-      {/if}
-      <p><strong>Rarity:</strong> {potion.liquid.rarity}</p>
-      <p><strong>Value:</strong> {valueToString(potion.liquid.value, COMMON_FANTASY)}</p>
-      <p>
-        <strong>Form:</strong>
-        {potion.liquid.properties.includes('oil')
-          ? 'oil'
-          : potion.liquid.properties.includes('ointment')
-            ? 'ointment'
-            : 'drink'}
-      </p>
+        <h3>Effect</h3>
+        <p>{describeEffect(potion.effect)}</p>
+        <p><strong>Duration:</strong> {describeDurationShort(potion.effect.duration)}</p>
+        <p><strong>Magnitude:</strong> {potion.effect.magnitude}</p>
 
-      <h3>Effect</h3>
-      <p>{describeEffect(potion.effect)}</p>
-      <p><strong>Duration:</strong> {describeDurationShort(potion.effect.duration)}</p>
-      <p><strong>Magnitude:</strong> {potion.effect.magnitude}</p>
+        <h3>Sensory Profile</h3>
+        <ul>
+          <li><strong>Appearance:</strong> {potion.sensory.appearance}</li>
+          <li><strong>Viscosity:</strong> {potion.sensory.viscosity}</li>
+          <li><strong>Flavor:</strong> {potion.sensory.flavor}</li>
+          <li><strong>Scent:</strong> {potion.sensory.scent}</li>
+        </ul>
 
-      <h3>Sensory Profile</h3>
-      <ul>
-        <li><strong>Appearance:</strong> {potion.sensory.appearance}</li>
-        <li><strong>Viscosity:</strong> {potion.sensory.viscosity}</li>
-        <li><strong>Flavor:</strong> {potion.sensory.flavor}</li>
-        <li><strong>Scent:</strong> {potion.sensory.scent}</li>
-      </ul>
+        <h3>Container</h3>
+        <p>{potion.container.name}: {potion.container.description}</p>
+        <p>
+          <strong>Container value:</strong>
+          {valueToString(potion.container.value, COMMON_FANTASY)}
+        </p>
 
-      <h3>Container</h3>
-      <p>{potion.container.name}: {potion.container.description}</p>
-      <p>
-        <strong>Container value:</strong>
-        {valueToString(potion.container.value, COMMON_FANTASY)}
-      </p>
-
-      <h3>Description</h3>
-      <p>{potion.liquid.description}</p>
+        <h3>Description</h3>
+        <p>{potion.liquid.description}</p>
+      </div>
     </article>
   {/if}
 </GeneratorPage>
 
 <style>
+  /* The keyline, the corner and the padding are the panel's now. What is left is where the
+     result sits on the page. */
   .potion-result {
-    margin-top: 1.5rem;
-    padding: 1rem;
-    border: 1px solid var(--border);
-    border-radius: 0.5rem;
+    margin-top: var(--s7);
   }
 
   .potion-result h3 {
-    margin-top: 1rem;
-    margin-bottom: 0.25rem;
+    margin-top: var(--s6);
+    margin-bottom: var(--s2);
   }
 </style>

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -659,32 +659,14 @@ describe('the panel language', () => {
   // #117's four entries — the two banners, the storage failure dialog and the snapshot dialog —
   // are gone, which is the first time this list has shrunk. They are the message family now, and
   // they are swept like everything else.
-  const DEFERRED = new Set([
-    // #119-#121: surfaces that hold generated output, which is what a genre skin dresses.
-    'src/components/characters/AdndCharacterBuilder.svelte',
-    'src/components/factions/CultureArtifactEditor.svelte',
-    'src/components/factions/EncounterGenerator.svelte',
-    'src/components/factions/ReligionArtifactEditor.svelte',
-    'src/components/heraldry/HeraldryArtifactView.svelte',
-    'src/components/locations/SettlementArtifactEditor.svelte',
-    'src/components/objects/EquipmentGenerator.svelte',
-    'src/components/objects/MerchantGenerator.svelte',
-    'src/components/objects/PotionGenerator.svelte',
-  ]);
-
-  const componentSheets = siteStylesheets().filter(
-    ({ name }) => name.endsWith('.svelte') && !DEFERRED.has(name),
-  );
-
-  it('defers only files another issue owns', () => {
-    // A deferred file that no longer exists is a list nobody pruned, and a list nobody prunes is
-    // how an exemption outlives the thing it was granted for.
-    const missing = [...DEFERRED].filter(
-      (name) => !siteStylesheets().some((sheet) => sheet.name === name),
-    );
-
-    expect(missing, 'a deferred file that is gone').toEqual([]);
-  });
+  // Every component, with nothing carried. A `DEFERRED` list of nine files sat here until #124,
+  // exempted on the grounds that they were "surfaces that hold generated output, which is what a
+  // genre skin dresses" and belonged to #119-#121. Those three issues closed without touching any
+  // of them, so the exemption had outlived its reason — which is exactly what the list's own guard
+  // test was written against, and exactly what that guard could not see, because it only checked
+  // that a deferred file still existed. Twelve hexes and sixty-five off-ramp values later, the
+  // list is gone rather than shorter.
+  const componentSheets = siteStylesheets().filter(({ name }) => name.endsWith('.svelte'));
 
   it('declares the two shadows, and the halo is a state rather than an elevation', () => {
     // `--lift` sits a panel off the page and is fixed across the genres so two panels beside each


### PR DESCRIPTION
Closes #124, the last issue in #77's original scope.

Design: [`docs/visual-design.md`, "Walking it, and what a walk should leave behind"](https://github.com/ironarachne/ironarachne/blob/issue-124-route-walk/docs/visual-design.md#walking-it-and-what-a-walk-should-leave-behind), approved before implementation.

### The premise was wrong, and the design says so

The issue asks for every route "before and after". **There is no before** — the redesign landed over ten issues and `main` has been the after since #113. The only before is in git history, and a pixel diff against it would report the whole redesign as one enormous regression, since changing how the site looks was the point. The comparison is against the document.

And a walk that ends in an album has to be repeated. Every finding here left a fix, a test, or a question pushed back to the document.

### The exemption list is gone

Nine components were exempt from the hex and ramp sweeps, deferred to #119–#121 as "surfaces that hold generated output, which is what a genre skin dresses". **Those three issues closed without touching any of them**, and the list's own guard could not tell: it checked that a deferred *file* still existed, not that its *reason* still held.

Clearing them was expected to be twelve hexes and sixty-five off-ramp sizes. It was also **four hand-rolled panels and eight corners outside the vocabulary** — the list had been hiding those sweeps from those files too. An exemption is never as narrow as the sentence that grants it.

What that turned into:

| | |
| --- | --- |
| `merchant-result`, `potion-result`, `stat-block` | boxes with their own border, radius, padding and (one) invented fill → **panels**, two layers |
| four `<p role="alert">` boxes | hand-rolled bordered paragraphs → **`Notice tone="danger"`**, which is what the message family is for |
| three editors' `fieldset`s, the encounter's list rows | nested boxes inside panels → spacing and legend only; "when everything is a box, being one emphasises nothing" |
| equipment's item cards | own border/radius/fill → panels, with `Badge`es replacing bespoke tags |
| equipment's damage/defense/value colours | three hues meaning three things → gone; a fourth colour system beside the roles, tones and genres |
| two `--tan` separators | the plate's edge used as a divider → `--border` |

### The capture harness

A dispatch-only Playwright project screenshotting all 41 routes, **generated where there is something to generate** — the surfaces this walk looks hardest at only exist once a tool has run. It asserts nothing, and `goldens.yaml` is the precedent: render, hand it to a reviewer, gate nothing. Explicitly **not** a golden-image suite, for the reason the document gives.

Two things it taught:

- **`fullPage` captures nothing extra on this app.** The shell is a `100dvh` grid and scrolling happens *inside* the page region, so the document is always exactly one viewport tall. It grows the viewport to the region's own `scrollHeight` instead. Anything else reasoning about page height meets the same wall.
- **A Playwright project with no filter runs on a bare `playwright test`.** `testMatch` chooses a project's *files*, not whether the project runs — the first version put 240 screenshots into `verify:all` (689 tests instead of 449). It is behind `CAPTURE=1` now.

### Also recorded in the document

**Generated content carries its own colours, and the sweeps must not follow it there.** Species and archetype badges paint from `$lib/display_colors`, seeded from the name they belong to; heraldry composes SVG the same way. Those hues are the product, not the interface — the same line the icon sweep draws around components that *draw* rather than decorate.

**Two findings needed a decision this walk does not get to make**, both now triaged into #77: tables (#154) are still `main.css`'s literal `black`, with three components having each invented their own; stat blocks (#153) are `<strong>Label:</strong>` 229 times across 19 components. They are the same gap — **this document settles the frame and says nothing about the content inside a panel.**

### Checks

`npm run verify:all` green — 4475 unit tests, 449 Playwright tests, `svelte-check` 0 errors, coverage gate 99/99 with no baselined debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2wzaP74ffGJjghzcabKeT