### PR TITLE
Seat a mounted tool leftmost, and scroll to it on a phone

### DIFF
--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -306,9 +306,16 @@ above rather than contradicting it: the case it argues for is building a region 
 you can see, and those settlements are artifacts. What is single is the **instrument**, not the
 bench — a workbench has one thing clamped in it and as many references open around it as you like.
 
+**The tool is mounted at the left-hand end**, in front of whatever artifacts are already open;
+artifacts still open at the right. The instrument leads, and a bench that has collected a few
+references must not push the tool the user just asked for off to the right of them — on a phone,
+where the bench is a single column, that is the work below the fold and the notes above it. The
+seat is chosen only on the way in, so the move controls still mean what they say: a user who puts
+the tool to the right of an artifact keeps it there.
+
 The invariant is enforced in `renumberPanels`, which every mutation and every read passes through,
 so a bench stored before the rule existed comes back obeying it — keeping the rightmost tool, which
-is the one most recently opened. Swapping a tool out asks first when it is holding generated
+was the one most recently opened back when tools were appended. Swapping a tool out asks first when it is holding generated
 content nobody has saved, through the same unsaved-edits registry that guards closing a panel;
 `SaveArtifactButton` is what registers that answer for a generator.
 

--- a/e2e/workshop.spec.ts
+++ b/e2e/workshop.spec.ts
@@ -243,7 +243,26 @@ test.describe('the workshop bench', () => {
     await mountTool(page, /^Heraldry/);
 
     await expect(panels(page)).toHaveCount(2);
-    await expect(panelTitles(page)).toHaveText([/The Emberfolk/, /Heraldry/]);
+    await expect(panelTitles(page)).toHaveText([/Heraldry/, /The Emberfolk/]);
+  });
+
+  test('mounts a tool leftmost, in front of the artifacts already open', async ({ page }) => {
+    // The instrument leads. An artifact is reference for the work, so a bench that has collected
+    // a few of them must not push the tool the user just asked for off to their right — which on
+    // a phone, where the bench is one column, is the work below the fold and the notes above it.
+    await createProject(page, 'Ashfall');
+    await saveACulture(page, 'The Emberfolk');
+    await artifactRow(page, 'The Emberfolk').click();
+    await expect(panelTitles(page)).toHaveText([/Culture/, /The Emberfolk/]);
+
+    // Closing the tool and mounting one against a bench that already holds the artifact is the
+    // case the rule is about: the tool arrives second and still lands first.
+    await page.getByRole('button', { name: /^Close Culture/ }).click();
+    await expect(panelTitles(page)).toHaveText([/The Emberfolk/]);
+
+    await mountTool(page, /^Heraldry/);
+
+    await expect(panelTitles(page)).toHaveText([/Heraldry/, /The Emberfolk/]);
   });
 
   test('does not mount a second copy of a tool already on the bench', async ({ page }) => {
@@ -533,6 +552,40 @@ test.describe('the bench on a phone', () => {
 
     await expectNoHorizontalOverflow(page);
     await expectInteractiveControlsReachable(page);
+  });
+
+  /**
+   * On a phone the rail's two lists sit above the bench, so a tool mounted from the browser lands
+   * somewhere off the bottom of the screen: the tap changes a part of the page nobody can see, and
+   * reads as a control that did nothing. The page follows the panel instead.
+   *
+   * Asserted on where the panel ends up relative to the viewport rather than on a scroll offset,
+   * because what the user is owed is seeing the thing they opened, not a particular number of
+   * pixels having gone by.
+   */
+  test('scrolls to a panel mounted on a phone', async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 720 });
+    await openEmptyWorkshop(page);
+
+    await mountTool(page, /^Culture/);
+
+    const panel = panels(page).first();
+    await expect(panel).toBeVisible();
+    await expect
+      .poll(async () => {
+        const box = await panel.boundingBox();
+        const height = page.viewportSize()?.height ?? 0;
+        // Its top edge is on screen, which for a panel taller than the phone is the whole of what
+        // "scrolled to it" can mean — and the page moved to put it there, rather than the bench
+        // having happened to fit under the rail.
+        // The shell's page region is the scroller, not the document: `.shell__page` is a grid
+        // item with `overflow-y: auto`, so the window never scrolls on this site.
+        const scrolled = await page.evaluate(
+          () => document.querySelector('.shell__page')?.scrollTop ?? 0,
+        );
+        return box !== null && box.y >= 0 && box.y < height && scrolled > 0;
+      })
+      .toBe(true);
   });
 });
 

--- a/src/components/layout/WorkshopPage.svelte
+++ b/src/components/layout/WorkshopPage.svelte
@@ -197,6 +197,7 @@
       }
     }
     updateBench(withPanelOpened(bench, { toolPath: tool.path }));
+    void revealPanel({ toolPath: tool.path });
     return true;
   }
 
@@ -224,6 +225,41 @@
 
   function openArtifact(artifactId: string) {
     updateBench(withPanelOpened(bench, { artifactId }));
+    void revealPanel({ artifactId });
+  }
+
+  /**
+   * Bring a panel that has just been put on the bench into view.
+   *
+   * Only where the bench is stacked under the rail, which is the arrangement the same 48rem
+   * breakpoint below produces: on a phone the rail's two lists are between the user and the bench,
+   * so tapping a tool changes a part of the page nobody can see and reads as a control that did
+   * nothing. Where the columns sit side by side the bench is already beside the list that was
+   * tapped, and scrolling the page under someone who can see the result is the more disruptive
+   * of the two.
+   *
+   * The panel is found by position rather than by a selector of its own, the same way
+   * `placeFocusAfterClose` finds one: the bench renders panels in `bench.panels` order, and that
+   * is the only correspondence either needs.
+   */
+  async function revealPanel(target: PanelTarget): Promise<void> {
+    if (!window.matchMedia('(max-width: 48rem)').matches) {
+      return;
+    }
+    await tick();
+
+    const index = bench.panels.findIndex((panel) => panelKey(panel) === panelKey(target));
+    if (index === -1) {
+      return;
+    }
+    const element = benchElement?.querySelectorAll('section.workshop-panel')[index];
+    if (!(element instanceof HTMLElement)) {
+      return;
+    }
+    // Smoothly, so the movement is legible as the page travelling rather than as a jump to
+    // somewhere unrecognisable — but not for a user who has asked the site to stop moving.
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    element.scrollIntoView({ behavior: reducedMotion ? 'auto' : 'smooth', block: 'start' });
   }
 
   function targetOf(panel: PanelState): PanelTarget {

--- a/src/lib/workspaces/README.md
+++ b/src/lib/workspaces/README.md
@@ -30,8 +30,13 @@ that content is its identity, which `panelKey` spells out. Opening something alr
 moves to it rather than putting a second copy beside the first, because two panels showing one tool
 are two copies of one thing with separately drifting state.
 
+A **tool** goes on at the left-hand end and an **artifact** at the right: the instrument leads, and
+the references it is being built from sit beside it rather than in front of it. Placement happens on
+the way in only — nothing re-seats a panel afterwards, so `withPanelMoved` is not fighting a rule.
+
 `MAX_PANELS` caps the bench. A full bench drops its leftmost panel to make room rather than
-refusing, so a user is never left working out which panel is in the way of the one they asked for.
+refusing, so a user is never left working out which panel is in the way of the one they asked for —
+the oldest panel goes, whichever end the arriving one lands at.
 
 ## Usage
 

--- a/src/lib/workspaces/workspaces.test.ts
+++ b/src/lib/workspaces/workspaces.test.ts
@@ -148,10 +148,23 @@ describe('normalizePanels', () => {
 });
 
 describe('withPanelOpened', () => {
-  it('adds a panel at the right-hand end', () => {
-    expect(keysOf(benchOf({ toolPath: '/culture' }, { artifactId: 'a1' }))).toEqual([
+  it('adds an artifact at the right-hand end', () => {
+    expect(keysOf(benchOf({ artifactId: 'a1' }, { artifactId: 'a2' }))).toEqual([
+      'artifact:a1',
+      'artifact:a2',
+    ]);
+  });
+
+  it('adds a tool at the left-hand end, in front of the artifacts already open', () => {
+    // The instrument leads. A bench that had collected artifacts would otherwise put the tool to
+    // the right of its own reference material, which on a single-column phone bench is the work
+    // below the fold and the notes above it.
+    const bench = benchOf({ artifactId: 'a1' }, { artifactId: 'a2' });
+
+    expect(keysOf(withPanelOpened(bench, { toolPath: '/culture' }))).toEqual([
       'tool:/culture',
       'artifact:a1',
+      'artifact:a2',
     ]);
   });
 
@@ -162,11 +175,15 @@ describe('withPanelOpened', () => {
   });
 
   it('does not move a panel that is reopened', () => {
+    // Including a tool a user has deliberately moved: placement happens on the way in, so opening
+    // what is already open is not a second chance to re-seat it.
     const bench = benchOf({ toolPath: '/culture' }, { artifactId: 'a1' });
+    const moved = withPanelMoved(bench, { toolPath: '/culture' }, 1);
+    expect(keysOf(moved)).toEqual(['artifact:a1', 'tool:/culture']);
 
-    expect(keysOf(withPanelOpened(bench, { toolPath: '/culture' }))).toEqual([
-      'tool:/culture',
+    expect(keysOf(withPanelOpened(moved, { toolPath: '/culture' }))).toEqual([
       'artifact:a1',
+      'tool:/culture',
     ]);
   });
 
@@ -182,9 +199,9 @@ describe('withPanelOpened', () => {
     const bench = benchOf({ artifactId: 'a1' }, { toolPath: '/culture' }, { artifactId: 'a2' });
 
     expect(keysOf(withPanelOpened(bench, { toolPath: '/heraldry' }))).toEqual([
+      'tool:/heraldry',
       'artifact:a1',
       'artifact:a2',
-      'tool:/heraldry',
     ]);
   });
 
@@ -201,11 +218,13 @@ describe('withPanelOpened', () => {
     const swapped = withPanelOpened(full, { toolPath: '/heraldry' });
 
     expect(swapped.panels).toHaveLength(MAX_PANELS);
-    expect(keysOf(swapped)[0]).toBe('artifact:a0');
-    expect(keysOf(swapped).at(-1)).toBe('tool:/heraldry');
+    expect(keysOf(swapped)[0]).toBe('tool:/heraldry');
+    expect(keysOf(swapped).at(-1)).toBe(`artifact:a${MAX_PANELS - 2}`);
   });
 
   it('drops the leftmost panel to make room on a full bench', () => {
+    // The oldest panel goes, not the one nearest where the tool lands: what is in the way is
+    // whatever the user opened longest ago, wherever the arriving panel is seated.
     const full = Array.from({ length: MAX_PANELS }, (_unused, index) => ({
       artifactId: `a${index}`,
     })).reduce((workspace, target) => withPanelOpened(workspace, target), emptyWorkspace('p1'));
@@ -213,8 +232,8 @@ describe('withPanelOpened', () => {
     const opened = withPanelOpened(full, { toolPath: '/culture' });
 
     expect(opened.panels).toHaveLength(MAX_PANELS);
-    expect(keysOf(opened)[0]).toBe('artifact:a1');
-    expect(keysOf(opened).at(-1)).toBe('tool:/culture');
+    expect(keysOf(opened)[0]).toBe('tool:/culture');
+    expect(keysOf(opened)[1]).toBe('artifact:a1');
   });
 });
 
@@ -230,13 +249,13 @@ describe('isPanelOpen', () => {
 
 describe('withPanelClosed', () => {
   it('removes the panel and renumbers what is left', () => {
-    const bench = benchOf({ artifactId: 'a1' }, { artifactId: 'a2' }, { toolPath: '/heraldry' });
+    const bench = benchOf({ toolPath: '/heraldry' }, { artifactId: 'a1' }, { artifactId: 'a2' });
 
-    const closed = withPanelClosed(bench, { artifactId: 'a2' });
+    const closed = withPanelClosed(bench, { artifactId: 'a1' });
 
     expect(closed.panels).toEqual([
-      { order: 0, artifactId: 'a1' },
-      { order: 1, toolPath: '/heraldry' },
+      { order: 0, toolPath: '/heraldry' },
+      { order: 1, artifactId: 'a2' },
     ]);
   });
 
@@ -248,7 +267,13 @@ describe('withPanelClosed', () => {
 });
 
 describe('withPanelMoved', () => {
-  const bench = benchOf({ artifactId: 'a1' }, { toolPath: '/heraldry' }, { artifactId: 'a2' });
+  // A tool sitting between two artifacts, which the bench only reaches by hand: an opened tool
+  // lands on the left, and a user moved it one to the right.
+  const bench = withPanelMoved(
+    benchOf({ toolPath: '/heraldry' }, { artifactId: 'a1' }, { artifactId: 'a2' }),
+    { toolPath: '/heraldry' },
+    1,
+  );
 
   it('swaps a panel with its left neighbour', () => {
     expect(keysOf(withPanelMoved(bench, { toolPath: '/heraldry' }, -1))).toEqual([

--- a/src/lib/workspaces/workspaces.ts
+++ b/src/lib/workspaces/workspaces.ts
@@ -31,8 +31,11 @@ function panelFromTarget(target: PanelTarget, order: number): PanelState {
 }
 
 /**
- * The bench holds at most one tool, keeping the rightmost — which is the most recently opened,
- * since {@link withPanelOpened} appends.
+ * The bench holds at most one tool, keeping the rightmost.
+ *
+ * Only a bench stored before the one-tool rule can hold two, and there the rightmost was the most
+ * recently opened, since {@link withPanelOpened} appended tools then. Nothing this build writes
+ * reaches here with a choice to make: opening a tool takes the previous one off first.
  *
  * Artifacts are not capped: the composition case in docs/workshop.md is a settlement open beside
  * the region generator being built from it, and that still wants several things visible. What is
@@ -101,12 +104,23 @@ export function isPanelOpen(workspace: ProjectWorkspace, target: PanelTarget): b
 }
 
 /**
- * Put something on the bench, at the right-hand end.
+ * Put something on the bench: an **artifact** at the right-hand end, a **tool** at the left.
+ *
+ * The sides differ because the two hold different things. A tool is the instrument being worked
+ * with, and a bench that has collected a few artifacts would otherwise push it off to the right
+ * of its own reference material — on a phone, where the bench is a single column, that is the
+ * work below the fold and the notes above it. Artifacts still append, so a second one opened is
+ * beside the first rather than in front of it.
+ *
+ * A tool is only placed on the way in. Nothing re-seats it afterwards, so the move controls still
+ * mean what they say: a user who puts a tool to the right of an artifact keeps it there.
  *
  * Opening what is already open returns the workspace unchanged rather than duplicating it, so a
  * user clicking a tool twice does not end up with two of it. A bench already holding
  * {@link MAX_PANELS} drops its leftmost panel to make room: refusing instead would leave the user
- * to work out which panel is in the way of the one they just asked for.
+ * to work out which panel is in the way of the one they just asked for. That is still the leftmost
+ * when a tool is arriving — the oldest panel goes, rather than the one nearest where the tool
+ * lands.
  *
  * Opening a **tool** takes the tool that was there off first: one instrument at a time. The
  * removal happens here rather than being left to `renumberPanels` so that replacing a tool costs
@@ -125,7 +139,11 @@ export function withPanelOpened(
       ? workspace.panels
       : workspace.panels.filter((panel) => panel.toolPath === undefined);
   const kept = existing.slice(Math.max(0, existing.length - (MAX_PANELS - 1)));
-  return withPanels(workspace, [...kept, panelFromTarget(target, kept.length)]);
+  const panels =
+    target.toolPath === undefined
+      ? [...kept, panelFromTarget(target, kept.length)]
+      : [panelFromTarget(target, 0), ...kept];
+  return withPanels(workspace, panels);
 }
 
 /** Take something off the bench. Closing what is not open changes nothing. */


### PR DESCRIPTION
The instrument leads. `withPanelOpened` put every panel at the right-hand end, so a bench holding a few artifacts pushed the tool the user had just asked for off to the right of its own reference material — on a phone, where the bench is one column, that is the work below the fold and the notes above it.

- **A tool is mounted at the left-hand end**; artifacts still append at the right. Placement happens only on the way in, so the move controls still mean what they say — a tool a user moves to the right stays there. The cap still drops the leftmost (oldest) panel, whichever end the arriving one lands at.
- **`revealPanel` scrolls a newly opened panel into view** where the bench is stacked under the rail, gated on the same 48rem breakpoint as that stacking, and jumping rather than gliding under `prefers-reduced-motion`.

Docs updated in `docs/workshop.md` and `src/lib/workspaces/README.md`. Unit tests cover the new seating (including that reopening does not re-seat a moved tool); e2e covers the leftmost rule and the phone scroll.

`npm run verify:all` is green locally, browser suite included (458 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186L6Xc5Ft5VZmdww1G2MvB