### PR TITLE
Mark the character design accepted, for #46

### DIFF
--- a/docs/fantasy-character.md
+++ b/docs/fantasy-character.md
@@ -10,8 +10,10 @@ against [Tool release readiness](workshop.md#tool-release-readiness). Culture (#
 [docs/adnd-character.md](adnd-character.md)) are the worked examples, and this follows them rather
 than inventing a second shape.
 
-**Status:** proposal. The [domain model](#domain-model) has not yet been reviewed;
-implementation does not start until it has been approved.
+**Status:** accepted; not yet built. The [domain model](#domain-model) was reviewed and approved,
+so [the plan](#the-plan) is clear to start. The one question in [Still open](#still-open) — whether
+the editor lets a saved character's species be changed — is still open, and item 6 of the plan is
+where it has to be answered.
 
 ## The problem
 

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -1805,8 +1805,8 @@ recorded as provenance so a hand-built character is reproducible — is what the
 character kind will meet.
 
 The system-neutral **Fantasy Character** generator follows it in
-[The fantasy character artifact](fantasy-character.md), which is a proposal awaiting review of its
-domain model. It takes the same bargain one step further — a species and an archetype stored by
+[The fantasy character artifact](fantasy-character.md), which is accepted and not yet built. It
+takes the same bargain one step further — a species and an archetype stored by
 name rather than embedded — and in doing so moves the `StoredCharacter` shape out of
 `$lib/settlements`, which is what makes the settlement payload the first here to advance a
 `payloadVersion`.


### PR DESCRIPTION
Follow-up to #168, docs only. Merging the design was the approval, so the status line no longer says the domain model is awaiting review.

- `docs/fantasy-character.md`: **Status: accepted; not yet built**, naming where the one still-open question (editing a saved character's species) gets answered — item 6 of the plan.
- `docs/workshop.md`: the pointer to it reads "accepted and not yet built", matching how the AD&D document is described a paragraph above.

Prettier clean. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Acb1bAUwcGdybvjyCsCYJK