### PR TITLE
Convert every stat to a pair, for #153

### DIFF
--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -165,8 +165,23 @@ and a walk that ends in sweeps is done once.** It also names debt that needs no 
 nine components still exempted from the hex and ramp sweeps for three issues that have since closed
 without touching them.
 
-Awaiting approval, unlike the amendments above it, which are built: #124 is `needs-design`, and the
-corrected premise, the findings-become-sweeps rule and the capture-is-not-a-gate decision are what
+Approved and built. The walk it describes found two things it was not allowed to settle, which is
+the next amendment.
+
+**Amended 2026-08-30 by [#153](https://github.com/ironarachne/ironarachne/issues/153) and
+[#154](https://github.com/ironarachne/ironarachne/issues/154)**, which add [the content
+language](#the-content-language-stats-and-tables) — the first section in this document about what is
+_inside_ a panel rather than about the panel. Everything before it settles the frame, and the walk
+is what made that gap impossible to keep ignoring: a stat is `<strong>Label:</strong>` 229 times
+across 19 components, and the base table still draws `1px solid black` around every cell while three
+components have each written their own instead.
+
+**The two issues are one section**, on a fact neither of them mentions: a table flipped for a phone
+_is_ a stat block. Designed apart, the site would answer the same question twice and differently
+below 640px.
+
+Awaiting approval, unlike the amendments above it, which are built: #153 and #154 are `needs-design`,
+and the pair as the unit, the row-not-cell table, and the flip-unless-it-is-a-matrix rule are what
 CLAUDE.md's review gate asks a human to approve before implementation starts.
 
 **Amended 2026-08-30, in review of the above:** every genre gets a panel shape of its own, which
@@ -3216,6 +3231,155 @@ blocks ([#153](https://github.com/ironarachne/ironarachne/issues/153)) are `<str
 229 times across 19 components. Both are the same gap, and it is worth naming: **this document
 settles the frame and says nothing about the content inside a panel.** Everything #77 converted was
 furniture. Those two issues are now in #77's scope, after this one.
+
+## The content language: stats and tables
+
+Everything above this settles the **frame** — the panel a result sits in, the controls that produced
+it, the message when something goes wrong, the shell around all of it, the genre it wears and the
+marks that classify it. **None of it settles what is inside the panel**, and the
+[route walk](#what-the-walk-found) is what made that impossible to keep ignoring: two of its
+findings needed a decision it could not make, and both were about the output rather than the
+furniture.
+
+This settles them. [#153](https://github.com/ironarachne/ironarachne/issues/153) and
+[#154](https://github.com/ironarachne/ironarachne/issues/154) are one section rather than two,
+because of a fact neither issue mentions: **a table flipped for a phone is a stat block.** Design
+them apart and the site gets two answers to the same question, one of them on screens under 640px.
+
+### What is actually there
+
+Counted rather than characterised:
+
+|                                 |                                                                                               |
+| ------------------------------- | --------------------------------------------------------------------------------------------- |
+| `<strong>Label:</strong> value` | **229 instances across 19 components** — 139 of them wrapped in a bare `<p>`, 13 in an `<li>` |
+| `<dl>`                          | 3 components, each styling it themselves; `main.css` has no `dl`, `dt` or `dd` rules at all   |
+| `<table>`                       | 5 components, of which **3 have written their own**                                           |
+| The base table                  | `main.css`, with `3px solid black`, `1px solid black` and `padding: 0.25rem`                  |
+
+That last row is the last element rule in the app still holding a literal colour, and the three
+bespoke tables are [nineteen copies of a box](#the-problem-is-nineteen-copies-of-a-box) happening a
+second time, for the same reason: the shared thing is unusable, so everyone works around it.
+
+### A stat is a pair, and it is not a sentence
+
+`<strong>Hit Points:</strong> 14` is a sentence that has been made to look like data. It reads as
+prose to a screen reader, it cannot be aligned with the stat above it, and the colon is doing the
+work a layout should. The pair is the unit:
+
+| Part      | Element | Type step                       | Ink           |
+| --------- | ------- | ------------------------------- | ------------- |
+| **Key**   | `<dt>`  | `--t-micro`, tracked, uppercase | `--ink-faint` |
+| **Value** | `<dd>`  | `--t-body`                      | `--ink`       |
+
+**That is deliberately the same recipe as [a control's label](#the-field-around-a-control).** A stat
+is a field nobody can type in, so it should look like one: the app already teaches a reader that a
+small uppercase line above a value names that value, and teaching it twice with two different looks
+is the whole failure this document exists to prevent.
+
+Consequences that follow from choosing the pair:
+
+- **No borders, no boxes, no rules between stats.** Separation is the space ramp, and a stat block
+  inside a panel that drew its own box would be the nested box the
+  [panel language](#three-levels-and-the-well-makes-four) refuses.
+- **A block is a grid**, `repeat(auto-fill, minmax(11rem, 1fr))` with `--s5` between cells, so a
+  character sheet is a grid at desktop width and one column on a phone without a media query.
+- **Keys do not repeat a heading.** A block under a "Combat" heading has an `Attack Bonus`, not a
+  `Combat Attack Bonus`.
+- **A value may be anything** — a number, a name, a `Badge`, a link — so the component takes a
+  snippet rather than a string. Several of the 229 already carry markup in the value.
+
+### A table is rows, not a grid of cells
+
+The base table draws a box around every cell. That is what makes it look like a spreadsheet dropped
+into the page, and it is the wrong emphasis: what a reader follows across a table is the **row**.
+
+| Part          | Recipe                                                                                               |
+| ------------- | ---------------------------------------------------------------------------------------------------- |
+| Header cell   | `--t-micro`, tracked, uppercase, `--ink-faint`, left-aligned                                         |
+| Header rule   | 1px `--border` under the head, and nothing else above it                                             |
+| Row separator | 1px `--border` under each row; **no vertical rules anywhere**                                        |
+| Cell padding  | `--s3` block, `--s4` inline, and `0` on the leading edge so a column lines up with the text above it |
+| Numeric cells | Right-aligned, and the header with them                                                              |
+| Long tables   | Scroll inside a `--surface-sunken` well, which is what the fourth surface is for                     |
+
+Two rules and no vertical rules is the whole change, and it is why the same table reads as cleaner
+without reading as plainer: the hairlines that survive are the ones a reader's eye was using.
+
+### The phone answer, which is where the two halves meet
+
+Three components each answered this differently, which is one more answer than the question has.
+`e2e/pages.mobile.spec.ts` already forbids horizontal overflow at 320px, so a table has exactly two
+honest options, and **the test between them is what a row means**:
+
+> **Flip by default.** If a row makes sense read as a list of key/value pairs, it becomes one below
+> 640px: the head is hidden, each cell takes its key from `data-label`, and the row becomes a stat
+> block. `StoragePanel` already does exactly this and is the most developed of the three, so the
+> shared answer is its answer.
+>
+> **Scroll only when the columns are a matrix.** If the columns mean something only _beside_ each
+> other — the word-generator cheat sheet is a grid where the comparison across a row is the content
+> — the table keeps its shape and scrolls inside its own `overflow-x` container. Never the page.
+
+**The flipped row is a stat block**, wearing the same key and value recipe, which is the reason
+these two issues are one design. A reader who has learned to read a character's stats has already
+learned to read a table on their phone.
+
+### Two components, and the elements they are
+
+```mermaid
+classDiagram
+    class StatBlock {
+        <<dl, a grid of pairs>>
+        +Snippet children
+        +string class
+    }
+    class Stat {
+        <<div wrapping dt + dd>>
+        +string label
+        +Snippet children
+    }
+    class DataTable {
+        <<table>>
+        +Column[] columns
+        +Snippet rows
+        +"flip" | "scroll" narrow
+    }
+    class Column {
+        +string label
+        +boolean numeric
+    }
+
+    StatBlock "1" o-- "*" Stat : holds
+    DataTable "1" o-- "*" Column : heads
+    DataTable ..> Stat : a flipped row is one
+```
+
+`Stat` renders `<div><dt>…</dt><dd>…</dd></div>` inside `StatBlock`'s `<dl>`, because a `dl` may not
+hold anything else and a bare `dt`/`dd` pair cannot be laid out as a cell. `DataTable` owns the
+`data-label` plumbing rather than each caller writing it out, which is where `StoragePanel`'s
+version leaks: every cell has to remember its own label or the flip silently drops it.
+
+### The skins get nothing new
+
+A stat block and a table are **content inside a panel**, and a skin already dresses that panel. They
+inherit `--ink`, `--ink-faint` and `--border` like everything else, so all four genres work with no
+new permission and [decision 2](#2-genre-skins-are-a-permitted-subset-not-a-second-look) does not
+move. #153 asks for "genre-skin treatments"; the answer is that it already has them, and a skin
+reaching further would be the second look decision 2 forbids.
+
+### What the content language enforces
+
+- **No component declares a `table`, `th` or `td` rule.** The table is `main.css`'s, and a component
+  reaching for one is the second implementation starting again — the same shape as "no skin file
+  declares a `button` rule". The three bespoke copies are deleted rather than tidied.
+- **No component writes `<strong>…:</strong>`.** That pattern is a stat that has not been converted,
+  and 229 of them are why the rule has to be a sweep rather than a guideline.
+- **The ramp sweep widens to every component.** It covers two named lists today, which is how
+  `StoragePanel`'s `0.8rem` and `0.35rem` survived the walk that deleted the exemption list. New
+  shared components make that gap indefensible.
+- **Every `DataTable` column declares its label**, so the flip cannot silently lose one — checked in
+  the browser at 320px, where a flipped row must show as many keys as the head had columns.
 
 ## Enforcement
 

--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -3368,13 +3368,39 @@ new permission and [decision 2](#2-genre-skins-are-a-permitted-subset-not-a-seco
 move. #153 asks for "genre-skin treatments"; the answer is that it already has them, and a skin
 reaching further would be the second look decision 2 forbids.
 
+### What converting 229 stats found
+
+**A stat with no value at all.** `AdndCharacterSheet` printed `Hit Point Adjustment:` and then
+nothing — in `main`, on every AD&D sheet, with `character.hitPointAdjustment` on the type the whole
+time. Converting a label-and-value pattern into a component that requires both is what surfaced it,
+which is the argument for components over conventions in one line: a convention cannot notice that
+half of it is missing.
+
+**A stat block written as a sentence.** The dungeon's room meta read
+`Purpose: x · Shape: y · Size: z` in one paragraph, where the middle dots were doing the work the
+grid does.
+
+**The colon was load-bearing in a test.** `e2e/helpers.ts` asserted on the text `Age Range:`, which
+stopped existing the moment the key became a `<dt>`. Worth stating because it generalises: a pattern
+that spans markup and prose leaks into anything that reads the page as text, and the punctuation is
+the part that leaks.
+
 ### What the content language enforces
 
 - **No component declares a `table`, `th` or `td` rule.** The table is `main.css`'s, and a component
   reaching for one is the second implementation starting again — the same shape as "no skin file
   declares a `button` rule". The three bespoke copies are deleted rather than tidied.
-- **No component writes `<strong>…:</strong>`.** That pattern is a stat that has not been converted,
-  and 229 of them are why the rule has to be a sweep rather than a guideline.
+- **No component writes `<strong>Label:</strong>` with a _constant_ key.** That pattern is a stat
+  that has not been converted, and 229 of them are why the rule has to be a sweep rather than a
+  guideline.
+
+  **The key's constancy is the line, and implementation drew it rather than this section.**
+  `<strong>{trait.name}:</strong> {trait.description}` is a term and a sentence about it — a
+  glossary, which is a content shape this document has not designed and should not be forced into a
+  grid of cells. A stat's key is written by the app; a glossary's comes from the generator, so
+  "constant" is a discriminator a sweep can see. Designing the glossary is a later issue's, and
+  eight sites are waiting for it.
+
 - **The ramp sweep widens to every component.** It covers two named lists today, which is how
   `StoragePanel`'s `0.8rem` and `0.35rem` survived the walk that deleted the exemption list. New
   shared components make that gap indefensible.

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -92,7 +92,10 @@ export async function expectGeneratorOutput(
       return;
     case 'stats':
       await expect(page.getByRole('heading', { name: 'Calculated Stats' })).toBeVisible();
-      await expect(page.getByText('Age Range:').first()).toBeVisible();
+      // The colon went with the sentence: a stat is a `<dt>` holding "Age Range" and a `<dd>`
+      // holding the value, so the key is matched exactly rather than by the punctuation that used
+      // to separate it from what followed. docs/visual-design.md, "A stat is a pair".
+      await expect(page.getByText('Age Range', { exact: true }).first()).toBeVisible();
       await expect(
         page.getByRole('heading', { name: 'adult', level: 5, exact: true }).first(),
       ).toBeVisible();

--- a/src/components/characters/AdndCharacterBuilder.svelte
+++ b/src/components/characters/AdndCharacterBuilder.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import * as RNG from '@ironarachne/rng';
   import { resolve } from '$app/paths';
   import * as Dice from '$lib/dice';
@@ -940,14 +942,13 @@
           Allocate exactly {getThiefSkillPointPool(thiefSkillKind)} points (max {ADND_THIEF_SKILL_BONUS_CAP}
           per skill). Base scores include Dexterity and racial modifiers.
         </p>
-        <p>
-          <strong>Allocated:</strong>
+        <Stat label="Allocated">
           {sumThiefSkillBonuses(thiefSkillBonuses)} /
           {getThiefSkillPointPool(
             thiefSkillKind,
           )}{#if thiefSkillKind && sumThiefSkillBonuses(thiefSkillBonuses) !== getThiefSkillPointPool(thiefSkillKind)}
             — must match total{/if}
-        </p>
+        </Stat>
         <div class="thief-skill-grid">
           {#each thiefSkillRowsForBuilder as row (row.name)}
             <label>
@@ -985,7 +986,9 @@
         Typical random roll for this class: {startingFundsDiceLine(selectedClass)}. Values below use
         gp, sp, and cp (the rules reference copper totals internally).
       </p>
-      <p><strong>Total:</strong> {formatWealthCp(startingWealthCp)}</p>
+      <StatBlock>
+        <Stat label="Total">{formatWealthCp(startingWealthCp)}</Stat>
+      </StatBlock>
       <p>
         <BaseButton onclick={rollStartingFunds}
           >Roll starting funds ({startingFundsDiceLine(selectedClass)})</BaseButton

--- a/src/components/characters/AdndCharacterSheet.svelte
+++ b/src/components/characters/AdndCharacterSheet.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import * as Words from '@ironarachne/words';
   import { Currency } from '$lib/currency';
   import { adndRaceDisplayName, type ADNDCharacter } from '$lib/adnd';
@@ -16,127 +18,135 @@
 
 <p>A level {character.level} {adndRaceDisplayName(character)} {character.class.name}</p>
 
-<p><strong>XP:</strong> {character.xp}</p>
-<p><strong>HP:</strong> {character.hp}</p>
-<p><strong>AC:</strong> {character.ac}</p>
-<p><strong>THAC0:</strong> {character.thaco}</p>
-<p><strong>Alignment:</strong> {character.alignment}</p>
-<p>
-  <strong>Currency:</strong>
+<StatBlock>
+  <Stat label="XP">{character.xp}</Stat>
+  <Stat label="HP">{character.hp}</Stat>
+  <Stat label="AC">{character.ac}</Stat>
+  <Stat label="THAC0">{character.thaco}</Stat>
+  <Stat label="Alignment">{character.alignment}</Stat>
+</StatBlock>
+<Stat label="Currency">
   {Currency.valueToGpSpCpString(Number.isFinite(character.currency) ? character.currency : 0)}
-</p>
+</Stat>
 
 <h3>Attributes</h3>
 
-<p>
-  <strong>Strength:</strong>
+<Stat label="Strength">
   {character.strength}{#if character.exceptionalStrength != -1}/{getEStrength(
       character.exceptionalStrength,
     )}{/if}
-</p>
-<p><strong>Dexterity:</strong> {character.dexterity}</p>
-<p><strong>Constitution:</strong> {character.constitution}</p>
-<p><strong>Charisma:</strong> {character.charisma}</p>
-<p><strong>Intelligence:</strong> {character.intelligence}</p>
-<p><strong>Wisdom:</strong> {character.wisdom}</p>
+</Stat>
+<StatBlock>
+  <Stat label="Dexterity">{character.dexterity}</Stat>
+  <Stat label="Constitution">{character.constitution}</Stat>
+  <Stat label="Charisma">{character.charisma}</Stat>
+  <Stat label="Intelligence">{character.intelligence}</Stat>
+  <Stat label="Wisdom">{character.wisdom}</Stat>
+</StatBlock>
 
 <h3>Saving Throws</h3>
 
-<p><strong>Paralyzation, Poison, or Death Magic:</strong> {character.poisonSavingThrow}</p>
-<p><strong>Rod, Staff, or Wand:</strong> {character.rodSavingThrow}</p>
-<p><strong>Petrification or Polymorph:</strong> {character.petrificationSavingThrow}</p>
-<p><strong>Breath Weapon:</strong> {character.breathSavingThrow}</p>
-<p><strong>Spell:</strong> {character.spellSavingThrow}</p>
+<StatBlock>
+  <Stat label="Paralyzation, Poison, or Death Magic">{character.poisonSavingThrow}</Stat>
+  <Stat label="Rod, Staff, or Wand">{character.rodSavingThrow}</Stat>
+  <Stat label="Petrification or Polymorph">{character.petrificationSavingThrow}</Stat>
+  <Stat label="Breath Weapon">{character.breathSavingThrow}</Stat>
+  <Stat label="Spell">{character.spellSavingThrow}</Stat>
+</StatBlock>
 
 <h3>Derived Stats</h3>
 
-<p><strong>Hit Probability:</strong> {character.hitProbability}</p>
-<p><strong>Damage Adjustment:</strong> {character.damageAdjustment}</p>
-<p><strong>Weight Allowance:</strong> {character.weightAllowance}</p>
-<p><strong>Maximum Press:</strong> {character.maxPress}</p>
-<p><strong>Open Doors:</strong> {character.openDoors}</p>
-<p><strong>Bend Bars/Lift Gates:</strong> {character.bendBarsLiftGates}%</p>
-<p>
-  <strong>Reaction Adjustment:</strong>
+<StatBlock>
+  <Stat label="Hit Probability">{character.hitProbability}</Stat>
+  <Stat label="Damage Adjustment">{character.damageAdjustment}</Stat>
+  <Stat label="Weight Allowance">{character.weightAllowance}</Stat>
+  <Stat label="Maximum Press">{character.maxPress}</Stat>
+  <Stat label="Open Doors">{character.openDoors}</Stat>
+  <Stat label="Bend Bars/Lift Gates">{character.bendBarsLiftGates}%</Stat>
+</StatBlock>
+<Stat label="Reaction Adjustment">
   {character.reactionAdjustment > 0
     ? `+${character.reactionAdjustment}`
     : character.reactionAdjustment}
-</p>
-<p>
-  <strong>Missile Attack Adjustment:</strong>
+</Stat>
+<Stat label="Missile Attack Adjustment">
   {character.missileAttackAdjustment > 0
     ? `+${character.missileAttackAdjustment}`
     : character.missileAttackAdjustment}
-</p>
-<p>
-  <strong>Defensive Adjustment:</strong>
+</Stat>
+<Stat label="Defensive Adjustment">
   {character.defensiveAdjustment > 0
     ? `+${character.defensiveAdjustment}`
     : character.defensiveAdjustment}
-</p>
-<p><strong>Hit Point Adjustment:</strong></p>
-<p><strong>System Shock:</strong> {character.systemShock}%</p>
-<p><strong>Resurrection Survival:</strong> {character.resurrectionSurvival}%</p>
-<p>
-  <strong>Poison Save:</strong>
+</Stat>
+<StatBlock>
+  <!-- The value was missing outright before #153: the sheet printed "Hit Point Adjustment:" with
+       nothing after it. Converting a label-and-value pattern into a component that needs both is
+       what found it — `character.hitPointAdjustment` has been on the type all along. -->
+  <Stat label="Hit Point Adjustment"
+    >{character.hitPointAdjustment > 0
+      ? `+${character.hitPointAdjustment}`
+      : character.hitPointAdjustment}</Stat
+  >
+  <Stat label="System Shock">{character.systemShock}%</Stat>
+  <Stat label="Resurrection Survival">{character.resurrectionSurvival}%</Stat>
+</StatBlock>
+<Stat label="Poison Save">
   {character.poisonSave > 0 ? `+${character.poisonSave}` : character.poisonSave}
-</p>
-<p><strong>Regeneration:</strong> {character.regeneration}</p>
-<p><strong>Number of Languages:</strong> {character.numberOfLanguages}</p>
-<p>
-  <strong>Spell Level:</strong>
+</Stat>
+<StatBlock>
+  <Stat label="Regeneration">{character.regeneration}</Stat>
+  <Stat label="Number of Languages">{character.numberOfLanguages}</Stat>
+</StatBlock>
+<Stat label="Spell Level">
   {character.spellLevel == -1
     ? 'N/A'
     : `${character.spellLevel}${Words.getOrdinal(character.spellLevel)}`}
-</p>
-<p>
-  <strong>Chance To Learn Spell:</strong>
+</Stat>
+<Stat label="Chance To Learn Spell">
   {character.chanceToLearnSpell == -1 ? 'N/A' : `${character.chanceToLearnSpell}%`}
-</p>
-<p>
-  <strong>Maximum Number of Spells Per Level:</strong>
+</Stat>
+<Stat label="Maximum Number of Spells Per Level">
   {character.maximumNumberOfSpellsPerLevel == -1
     ? 'N/A'
     : character.maximumNumberOfSpellsPerLevel == 99
       ? 'All'
       : character.maximumNumberOfSpellsPerLevel}
-</p>
-<p>
-  <strong>Illusion Immunity:</strong>
+</Stat>
+<Stat label="Illusion Immunity">
   {character.illusionImmunity == -1
     ? 'N/A'
     : `${character.illusionImmunity}${Words.getOrdinal(character.illusionImmunity)}-level`}
-</p>
-<p>
-  <strong>Magical Defense Adjustment:</strong>
+</Stat>
+<Stat label="Magical Defense Adjustment">
   {character.magicalDefenseAdjustment > 0
     ? `+${character.magicalDefenseAdjustment}`
     : character.magicalDefenseAdjustment}
-</p>
-<p>
-  <strong>Bonus Priest Spells:</strong>
+</Stat>
+<Stat label="Bonus Priest Spells">
   {character.bonusSpells.length == 0
     ? 'N/A'
     : character.bonusSpells[0] == 0
       ? '0'
       : character.bonusSpells.join(', ')}
-</p>
-<p><strong>Chance of Spell Failure:</strong> {character.chanceOfSpellFailure}%</p>
-<p>
-  <strong>Spell Immunity:</strong>
+</Stat>
+<StatBlock>
+  <Stat label="Chance of Spell Failure">{character.chanceOfSpellFailure}%</Stat>
+</StatBlock>
+<Stat label="Spell Immunity">
   {character.spellImmunity.length == 0 ? 'N/A' : character.spellImmunity.join(', ')}
-</p>
-<p><strong>Maximum Number of Henchmen:</strong> {character.maximumNumberOfHenchmen}</p>
-<p>
-  <strong>Loyalty Base:</strong>
+</Stat>
+<StatBlock>
+  <Stat label="Maximum Number of Henchmen">{character.maximumNumberOfHenchmen}</Stat>
+</StatBlock>
+<Stat label="Loyalty Base">
   {character.loyaltyBase > 0 ? `+${character.loyaltyBase}` : character.loyaltyBase}
-</p>
-<p>
-  <strong>Reaction Adjustment (NPCs):</strong>
+</Stat>
+<Stat label="Reaction Adjustment (NPCs)">
   {character.npcReactionAdjustment > 0
     ? `+${character.npcReactionAdjustment}`
     : character.npcReactionAdjustment}
-</p>
+</Stat>
 
 <h3>Weapons</h3>
 

--- a/src/components/characters/CharacterGenerator.svelte
+++ b/src/components/characters/CharacterGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import { RNG } from '@ironarachne/rng';
   import * as Measurements from '$lib/measurements';
   import {
@@ -266,27 +268,29 @@
         {/each}
       </ul>
     {/if}
-    <p><strong>Description:</strong> {character.description}</p>
-    <p><strong>Gender:</strong> {character.gender.name}</p>
-    <p><strong>Species:</strong> {character.species.name}</p>
-    {#if character.creatureTypes.length > 0}
-      <p><strong>Type:</strong> {character.creatureTypes.join(', ')}</p>
-    {/if}
-    {#if character.archetype}
-      <p><strong>Archetype:</strong> {character.archetype.name}</p>
-    {/if}
-    <p><strong>Age:</strong> {character.age} years ({character.ageCategory.name})</p>
-    <p>
-      <strong>Height:</strong>
+    <StatBlock>
+      <Stat label="Description">{character.description}</Stat>
+      <Stat label="Gender">{character.gender.name}</Stat>
+      <Stat label="Species">{character.species.name}</Stat>
+      {#if character.creatureTypes.length > 0}
+        <Stat label="Type">{character.creatureTypes.join(', ')}</Stat>
+      {/if}
+      {#if character.archetype}
+        <Stat label="Archetype">{character.archetype.name}</Stat>
+      {/if}
+      <Stat label="Age">{character.age} years ({character.ageCategory.name})</Stat>
+    </StatBlock>
+    <Stat label="Height">
       {Measurements.inchesToFeetExpression(Measurements.cmToInches(character.height))}
-    </p>
+    </Stat>
     {#if character.length > 0}
-      <p>
-        <strong>Length:</strong>
+      <Stat label="Length">
         {Measurements.inchesToFeetExpression(Measurements.cmToInches(character.length))}
-      </p>
+      </Stat>
     {/if}
-    <p><strong>Weight:</strong> {Measurements.kgToPounds(character.weight)} lbs.</p>
+    <StatBlock>
+      <Stat label="Weight">{Measurements.kgToPounds(character.weight)} lbs.</Stat>
+    </StatBlock>
 
     {#if character.physicalTraits.length > 0}
       <h3>Physical Traits</h3>

--- a/src/components/characters/DccCharacterGenerator.svelte
+++ b/src/components/characters/DccCharacterGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import { RNG } from '@ironarachne/rng';
   import {
     buildCharacterNameSource,
@@ -194,59 +196,58 @@
 
     <p>A level {character.level} {character.occupation.name}</p>
 
-    <p><strong>XP:</strong> {character.xp}</p>
-    <p><strong>HP:</strong> {character.hp}</p>
-    <p><strong>AC:</strong> {character.armorClass}</p>
-    <p><strong>Currency:</strong> {DCC.formatDccCurrency(character.currency)}</p>
-    <p><strong>Alignment:</strong> {character.alignment}</p>
-    <p><strong>Gender:</strong> {character.gender}</p>
-    <p><strong>Speed:</strong> {character.speed}'</p>
+    <StatBlock>
+      <Stat label="XP">{character.xp}</Stat>
+      <Stat label="HP">{character.hp}</Stat>
+      <Stat label="AC">{character.armorClass}</Stat>
+      <Stat label="Currency">{DCC.formatDccCurrency(character.currency)}</Stat>
+      <Stat label="Alignment">{character.alignment}</Stat>
+      <Stat label="Gender">{character.gender}</Stat>
+      <Stat label="Speed">{character.speed}'</Stat>
+    </StatBlock>
 
     <h3>Attributes</h3>
 
-    <p>
-      <strong>Strength:</strong>
+    <Stat label="Strength">
       {character.strength.value} ({DCC.formatDccModifier(character.strength.modifier)})
-    </p>
-    <p>
-      <strong>Agility:</strong>
+    </Stat>
+    <Stat label="Agility">
       {character.agility.value} ({DCC.formatDccModifier(character.agility.modifier)})
-    </p>
-    <p>
-      <strong>Stamina:</strong>
+    </Stat>
+    <Stat label="Stamina">
       {character.stamina.value} ({DCC.formatDccModifier(character.stamina.modifier)})
-    </p>
-    <p>
-      <strong>Personality:</strong>
+    </Stat>
+    <Stat label="Personality">
       {character.personality.value} ({DCC.formatDccModifier(character.personality.modifier)})
-    </p>
-    <p>
-      <strong>Intelligence:</strong>
+    </Stat>
+    <Stat label="Intelligence">
       {character.intelligence.value} ({DCC.formatDccModifier(character.intelligence.modifier)})
-    </p>
-    <p>
-      <strong>Luck:</strong>
+    </Stat>
+    <Stat label="Luck">
       {character.luck.value} ({DCC.formatDccModifier(character.luck.modifier)})
-    </p>
+    </Stat>
 
     <h3>Other Stats</h3>
 
-    <p>
-      <strong>Lucky Roll:</strong>
+    <Stat label="Lucky Roll">
       {DCC.formatDccLuckySign(character.luckyRoll)}
-    </p>
+    </Stat>
 
     <h3>Saving Throws</h3>
 
-    <p><strong>Fortitude:</strong> {DCC.formatDccModifier(character.fortitudeSave)}</p>
-    <p><strong>Reflex:</strong> {DCC.formatDccModifier(character.reflexSave)}</p>
-    <p><strong>Willpower:</strong> {DCC.formatDccModifier(character.willpowerSave)}</p>
+    <StatBlock>
+      <Stat label="Fortitude">{DCC.formatDccModifier(character.fortitudeSave)}</Stat>
+      <Stat label="Reflex">{DCC.formatDccModifier(character.reflexSave)}</Stat>
+      <Stat label="Willpower">{DCC.formatDccModifier(character.willpowerSave)}</Stat>
+    </StatBlock>
 
     <h3>Spellcasting</h3>
 
-    <p><strong>Spells Known:</strong> {spellsKnown}</p>
-    <p><strong>Wizard Max Spell Level:</strong> {character.wizardMaxSpellLevel}</p>
-    <p><strong>Cleric Max Spell Level:</strong> {character.clericMaxSpellLevel}</p>
+    <StatBlock>
+      <Stat label="Spells Known">{spellsKnown}</Stat>
+      <Stat label="Wizard Max Spell Level">{character.wizardMaxSpellLevel}</Stat>
+      <Stat label="Cleric Max Spell Level">{character.clericMaxSpellLevel}</Stat>
+    </StatBlock>
 
     <h3>Weapons</h3>
 

--- a/src/components/characters/SwnCharacterGenerator.svelte
+++ b/src/components/characters/SwnCharacterGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import * as RNG from '@ironarachne/rng';
   import { characters as CharGen, downloadSwnCharacterPdf } from '$lib/swn';
   import type { SWNCharacter } from '$lib/swn';
@@ -166,21 +168,25 @@
   <h2>{firstName || lastName ? `${firstName} ${lastName}`.trim() : 'Character'}</h2>
 
   {#if character}
-    <p><strong>Background:</strong> {character.background.name}</p>
-    <p><strong>Class:</strong> {character.characterClass.name}</p>
-    <p><strong>Hit Points:</strong> {character.hitPoints}</p>
-    {#if character.effort > 0}
-      <p><strong>Effort:</strong> {character.effort}</p>
-    {/if}
-    <p><strong>Base Attack Bonus:</strong> +{character.attackBonus}</p>
-    <p><strong>Armor Class:</strong> {character.armorClassEquipped}</p>
-    <p><strong>Credits:</strong> {character.credits}</p>
+    <StatBlock>
+      <Stat label="Background">{character.background.name}</Stat>
+      <Stat label="Class">{character.characterClass.name}</Stat>
+      <Stat label="Hit Points">{character.hitPoints}</Stat>
+      {#if character.effort > 0}
+        <Stat label="Effort">{character.effort}</Stat>
+      {/if}
+      <Stat label="Base Attack Bonus">+{character.attackBonus}</Stat>
+      <Stat label="Armor Class">{character.armorClassEquipped}</Stat>
+      <Stat label="Credits">{character.credits}</Stat>
+    </StatBlock>
 
     <h3>Saving Throws</h3>
 
-    <p><strong>Evasion:</strong> {character.savingThrowEvasion}</p>
-    <p><strong>Mental:</strong> {character.savingThrowMental}</p>
-    <p><strong>Physical:</strong> {character.savingThrowPhysical}</p>
+    <StatBlock>
+      <Stat label="Evasion">{character.savingThrowEvasion}</Stat>
+      <Stat label="Mental">{character.savingThrowMental}</Stat>
+      <Stat label="Physical">{character.savingThrowPhysical}</Stat>
+    </StatBlock>
 
     <h3>Focuses</h3>
 

--- a/src/components/characters/UnchartedWorldsCharacterGenerator.svelte
+++ b/src/components/characters/UnchartedWorldsCharacterGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import { CharGen, parseSkillDescription, downloadUwCharacterPdf } from '$lib/unchartedworlds';
   import type { UWCharacter } from '$lib/unchartedworlds';
   import * as RNG from '@ironarachne/rng';
@@ -172,11 +174,13 @@
   {#if character}
     <h3>Statistics</h3>
 
-    <p><strong>Physique:</strong> {character.stats.physique}</p>
-    <p><strong>Mettle:</strong> {character.stats.mettle}</p>
-    <p><strong>Expertise:</strong> {character.stats.expertise}</p>
-    <p><strong>Influence:</strong> {character.stats.influence}</p>
-    <p><strong>Interface:</strong> {character.stats.interface}</p>
+    <StatBlock>
+      <Stat label="Physique">{character.stats.physique}</Stat>
+      <Stat label="Mettle">{character.stats.mettle}</Stat>
+      <Stat label="Expertise">{character.stats.expertise}</Stat>
+      <Stat label="Influence">{character.stats.influence}</Stat>
+      <Stat label="Interface">{character.stats.interface}</Stat>
+    </StatBlock>
 
     <h2>Careers</h2>
 

--- a/src/components/common/Stat.svelte
+++ b/src/components/common/Stat.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  /**
+   * One stat: a key and its value.
+   *
+   * The key is `--t-micro`, tracked and uppercase in `--ink-faint`; the value is `--t-body` in
+   * `--ink`. **That is deliberately the recipe a control's label already uses** — a stat is a field
+   * nobody can type in, and the app has already taught a reader that a small uppercase line above a
+   * value names that value. Teaching that shape twice with two looks is the failure the design
+   * document exists to prevent.
+   *
+   * The value is a snippet rather than a string because a stat's value is often not one: a number,
+   * a name, a `Badge`, a link. Several of the sites #153 converted already carried markup.
+   *
+   * See docs/visual-design.md, "A stat is a pair, and it is not a sentence".
+   */
+
+  type Props = {
+    /** The key. Does not repeat the heading above the block — "Attack Bonus", not "Combat Attack Bonus". */
+    label: string;
+    /** The value. */
+    children: Snippet;
+    class?: string;
+  };
+
+  const { label, children, class: extraClass = '' }: Props = $props();
+</script>
+
+<div class="stat {extraClass}">
+  <dt>{label}</dt>
+  <dd>{@render children()}</dd>
+</div>
+
+<style>
+  .stat {
+    min-width: 0;
+  }
+
+  .stat dt {
+    color: var(--ink-faint);
+    font: var(--t-micro);
+    letter-spacing: var(--t-micro-tracking);
+    text-transform: uppercase;
+  }
+
+  .stat dd {
+    color: var(--ink);
+    font: var(--t-body);
+    margin: 0;
+    margin-top: var(--s1);
+    overflow-wrap: anywhere;
+  }
+</style>

--- a/src/components/common/StatBlock.svelte
+++ b/src/components/common/StatBlock.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  /**
+   * A block of stats: a grid of key/value pairs, as a character sheet reads them.
+   *
+   * See docs/visual-design.md, "The content language: stats and tables". Before #153 a stat was
+   * `<strong>Label:</strong> value` — 229 times across 19 components — which is a sentence made to
+   * look like data: it reads as prose to a screen reader, it cannot align with the stat above it,
+   * and the colon does the work a layout should.
+   *
+   * A `<dl>`, because that is what a list of pairs is. `Stat` wraps each pair in a `<div>` rather
+   * than putting `<dt>` and `<dd>` in here directly: a `dl` may hold nothing else between them,
+   * and a bare pair cannot be laid out as one grid cell.
+   *
+   * **No borders and no rules between stats.** A block sits inside a panel, and a block that drew
+   * its own box would be the nested box the panel language refuses; the space ramp separates them.
+   * The grid is `auto-fill`, so a sheet is a grid at desktop width and one column on a phone
+   * without a media query.
+   */
+
+  type Props = {
+    /** `Stat` items. */
+    children: Snippet;
+    /** The caller's own layout — where the block sits. Never the look. */
+    class?: string;
+  };
+
+  const { children, class: extraClass = '' }: Props = $props();
+</script>
+
+<dl class="stat-block {extraClass}">
+  {@render children()}
+</dl>
+
+<style>
+  .stat-block {
+    display: grid;
+    gap: var(--s5);
+    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+    margin: 0;
+  }
+</style>

--- a/src/components/factions/FamilyGenerator.svelte
+++ b/src/components/factions/FamilyGenerator.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
   import { CommonSpecies } from '$lib/species';
   import * as Families from '$lib/families';
   import * as Names from '$lib/names';
@@ -350,14 +351,13 @@
     <p>{member.description}</p>
     {@const mate = getMate(family, member)}
     {#if mate}
-      <p>
-        <strong>Mate:</strong>
+      <Stat label="Mate">
         {mate.firstName}
         {mate.lastName}
         <span class="gender-symbol" title={mate.gender.name}>
           {getGenderSymbol(mate.gender.name)}
         </span>
-      </p>
+      </Stat>
     {/if}
     {@const children = getChildren(family, member)}
     {#if children.length > 0}

--- a/src/components/factions/ReligionGenerator.svelte
+++ b/src/components/factions/ReligionGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import { onMount } from 'svelte';
   import * as Names from '$lib/names';
   import * as RNG from '@ironarachne/rng';
@@ -676,10 +678,9 @@
     {#if religion.nonTheisticDetail}
       <h3>Tradition detail (non-theistic)</h3>
       <p>{religion.nonTheisticDetail.mediationSummary}</p>
-      <p>
-        <strong>Purity and pollution:</strong>
+      <Stat label="Purity and pollution">
         {religion.nonTheisticDetail.pollutionOrPurityNotes}
-      </p>
+      </Stat>
     {/if}
 
     {#if religion.dimensions}
@@ -736,25 +737,30 @@
             <p>{deityTitleLine(member)}</p>
           {/if}
 
-          <p><strong>Domains:</strong> {listDomains(member.domains)}</p>
-
-          {#if member.holyItem !== null}
-            <p><strong>Holy Item:</strong> {member.holyItem}</p>
-          {/if}
-          {#if member.holySymbol !== null}
-            <p><strong>Holy Symbol:</strong> {member.holySymbol}</p>
-          {/if}
+          <StatBlock>
+            <Stat label="Domains">{listDomains(member.domains)}</Stat>
+            {#if member.holyItem !== null}
+              <Stat label="Holy Item">{member.holyItem}</Stat>
+            {/if}
+            {#if member.holySymbol !== null}
+              <Stat label="Holy Symbol">{member.holySymbol}</Stat>
+            {/if}
+          </StatBlock>
 
           <p>{member.description}</p>
 
           {#if member.relationships.length > 0}
             <div>
-              <strong>Relationships:</strong>
-              <ul>
-                {#each member.relationships as relationship}
-                  <li>{relationship.description}</li>
-                {/each}
-              </ul>
+              <!-- A pair whose value is a list, which is what `Stat` taking a snippet is for. -->
+              <StatBlock>
+                <Stat label="Relationships">
+                  <ul>
+                    {#each member.relationships as relationship}
+                      <li>{relationship.description}</li>
+                    {/each}
+                  </ul>
+                </Stat>
+              </StatBlock>
             </div>
           {/if}
         </div>

--- a/src/components/factions/StarNationGenerator.svelte
+++ b/src/components/factions/StarNationGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import * as RNG from '@ironarachne/rng';
   import * as Words from '@ironarachne/words';
   import { renderStarSystemPreviewImage } from '$lib/renderers/astronomical_preview';
@@ -171,18 +173,21 @@
       <p>{extraDescription}</p>
     {/if}
 
-    <p><strong>Government Type:</strong> {nation.government_type.name}</p>
-    <p><strong>Economy:</strong> {nation.economy_type.name}</p>
-    <p><strong>Military:</strong> {nation.military.quality}</p>
-    <p>
-      <strong>Technology:</strong>
+    <StatBlock>
+      <Stat label="Government Type">{nation.government_type.name}</Stat>
+      <Stat label="Economy">{nation.economy_type.name}</Stat>
+      <Stat label="Military">{nation.military.quality}</Stat>
+    </StatBlock>
+    <Stat label="Technology">
       {nation.technology_level} (<span
         class="tooltip"
         title={getTechnologyLevelByLevel(nation.technology_level).description}
         >{getTechnologyLevelByLevel(nation.technology_level).name}</span
       >)
-    </p>
-    <p><strong>Home Planet:</strong> {homeSystem.planets[homePlanet].name}</p>
+    </Stat>
+    <StatBlock>
+      <Stat label="Home Planet">{homeSystem.planets[homePlanet].name}</Stat>
+    </StatBlock>
 
     <h3>The {homeSystemRegion.name} System</h3>
 

--- a/src/components/locations/DungeonGenerator.svelte
+++ b/src/components/locations/DungeonGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import * as RNG from '@ironarachne/rng';
   import * as Words from '@ironarachne/words';
   import { onMount, tick } from 'svelte';
@@ -245,9 +247,11 @@
   {#if dungeon}
     <h2>{dungeon.name}</h2>
 
-    <p><strong>Theme:</strong> {dungeon.theme.name}</p>
-    <p><strong>Environment:</strong> {dungeon.theme.environment.description}</p>
-    <p><strong>Blueprint:</strong> {dungeon.theme.blueprint.description}</p>
+    <StatBlock>
+      <Stat label="Theme">{dungeon.theme.name}</Stat>
+      <Stat label="Environment">{dungeon.theme.environment.description}</Stat>
+      <Stat label="Blueprint">{dungeon.theme.blueprint.description}</Stat>
+    </StatBlock>
 
     <p class="map-legend">
       Doors are blue bars (open doors show a gap; secret doors have an <strong>S</strong> overlaid); locked
@@ -267,19 +271,22 @@
     {#each dungeon.rooms as room (room.id)}
       <div class="room">
         <h3>{Words.title(room.name)} <span class="room-id">(room {room.id})</span></h3>
-        <p class="room-meta">
-          <strong>Purpose:</strong>
-          {room.purpose} · <strong>Shape:</strong>
-          {room.primitive.style} · <strong>Size:</strong>
-          {room.primitive.width}×{room.primitive.height}
-        </p>
+        <!-- Three pairs run together with separators until #153, which is a stat block written as
+             a sentence: the middle dots were doing the work the grid does. -->
+        <StatBlock class="room-meta">
+          <Stat label="Purpose">{room.purpose}</Stat>
+          <Stat label="Shape">{room.primitive.style}</Stat>
+          <Stat label="Size">{room.primitive.width}×{room.primitive.height}</Stat>
+        </StatBlock>
         <div class="room-description">
           {room.description}
         </div>
         {#if room.encounter}
           <div class="encounter">
             <h4>Encounter</h4>
-            <p><strong>Difficulty:</strong> {room.encounter.difficulty}</p>
+            <StatBlock>
+              <Stat label="Difficulty">{room.encounter.difficulty}</Stat>
+            </StatBlock>
             <p>{room.encounter.description}</p>
             {#each room.encounter.groups as group, gi (`${room.id}-grp-${gi}`)}
               <p>
@@ -344,9 +351,14 @@
             <ul>
               {#each dungeon.keys.filter((k) => k.x >= room.x && k.x < room.x + room.primitive.width && k.y >= room.y && k.y < room.y + room.primitive.height) as key (key.id)}
                 <li>
-                  <strong>Key:</strong>
-                  {key.description}
-                  {getKeyDescription(key.id, key.doorId, dungeon)}
+                  <!-- One key per row, and each row is a pair: the label was a bold run inside the
+                       sentence until #153. -->
+                  <StatBlock>
+                    <Stat label="Key">
+                      {key.description}
+                      {getKeyDescription(key.id, key.doorId, dungeon)}
+                    </Stat>
+                  </StatBlock>
                 </li>
               {/each}
             </ul>
@@ -390,9 +402,11 @@
     font-size: 0.9em;
   }
 
-  .room-meta {
-    font-size: 0.95rem;
-    margin: 0.25rem 0 0.5rem;
+  /* `:global`, because the class lands on `StatBlock`'s own element. The font size went with the
+     conversion: a stat's key and value take their steps from the ramp, so a paragraph-wide 0.95rem
+     over the top of them was overriding one ramp with another. */
+  .room :global(.room-meta) {
+    margin: var(--s2) 0 var(--s4);
   }
 
   div.mobs {

--- a/src/components/locations/EnvironmentGenerator.svelte
+++ b/src/components/locations/EnvironmentGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import * as RNG from '@ironarachne/rng';
   import { Directions } from '$lib/geometry';
   import { Environments } from '$lib/environment';
@@ -146,75 +148,83 @@
   {#if environment}
     <h2>Terrain</h2>
 
-    <p>
-      <strong>Elevation Min:</strong>
+    <Stat label="Elevation Min">
       {environment.terrain.elevationMin} ({elevationToFeet(environment.terrain.elevationMin)} ft.)
-    </p>
-    <p>
-      <strong>Elevation Max:</strong>
+    </Stat>
+    <Stat label="Elevation Max">
       {environment.terrain.elevationMax} ({elevationToFeet(environment.terrain.elevationMax)} ft.)
-    </p>
-    <p><strong>Relief Energy:</strong> {environment.terrain.reliefEnergy}</p>
-    <p>
-      <strong>Normal Vector:</strong>
+    </Stat>
+    <StatBlock>
+      <Stat label="Relief Energy">{environment.terrain.reliefEnergy}</Stat>
+    </StatBlock>
+    <Stat label="Normal Vector">
       {environment.terrain.normalVector} ({describeSlope(environment.terrain.normalVector)})
-    </p>
+    </Stat>
 
     <h2>Water System</h2>
 
-    <p>
-      <strong>Water Level:</strong>
+    <Stat label="Water Level">
       {environment.waterSystem.surfaceLevel} ({elevationToFeet(
         environment.waterSystem.surfaceLevel,
       )} ft.)
-    </p>
-    <p><strong>Water Type:</strong> {environment.waterSystem.waterType}</p>
-    <p>
-      <strong>Temperature:</strong>
+    </Stat>
+    <StatBlock>
+      <Stat label="Water Type">{environment.waterSystem.waterType}</Stat>
+    </StatBlock>
+    <Stat label="Temperature">
       {Temperature.getComparativeString(environment.waterSystem.temperature, 'celsius')}
-    </p>
-    <p><strong>Current:</strong> {environment.waterSystem.current}</p>
+    </Stat>
+    <StatBlock>
+      <Stat label="Current">{environment.waterSystem.current}</Stat>
+    </StatBlock>
 
     <h2>Climate</h2>
 
     <p>{environment.climate.description}</p>
 
-    <p><strong>Climate Type:</strong> {environment.climate.name}</p>
-    <p><strong>Cloud Cover:</strong> {environment.climate.cloudCover}</p>
-    <p><strong>Wind:</strong> {environment.climate.wind}</p>
+    <StatBlock>
+      <Stat label="Climate Type">{environment.climate.name}</Stat>
+      <Stat label="Cloud Cover">{environment.climate.cloudCover}</Stat>
+      <Stat label="Wind">{environment.climate.wind}</Stat>
+    </StatBlock>
 
     <canvas id="windArrow" width="100" height="100"></canvas>
 
-    <p>
-      <strong>Temperature Min:</strong>
+    <Stat label="Temperature Min">
       {Temperature.getComparativeString(environment.climate.temperatureMin, 'celsius')}
-    </p>
-    <p>
-      <strong>Temperature Max:</strong>
+    </Stat>
+    <Stat label="Temperature Max">
       {Temperature.getComparativeString(environment.climate.temperatureMax, 'celsius')}
-    </p>
-    <p><strong>Precipitation Amount:</strong> {environment.climate.precipitationAmount}</p>
-    <p><strong>Precipitation Frequency:</strong> {environment.climate.precipitationFrequency}</p>
-    <p><strong>Humidity:</strong> {environment.climate.humidity}</p>
+    </Stat>
+    <StatBlock>
+      <Stat label="Precipitation Amount">{environment.climate.precipitationAmount}</Stat>
+      <Stat label="Precipitation Frequency">{environment.climate.precipitationFrequency}</Stat>
+      <Stat label="Humidity">{environment.climate.humidity}</Stat>
+    </StatBlock>
 
     <h3>Seasons</h3>
 
     {#each environment.climate.seasons as season}
-      <p><strong>Season Name:</strong> {season.name}</p>
-      <p><strong>Temperature Adjustment:</strong> {season.temperatureAdjustment}</p>
-      <p><strong>Humidity Adjustment:</strong> {season.humidityAdjustment}</p>
+      <StatBlock>
+        <Stat label="Season Name">{season.name}</Stat>
+        <Stat label="Temperature Adjustment">{season.temperatureAdjustment}</Stat>
+        <Stat label="Humidity Adjustment">{season.humidityAdjustment}</Stat>
+      </StatBlock>
     {/each}
 
     <h2>Biome</h2>
 
-    <p><strong>Biome Name:</strong> {environment.biome.name}</p>
-    <p><strong>Temperature:</strong> {environment.biome.temperature}</p>
-    <p>
-      <strong>Altitude:</strong>
+    <StatBlock>
+      <Stat label="Biome Name">{environment.biome.name}</Stat>
+      <Stat label="Temperature">{environment.biome.temperature}</Stat>
+    </StatBlock>
+    <Stat label="Altitude">
       {environment.biome.altitude} ({elevationToFeet(environment.biome.altitude)} ft.)
-    </p>
-    <p><strong>Humidity:</strong> {environment.biome.humidity}</p>
-    <p><strong>Is Aquatic:</strong> {environment.biome.isAquatic}</p>
+    </Stat>
+    <StatBlock>
+      <Stat label="Humidity">{environment.biome.humidity}</Stat>
+      <Stat label="Is Aquatic">{environment.biome.isAquatic}</Stat>
+    </StatBlock>
 
     <h3>Descriptions</h3>
 

--- a/src/components/locations/PlanetGenerator.svelte
+++ b/src/components/locations/PlanetGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import * as RNG from '@ironarachne/rng';
   import {
     getPlanetClassifications,
@@ -165,67 +167,62 @@
 
     <p>{planet.description}</p>
 
-    <p><strong>Planet Type:</strong> {planet.classification}</p>
+    <StatBlock>
+      <Stat label="Planet Type">{planet.classification}</Stat>
+    </StatBlock>
 
     {#if is_inhabited && civilization}
       <h3>Civilization</h3>
-      <p><strong>Name:</strong> {civilization.name}</p>
-      <p><strong>Population:</strong> {getFriendlyPopulation(civilization.population)}</p>
-      <p><strong>Government:</strong> {civilization.government_type.name}</p>
-      <p><strong>Economy:</strong> {civilization.economy_type.name}</p>
-      <p>
-        <strong>Technology Level:</strong>
+      <StatBlock>
+        <Stat label="Name">{civilization.name}</Stat>
+        <Stat label="Population">{getFriendlyPopulation(civilization.population)}</Stat>
+        <Stat label="Government">{civilization.government_type.name}</Stat>
+        <Stat label="Economy">{civilization.economy_type.name}</Stat>
+      </StatBlock>
+      <Stat label="Technology Level">
         <span
           class="tooltip"
           title={getTechnologyLevelByLevel(civilization.technology_level).description}
           >{getTechnologyLevelByLevel(civilization.technology_level).name}</span
         >
-      </p>
+      </Stat>
     {/if}
 
     <h3>Statistics</h3>
 
-    <p>
-      <strong>Distance from Star:</strong>
+    <Stat label="Distance from Star">
       {formatNumber(planet.orbital_distance)} AU
-    </p>
-    <p>
-      <strong>Mass:</strong>
+    </Stat>
+    <Stat label="Mass">
       {formatNumber(planet.mass)} &times; 10<sup>24</sup> kg ({formatNumber(
         Math.floor((planet.mass / 5.9722) * 100),
         0,
       )}% Earth's mass)
-    </p>
-    <p>
-      <strong>Radius:</strong>
+    </Stat>
+    <Stat label="Radius">
       {formatNumber(Math.floor(planet.radius))} km ({formatNumber(
         Math.floor((planet.radius / 6378) * 100),
         0,
       )}% Earth's radius)
-    </p>
-    <p>
-      <strong>Gravity:</strong>
+    </Stat>
+    <Stat label="Gravity">
       {formatNumber(planet.gravity)} m/s<sup>2</sup>
       ({formatNumber(Math.floor((planet.gravity / 9.81) * 100), 0)}% Earth's gravity)
-    </p>
-    <p>
-      <strong>Orbital Period:</strong>
+    </Stat>
+    <Stat label="Orbital Period">
       {formatNumber(Math.floor(planet.orbital_period), 0)} days
-    </p>
-    <p>
-      <strong>Rotation Period (Length of Day):</strong>
+    </Stat>
+    <Stat label="Rotation Period (Length of Day)">
       {formatNumber(Math.floor(planet.rotation_period), 0)} hours
-    </p>
-    <p>
-      <strong>Surface Pressure:</strong>
+    </Stat>
+    <Stat label="Surface Pressure">
       {formatNumber(planet.surface_pressure)} atm
-    </p>
-    <p>
-      <strong>Average Temperature:</strong>
+    </Stat>
+    <Stat label="Average Temperature">
       {formatNumber(planet.surface_temperature)} K ({Math.round(
         Measurements.kToC(planet.surface_temperature),
       )} °C, {Math.round(Measurements.kToF(planet.surface_temperature))} °F)
-    </p>
+    </Stat>
   {/if}
 
   {#if moons.length > 0}
@@ -235,40 +232,34 @@
         <li>
           <strong>{moon.name}</strong> - {moon.classification}
           <p>{moon.description}</p>
-          <p>
-            <strong>Orbital Distance:</strong>
+          <Stat label="Orbital Distance">
             {formatNumber(convertAUToKM(moon.orbital_distance))} km
-          </p>
-          <p>
-            <strong>Mass:</strong>
+          </Stat>
+          <Stat label="Mass">
             {formatNumber(moon.mass)} &times; 10<sup>24</sup> kg ({formatNumber(
               Math.floor((moon.mass / 0.0735) * 100),
               0,
             )}% Moon's mass)
-          </p>
-          <p>
-            <strong>Radius:</strong>
+          </Stat>
+          <Stat label="Radius">
             {formatNumber(Math.floor(moon.radius))} km ({formatNumber(
               Math.floor((moon.radius / 1737.4) * 100),
               0,
             )}% Moon's radius)
-          </p>
-          <p>
-            <strong>Gravity:</strong>
+          </Stat>
+          <Stat label="Gravity">
             {formatNumber(moon.gravity)} m/s<sup>2</sup> ({formatNumber(
               Math.floor((moon.gravity / 1.62) * 100),
               0,
             )}% Moon's gravity, {formatNumber(Math.floor((moon.gravity / 9.81) * 100), 0)}% Earth's
             gravity)
-          </p>
-          <p>
-            <strong>Orbital Period:</strong>
+          </Stat>
+          <Stat label="Orbital Period">
             {formatNumber(Math.floor(moon.orbital_period), 0)} days
-          </p>
-          <p>
-            <strong>Rotation Period (Length of Day):</strong>
+          </Stat>
+          <Stat label="Rotation Period (Length of Day)">
             {formatNumber(Math.floor(moon.rotation_period), 0)} days
-          </p>
+          </Stat>
         </li>
       {/each}
     </ul>

--- a/src/components/locations/SettlementGenerator.svelte
+++ b/src/components/locations/SettlementGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import { RNG } from '@ironarachne/rng';
   import { onMount } from 'svelte';
 
@@ -380,8 +382,10 @@
 
     {#if settlement.primaryImports && settlement.primaryImports.length > 0}
       <h3>Trade</h3>
-      <p><strong>Exports:</strong> {settlement.primaryExports?.join(', ')}</p>
-      <p><strong>Imports:</strong> {settlement.primaryImports.join(', ')}</p>
+      <StatBlock>
+        <Stat label="Exports">{settlement.primaryExports?.join(', ')}</Stat>
+        <Stat label="Imports">{settlement.primaryImports.join(', ')}</Stat>
+      </StatBlock>
       {#if settlement.tradeBlurb}
         <p>{settlement.tradeBlurb}</p>
       {/if}

--- a/src/components/locations/StarSystemGenerator.svelte
+++ b/src/components/locations/StarSystemGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import * as RNG from '@ironarachne/rng';
   import {
     renderPlanetPreviewImage,
@@ -159,26 +161,21 @@
         <div>
           <h5>{star.name}</h5>
           <p>{star.description}</p>
-          <p>
-            <strong>Star Type:</strong>
+          <Stat label="Star Type">
             {star.classification}
-          </p>
-          <p>
-            <strong>Radius:</strong>
+          </Stat>
+          <Stat label="Radius">
             {new Intl.NumberFormat().format(star.radius)} km
-          </p>
-          <p>
-            <strong>Mass:</strong>
+          </Stat>
+          <Stat label="Mass">
             {new Intl.NumberFormat().format(star.mass)} &times; 10<sup>30</sup> kg
-          </p>
-          <p>
-            <strong>Luminosity:</strong>
+          </Stat>
+          <Stat label="Luminosity">
             {new Intl.NumberFormat().format(star.luminosity)} &times; 10<sup>26</sup> W
-          </p>
-          <p>
-            <strong>Temperature:</strong>
+          </Stat>
+          <Stat label="Temperature">
             {new Intl.NumberFormat().format(star.surface_temperature)}K
-          </p>
+          </Stat>
         </div>
       </article>
     {/each}
@@ -193,39 +190,33 @@
         <div>
           <h5>{planet.name}</h5>
           <p>{planet.description}</p>
-          <p><strong>Planet Type:</strong> {planet.classification}</p>
-          <p>
-            <strong>Distance from Star:</strong>
+          <StatBlock>
+            <Stat label="Planet Type">{planet.classification}</Stat>
+          </StatBlock>
+          <Stat label="Distance from Star">
             {new Intl.NumberFormat().format(planet.orbital_distance)} AU
-          </p>
-          <p>
-            <strong>Mass:</strong>
+          </Stat>
+          <Stat label="Mass">
             {new Intl.NumberFormat().format(planet.mass)} &times; 10<sup>24</sup> kg
-          </p>
-          <p>
-            <strong>Radius:</strong>
+          </Stat>
+          <Stat label="Radius">
             {new Intl.NumberFormat().format(Math.floor(planet.radius))} km
-          </p>
-          <p>
-            <strong>Gravity:</strong>
+          </Stat>
+          <Stat label="Gravity">
             {new Intl.NumberFormat().format(planet.gravity)} m/s<sup>2</sup>
-          </p>
-          <p>
-            <strong>Orbital Period:</strong>
+          </Stat>
+          <Stat label="Orbital Period">
             {new Intl.NumberFormat().format(Math.floor(planet.orbital_period))} days
-          </p>
-          <p>
-            <strong>Rotation Period (Length of Day):</strong>
+          </Stat>
+          <Stat label="Rotation Period (Length of Day)">
             {new Intl.NumberFormat().format(Math.floor(planet.rotation_period))} hours
-          </p>
-          <p>
-            <strong>Surface Pressure:</strong>
+          </Stat>
+          <Stat label="Surface Pressure">
             {new Intl.NumberFormat().format(planet.surface_pressure)} atm
-          </p>
-          <p>
-            <strong>Average Temperature:</strong>
+          </Stat>
+          <Stat label="Average Temperature">
             {new Intl.NumberFormat().format(planet.surface_temperature)}K
-          </p>
+          </Stat>
         </div>
       </article>
     {/each}

--- a/src/components/objects/MerchantGenerator.svelte
+++ b/src/components/objects/MerchantGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import { onMount } from 'svelte';
   import { valueToString, COMMON_FANTASY } from '$lib/currency';
   import { generateMerchant, getDefaultMerchantConfig, type Merchant } from '$lib/merchants';
@@ -174,17 +176,20 @@
         <p><strong>{merchant.proprietor.fullName}</strong></p>
         <p>{merchant.proprietor.description}</p>
         {#if merchant.proprietor.personalityTraits.length > 0}
-          <p><strong>Temperament:</strong> {merchant.proprietor.personalityTraits.join(', ')}</p>
+          <StatBlock>
+            <Stat label="Temperament">{merchant.proprietor.personalityTraits.join(', ')}</Stat>
+          </StatBlock>
         {/if}
 
         <h3>Trading Character</h3>
         <ul class="trading-notes">
-          <li><strong>Honesty:</strong> {merchant.honesty}</li>
-          <li><strong>Price level:</strong> {merchant.priceLevel}</li>
-          <li>
-            <strong>Price modifier:</strong>
-            {formatModifier(merchant.priceModifier)} of catalog value
-          </li>
+          <StatBlock>
+            <Stat label="Honesty">{merchant.honesty}</Stat>
+            <Stat label="Price level">{merchant.priceLevel}</Stat>
+            <Stat label="Price modifier"
+              >{formatModifier(merchant.priceModifier)} of catalog value</Stat
+            >
+          </StatBlock>
           <li>{merchant.honestyNotes}</li>
           <li>{merchant.hagglingAdvice}</li>
         </ul>

--- a/src/components/objects/PotionGenerator.svelte
+++ b/src/components/objects/PotionGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import { onMount } from 'svelte';
   import { valueToString, COMMON_FANTASY } from '$lib/currency';
   import {
@@ -66,45 +68,50 @@
         <h2>{potion.displayName}</h2>
 
         {#if potion.modifications.length > 0}
-          <p>
-            <strong>Modifications:</strong>
+          <Stat label="Modifications">
             {potion.modifications.map((mod) => mod.kind).join(', ')}
-          </p>
+          </Stat>
         {/if}
 
         {#if potion.canonicalName && potion.canonicalName !== potion.displayName}
-          <p><strong>Base formula:</strong> {potion.canonicalName}</p>
+          <StatBlock>
+            <Stat label="Base formula">{potion.canonicalName}</Stat>
+          </StatBlock>
         {/if}
-        <p><strong>Rarity:</strong> {potion.liquid.rarity}</p>
-        <p><strong>Value:</strong> {valueToString(potion.liquid.value, COMMON_FANTASY)}</p>
-        <p>
-          <strong>Form:</strong>
+        <StatBlock>
+          <Stat label="Rarity">{potion.liquid.rarity}</Stat>
+          <Stat label="Value">{valueToString(potion.liquid.value, COMMON_FANTASY)}</Stat>
+        </StatBlock>
+        <Stat label="Form">
           {potion.liquid.properties.includes('oil')
             ? 'oil'
             : potion.liquid.properties.includes('ointment')
               ? 'ointment'
               : 'drink'}
-        </p>
+        </Stat>
 
         <h3>Effect</h3>
         <p>{describeEffect(potion.effect)}</p>
-        <p><strong>Duration:</strong> {describeDurationShort(potion.effect.duration)}</p>
-        <p><strong>Magnitude:</strong> {potion.effect.magnitude}</p>
+        <StatBlock>
+          <Stat label="Duration">{describeDurationShort(potion.effect.duration)}</Stat>
+          <Stat label="Magnitude">{potion.effect.magnitude}</Stat>
+        </StatBlock>
 
         <h3>Sensory Profile</h3>
         <ul>
-          <li><strong>Appearance:</strong> {potion.sensory.appearance}</li>
-          <li><strong>Viscosity:</strong> {potion.sensory.viscosity}</li>
-          <li><strong>Flavor:</strong> {potion.sensory.flavor}</li>
-          <li><strong>Scent:</strong> {potion.sensory.scent}</li>
+          <StatBlock>
+            <Stat label="Appearance">{potion.sensory.appearance}</Stat>
+            <Stat label="Viscosity">{potion.sensory.viscosity}</Stat>
+            <Stat label="Flavor">{potion.sensory.flavor}</Stat>
+            <Stat label="Scent">{potion.sensory.scent}</Stat>
+          </StatBlock>
         </ul>
 
         <h3>Container</h3>
         <p>{potion.container.name}: {potion.container.description}</p>
-        <p>
-          <strong>Container value:</strong>
+        <Stat label="Container value">
           {valueToString(potion.container.value, COMMON_FANTASY)}
-        </p>
+        </Stat>
 
         <h3>Description</h3>
         <p>{potion.liquid.description}</p>

--- a/src/components/objects/SwnStarshipGenerator.svelte
+++ b/src/components/objects/SwnStarshipGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import { onMount } from 'svelte';
   import * as RNG from '@ironarachne/rng';
   // Deep by necessity: `$lib/swn` also carries the character PDF renderer, which reaches
@@ -52,45 +54,46 @@
   {#if starship}
     <h2>{starship.name}</h2>
 
-    <p><strong>Owner Type:</strong> {starship.ownerType.name}</p>
-    <p><strong>Manufacturer:</strong> {starship.manufacturer}</p>
-    <p><strong>Model:</strong> {starship.className}</p>
-    <p><strong>Hull Type:</strong> {starship.hullType.name}</p>
-    <p><strong>Hull Class:</strong> {starship.hullType.hullClassName}</p>
-    <p><strong>Drive:</strong> {starship.drive.name}</p>
-    <p>
-      <strong>Mass:</strong>
+    <StatBlock>
+      <Stat label="Owner Type">{starship.ownerType.name}</Stat>
+      <Stat label="Manufacturer">{starship.manufacturer}</Stat>
+      <Stat label="Model">{starship.className}</Stat>
+      <Stat label="Hull Type">{starship.hullType.name}</Stat>
+      <Stat label="Hull Class">{starship.hullType.hullClassName}</Stat>
+      <Stat label="Drive">{starship.drive.name}</Stat>
+    </StatBlock>
+    <Stat label="Mass">
       {starship.usedMass}/{starship.hullType.mass}
       ({starship.hullType.mass - starship.usedMass} free)
-    </p>
-    <p>
-      <strong>Power:</strong>
+    </Stat>
+    <Stat label="Power">
       {starship.usedPower}/{starship.hullType.power}
       ({starship.hullType.power - starship.usedPower} free)
-    </p>
-    <p>
-      <strong>Hardpoints:</strong>
+    </Stat>
+    <Stat label="Hardpoints">
       {starship.usedHardPoints}/{starship.hullType.hardPoints}
       ({starship.hullType.hardPoints - starship.usedHardPoints} free)
-    </p>
-    <p><strong>Speed:</strong> {starship.hullType.speed}</p>
-    <p><strong>Armor:</strong> {starship.hullType.armor}</p>
-    <p><strong>AC:</strong> {starship.hullType.ac}</p>
-    <p><strong>HP:</strong> {starship.hullType.hp}</p>
-    <p><strong>Minimum Crew:</strong> {starship.hullType.crewMinimum}</p>
-    <p><strong>Maximum Crew:</strong> {starship.hullType.crewMaximum}</p>
-    <p><strong>Current Crew:</strong> {starship.currentCrew}</p>
-    <p>
-      <strong>Total Ship Value:</strong>
+    </Stat>
+    <StatBlock>
+      <Stat label="Speed">{starship.hullType.speed}</Stat>
+      <Stat label="Armor">{starship.hullType.armor}</Stat>
+      <Stat label="AC">{starship.hullType.ac}</Stat>
+      <Stat label="HP">{starship.hullType.hp}</Stat>
+      <Stat label="Minimum Crew">{starship.hullType.crewMinimum}</Stat>
+      <Stat label="Maximum Crew">{starship.hullType.crewMaximum}</Stat>
+      <Stat label="Current Crew">{starship.currentCrew}</Stat>
+    </StatBlock>
+    <Stat label="Total Ship Value">
       {new Intl.NumberFormat('en-US').format(starship.totalCost)} credits
-    </p>
-    <p>
-      <strong>Total Crew Cost:</strong>
+    </Stat>
+    <Stat label="Total Crew Cost">
       {new Intl.NumberFormat('en-US').format(starship.currentCrew * 43800)}
       credits per year
-    </p>
-    <p><strong>Crew Skill:</strong> {starship.hullType.crewSkill}</p>
-    <p><strong>Cargo Space:</strong> {starship.tonsOfCargo} tons</p>
+    </Stat>
+    <StatBlock>
+      <Stat label="Crew Skill">{starship.hullType.crewSkill}</Stat>
+      <Stat label="Cargo Space">{starship.tonsOfCargo} tons</Stat>
+    </StatBlock>
 
     <h4>Fittings</h4>
 

--- a/src/components/utilities/LanguageGenerator.svelte
+++ b/src/components/utilities/LanguageGenerator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import { onMount } from 'svelte';
   import { RNG } from '@ironarachne/rng';
   import {
@@ -59,18 +61,19 @@
 
   {#if language}
     <h2>{language.name}</h2>
-    <p><strong>Word order:</strong> {language.wordOrder}</p>
-    <p><strong>Article system:</strong> {language.articleSystem}</p>
-    <p><strong>Possession strategy:</strong> {language.possessionStrategy.kind}</p>
-    <p><strong>Syllable template:</strong> {language.syllableProfile}</p>
-    <p><strong>Orthography:</strong> {language.orthographySummary}</p>
-    <p>
-      <strong>Sample morphology:</strong>
+    <StatBlock>
+      <Stat label="Word order">{language.wordOrder}</Stat>
+      <Stat label="Article system">{language.articleSystem}</Stat>
+      <Stat label="Possession strategy">{language.possessionStrategy.kind}</Stat>
+      <Stat label="Syllable template">{language.syllableProfile}</Stat>
+      <Stat label="Orthography">{language.orthographySummary}</Stat>
+    </StatBlock>
+    <Stat label="Sample morphology">
       plural {language.morphology.pluralPlacement}
       <code>{language.morphology.pluralAffix}</code>
       · past {language.morphology.pastPlacement}
       <code>{language.morphology.pastAffix}</code>
-    </p>
+    </Stat>
 
     <h3>Simple sentence translation</h3>
     <p>

--- a/src/components/utilities/SpeciesStatsCalculator.svelte
+++ b/src/components/utilities/SpeciesStatsCalculator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import { AgeCategories } from '$lib/age';
   import { Sizes, convertMatrixToSummary } from '$lib/size';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
@@ -74,9 +76,11 @@
       {#each femaleData as entry}
         <div>
           <h5>{entry.ageCategoryName}</h5>
-          <p><strong>Age Range:</strong> {entry.minAge} to {entry.maxAge} years</p>
-          <p><strong>Female Height:</strong> {entry.heightRange}</p>
-          <p><strong>Female Weight:</strong> {entry.weightRange}</p>
+          <StatBlock>
+            <Stat label="Age Range">{entry.minAge} to {entry.maxAge} years</Stat>
+            <Stat label="Female Height">{entry.heightRange}</Stat>
+            <Stat label="Female Weight">{entry.weightRange}</Stat>
+          </StatBlock>
         </div>
       {/each}
     </div>
@@ -85,9 +89,11 @@
       {#each maleData as entry}
         <div>
           <h5>{entry.ageCategoryName}</h5>
-          <p><strong>Age Range:</strong> {entry.minAge} to {entry.maxAge} years</p>
-          <p><strong>Male Height:</strong> {entry.heightRange}</p>
-          <p><strong>Male Weight:</strong> {entry.weightRange}</p>
+          <StatBlock>
+            <Stat label="Age Range">{entry.minAge} to {entry.maxAge} years</Stat>
+            <Stat label="Male Height">{entry.heightRange}</Stat>
+            <Stat label="Male Weight">{entry.weightRange}</Stat>
+          </StatBlock>
         </div>
       {/each}
     </div>
@@ -97,10 +103,12 @@
 
   <p>This is for Ingenium Second Edition heritages.</p>
 
-  <p><strong>Female Height:</strong> {ingenium.femaleHeight}</p>
-  <p><strong>Male Height:</strong> {ingenium.maleHeight}</p>
-  <p><strong>Female Weight:</strong> {ingenium.femaleWeight}</p>
-  <p><strong>Male Weight:</strong> {ingenium.maleWeight}</p>
-  <p><strong>Adult Age:</strong> {ingenium.adultAge}</p>
-  <p><strong>Maximum Lifespan:</strong> {maximumAge}</p>
+  <StatBlock>
+    <Stat label="Female Height">{ingenium.femaleHeight}</Stat>
+    <Stat label="Male Height">{ingenium.maleHeight}</Stat>
+    <Stat label="Female Weight">{ingenium.femaleWeight}</Stat>
+    <Stat label="Male Weight">{ingenium.maleWeight}</Stat>
+    <Stat label="Adult Age">{ingenium.adultAge}</Stat>
+    <Stat label="Maximum Lifespan">{maximumAge}</Stat>
+  </StatBlock>
 </GeneratorPage>

--- a/src/lib/styles/tokens.test.ts
+++ b/src/lib/styles/tokens.test.ts
@@ -1022,6 +1022,67 @@ describe('icons', () => {
   });
 });
 
+describe('the content language', () => {
+  // docs/visual-design.md, "The content language: stats and tables".
+  function componentFiles(): string[] {
+    const walk = (dir: string): string[] =>
+      readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const path = join(dir, entry.name);
+        return entry.isDirectory() ? walk(path) : entry.name.endsWith('.svelte') ? [path] : [];
+      });
+
+    return walk(COMPONENTS_DIR);
+  }
+
+  it('writes no stat as a sentence', () => {
+    // `<p><strong>Label:</strong> value</p>` was the house style — 229 of them across 19
+    // components — and it is a sentence made to look like data: prose to a screen reader, unable to
+    // align with the stat above it, with the colon doing a layout's job. `Stat` is the shape now.
+    //
+    // **Scoped to a constant key**, which is the line implementation drew and the design did not:
+    // `<strong>{trait.name}:</strong> {trait.description}` is a term and a sentence about it, which
+    // is a glossary rather than a stat block, and the document says so. A key that comes from the
+    // data is the discriminator, because a stat's key is written by the app and a glossary's is
+    // written by the generator.
+    const offenders = componentFiles().filter((path) => {
+      if (path.endsWith('Stat.svelte') || path.endsWith('StatBlock.svelte')) {
+        return false;
+      }
+      return /<strong>[A-Z][^<{]*?:<\/strong>/.test(readFileSync(path, 'utf8'));
+    });
+
+    expect(offenders, 'a stat is still written as a sentence').toEqual([]);
+  });
+
+  it('keeps a stat pair on the ramps', () => {
+    // The pair is the recipe a control's label already uses: `--t-micro` tracked and uppercase in
+    // `--ink-faint` over `--t-body` in `--ink`. A stat that invented its own steps would be the
+    // second answer to a question the field around a control already answered.
+    const stat = readFileSync(join(COMPONENTS_DIR, 'common/Stat.svelte'), 'utf8');
+
+    expect(stat).toContain('var(--t-micro)');
+    expect(stat).toContain('var(--t-micro-tracking)');
+    expect(stat).toContain('var(--ink-faint)');
+    expect(stat).toContain('var(--t-body)');
+
+    const sizes = [...stat.matchAll(/(?:font-size|padding|margin|gap)[^:;]*:\s*([^;{}]+);/g)]
+      .map(([, value]) => value.trim())
+      .filter((value) => /\d/.test(value) && !value.includes('var(') && value !== '0');
+
+    expect(sizes, 'a stat sizes something outside the ramps').toEqual([]);
+  });
+
+  it('draws no box around a stat', () => {
+    // A block sits inside a panel, and a block that drew its own box is the nested box the panel
+    // language refuses. Separation is the space ramp.
+    for (const name of ['common/Stat.svelte', 'common/StatBlock.svelte']) {
+      const css = withoutComments(readFileSync(join(COMPONENTS_DIR, name), 'utf8'));
+
+      expect(css, `${name} draws a box`).not.toMatch(/(?:^|[;{])\s*(?:border|box-shadow)\s*:/);
+    }
+  });
+});
+
 describe('motion', () => {
   it('declares one duration, and it is swift', () => {
     expect(tokens.get('--motion-swift')).toBe('120ms');


### PR DESCRIPTION
Closes #153. First of two PRs against the content language; #154's tables follow.

Design: [`docs/visual-design.md`, "The content language: stats and tables"](https://github.com/ironarachne/ironarachne/blob/issue-153-stat-blocks/docs/visual-design.md#the-content-language-stats-and-tables) — the section covers both issues, and lands here because a table flipped for a phone *is* a stat block.

### What was there

`<strong>Label:</strong> value` — **229 instances across 19 components**, 139 of them in a bare `<p>`. It is a sentence made to look like data: prose to a screen reader, unable to align with the stat above it, and the colon doing a layout's job.

### What it is now

| Part | Element | Type | Ink |
| --- | --- | --- | --- |
| Key | `<dt>` | `--t-micro`, tracked, uppercase | `--ink-faint` |
| Value | `<dd>` | `--t-body` | `--ink` |

**Deliberately the recipe a control's label already uses.** A stat is a field nobody can type in, and the app had already taught readers that a small uppercase line above a value names it. `StatBlock` is the `<dl>`, laid out `repeat(auto-fill, minmax(11rem, 1fr))` — a grid at desktop, one column on a phone, no media query. `Stat` wraps each pair in a `<div>`, because a `dl` may hold nothing else between `dt` and `dd` and a bare pair cannot be a grid cell.

No borders and no rules between stats: a block sits inside a panel, and one that drew its own box would be the nested box the panel language refuses.

### Three things the conversion found

**A stat with no value at all.** `AdndCharacterSheet` printed `Hit Point Adjustment:` and then nothing — in `main`, on every AD&D sheet, with `character.hitPointAdjustment` on the type the whole time. Converting to a component that *requires* both halves is what surfaced it, which is the argument for components over conventions in one line: **a convention cannot notice that half of it is missing.**

**A stat block written as a sentence.** The dungeon's room meta read `Purpose: x · Shape: y · Size: z` in one paragraph, where the middle dots were doing the work the grid does.

**The colon was load-bearing in a test.** `e2e/helpers.ts` asserted on the text `Age Range:`, which stopped existing the moment the key became a `<dt>` — six failures, all `/species-stats`. It generalises: a pattern spanning markup and prose leaks into anything reading the page as text, and the punctuation is the part that leaks.

### A boundary the design did not draw

The sweep forbids `<strong>Label:</strong>` **with a constant key**. `<strong>{trait.name}:</strong> {trait.description}` is a term and a sentence about it — a **glossary**, which this document has not designed and which would be worse forced into a grid of cells. A stat's key is written by the app; a glossary's comes from the generator, so constancy is a discriminator a sweep can see. Eight sites wait for the issue that designs it, and the document says so rather than leaving the narrowing unexplained.

### Enforcement

- **No component writes a constant-key `<strong>Label:</strong>`.**
- **A stat pair stays on the ramps** — the four roles by name, and nothing sized off-ramp.
- **Neither `Stat` nor `StatBlock` draws a box**, swept as `border`/`box-shadow`, because that rule is the one a later "just a little separation" would break first.

### Checks

`npm run verify:all` green — 4478 unit tests, 449 Playwright tests, `svelte-check` 0 errors, coverage gate 99/99 with no baselined debt. Checked on the page as well: the SWN sheet now reads as a sheet — three columns of small uppercase keys over their values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2wzaP74ffGJjghzcabKeT