### PR TITLE
Stop the shell widening the app on a phone

### DIFF
--- a/e2e/mobile_layout.ts
+++ b/e2e/mobile_layout.ts
@@ -4,6 +4,25 @@ import { expect, type Page } from '@playwright/test';
 const OVERFLOW_TOLERANCE_PX = 1;
 
 /**
+ * Marks an element that is *meant* to scroll sideways, and is the only thing that excuses one.
+ *
+ * There are three in the app — the scrolling variant of `DataTable`, the family tree, and the
+ * phonetics table on the word-generator cheat sheet — and each carries this attribute beside the
+ * `overflow-x: auto` that makes it real, so the exemption and the behaviour it excuses are written
+ * in the same place.
+ *
+ * The attribute exists because the obvious test — "does an ancestor scroll horizontally?" — is
+ * wrong in a way that cost this suite its meaning. `.shell__page` sets `overflow-y: auto` so the
+ * page region scrolls under the pinned shell; CSS then computes the *other* axis to `auto` too,
+ * because `visible` cannot pair with a scrolling value. So the page region is a horizontal scroll
+ * container by accident, every element on every page has a horizontally-scrolling ancestor, and a
+ * check that skips those skips the entire application. That is what it did: `mobile-390` passed
+ * forty routes green while a real phone scrolled sideways, because the overflow was trapped inside
+ * that scroller where neither the element sweep nor `documentElement.scrollWidth` could see it.
+ */
+const DELIBERATE_SCROLLER = 'data-scroll-x';
+
+/**
  * Most generators seed themselves from a random string on mount, so the content
  * on screen — and therefore how wide it is — differs run to run. Pinning the
  * seed makes a layout baseline mean something: the same words, at the same
@@ -39,77 +58,114 @@ export type LayoutOffender = {
   width: number;
 };
 
+export type OverflowingScroller = {
+  description: string;
+  scrollWidth: number;
+  clientWidth: number;
+};
+
 export type HorizontalOverflowReport = {
   viewportWidth: number;
   documentScrollWidth: number;
   offenders: LayoutOffender[];
+  scrollers: OverflowingScroller[];
 };
 
 /**
- * Reports elements that extend past either edge of the viewport, ignoring any
- * whose ancestor clips or scrolls horizontally on purpose (a deliberately
- * scrollable table, for instance, is not a layout bug).
+ * Reports two distinct ways a page can be too wide for a phone.
+ *
+ * `offenders` are elements that extend past either edge of the viewport, ignoring only those
+ * inside a scroller marked `data-scroll-x`. Nothing else is excused — in particular, being inside
+ * `.shell__page` is not a defence, which is the whole point of the rewrite.
+ *
+ * `scrollers` are scroll containers with more content than they can show. This catches the same
+ * bug from the other side: when a wide child sits inside the page region, the child's rect and the
+ * region's `scrollWidth` both say so, but the *document* stays exactly one viewport wide because
+ * the region absorbed it. A check that only ever asked the document could not tell a page that
+ * fits from a page whose overflow had somewhere to hide.
  *
  * Only the innermost offenders are returned: when a wide child forces a chain
  * of ancestors wide, the child is the thing worth naming.
  */
 export async function findHorizontalOverflow(page: Page): Promise<HorizontalOverflowReport> {
-  return page.evaluate((tolerance) => {
-    const viewportWidth = document.documentElement.clientWidth;
+  return page.evaluate(
+    ({ tolerance, deliberate }) => {
+      const viewportWidth = document.documentElement.clientWidth;
 
-    const describeElement = (element: Element): string => {
-      const id = element.id ? `#${element.id}` : '';
-      const className = element.getAttribute('class')?.trim() ?? '';
-      const classes = className ? `.${className.split(/\s+/).join('.')}` : '';
-      const text = (element.textContent ?? '').replace(/\s+/g, ' ').trim().slice(0, 50);
-      return `${element.tagName.toLowerCase()}${id}${classes}${text ? ` — "${text}"` : ''}`;
-    };
+      const describeElement = (element: Element): string => {
+        const id = element.id ? `#${element.id}` : '';
+        const className = element.getAttribute('class')?.trim() ?? '';
+        const classes = className ? `.${className.split(/\s+/).join('.')}` : '';
+        const text = (element.textContent ?? '').replace(/\s+/g, ' ').trim().slice(0, 50);
+        return `${element.tagName.toLowerCase()}${id}${classes}${text ? ` — "${text}"` : ''}`;
+      };
 
-    const hasScrollingAncestor = (element: Element): boolean => {
-      for (let node = element.parentElement; node; node = node.parentElement) {
-        const { overflowX } = window.getComputedStyle(node);
-        if (overflowX === 'auto' || overflowX === 'scroll' || overflowX === 'hidden') {
-          return true;
+      const hasDeliberateScrollAncestor = (element: Element): boolean => {
+        for (let node = element.parentElement; node; node = node.parentElement) {
+          if (node.hasAttribute(deliberate)) {
+            return true;
+          }
         }
-      }
-      return false;
-    };
+        return false;
+      };
 
-    const isRendered = (element: Element): boolean => {
-      const { display, visibility } = window.getComputedStyle(element);
-      return display !== 'none' && visibility !== 'hidden';
-    };
+      const isRendered = (element: Element): boolean => {
+        const { display, visibility } = window.getComputedStyle(element);
+        return display !== 'none' && visibility !== 'hidden';
+      };
 
-    const overflowsViewport = (rect: DOMRect): boolean =>
-      rect.width > 0 &&
-      rect.height > 0 &&
-      (rect.right > viewportWidth + tolerance || rect.left < -tolerance);
+      const overflowsViewport = (rect: DOMRect): boolean =>
+        rect.width > 0 &&
+        rect.height > 0 &&
+        (rect.right > viewportWidth + tolerance || rect.left < -tolerance);
 
-    const candidates = Array.from(document.body.querySelectorAll('*')).filter(
-      (element) =>
-        isRendered(element) &&
-        overflowsViewport(element.getBoundingClientRect()) &&
-        !hasScrollingAncestor(element),
-    );
+      const candidates = Array.from(document.body.querySelectorAll('*')).filter(
+        (element) =>
+          isRendered(element) &&
+          overflowsViewport(element.getBoundingClientRect()) &&
+          !hasDeliberateScrollAncestor(element),
+      );
 
-    const innermost = candidates.filter(
-      (element) => !candidates.some((other) => other !== element && element.contains(other)),
-    );
+      const innermost = candidates.filter(
+        (element) => !candidates.some((other) => other !== element && element.contains(other)),
+      );
 
-    return {
-      viewportWidth,
-      documentScrollWidth: document.documentElement.scrollWidth,
-      offenders: innermost.slice(0, 8).map((element) => {
-        const rect = element.getBoundingClientRect();
-        return {
+      // Only genuine scroll containers. `overflow: hidden` is deliberately not one of them: it
+      // clips rather than scrolls, and the app uses it for the visually-hidden label pattern,
+      // where a 1px box holding a 112px word is the technique working rather than a layout fault.
+      // A control clipped out of reach is still caught, by `expectInteractiveControlsReachable`.
+      const scrollers = Array.from(document.querySelectorAll('*')).filter((element) => {
+        if (element.hasAttribute(deliberate) || !isRendered(element)) {
+          return false;
+        }
+        const { overflowX } = window.getComputedStyle(element);
+        if (overflowX !== 'auto' && overflowX !== 'scroll') {
+          return false;
+        }
+        return element.scrollWidth > element.clientWidth + tolerance;
+      });
+
+      return {
+        viewportWidth,
+        documentScrollWidth: document.documentElement.scrollWidth,
+        offenders: innermost.slice(0, 8).map((element) => {
+          const rect = element.getBoundingClientRect();
+          return {
+            description: describeElement(element),
+            left: Math.round(rect.left),
+            right: Math.round(rect.right),
+            width: Math.round(rect.width),
+          };
+        }),
+        scrollers: scrollers.slice(0, 8).map((element) => ({
           description: describeElement(element),
-          left: Math.round(rect.left),
-          right: Math.round(rect.right),
-          width: Math.round(rect.width),
-        };
-      }),
-    };
-  }, OVERFLOW_TOLERANCE_PX);
+          scrollWidth: element.scrollWidth,
+          clientWidth: element.clientWidth,
+        })),
+      };
+    },
+    { tolerance: OVERFLOW_TOLERANCE_PX, deliberate: DELIBERATE_SCROLLER },
+  );
 }
 
 function formatOffenders(offenders: LayoutOffender[]): string {
@@ -124,10 +180,19 @@ function formatOffenders(offenders: LayoutOffender[]): string {
     .join('\n');
 }
 
+function formatScrollers(scrollers: OverflowingScroller[]): string {
+  return scrollers
+    .map(
+      (scroller) =>
+        `  ${scroller.description}\n    scrollWidth=${scroller.scrollWidth} clientWidth=${scroller.clientWidth}`,
+    )
+    .join('\n');
+}
+
 /**
- * The core mobile guard: nothing may sit outside the viewport horizontally, and
- * the page as a whole must not scroll sideways. A desktop-first redesign that
- * assumes a wide window breaks this first.
+ * The core mobile guard: nothing may sit outside the viewport horizontally, no scroll container
+ * may be hiding content off to the side, and the page as a whole must not scroll sideways. A
+ * desktop-first redesign that assumes a wide window breaks this first.
  */
 export async function expectNoHorizontalOverflow(page: Page): Promise<void> {
   const report = await findHorizontalOverflow(page);
@@ -138,15 +203,20 @@ export async function expectNoHorizontalOverflow(page: Page): Promise<void> {
   ).toEqual([]);
 
   expect(
+    report.scrollers,
+    `Content is hidden sideways inside a scroll container that is not marked ${DELIBERATE_SCROLLER}:\n${formatScrollers(report.scrollers)}`,
+  ).toEqual([]);
+
+  expect(
     report.documentScrollWidth,
     `Page scrolls horizontally at ${report.viewportWidth}px (scrollWidth ${report.documentScrollWidth}px).`,
   ).toBeLessThanOrEqual(report.viewportWidth + OVERFLOW_TOLERANCE_PX);
 }
 
 /**
- * Catches controls pushed out of reach by a clipping ancestor. `overflow: hidden`
- * excuses an element from the overflow check above, but a button hidden that way
- * is genuinely unusable on a phone, so it is checked separately.
+ * Catches controls pushed out of reach by a clipping ancestor. `overflow: hidden` excuses an
+ * element from the sweep above — it clips rather than scrolls — but a button hidden that way is
+ * genuinely unusable on a phone, so it is checked separately.
  */
 export async function expectInteractiveControlsReachable(page: Page): Promise<void> {
   const unreachable = await page.evaluate((tolerance) => {

--- a/e2e/pages.mobile.spec.ts
+++ b/e2e/pages.mobile.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { PAGE_MANIFEST, type PageEntry } from './page_manifest';
 import {
   clickGenerateButton,
@@ -12,6 +12,7 @@ import {
   expectNoHorizontalOverflow,
   pinGeneratorSeed,
 } from './mobile_layout';
+import { createProject } from './projects';
 
 /**
  * The mobile baseline. Runs once per width in MOBILE_VIEWPORTS via the
@@ -51,3 +52,35 @@ for (const entry of PAGE_MANIFEST) {
     await expectInteractiveControlsReachable(page);
   });
 }
+
+/**
+ * The shell carrying a project name, which is the one piece of text in the top bar the user
+ * writes and therefore the one that can be any length at all.
+ *
+ * Every test above visits a route in a fresh browser with an empty vault, where the bar reads
+ * "Project: None" and fits any phone. That is why a long name shipped: the bar was never measured
+ * with a real one in it. A name this long used to push the header past the viewport, and because
+ * the top bar is shell furniture rather than page content, it made *every page in the app* scroll
+ * sideways at once.
+ */
+const LONG_PROJECT_NAME = 'The Shattered Coast of Vel Anareth';
+
+test(`mobile layout: the shell with a project open`, async ({ page }) => {
+  await visitRoute(page, '/');
+  await createProject(page, LONG_PROJECT_NAME);
+
+  // The name has to actually be in the bar before measuring it, or this passes by measuring
+  // "None". The top bar reads the vault after hydrating it, so the name arrives a tick after the
+  // navigation settles.
+  await expect(page.locator('.top-bar__stat--project dd')).toHaveText(LONG_PROJECT_NAME);
+
+  // Checked on Home and on a generator: the bar is the same element on both, but a page that
+  // already fills its width is where an over-wide bar shows up as something other than the bar.
+  for (const path of ['/', '/character']) {
+    await visitRoute(page, path);
+    await expect(page.locator('.top-bar__stat--project dd')).toHaveText(LONG_PROJECT_NAME);
+
+    await expectNoHorizontalOverflow(page);
+    await expectInteractiveControlsReachable(page);
+  }
+});

--- a/src/components/common/DataTable.svelte
+++ b/src/components/common/DataTable.svelte
@@ -45,7 +45,15 @@
   const { columns, rows, narrow = 'flip', label, class: extraClass = '' }: Props = $props();
 </script>
 
-<div class="data-table {extraClass}" class:data-table--scroll={narrow === 'scroll'}>
+<!-- `data-scroll-x` is what excuses this wrapper from the mobile overflow guard, and it is set
+     by the same condition that makes it scroll — see `DELIBERATE_SCROLLER` in e2e/mobile_layout.ts.
+     The flipping variant must not carry it: a stack of labelled rows has nothing to scroll, so an
+     exemption there would only hide a fault. -->
+<div
+  class="data-table {extraClass}"
+  class:data-table--scroll={narrow === 'scroll'}
+  data-scroll-x={narrow === 'scroll' ? '' : undefined}
+>
   <table aria-label={label}>
     <thead>
       <tr>

--- a/src/components/common/StatBlock.svelte
+++ b/src/components/common/StatBlock.svelte
@@ -37,7 +37,13 @@
   .stat-block {
     display: grid;
     gap: var(--s5);
-    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+    /* `min(11rem, 100%)` and not a bare `11rem`. `auto-fill` lays down at least one track, and a
+       bare minimum makes that track 11rem wide even when the block has less room than that — so a
+       stat block nested a couple of levels in (a planet inside a star system, an age band inside a
+       species) pushed its pairs off the side of a 320px phone while reporting a tidy 176px width.
+       Wrapping the minimum in `min()` lets the track collapse to the space that actually exists.
+       The same idiom is already what `AllToolsPage`, `HomePage` and `ProjectsPage` use. */
+    grid-template-columns: repeat(auto-fill, minmax(min(11rem, 100%), 1fr));
     margin: 0;
   }
 </style>

--- a/src/components/factions/FamilyGenerator.svelte
+++ b/src/components/factions/FamilyGenerator.svelte
@@ -329,7 +329,8 @@
   <h2>The {family.name} Family</h2>
 
   <h3>Family Tree</h3>
-  <div class="family-tree">
+  <!-- Scrolls sideways on purpose; see `DELIBERATE_SCROLLER` in e2e/mobile_layout.ts. -->
+  <div class="family-tree" data-scroll-x>
     <!-- Renders app-generated markup (no external or user-supplied input). -->
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     {@html familyTreeSVG}

--- a/src/components/layout/TopBar.svelte
+++ b/src/components/layout/TopBar.svelte
@@ -151,16 +151,24 @@
 
   /* The status items sit together in the middle; the date is pushed to the far right by this
      margin rather than by `justify-content`, which would spread the identity too. */
+  /* `min-width: 0` on the status group and on each stat inside it, because a flex item's default
+     `min-width: auto` refuses to shrink below its content. The project name is the one value here
+     the user writes, so it is the one that can be arbitrarily long — and with the default a long
+     name pushes the bar past the viewport, which makes the *whole app* scroll sideways on every
+     page, the top bar being shell furniture rather than page content. Allowing the group to shrink
+     is what lets the ellipsis below actually happen. */
   .top-bar__status {
     display: flex;
     gap: var(--s6);
     margin: 0 auto 0 var(--s4);
+    min-width: 0;
   }
 
   .top-bar__stat {
     display: flex;
     align-items: baseline;
     gap: var(--s3);
+    min-width: 0;
     white-space: nowrap;
   }
 
@@ -179,10 +187,29 @@
     margin: 0;
   }
 
+  /* The label is fixed width and the name is not, so the name is the half that gives. It truncates
+     rather than wraps: the bar is exactly one hit target tall, and a second line would push the
+     page region down by the height of a row. The full name is a tap away on Projects, which is
+     where the link goes. */
+  .top-bar__stat--project dd {
+    min-width: 0;
+    overflow: hidden;
+  }
+
   /* The one status that is also a control, so it takes the accent every other link on the site
-     takes rather than reading as a value. */
+     takes rather than reading as a value.
+
+     It is also where the ellipsis has to live rather than on the `dd` above. An inline anchor
+     keeps its full content width even inside a clipping parent — the text is drawn cut off, but
+     the link's own box still reports itself off the side of the screen, which is exactly what
+     `expectInteractiveControlsReachable` is looking for and is right to flag. Making the anchor a
+     block gives it the `dd`'s width, so the box the user can tap and the text they can see are
+     the same thing. */
   .top-bar__stat--project dd a {
     color: var(--accent);
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .top-bar__date {

--- a/src/components/utilities/WordGeneratorCheatSheet.svelte
+++ b/src/components/utilities/WordGeneratorCheatSheet.svelte
@@ -66,7 +66,8 @@
 
   <h2>Element Reference</h2>
 
-  <div class="element-table-scroll">
+  <!-- Scrolls sideways on purpose; see `DELIBERATE_SCROLLER` in e2e/mobile_layout.ts. -->
+  <div class="element-table-scroll" data-scroll-x>
     <!-- Renders app-generated markup (no external or user-supplied input). -->
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     {@html html}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -179,8 +179,16 @@
     height: 100dvh;
   }
 
+  /* `min-width: 0` for the same reason `.shell__page` has it, and it is the other half of the top
+     bar fitting a phone. A grid item's automatic minimum size is its min-content width, so a `1fr`
+     track does *not* cap its item at the track — it grows the track to fit. A long project name
+     therefore widened this column to the bar's min-content width, the grid to match, and with the
+     bar handed more room than the viewport the flex shrinking inside it never had a deficit to
+     resolve: every rule asking the name to ellipsize was satisfied at a width nobody could see.
+     Capping the item is what turns that into the shrink the bar's own styles are written for. */
   .shell > :global(.top-bar) {
     grid-area: bar;
+    min-width: 0;
   }
 
   /* The shell's widths are stated in `px` and not in `rem`. `main.css` sets a fluid root —


### PR DESCRIPTION
Reported from an iPhone 16: the app was too wide and scrolled sideways on every page. It reproduces anywhere once a project with a long name is open — Chromium and WebKit both — and it is not iOS-specific.

Measured at 393px, `document.scrollWidth`:

| Project name | Before | After |
| --- | --- | --- |
| `None` | 393 | 393 |
| `Ashfall` | 393 | 393 |
| `The Shattered Coast of Vel Anareth` | **456** | 393 |

## The bug

The top bar is shell furniture rather than page content, so one over-wide bar takes the whole site with it. Two things had to be true for a long name to fit, and neither was:

- **A grid item's automatic minimum size is its min-content width**, so the `1fr` track did not cap the top bar — it grew to fit it. At 320px the bar was handed 346px, the flex shrinking inside it never had a deficit to resolve, and every rule asking the name to ellipsize was satisfied at a width nobody could see. `.shell__page` already carried `min-width: 0` for exactly this reason; the bar did not.
- **The status group and its stats are flex items**, defaulting to `min-width: auto`, so they refuse to shrink below their content — and `.top-bar__stat` sets `white-space: nowrap`.

The ellipsis goes on the anchor rather than the `dd`: an inline anchor keeps its full content width inside a clipping parent, so the text drew cut off while the link's box still sat at `right=455`, which is exactly what `expectInteractiveControlsReachable` is for and right to flag. `display: block` makes the tappable box and the visible text the same rectangle.

## Why no test caught it

`.shell__page` sets `overflow-y: auto`, and CSS computes the other axis to `auto` because `visible` cannot pair with a scrolling value. Verified: `{ overflowX: 'auto', overflowY: 'auto' }`. So the page region is a horizontal scroll container by accident, **every element in the app had a horizontally-scrolling ancestor**, and `findHorizontalOverflow` skipped all of them. The overflow was trapped inside that scroller where `documentElement.scrollWidth` could not see it either.

Forty routes reported green while a real phone scrolled sideways. The suite was green because it was blind, not because the pages fit.

Only a `data-scroll-x` ancestor excuses an element now, and the three elements that genuinely scroll sideways — `DataTable`'s scroll variant, the family tree, the phonetics table — carry it beside the `overflow-x: auto` that makes it real. A second assertion catches scroll containers hiding content sideways, which is the same bug from the other end.

## What un-blinding it found

`StatBlock` used a bare `minmax(11rem, 1fr)`. `auto-fill` lays down at least one track at that full 176px even when the block has less room, so a stat block nested a couple of levels in — a planet inside a star system, an age band inside a species — pushed its pairs off the side of a 320px phone while reporting a tidy 176px width. Now `minmax(min(11rem, 100%), 1fr)`, the idiom `AllToolsPage`, `HomePage` and `ProjectsPage` already use.

This failed at 320/360/375 on `/species-stats` and at 320 on `/star-system` — all of it pre-existing, and all of it invisible to the old guard.

## The new test

`mobile layout: the shell with a project open` creates a long-named project and measures the bar on Home and on a generator. Every other mobile test runs with an empty vault where the bar reads "Project: None" and fits anything; that gap is what let this ship.

## Verification

- `npm run verify:all` green — 4479 unit tests, 456 e2e, coverage gate passed with 0 baselined debt.
- Two negative controls, because a guard that cannot fail is what got us here:
  - A run against a stale build reported real SVG offenders at `right=808` on a 390px viewport, proving the sweep now sees inside the page region.
  - Stashing only the TopBar fix makes the new test fail with `Elements extend past the 390px viewport`.

## Notes

- The shell has been able to widen the whole app since the grid landed. The project name was just the first content long enough to trigger it.
- Raw colours in three components, found incidentally, are filed separately as #165 rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013g8k3mU1UkgV94K1jWf5Vo
