### PR TITLE
Design the readiness pass, for #48-#76

### DIFF
--- a/docs/readiness-characters.md
+++ b/docs/readiness-characters.md
@@ -1,0 +1,345 @@
+# Readiness: the characters domain
+
+Five tools, taken to Release-ready: the Dungeon Crawl Classics character generator
+([#48](https://github.com/ironarachne/ironarachne/issues/48)), the Stars Without Number character
+generator ([#49](https://github.com/ironarachne/ironarachne/issues/49)), the Uncharted Worlds
+character generator ([#50](https://github.com/ironarachne/ironarachne/issues/50)), the heraldry
+generator ([#51](https://github.com/ironarachne/ironarachne/issues/51), Beta rather than
+Experimental), and Velgarth Gifts
+([#52](https://github.com/ironarachne/ironarachne/issues/52)).
+
+Part of [the readiness pass](tool-readiness.md); read that first for what all twenty-eight tools
+share — the determinism fix, the stored vocabulary, the kind ids, and the field-editor decision.
+Measured against [Tool release readiness](workshop.md#tool-release-readiness).
+
+**Status:** proposal, with [the pass](tool-readiness.md#domain-model). Not reviewed.
+
+## The three system characters
+
+#48, #49 and #50 are one design problem in three costumes, and the AD&D character
+([docs/adnd-character.md](adnd-character.md)) already solved it. A system character is **mostly
+rule data applied to a handful of user decisions**, and the two are tangled in one flat object.
+The answers carry over unchanged:
+
+- The kind is system-qualified: `character.dcc`, `character.swn`, `character.uncharted-worlds`.
+- Every derived number stays in the payload. A DM who edits a saving throw has made a decision no
+  recomputation may overrule, and a character saved under one edition of the tables must still be
+  that character after the tables change.
+- Rule objects are stored by name and resolved on read; a name this build no longer has rebuilds a
+  placeholder rather than quarantining the character.
+- Recomputation exists, as an explicit and clearly destructive command (4.3), never as something
+  that happens on open.
+
+What differs per system is which fields carry a closure, and what the user decided that the
+payload does not currently record. Those are below.
+
+### #48 — Dungeon Crawl Classics
+
+**The closures are named in the types.** `DCCOccupation.apply` and `DCCLuckyRoll.apply`
+(`src/lib/dcc/dcc_types.ts:65`, `:73`) are functions held in data, so neither object may reach the
+payload. The snapshot stores `occupationName` and `luckyRollName` and resolves both on read, in the
+shape AD&D stores its race and class:
+
+```
+DccCharacterSnapshot =
+  Omit<DCCCharacter, 'occupation' | 'luckyRoll'> & {
+    occupationName: string;
+    luckyRollName: string;
+  }
+```
+
+Everything else on `DCCCharacter` is plain: six attributes as `{ value, modifier }`, the saves,
+`specialRules: string[]`, `currency: Record<string, number>`, and arrays of `DCCItem` and
+`DCCWeapon`, none of which carries a function.
+
+**The funnel is the interesting part, and it decides the kind's cardinality.** DCC's zero-level
+funnel produces several characters at once, which is what makes this tool unlike its neighbours.
+Two readings were available and the choice matters:
+
+- One artifact per character, saved individually.
+- One artifact holding the funnel — `{ characters: DccCharacterSnapshot[] }`.
+
+**The payload is one character, and a funnel saves several artifacts.** A funnel is a way of
+rolling, not a thing in the world: the four peasants who walk into the dungeon are four characters,
+three of them about to die, and the survivor is a character a player keeps for a year. An artifact
+holding all four would make that survivor unopenable on their own, un-renamable, and impossible to
+reference from anything else — and 3.5 (name on save, rename after) is unanswerable for a bundle.
+
+So the generator's save control, when a funnel is on screen, saves each character as its own
+artifact, naming them from the same prompt with an index. That is the one place in this pass where
+one press of **Save** writes more than one artifact, and it is worth the special case.
+
+**8.4** — the README says DCC as published in the core rulebook, that the funnel implements
+zero-level characters only, and that levelled advancement is deliberately out of scope.
+
+### #49 — Stars Without Number
+
+**No closures in the character.** `SWNCharacter`'s `abilities: ClassAbility[]` is a discriminated
+union of plain records (`{ kind: 'effortAbility', description }` and friends,
+`src/lib/swn/character.ts:198`), and stats, skills, foci, equipment and weapons are all plain data.
+The snapshot is close to the identity function, which is unusual here and worth saying rather than
+leaving a reader to wonder what was missed.
+
+**What the issue asks for is the pick, not the effect.** Foci and psychic disciplines are levelled
+choices (`focus_data.ts`, `psychic_discipline_data.ts`) whose effects are resolved into the
+character at generation time. The payload keeps **both**: the resolved numbers, because 4.2 says
+the payload is authoritative, and the picks that produced them, because an editor cannot offer a
+decision it cannot read back and advancement is otherwise a migration.
+
+That means `SWNCharacter` grows one field — `picks: { focusName: string; level: number }[]` and the
+psychic equivalent — in the same way the AD&D character grew `thiefSkills`. It is the same
+finding: a user decision that was never recorded as data, only as its consequence.
+
+**6.3 is largely in hand** — `render_swn_character_pdf.ts` already exists. What it needs is the
+presentation document beneath it so the PDF and any Markdown export cannot disagree.
+
+### #50 — Uncharted Worlds
+
+The simplest of the three: `UWCharacter` is descriptors, a stat block, careers, an origin, skills,
+a workspace, assets and a name (`src/lib/unchartedworlds/character.ts:8`), with **no function-typed
+field anywhere in the library** — the search for one returns nothing.
+
+**Skill descriptions are derived and stay derived.** `skill_description.ts` turns a skill into its
+prose; the payload stores the skill, and the description is produced on read. A wording fix then
+reaches a character saved last month, which is the whole reason not to store it. This is the one
+place in this domain where _not_ storing something is the right answer, and it is safe precisely
+because the derivation takes no RNG and no user input: it is a lookup, not a roll.
+
+The edit that follows: a user who rewrites a skill description is editing prose the library owns,
+so the editor does not offer that field. Careers, origin, workspace, assets and the stat block are
+what it offers.
+
+## #51 — Heraldry, from Beta to Release-ready
+
+The shortest run on the site, and the one requirement in the way is the one the spec calls the
+requirement that separates a workshop from a gallery.
+
+**What is already true**, and this is assessed, not inherited: heraldry clears sections 1–3
+(a registered kind with a validating v1→v2 migration, a round-tripping snapshot, provenance and a
+name on save), 6 (mobile, keyboard, SVG and PNG export) and 7.1–7.2. `ARTIFACT_EDITORS` registers
+`HeraldryArtifactView` — a viewer, not an editor — so a saved coat of arms can be looked at and
+downloaded, and not changed. Outstanding: **4.1–4.4, 5.1–5.3, 7.3 and 7.4.**
+
+### The editor is a device editor, and the stored shape is already the right one
+
+`StoredDevice` (`src/lib/heraldry/heraldry_snapshot.ts`) is exactly the vocabulary an editor needs:
+
+```
+StoredDevice  = { fieldName, variations: StoredVariation[], chargeGroups: StoredChargeGroup[] }
+StoredVariation   = { variationName, tinctureNames: string[] }
+StoredChargeGroup = { chargeName, chargeTinctureName, numberOfCharges, arrangementName, position? }
+```
+
+So the editor is a form over names, and every control it needs already exists for the generator:
+`resolveFieldOptions`, `eligibleVariationTinctures`, `fieldVariationSlotCountForDivision` and
+`variationTinctureCountForSlot` in `heraldry_ui_options.ts`, plus `Fields`, `Tinctures`,
+`Variations` and the charge data exported from the library's index.
+
+**Each change redraws and re-blazons, and re-rolls nothing** (4.2, 4.4). Changing the field's
+tincture must leave the charges alone; adding a charge group must not disturb the field. That falls
+out of `heraldry_editing.ts` being snapshot-to-snapshot functions, as culture's is — with one
+addition heraldry needs and culture did not: **the blazon is derived, not edited.**
+`renderDeviceBlazon(device)` recomputes it after every change, because a stored blazon that no
+longer describes the device is worse than no blazon.
+
+This is deliberately _not_ a `SnapshotFieldEditor` case
+([decision 5](tool-readiness.md#5-flat-payloads-get-a-declared-field-editor-not-twenty-five-bespoke-components)):
+a charge group is a repeating structure with its own add and remove, and the editor renders the
+arms beside the controls. A flat list of inputs would be a worse editor than the viewer it
+replaces.
+
+### Composition, and why heraldry is the kind that tests 5.4
+
+5.1 for heraldry itself is thin — a coat of arms takes no other artifact as an input — so what it
+owes is 5.3 (works with nothing supplied: already true) and its side of everyone else's
+references. Five kinds in this pass reference `heraldry`: character, organization, family, merchant
+and region.
+
+That makes heraldry the kind most likely to sit in a cycle — a region's authority bears the arms of
+the organization the region references — and 5.4 is tested in whatever walks references, once, not
+in this tool. Retiring `heraldry_saved_state.ts` is part of this issue;
+`src/lib/legacy_adoption` is what carries existing saves across and does not change.
+
+## #52 — Velgarth Gifts
+
+The smallest generator in the pass with a real payload. `Gift` is `{ name, description, strength }`
+(`src/lib/velgarth_gifts/gift.ts`) and the tool produces a list of them; the component is 47 lines
+and the library has no dependency on any other.
+
+- **Kind `velgarth-gifts`**, payload `{ gifts: Gift[] }`. The name is the setting rather than a
+  system, for the reason [the spine](tool-readiness.md#kind-ids) gives: a Velgarth gift is fan
+  content for one setting, there is no `setting:` namespace to qualify with, and the generic kind
+  `gifts` would claim a concept this does not own.
+- **The editor is a `SnapshotFieldEditor` case** over a string list plus a number per gift — the
+  simplest instance of decision 5 in the pass.
+- **8.4 applies to a setting as much as to a system.** The README says which of Velgarth's gifts
+  are represented, that strength levels follow the published descriptions rather than any
+  mechanical system, and that this is unofficial fan content.
+
+## What every tool in this domain owes
+
+Beyond the per-tool notes above, and identical for all five:
+
+- **`*_roll.ts` and the end of `Date.now()`.** All four generators call it — DCC, SWN and Uncharted
+  Worlds twice each, Velgarth twice, heraldry once. Wave 0 of the pass does not fix this; each
+  tool's own work item does.
+- **`SaveArtifactButton`**, provenance (tool path, seed, config), and the no-project case on the
+  tool's own route (3.6, 3.7). Heraldry has this already.
+- **A culture reference for naming** where the tool names anyone: DCC, SWN and Uncharted Worlds all
+  import `$lib/characters` and can take `CharacterNameSection`'s existing `offerReferencedCulture`
+  opt-in, which was built for #45 and costs a prop.
+- **A presentation document** and an export control (6.3). The three system characters have PDF
+  renderers already and need the document under them; Velgarth needs both.
+- **7.2, 7.3, 7.4**: a round-trip test, a migration test where a version step exists, and an
+  end-to-end spec beside `e2e/adnd_character.spec.ts` covering generate, save, reopen, edit.
+
+## Domain model
+
+### The three system characters
+
+```mermaid
+classDiagram
+    class DCCCharacter {
+        +string firstName
+        +string lastName
+        +number level
+        +number hp
+        +DCCAttribute strength
+        +string[] specialRules
+    }
+    class DccCharacterSnapshot {
+        +string occupationName
+        +string luckyRollName
+        +number level
+        +number hp
+        +string[] specialRules
+    }
+    class DCCOccupation {
+        +string name
+        +function apply
+    }
+    class DCCLuckyRoll {
+        +string name
+        +function apply
+    }
+    class SWNCharacter {
+        +Stat[] stats
+        +Skill[] skills
+        +Focus[] focuses
+        +ClassAbility[] abilities
+        +number hitPoints
+    }
+    class SwnCharacterSnapshot {
+        +Stat[] stats
+        +Skill[] skills
+        +FocusPick[] picks
+        +ClassAbility[] abilities
+        +number hitPoints
+    }
+    class FocusPick {
+        +string focusName
+        +number level
+    }
+    class UWCharacter {
+        +StatBlock stats
+        +Career[] careers
+        +Origin origin
+        +Skill[] skills
+        +Asset[] assets
+    }
+    class UwCharacterSnapshot {
+        +StatBlock stats
+        +Career[] careers
+        +Origin origin
+        +Skill[] skills
+        +Asset[] assets
+    }
+
+    DCCCharacter "1" o-- "1" DCCOccupation
+    DCCCharacter "1" o-- "1" DCCLuckyRoll
+    DCCCharacter --> DccCharacterSnapshot : rule objects by name
+    SWNCharacter --> SwnCharacterSnapshot : picks recorded beside effects
+    SwnCharacterSnapshot "1" o-- "*" FocusPick
+    UWCharacter --> UwCharacterSnapshot : identity, descriptions derived on read
+```
+
+### Heraldry, edited
+
+```mermaid
+classDiagram
+    class HeraldrySnapshot {
+        +string name
+        +string seed
+        +string blazon
+        +HeraldryGeneratorOptionsSnapshot generatorOptions
+    }
+    class StoredDevice {
+        +string fieldName
+    }
+    class StoredVariation {
+        +string variationName
+        +string[] tinctureNames
+    }
+    class StoredChargeGroup {
+        +string chargeName
+        +string chargeTinctureName
+        +number numberOfCharges
+        +string arrangementName
+        +string position
+    }
+    class HeraldryEditing {
+        +setField(snapshot, fieldName)
+        +setVariationTincture(snapshot, slot, index, name)
+        +setChargeGroup(snapshot, index, changes)
+        +addChargeGroup(snapshot)
+        +removeChargeGroup(snapshot, index)
+    }
+
+    HeraldrySnapshot "1" o-- "1" StoredDevice
+    StoredDevice "1" o-- "*" StoredVariation
+    StoredDevice "1" o-- "*" StoredChargeGroup
+    HeraldryEditing --> HeraldrySnapshot : returns a new one
+    HeraldrySnapshot --> HeraldrySnapshot : blazon rederived after every edit
+```
+
+## Decisions taken here
+
+### 1. A DCC funnel saves one artifact per character
+
+A funnel is a way of rolling, not a thing in the world. One artifact per character keeps the
+survivor openable, renamable and referenceable; a bundle makes 3.5 unanswerable and the survivor
+unreachable. The cost is the pass's one save control that writes several artifacts at once.
+
+### 2. SWN stores the pick and the effect, not one or the other
+
+The effect, because 4.2 makes the payload authoritative. The pick, because an editor cannot offer a
+decision it cannot read back, and because levelling a character otherwise becomes a payload
+migration. This is the AD&D thief-skills finding in a different system.
+
+### 3. Uncharted Worlds derives skill descriptions on read
+
+The one thing in this domain deliberately not stored. It is a lookup with no RNG and no user input,
+so deriving it is safe, and a wording fix then reaches characters saved before it. The editor does
+not offer the field, because it is not the user's text.
+
+### 4. Heraldry's editor is bespoke, and the blazon is derived
+
+A charge group is a repeating structure with its own add and remove, and the arms are drawn beside
+the controls, so this is not a flat-form case. The blazon is recomputed from the device after every
+edit rather than stored as an editable string: a blazon that no longer describes the device is
+worse than none.
+
+### 5. Velgarth Gifts is named for its setting
+
+Neither generic nor system-qualified, because it is neither. The README carries the same courtesy
+8.4 asks for a system: what is represented, what is not, and that it is unofficial.
+
+## Still open
+
+- **#14 (Convention Special DCC generator) builds on #48.** It is not folded in here. What #48 owes
+  it is a settled `character.dcc` kind, which is what makes #14 small; if #14 lands first it will
+  need one anyway.
+- **Whether the SWN pick fields belong on `SWNCharacter` or only on the snapshot.** This document
+  puts them on the character, matching what AD&D did with `thiefSkills`, on the grounds that a
+  field only the stored form has is a field the generator cannot fill honestly. A reviewer who
+  disagrees changes one type and nothing else.

--- a/docs/readiness-factions.md
+++ b/docs/readiness-factions.md
@@ -1,0 +1,320 @@
+# Readiness: the factions domain
+
+Five tools: the arms manufacturer
+([#53](https://github.com/ironarachne/ironarachne/issues/53)), the fantasy encounter generator
+([#54](https://github.com/ironarachne/ironarachne/issues/54)), the fantasy family generator
+([#55](https://github.com/ironarachne/ironarachne/issues/55)), the fantasy organization generator
+([#56](https://github.com/ironarachne/ironarachne/issues/56)) and the star nation generator
+([#57](https://github.com/ironarachne/ironarachne/issues/57)).
+
+Part of [the readiness pass](tool-readiness.md). Measured against
+[Tool release readiness](workshop.md#tool-release-readiness).
+
+**Status:** proposal, with [the pass](tool-readiness.md#domain-model). Not reviewed.
+
+This domain holds the pass's easiest tool and its second-hardest. The arms manufacturer is three
+files and a flat payload; the organization generator is the richest generator on the site, with a
+kind registry of its own, hierarchies held as `Map`s, and four libraries' worth of generated
+imagery. They are in one document because they are one catalog domain, not because they are alike.
+
+## #53 — Arms manufacturer
+
+`ArmsManufacturer` is `{ name, description, models: Weapon[] }`
+(`src/lib/arms_manufacturer/arms_manufacturer.ts`) — three fields, no closures, no imagery, no
+cross-library dependency except `$lib/weapons`, which nothing else on the site imports.
+
+- **Kind `arms-manufacturer`**, payload the type as it stands. `Weapon` from `$lib/weapons` is
+  plain data; this is the one snapshot in the pass that is genuinely the identity function, and
+  saying so is more useful than inventing a conversion to look thorough.
+- **2.3 fails and is most of the work.** `ArmsManufacturerGenerator.svelte` renders no
+  `SeedControls` and calls `Date.now()` three times. It gets the seed control every other generator
+  has, and an `arms_manufacturer_roll.ts` behind it.
+- **The editor is a `SnapshotFieldEditor` case**: two text fields and a list of models.
+- **6.3** is a presentation document of the manufacturer and its catalogue, exported as Markdown
+  and PDF.
+
+The issue calls this a good tool to take through the whole spec early precisely because nothing
+about it is hard, and [wave 1](tool-readiness.md#the-order-of-the-work) agrees.
+
+**One thing to settle while here.** `$lib/weapons` is imported by `$lib/arms_manufacturer` and by
+nothing else in the application — its science-fiction weapon path belongs to this tool. #69 assumes
+that library backs the _fantasy_ weapon generator and it does not; see
+[Objects](readiness-objects.md#66-and-69--one-kind-item) and
+[the pass's corrections](tool-readiness.md#corrections-to-the-issues).
+
+## #54 — Fantasy encounter
+
+An `Encounter` is `{ name, description, difficulty, groups: MobGroup[] }`
+(`src/lib/encounters/encounter_types.ts`), and a `MobGroup` holds `Mob`s — which for this generator
+are `Creature`s and `Character`s, each embedding a whole `Species`.
+
+- **Kind `encounter`.** The payload composes `StoredCreature` and `StoredCharacter` from
+  [the stored vocabulary](tool-readiness.md#the-stored-vocabulary); `StoredCreature` is new and
+  this is the tool that needs it first.
+- **`EncounterGroupTemplate` never reaches the payload.** It carries `Mutator<Character>[]`,
+  `Mutator<Creature>[]` and `Mutator<Species>[]` — arrays of functions — plus tag filters. They are
+  generator input, not content: what the mutators produced is in the creatures. The template's
+  name is recorded as provenance so a re-roll can find it again.
+- **Composition:** an `environment` reference for where the encounter happens (5.1), which is why
+  #60 lands first. The encounter generates its own if given nothing (5.3).
+- **6.3 is the point of this tool.** An encounter is a thing a GM prints and puts on the table, and
+  it has no export today. The presentation document is per group: creatures with their numbers, the
+  difficulty line, and the environment when one was supplied.
+- **6.4 has teeth here.** An encounter with no treasure and no complication must not print their
+  headings. The document model drops empty sections, as settlement's does.
+
+The editor is bespoke but small: a group is a repeating structure (name, count, creatures), so it
+is a list editor rather than a flat form.
+
+## #55 — Fantasy family
+
+The payload is a graph, and the graph is the risk the issue names: a family contains cycles by
+construction, because two people are each other's siblings and a spouse edge points both ways.
+
+- **Kind `family`.** `Family` is `{ id, name, headId?, members: Character[], memberIds: string[],
+relationships: Relationship[], femaleNameGenerator, maleNameGenerator }`. Two of those fields are
+  `NameGenerator`s carrying closures, and the members are characters.
+- **The snapshot is `StoredCharacter[]` plus a stored pattern set.** The name generators become a
+  `StoredNameGeneratorPatternSet`, exactly as a culture's do, and are rebuilt on read from the RNG
+  the codec is handed. The relationships are plain records of ids and need no conversion.
+- **Cycles are not a problem for the snapshot, and are for anything that walks it.** The members
+  are a flat array and the relationships reference ids, so `structuredClone` never recurses — the
+  graph is only a graph once `graph.ts` builds it. 3.2's round-trip test uses a real
+  multi-generation family, as the issue asks, and 5.4 belongs to the reference walker.
+
+**6.3 is already built and unused.** `getFamilyTreeSVG(family)` in `src/lib/families/graph.ts:365`
+renders a family tree as SVG with `xmlbuilder2`, and `FamilyGenerator.svelte` does not call it. So
+the issue's question — "a family diagram is not free; say whether it is in scope" — is answered by
+the code: the diagram exists, and 6.3 here is a download control over a function that already
+works, plus the Markdown roster beside it. That is the cheapest 6.3 in the pass.
+
+**Composition:** a `culture` reference for naming, and `heraldry` for a family's arms.
+
+## #56 — Fantasy organization
+
+The richest generator on the site, and the one whose payload is most nearly written already.
+
+`Organization` (`src/lib/organizations/organization_types.ts:75`) is `{ id, name, description,
+memberCount, profile, visualIdentity, hierarchy, leader, notableMembers, relationships, genre,
+kindId }`. Three of those need conversion, and **`settlement_snapshot.ts` already converts all
+three** — `StoredOrganization`, `StoredOrganizationHierarchy`, `StoredVisualIdentity` and
+`StoredVisualEmblem` exist today, because a settlement holds organizations.
+
+So this tool's payload work is mostly [wave 0](tool-readiness.md#the-order-of-the-work): move those
+types to `$lib/organizations` and `$lib/visual_identity`, which is where they belong, and the
+organization kind composes what the settlement kind has been using all along.
+
+What remains is genuinely this tool's:
+
+- **The hierarchy is three `Map`s** (`childToParent`, `idToOrder`, `roleById`). `JSON.stringify`
+  turns a `Map` into `{}` without complaining, which is how a naively stored settlement came back
+  with every organization's structure silently emptied. They travel as entry arrays.
+- **`kindId` is already the right shape.** `OrganizationKind` carries `buildVisualExtras`,
+  `generateName` and `prepareCharacterConfigForRole` — three closures — and the organization
+  records only `kindId`, resolving the kind on read. Nothing to design; it is already done, and it
+  is why this payload is less work than its size suggests.
+- **Imagery round-trips as parameters, never as a rendered SVG.** The issue is right and the reason
+  is worth keeping: a stored SVG is a fossil — it cannot be re-themed, cannot be re-rendered at
+  another size, and pins the payload to the renderer that made it. `StoredVisualEmblem` stores the
+  emblem's parameters and, when it is heraldic, `StoredArms`.
+- **The two registries must not be conflated.** `$lib/organizations`'s kind registry predates the
+  artifact kind registry and means something else entirely. In code they stay `kindId` and
+  `ArtifactKind`; in the README the distinction gets a sentence, because the next reader will
+  otherwise assume one is the other.
+
+**The editor is bespoke.** A hierarchy is a tree of roles with people in them, and the flat-form
+editor would be a worse view of it than the generic snapshot view. What it must reach: the name and
+description, the profile's traits, goal, weakness and standing, each role's holder, and the visual
+identity's parameters — with a redraw, not a re-roll, after each change.
+
+**Composition:** `heraldry` for the arms, `character` for the leader and notable members, `culture`
+for naming.
+
+## #57 — Star nation
+
+`Civilization` is `{ name, description, population, technology_level, government_type,
+economy_type, military }` (`src/lib/civilizations/civilizations.ts`), and the generator assembles a
+nation from a civilization, two `RegionOfControl`s — the home system and the home planet — and a
+generated star system. All of it is plain data.
+
+- **Kind `star-nation`**, payload the civilization, its regions of control, and the home system's
+  identity. The star system itself is a **reference** to a `star-system` artifact when the user
+  supplied one, and embedded otherwise: the same shape culture uses for religion.
+- **Renderer output is not stored.** The component calls `renderStarSystemPreviewImage`; what is
+  stored is what the renderer takes — the system's bodies and their parameters — never the image.
+- **The editor is a `SnapshotFieldEditor` case.** Every field is a string, a number or a select
+  over a named table, which is exactly the four controls decision 5 allows.
+- **2.2**: two `Date.now()` calls, and the component already carries a comment about one of them
+  generating from a clock rather than from the seed. The roll module ends that.
+
+**#11 is the open question and this document does not close it.** #11 proposes reframing the
+civilization generator as setting flavour over RPG stats — which would remove or reshape
+`military.quality`, `training_level` and their neighbours. A payload built around stats that are
+about to be removed is a migration nobody needed. So: **#57 does not start until #11 is decided.**
+It is the one tool in the pass with a hard external dependency, and pretending otherwise is how a
+payload version 2 gets written three weeks after version 1.
+
+## Domain model
+
+### The two flat payloads
+
+```mermaid
+classDiagram
+    class ArmsManufacturerSnapshot {
+        +string name
+        +string description
+        +Weapon[] models
+    }
+    class StarNationSnapshot {
+        +string name
+        +string description
+        +number population
+        +number technologyLevel
+        +GovernmentType governmentType
+        +EconomyType economyType
+        +Military military
+        +RegionOfControl[] regionsOfControl
+    }
+    class ArtifactReference {
+        +string artifactId
+        +string role
+    }
+    StarNationSnapshot "1" ..> "0..1" ArtifactReference : home system, when referenced
+```
+
+### Encounter and family
+
+```mermaid
+classDiagram
+    class EncounterSnapshot {
+        +string name
+        +string description
+        +number difficulty
+    }
+    class StoredMobGroup {
+        +string name
+    }
+    class StoredCreature {
+        +string speciesName
+        +string name
+    }
+    class StoredCharacter {
+        +string speciesName
+    }
+    class FamilySnapshot {
+        +string id
+        +string name
+        +string headId
+        +string[] memberIds
+    }
+    class Relationship {
+        +string sourceId
+        +string targetId
+        +string type
+    }
+    class StoredNameGeneratorPatternSet {
+        +string name
+    }
+
+    EncounterSnapshot "1" o-- "*" StoredMobGroup
+    StoredMobGroup "1" o-- "*" StoredCreature
+    StoredMobGroup "1" o-- "*" StoredCharacter
+    FamilySnapshot "1" o-- "*" StoredCharacter : members
+    FamilySnapshot "1" o-- "*" Relationship
+    FamilySnapshot "1" o-- "2" StoredNameGeneratorPatternSet : female, male
+```
+
+### Organization
+
+```mermaid
+classDiagram
+    class OrganizationSnapshot {
+        +string id
+        +string name
+        +string description
+        +number memberCount
+        +string kindId
+        +OrganizationGenre genre
+    }
+    class OrganizationProfile {
+        +string[] traits
+        +string goal
+        +string weakness
+        +string standing
+    }
+    class StoredOrganizationHierarchy {
+        +array childToParent
+        +array idToOrder
+        +array roleById
+    }
+    class StoredVisualIdentity {
+        +StoredVisualEmblem emblem
+    }
+    class StoredArms {
+        +StoredDevice device
+        +string blazon
+    }
+    class StoredCharacter
+    class OrganizationKind {
+        +string id
+        +function generateName
+        +function buildVisualExtras
+        +function prepareCharacterConfigForRole
+    }
+
+    OrganizationSnapshot "1" o-- "1" OrganizationProfile
+    OrganizationSnapshot "1" o-- "1" StoredOrganizationHierarchy
+    OrganizationSnapshot "1" o-- "1" StoredVisualIdentity
+    OrganizationSnapshot "1" o-- "1" StoredCharacter : leader
+    OrganizationSnapshot "1" o-- "*" StoredCharacter : notable members
+    StoredVisualIdentity "1" o-- "0..1" StoredArms
+    OrganizationSnapshot ..> OrganizationKind : by kindId, resolved on read
+```
+
+## Decisions taken here
+
+### 1. `StoredCreature` is declared in `$lib/creatures`, and the encounter is its first consumer
+
+A `Creature` embeds a whole `Species` exactly as a `Character` does, and both the encounter and the
+dungeon payloads need it. Declaring it here rather than inside the encounter payload keeps the
+dungeon from writing a second one.
+
+### 2. Encounter group templates are generator input and never reach the payload
+
+They carry three arrays of mutator functions. What the mutators produced is in the creatures, which
+is the content; the template's name goes to provenance so a re-roll can find it.
+
+### 3. The family diagram is in scope, because it already exists
+
+`getFamilyTreeSVG` works and nothing calls it. 6.3 for this tool is a download control, not a
+render pipeline, and the issue's hesitation was written without that fact.
+
+### 4. The organization's stored shape is the settlement's, moved
+
+`StoredOrganization` and its parts already exist in `$lib/settlements` and already ship. Moving
+them to the library that owns the concept is [wave 0](tool-readiness.md#the-order-of-the-work) and
+costs one settlement payload migration shared with the character move; writing a second stored
+organization beside the first would cost a silent divergence the first time a field is added.
+
+### 5. Generated imagery is stored as parameters
+
+For every tool in this domain and the next: parameters, never a rendered SVG or PNG. A stored image
+cannot be re-themed, re-rendered at another size, or read by anything but the renderer that made
+it, and this site re-themes by genre.
+
+### 6. #57 waits on #11
+
+The star nation payload is mostly the civilization's stats, and #11 proposes replacing those stats
+with setting flavour. Building the payload first means migrating it immediately. This is a
+sequencing decision rather than a design one, and it is the only hard external dependency in the
+pass.
+
+## Still open
+
+- **Whether an encounter should reference the creatures' species as artifacts.** There is no
+  species kind and this pass does not add one; creatures carry `speciesName` and rebuild. If a
+  species kind ever exists — #19 and #25 circle it — the encounter is where it would first pay off.
+- **How much of an organization's hierarchy an editor should let a user restructure.** This
+  document says roles and holders are editable and the tree's shape is not, on the grounds that a
+  hierarchy with a cycle in it is a bug the generator cannot produce and an editor should not
+  invent. A reviewer may want the stronger version.

--- a/docs/readiness-locations.md
+++ b/docs/readiness-locations.md
@@ -1,0 +1,273 @@
+# Readiness: the locations domain
+
+Six tools: the cyberpunk chop shop
+([#58](https://github.com/ironarachne/ironarachne/issues/58)), the dungeon generator
+([#59](https://github.com/ironarachne/ironarachne/issues/59)), the environment generator
+([#60](https://github.com/ironarachne/ironarachne/issues/60)), the planet generator
+([#61](https://github.com/ironarachne/ironarachne/issues/61)), the region generator
+([#62](https://github.com/ironarachne/ironarachne/issues/62)) and the star system generator
+([#63](https://github.com/ironarachne/ironarachne/issues/63)).
+
+Part of [the readiness pass](tool-readiness.md). Measured against
+[Tool release readiness](workshop.md#tool-release-readiness).
+
+**Status:** proposal, with [the pass](tool-readiness.md#domain-model). Not reviewed.
+
+The pass's two heaviest tools are here — the dungeon and the region — and so is one of its
+cheapest. The environment generator goes first regardless of size, because two other tools
+reference it.
+
+## #60 — Environment
+
+`Environment` is `{ biome, climate, terrain, waterSystem, dominantEcosystem, ecosystems,
+description }` (`src/lib/environment/environment.ts`), and every part of it is a plain record of
+strings, numbers and number arrays. No closures, no `Map`s, no imagery.
+
+- **Kind `environment`**, payload the type as it stands.
+- **The editor is a `SnapshotFieldEditor` case** — selects over the biome, climate and water
+  vocabularies, numbers for the terrain's elevation and relief, a textarea for the description.
+- **Genre-neutral**, one of only four tools carrying no genre tag, so it is visible in every
+  project. That is why it is first in [wave 1](tool-readiness.md#the-order-of-the-work): the
+  encounter and dungeon generators both reference it, and a genre-neutral kind is one every project
+  can use.
+
+## #58 — Cyberpunk chop shop
+
+`src/lib/chopshop/index.ts` is a single file whose `generate(rng)` returns **a string** — a
+paragraph assembled from five phrase tables. There is no type to snapshot, and that is the design
+problem rather than an oversight.
+
+- **Kind `chop-shop`**, payload `{ text: string }`, per
+  [decision 4 of the pass](tool-readiness.md#4-prose-generators-get-a-kind-and-it-holds-the-prose).
+  The thing a user wants to keep is the paragraph.
+- **The editor is a textarea**, which is the honest editing view for prose and satisfies 4.1
+  completely: every field displayed is the field.
+- **8.3 needs the library split.** Types and generation live in one `index.ts`; CODE_STYLE.md wants
+  them apart, so this grows `chop_shop_types.ts` and a generation module beside it. It is the only
+  real code change in the tool.
+- **2.3 fails**: no `SeedControls`, two `Date.now()` calls. It gets both halves of the standard fix.
+
+**One of two cyberpunk tools** on the site, with `/drug`. A cyberpunk project sees a very short tool
+list, which is a fact about the catalog rather than a bug in this tool.
+
+## #61 — Planet and #63 — Star system
+
+One library backs both — `$lib/astronomical_bodies` — and their payloads are the same plain shape,
+so they are designed together and shipped separately.
+
+`AstronomicalBody` is fifteen numbers and three strings: albedo, gravity, luminosity, mass, orbital
+distance and period, radius, rotation period, surface pressure and temperature, and a
+classification. `StarSystem` is `{ name, description, star_count, planet_count, stars: [],
+planets: [] }`. Nothing in either carries a function.
+
+- **Kinds `planet` and `star-system`.** A star system references its planets when the user built it
+  from saved ones and embeds them otherwise — the shape culture uses for religion, and the reason
+  #61 lands before #63.
+- **Both editors are `SnapshotFieldEditor` cases.** A planet is a form of numbers; a star system is
+  a list of planets plus a name and a description.
+- **Renderer output is never stored.** Both components render through `$lib/renderers`; what the
+  payload keeps is what the renderer takes.
+- **2.5 binds.** The previews are WebGL, and a machine that cannot run WebGL must still get the
+  numbers and the prose. `webgl_scene_draw.ts` is the single non-test entry in `coverage.exclude`,
+  covered by `e2e/preview_pixels.spec.ts` in a real browser — that exclusion is not extended by any
+  work in this pass.
+
+**#16 and #17 are 6.3 work on exactly these two tools** — an orbital view image, and SVG output for
+the stellar generators. This document does not fold them in, and recommends they land _with_ these
+issues rather than beside them: the presentation document is being written either way, and an SVG
+export is a renderer this domain has been asked for twice.
+
+**#61 is featured on the home page**, and one of only two featured tools that is not already
+Release-ready. A regression here is visible on the first screen a visitor sees.
+
+## #62 — Region
+
+The most composed payload on the site. `Region` is `{ name, environment, description,
+dominantCulture, settlements, mainRealm, realms, authority, organizations, map }`
+(`src/lib/regions/region.ts`) — a culture with its name generators, an array of settlements, an
+array of organizations with their hierarchies and emblems, a character, and a map.
+
+Every one of those already has a stored form by the time this tool starts, which is the whole point
+of the ordering:
+
+| Field             | Stored as                                                   |
+| ----------------- | ----------------------------------------------------------- |
+| `dominantCulture` | a `culture` reference, or `CultureSnapshot` embedded        |
+| `settlements`     | `settlement` references, or `SettlementSnapshot[]` embedded |
+| `organizations`   | `StoredOrganization[]`, from `$lib/organizations`           |
+| `authority`       | `StoredCharacter`, from `$lib/characters`                   |
+| `environment`     | `Environment`, plain                                        |
+| `map`             | `RegionMap`, plain — nodes, edges, corners                  |
+
+- **Kind `region`.** It lands last in the pass with the dungeon, because it is the sum of
+  everything above.
+- **`RegionMap` is stored, and a rendered map is not.** The map is a plain graph
+  (`src/lib/map/map_graph.ts:71`), so it survives `structuredClone` as it stands. What must never be
+  stored is the SVG `region_map_svg.ts` produces: a rendered map cannot be re-themed or re-rendered
+  at another size, and the tile arrays the issue worries about are smaller than the picture of them.
+- **Composition is the tool's whole character.** `RegionGenerator.svelte` already carries a
+  `SavedArtifactPicker` — the only generator in the pass that does — and #20 took settlements to
+  Release-ready partly so that regions built from saved settlements would become possible. This is
+  that issue arriving.
+- **The editor is bespoke**: a region is a list of places with a map beside it, and the fields a
+  user changes are its name, description, which settlement is the seat, and the realms.
+- **6.3 is the map.** A region is a map and a map is the export — SVG through
+  `region_map_svg.ts`, which exists, plus the Markdown gazetteer of settlements and realms.
+
+## #59 — Dungeon
+
+The largest tool in the pass. `EngineeredDungeon` is `{ name, theme, layout, rooms, doors, keys,
+entrances }` (`src/lib/dungeon/generator/types.ts:22`), where a `PopulatedRoom` carries an optional
+`Encounter` and optional treasure `Item[]`, and the library has generator, grid, layout,
+interactive, render, room and theme subdirectories drawing through Three.js and GLSL.
+
+- **Kind `dungeon`.** The payload is the blueprint: grid, layout, rooms, doors, keys, entrances,
+  theme. It composes `encounter`'s stored shape for room encounters, which is why #54 lands first.
+- **The scene is not the payload.** Three.js meshes, shaders and the WebGL renderer are how a
+  dungeon is _drawn_; none of it is stored, and `stripFunctionValuesDeep` is not the answer either
+  — the blueprint never held them in the first place.
+- **2.5 binds hardest here.** A machine without WebGL must still get a dungeon it can read: the
+  room list, the doors and keys, the encounters, the map as a classic module-style plan
+  (`render/classic_module_map.ts` already exists). The 3D view is the enhancement, not the tool.
+- **Payload size is a real constraint.** A large dungeon is not a small object, and the vault
+  reports its quota for a reason. The rule is the pass's: store what a user could have edited — the
+  rooms, their contents, the doors — and regenerate nothing that a seed cannot honestly reproduce.
+- **The editor is bespoke and room-shaped**: rename the dungeon, retheme it, and edit a room's
+  name, purpose, description, encounter and treasure without disturbing its neighbours (4.4).
+- **`verify:all` more than once.** This tool touches rendering, and no Playwright suite runs against
+  a pull request.
+
+## Domain model
+
+### The plain payloads
+
+```mermaid
+classDiagram
+    class EnvironmentSnapshot {
+        +Biome biome
+        +Climate climate
+        +Terrain terrain
+        +WaterSystem waterSystem
+        +Ecosystem[] ecosystems
+        +string description
+    }
+    class AstronomicalBody {
+        +string name
+        +string classification
+        +number mass
+        +number radius
+        +number gravity
+        +number orbitalDistance
+        +number surfaceTemperature
+    }
+    class StarSystemSnapshot {
+        +string name
+        +string description
+        +number starCount
+        +number planetCount
+    }
+    class ChopShopSnapshot {
+        +string text
+    }
+    class ArtifactReference {
+        +string artifactId
+        +string role
+    }
+
+    StarSystemSnapshot "1" o-- "*" AstronomicalBody : stars
+    StarSystemSnapshot "1" o-- "*" AstronomicalBody : planets, when embedded
+    StarSystemSnapshot "1" ..> "*" ArtifactReference : planets, when referenced
+```
+
+### Region and dungeon
+
+```mermaid
+classDiagram
+    class RegionSnapshot {
+        +string name
+        +string description
+        +number mainRealm
+        +Realm[] realms
+    }
+    class RegionMap {
+        +number width
+        +number height
+        +MapNode[] nodes
+        +MapEdge[] edges
+        +MapCorner[] corners
+    }
+    class SettlementSnapshot
+    class CultureSnapshot
+    class StoredOrganization
+    class StoredCharacter
+    class EnvironmentSnapshot
+
+    class DungeonSnapshot {
+        +string name
+        +DungeonTheme theme
+        +DungeonLayout layout
+        +Door[] doors
+        +Key[] keys
+        +DungeonEntrance[] entrances
+    }
+    class PopulatedRoomSnapshot {
+        +string id
+        +string name
+        +string purpose
+        +string description
+    }
+    class EncounterSnapshot
+    class Item
+
+    RegionSnapshot "1" o-- "1" RegionMap
+    RegionSnapshot "1" o-- "1" EnvironmentSnapshot
+    RegionSnapshot "1" o-- "0..1" CultureSnapshot : embedded, or referenced
+    RegionSnapshot "1" o-- "*" SettlementSnapshot : embedded, or referenced
+    RegionSnapshot "1" o-- "*" StoredOrganization
+    RegionSnapshot "1" o-- "1" StoredCharacter : authority
+    DungeonSnapshot "1" o-- "*" PopulatedRoomSnapshot
+    PopulatedRoomSnapshot "1" o-- "0..1" EncounterSnapshot
+    PopulatedRoomSnapshot "1" o-- "*" Item : treasure
+```
+
+## Decisions taken here
+
+### 1. The environment kind goes first in the pass, despite being small
+
+Two other tools reference it, it is genre-neutral so every project sees it, and its payload is
+plain data with no conversion at all. It is the cheapest thing that unblocks something else.
+
+### 2. A star system references its planets, or embeds them
+
+The same shape culture uses for a religion: referenced when the user built it from saved planets,
+embedded when the generator made its own. That keeps 5.2 (record by id, do not copy) true without
+making a system built from nothing unreadable.
+
+### 3. The map is stored as a graph and never as a picture
+
+`RegionMap` is plain and survives storage as it stands. The SVG is a rendering, and a rendering is
+a fossil — it cannot be re-themed by genre, re-rendered larger, or read by anything but the
+renderer that produced it. The same rule governs the dungeon's 3D scene.
+
+### 4. The dungeon's payload is the blueprint, and WebGL is an enhancement
+
+2.5 is not a footnote for this tool: the readable dungeon — rooms, doors, keys, encounters, a plan
+view — is what the payload holds and what a machine with no WebGL still gets. The scene is drawn
+from the blueprint every time it is shown.
+
+### 5. #16 and #17 land with #61 and #63 rather than beside them
+
+Both are 6.3 work on the two stellar tools, whose presentation documents are being written by this
+pass anyway. Landing them together costs one design conversation instead of two and one round of
+`verify:all` instead of two.
+
+## Still open
+
+- **How large a dungeon actually is once stored.** The design says store the blueprint; whether a
+  large one is measured in tens or hundreds of kilobytes is a measurement #59 should take before it
+  writes the kind, in the same way #74 is asked to measure a lexicon. Nothing about the shape
+  changes if it is large — it changes what the tool tells the user about quota.
+- **Whether a region should be able to reference a dungeon.** The reference table in the pass says
+  no, on the grounds that a dungeon sits inside a settlement or a wilderness hex rather than in the
+  region's own structure. If the answer is yes, it is one more picker and one more role, and it
+  belongs to whichever of the two lands second.

--- a/docs/readiness-objects.md
+++ b/docs/readiness-objects.md
@@ -1,0 +1,314 @@
+# Readiness: the objects domain
+
+Nine tools: the cyberpunk drug generator
+([#64](https://github.com/ironarachne/ironarachne/issues/64)), the fantasy equipment price lists
+([#65](https://github.com/ironarachne/ironarachne/issues/65)), the fantasy equipment generator
+([#66](https://github.com/ironarachne/ironarachne/issues/66)), the fantasy merchant generator
+([#67](https://github.com/ironarachne/ironarachne/issues/67)), the fantasy potion generator
+([#68](https://github.com/ironarachne/ironarachne/issues/68)), the fantasy weapon generator
+([#69](https://github.com/ironarachne/ironarachne/issues/69)), the fantasy treasure hoard
+generator ([#70](https://github.com/ironarachne/ironarachne/issues/70)), the spooky starship
+generator ([#71](https://github.com/ironarachne/ironarachne/issues/71)) and the Stars Without
+Number starship generator ([#72](https://github.com/ironarachne/ironarachne/issues/72)).
+
+Part of [the readiness pass](tool-readiness.md). Measured against
+[Tool release readiness](workshop.md#tool-release-readiness).
+
+**Status:** proposal, with [the pass](tool-readiness.md#domain-model). Not reviewed.
+
+The largest domain in the pass by count and the smallest by difficulty. Seven of the nine are flat
+payloads that the declared field editor serves; one is a reference tool with no kind at all; and
+the interesting question here is not any single tool but how many kinds these nine should produce.
+The answer is seven.
+
+## #66 and #69 — one kind, `item`
+
+Both produce an `Item` from `$lib/equipment`. The weapon generator is the equipment generator with
+the major type fixed to a weapon and `domains` from `$lib/religion` steering the enchantment;
+`WeaponGenerator.svelte` imports `$lib/equipment` and nothing else that makes an object.
+
+Two kinds for one payload shape would split a user's gear across two vault entries, each openable
+by only one of the two tools that made it. That is the argument the AD&D builder and generator
+settled — [one kind, two tools](adnd-character.md#one-kind-named-characteradnd-2e) — and it holds
+here for the same reason.
+
+- **Kind `item`**, payload `Item` as it stands. `Item` is plain: strings, numbers, a value, a
+  rarity, and optional `material`, `refinement`, `enchantment`, `decoration` and `combatProfile`,
+  all of them plain records.
+- **The composition is stored, not just the prose.** #66 asks for this explicitly and it is right:
+  an item's enchantment and refinement are composed at generation time, and storing only the
+  rendered description would leave an editor able to rewrite prose and nothing else. The payload
+  keeps `material`, `refinement`, `enchantment` and `decoration` as the records they are.
+- **3.5 carries unusual weight.** Users accumulate many small artifacts of this kind, and an
+  unnamed item in a list of forty is unusable. The kind's `nameOf` returns `uniqueName ?? name`, and
+  the save dialog prefills it.
+- **Provenance tells the two tools apart.** `toolPath` is `/fantasy/equipment-generator` or
+  `/fantasy/weapon`, which is what the roller reads to know which config shape it is holding.
+
+**#69's genre question answers itself.** The issue asks whether the tool should carry a sci-fi tag
+because `src/lib/weapons` has a `scifi.ts`. `WeaponGenerator.svelte` does not import
+`$lib/weapons` at all — the only importer anywhere is `$lib/arms_manufacturer`, which is #53 and is
+already tagged `scifi`. Nothing science-fictional is reachable from `/fantasy/weapon`; the tag is
+right; the sci-fi weapon code is not dead, it belongs to another tool. See
+[the pass's corrections](tool-readiness.md#corrections-to-the-issues).
+
+## #68 — Fantasy potion
+
+A well-factored library already: catalog, descriptor, naming, sensory detail, value and a generator
+config, each with tests.
+
+- **Kind `potion`**, not folded into `item`. A `Potion` is `{ container, liquid, displayName,
+canonicalName?, sensory, effect, modifications }` — a richer shape with its own catalog identity,
+  and an editor for it reaches effects and sensory detail that an item editor has no field for.
+  Sharing `item`'s kind would mean one editor that is wrong for half its payloads.
+- **The editor is a `SnapshotFieldEditor` case** with a list control for modifications.
+- **1.4 is already satisfied.** The issue says the label reads "Fantasy Potion Generator"; the
+  catalog reads `Fantasy Potion`. Nothing is owed.
+
+## #70 — Fantasy treasure hoard
+
+`generateRandomTreasureHoard(seed, config)` returns `Item[]` — coins packed into piles, gems, art
+objects, mundane and magic items, and potions flattened into items.
+
+- **Kind `treasure-hoard`**, payload `{ items: Item[], targetValue: number }`. It is a list rather
+  than a bag of references: a hoard is one thing a GM reads out, and forty artifacts for one hoard
+  would be a vault nobody can browse.
+- **Composition, if it happens, is by reference.** A hoard built to contain a _saved_ potion or a
+  saved item records the reference beside the payload. 5.4 then belongs to the reference walker, as
+  the issue notes.
+- **6.4 has teeth**: a hoard with no art objects must not print the heading. The presentation
+  document drops empty sections by construction.
+- **The generator is already seeded properly** — it takes a `seed` string and builds its own RNG.
+  The clock is in the component, and the roll module is where it stops.
+
+## #67 — Fantasy merchant
+
+`Merchant` is `{ seed, proprietor, shop, mark, honesty, priceLevel, priceModifier, honestyNotes,
+hagglingAdvice, stock }` (`src/lib/merchants/merchant_types.ts`) — and it already carries its own
+seed, which is a good sign and a small trap: the payload's `seed` and the artifact's provenance
+seed must be the same value, and the snapshot keeps the field rather than growing a second one.
+
+- **Kind `merchant`.** `MerchantMark` is `{ chargeName, fillHex }` — a mark stored by the _name_ of
+  its charge, which is exactly the treatment
+  [decision 5 of the factions document](readiness-factions.md#5-generated-imagery-is-stored-as-parameters)
+  asks for, already done.
+- **Stock is stored as items, not regenerated.** #67 worries about duplicated item records making a
+  merchant the largest object in the vault. `MerchantStockItem` is `{ name, baseCost, price,
+quantity, note? }` — five fields, not a full `Item` — so a fifty-line inventory is a few
+  kilobytes. Storing it is right: a GM who crosses two items off the list has edited the shop.
+- **Composition:** a `culture` reference for naming (the config already carries a
+  `CharacterNameSource`), and a `settlement` reference for where the shop stands.
+- **6.3 matters here.** A shop inventory is a thing a GM wants on paper; the presentation document
+  is the proprietor, the shop, the haggling advice and the stock table.
+
+## #64 — Cyberpunk drug
+
+`Drug` is `{ name, description, drugType, method, effectType, effectDescription, strength, color,
+duration, sideEffect, commonality }` — ten strings and two small records.
+
+- **Kind `drug`.** `DrugType` is `{ name, methods }` and travels whole. `EffectType` carries a
+  `generate` closure in the effect tables (`src/lib/drug/drugs.ts`), so the payload stores the
+  effect's **name and its generated description**, never the type object.
+- **The editor is the simplest `SnapshotFieldEditor` case in the pass** — ten text fields.
+- **2.2**: two `Date.now()` calls, and a seed control that exists. The roll module is the only
+  change.
+
+The issue calls this a good tool to run the whole spec against early, to find the awkward corners
+of the process rather than of the tool. [Wave 1](tool-readiness.md#the-order-of-the-work) agrees,
+and pairs it with the arms manufacturer for exactly that purpose.
+
+## #71 — Spooky starship
+
+Like the chop shop, `src/lib/spooky_ship/index.ts` is a single file whose `generate(rng)` returns
+**a string** — an intro, an origin and a twist, assembled from phrase tables.
+
+- **Kind `spooky-ship`**, payload `{ text: string }`, per
+  [decision 4 of the pass](tool-readiness.md#4-prose-generators-get-a-kind-and-it-holds-the-prose).
+- **The editor is a textarea**, which is 4.1 satisfied completely.
+- **8.3 needs the library split** into types and generation, as the chop shop does.
+- **The only horror tool on the site**, and the only tool carrying two genres. A horror project sees
+  this tool and the four genre-neutral ones and nothing else — a fact about the catalog, worth
+  knowing when the project-genre work lands.
+
+## #72 — Stars Without Number starship
+
+`SWNStarship` is `{ name, className, manufacturer, hullType, currentCrew, totalCost, tonsOfCargo,
+usedMass, usedPower, usedHardPoints, ownerType, weapons, defenses, fittings, drive }`.
+
+- **Kind `starship.swn`**, system-qualified: a hull's mass, power and hardpoint budget means
+  something only under that ruleset.
+- **`OwnerType` carries closures** — `getRandomClassName` and `getRandomShipName`
+  (`src/lib/swn/starship.ts:565`, `starship_owner_type_data.ts:414`) — so the snapshot stores
+  `ownerTypeName` and resolves it on read, in the shape AD&D stores a class.
+- **Store the allocation, not only the totals.** #72 is right and it is the same finding as SWN's
+  character foci: `usedMass`, `usedPower` and `usedHardPoints` are derived from the fittings, and
+  the fittings are the user's decisions. The payload keeps both — the totals because 4.2 makes the
+  payload authoritative, the fittings because an editor cannot offer a decision it cannot read back.
+- **The editor is bespoke**: fittings are a repeating structure with a budget, and the budget lines
+  recompute as an explicit command rather than silently.
+- **8.4**: the README says which SWN edition the hulls and fittings come from, and what is
+  deliberately omitted.
+
+## #65 — Fantasy equipment price lists
+
+A **reference** tool. Sections 3, 4 and 5 do not apply, and neither do 2.2–2.4. What remains is
+sections 1, 2.1, 2.5, 6, 7.1 and 8 — and 6.1 is the whole job.
+
+`EquipmentPriceLists.svelte` renders price tables from `$lib/equipment` and `$lib/currency`. Wide
+tables at 320px are the classic horizontal-overflow failure, and `e2e/pages.mobile.spec.ts` fails
+on exactly that. The fix is the repository's own rule: **a table scrolls inside its own
+`overflow-x: auto` container; the page never scrolls sideways.** The site's table conventions were
+settled in [the visual design document](visual-design.md) and #154 already made tables rows rather
+than a grid of cells — this tool adopts that, it does not invent anything.
+
+6.2 is the other half: column headers associated with their columns, and every control keyboard
+reachable.
+
+## Domain model
+
+### Items, potions and hoards
+
+```mermaid
+classDiagram
+    class Item {
+        +string id
+        +string name
+        +string uniqueName
+        +string itemMajorType
+        +ItemValue value
+        +Rarity rarity
+        +number weight
+        +string[] properties
+    }
+    class Material {
+        +string name
+        +number weightMultiplier
+        +number valueMultiplier
+    }
+    class Enchantment {
+        +string name
+        +MagicIntent intent
+        +number magnitude
+    }
+    class Refinement {
+        +string name
+    }
+    class Decoration {
+        +string name
+    }
+    class PotionSnapshot {
+        +string displayName
+        +string canonicalName
+        +PotionSensoryProfile sensory
+        +PotionEffect effect
+        +PotionModification[] modifications
+    }
+    class Container
+    class TreasureHoardSnapshot {
+        +number targetValue
+    }
+
+    Item "1" o-- "0..1" Material
+    Item "1" o-- "0..1" Enchantment
+    Item "1" o-- "0..1" Refinement
+    Item "1" o-- "0..1" Decoration
+    PotionSnapshot "1" o-- "1" Container
+    TreasureHoardSnapshot "1" o-- "*" Item
+```
+
+### Merchants, ships and prose
+
+```mermaid
+classDiagram
+    class MerchantSnapshot {
+        +string seed
+        +MerchantProprietor proprietor
+        +MerchantShop shop
+        +string honestyNotes
+        +string hagglingAdvice
+        +number priceModifier
+    }
+    class MerchantStockItem {
+        +string name
+        +number baseCost
+        +number price
+        +number quantity
+    }
+    class MerchantMark {
+        +string chargeName
+        +string fillHex
+    }
+    class SwnStarshipSnapshot {
+        +string name
+        +string className
+        +string manufacturer
+        +string ownerTypeName
+        +number usedMass
+        +number usedPower
+        +number usedHardPoints
+    }
+    class Fitting {
+        +string name
+        +number mass
+        +number power
+    }
+    class HullType {
+        +string name
+    }
+    class ProseSnapshot {
+        +string text
+    }
+
+    MerchantSnapshot "1" o-- "*" MerchantStockItem
+    MerchantSnapshot "1" o-- "0..1" MerchantMark
+    SwnStarshipSnapshot "1" o-- "1" HullType
+    SwnStarshipSnapshot "1" o-- "*" Fitting : the allocation, beside the totals
+```
+
+`ProseSnapshot` is the shape both `chop-shop` and `spooky-ship` register — one field, and the
+editor is a textarea.
+
+## Decisions taken here
+
+### 1. The equipment generator and the weapon generator share the kind `item`
+
+One payload shape, one kind, and the provenance's tool path says which tool rolled it. Two kinds
+would split a user's gear across two vault entries and give each tool half the user's items.
+
+### 2. A potion is not an item
+
+It has its own catalog identity, its own effect and sensory structure, and an editor that reaches
+fields an item editor has no place for. Folding it into `item` would produce one editor that is
+wrong for half of what it opens.
+
+### 3. A hoard is one artifact, not forty
+
+A hoard is read out at a table as a unit. Forty artifacts per hoard is a vault nobody can browse,
+and the items in it are not things a user names individually.
+
+### 4. Merchant stock is stored, not regenerated
+
+`MerchantStockItem` is five fields, so an inventory is kilobytes rather than the megabyte the issue
+feared — the worry was about full `Item` records, which is not what stock holds. And a GM who
+crosses two items off has edited the shop, which 4.2 says the payload must remember.
+
+### 5. The SWN starship stores its allocation beside its totals
+
+The same finding as SWN's character foci and AD&D's thief skills: derived numbers stay because the
+payload is authoritative, and the decisions that produced them are recorded because an editor
+cannot offer what it cannot read back.
+
+### 6. The two prose generators get one shape and two kinds
+
+`{ text: string }` for both, registered separately so a vault listing keeps a chop shop apart from
+a haunted freighter. They are the pass's cheapest complete tools and go first for that reason.
+
+## Still open
+
+- **Whether `item` should carry the generator's config in provenance in enough detail to re-roll a
+  _similar_ item rather than the same one.** Re-roll means "the same seed and config again", which
+  for an item is the identical item — arguably useless. The alternative reading, "roll me another
+  like this", is a different feature and this document does not smuggle it in.
+- **Whether the price lists should offer a downloadable table (6.3).** It is a SHOULD for a
+  reference tool and the tables are already data; a CSV or Markdown download is a small addition
+  that #65 may take or leave.

--- a/docs/readiness-utilities.md
+++ b/docs/readiness-utilities.md
@@ -1,0 +1,230 @@
+# Readiness: the utilities domain
+
+Three tools: the language generator
+([#74](https://github.com/ironarachne/ironarachne/issues/74)), the species height and weight
+calculator ([#75](https://github.com/ironarachne/ironarachne/issues/75)) and the word generator
+cheat sheet ([#76](https://github.com/ironarachne/ironarachne/issues/76)).
+
+Part of [the readiness pass](tool-readiness.md). Measured against
+[Tool release readiness](workshop.md#tool-release-readiness).
+
+**Status:** proposal, with [the pass](tool-readiness.md#domain-model). Not reviewed.
+
+Two of these are reference tools with no artifact kind at all, which makes them the smallest jobs
+in the pass; they run in parallel with everything else rather than queueing behind it
+([decision 9](tool-readiness.md#9-the-three-reference-tools-do-not-queue-behind-the-generators)).
+The third is the largest single payload the site would store.
+
+## #74 — Language
+
+`src/lib/languages` is the largest library behind any single tool: phonology, morphology, a
+lexicon, typology, and two-way translation between English and the constructed language, across
+twenty-nine modules.
+
+The payload, happily, is not proportional to that. `ConstructedLanguage` is
+`{ name, phonemeSetName, wordOrder, syllableProfile, syllablePattern, morphology,
+orthographySummary, lexicon, articleSystem, possessionStrategy }`
+(`src/lib/languages/language_types.ts:59`) — **entirely plain data**. A `Lexicon` is
+`{ words: Word[] }`, a `Word` is plain, a `Morpheme` is a list of `Phoneme`s, and a `Phoneme` is
+four fields. There is no closure anywhere in it. The `Map`s and `Set`s the library uses live in the
+translation machinery, not in the language.
+
+- **Kind `language`**, payload the type as it stands. Genre-neutral, so every project sees it.
+- **The lexicon is stored whole.** #74 asks whether to store it or regenerate it from the seed, and
+  the answer is store: a user who renames one word has edited the language, and 4.2 says a seed may
+  not overrule that. Regeneration is a re-roll, and a re-roll is the destructive command.
+- **The measurement #74 asks for still happens**, and it belongs to that issue: a lexicon of a few
+  thousand words at four fields per phoneme is worth measuring against what the vault reports
+  before the kind ships, because it changes what the tool tells the user about quota — not what the
+  payload is.
+- **Determinism is worth proving explicitly here** (#74 says so and it is right). "Regenerate from
+  the seed" is only ever a storage strategy if it actually holds, and the way to know is a test
+  that generates the same language twice from one seed and compares the lexicon word for word. That
+  test is worth having even though this design stores the lexicon rather than relying on
+  regeneration — it is what makes the re-roll honest.
+- **2.3 fails.** `LanguageGenerator.svelte` renders no `SeedControls` and calls `Date.now()`. It
+  gets the seed control and a `language_roll.ts`, like every other generator in the pass.
+- **The editor is bespoke.** A lexicon is a long list of paired words, and the useful editing view
+  is a searchable table where one gloss can be rewritten without disturbing its neighbours (4.4).
+  This is explicitly not a `SnapshotFieldEditor` case: the typology fields would fit, the lexicon
+  never would.
+- **6.3 is a real loss today.** A conlang is a document — the phonology, the typology, and the
+  lexicon as a two-column glossary. Markdown and PDF, from one presentation document.
+
+## #75 — Species height and weight calculator
+
+A reference tool: sections 3, 4 and 5 do not apply, and neither do 2.2–2.4. The bar is sections 1,
+2.1, 2.5, 6, 7.1 and 8.
+
+**The issue's stated blocker does not apply to this tool, and that is worth settling before anyone
+spends a week on it.** #75 says #25 — 182 of 239 species carry placeholder human sizes — is "the
+blocker in spirit if not in process", on the reading that the calculator returns confident numbers
+from placeholder data.
+
+It does not read that data at all. `SpeciesStatsCalculator.svelte` takes four percentages — female
+and male height and weight, as a proportion of a modern human — plus a maximum age, and derives
+size and age tables from `Sizes.getHumanVariant` and `AgeCategories.getHumanVariant`. It never
+touches the species list. Its own description says so: _"To use it, just enter the percentage of
+human size you want to use... All numbers use modern human as a base."_
+
+So the tool is a calculator for **authoring** a species, and #25 is a fact about species data the
+calculator is used to _produce_. They are adjacent, not blocking. What #75 owes #25 is nothing;
+what #25 owes the site is a separate piece of work.
+
+What this tool actually owes:
+
+- **1.2 — drop the `fantasy` genre tag.** Height and weight as a proportion of a human baseline is
+  not fantasy-specific; a sci-fi setting inventing a heavy-worlder uses the identical arithmetic.
+  A mis-tagged tool disappears from the projects that need it once projects carry a genre, and
+  three of the four genre-neutral tools are already utilities.
+- **1.4 — one name, not two.** The catalog says **Species Height and Weight Calculator**; the page
+  renders `title="Species Stats Tool"`. A label that reads correctly out of context cannot be two
+  different labels, and the catalog's is the better one.
+- **6.1 and 6.2** — the numbers render as `Stat`/`StatBlock` pairs rather than a wide table, so the
+  usual overflow risk is low; the `NumberField` controls need labels and keyboard operation
+  confirmed rather than assumed.
+- **#19 (expand the calculator for specific settings)** is the other open issue here, and it is a
+  feature rather than a readiness gap. Read before scoping; not folded in.
+
+## #76 — Word generator cheat sheet
+
+The smallest job in the pass. A reference tool with no artifact kind, no seed, and no logic — and
+it is the tool that forces the one spec question in this domain.
+
+**Does a tool with no library satisfy 8.1 and 8.2?** `WordGeneratorCheatSheet.svelte` imports
+nothing from `$lib`; its content is a table of pattern elements built as an HTML string inside the
+component (`WordGeneratorCheatSheet.svelte:11`).
+
+[Decision 8 of the pass](tool-readiness.md#8-a-reference-tool-with-no-logic-still-gets-a-library)
+settles it: it gets a library. `src/lib/word_patterns` holds the element table as data — name,
+symbol, elements — and the component renders it as real markup rather than an interpolated string.
+Three reasons: the content is a table rather than prose, so it is data sitting in a component; the
+word generators elsewhere on the site document the same vocabulary, so it has a second reader; and
+a library gives 7.1 something to test where a component full of literals gives it nothing.
+
+Building the table as an HTML string is also what makes 6.2 hard to verify — headers exist in that
+string, but nothing checks them — and rendering from data fixes that as a side effect rather than
+as separate work.
+
+**6.1 is already handled and should not be re-done.** The component wraps the table in
+`.element-table-scroll` with `data-scroll-x`, and its style carries the reasoning: unbreakable
+terms set a minimum width, so the table scrolls on its own rather than the page scrolling sideways.
+That is exactly the repository rule. This is a case where the issue's expectation — "6.1 and 6.2
+are the real work" — is half met already.
+
+## Domain model
+
+```mermaid
+classDiagram
+    class LanguageSnapshot {
+        +string name
+        +string phonemeSetName
+        +WordOrder wordOrder
+        +string syllableProfile
+        +SyllableSegment[] syllablePattern
+        +string orthographySummary
+        +ArticleSystem articleSystem
+        +PossessionStrategy possessionStrategy
+    }
+    class Morphology {
+        +string strategy
+    }
+    class Lexicon {
+        +Word[] words
+    }
+    class Word {
+        +string meaning
+        +string form
+    }
+    class Morpheme {
+        +Phoneme[] phonemes
+    }
+    class Phoneme {
+        +string sound
+        +string[] transcriptions
+        +string[] classifiers
+        +number commonality
+    }
+    class LanguageDocument {
+        +string title
+    }
+    class LanguageSection {
+        +string heading
+        +string[] paragraphs
+        +string[] items
+    }
+
+    LanguageSnapshot "1" o-- "1" Morphology
+    LanguageSnapshot "1" o-- "1" Lexicon
+    Lexicon "1" o-- "*" Word
+    Word "1" o-- "*" Morpheme
+    Morpheme "1" o-- "*" Phoneme
+    LanguageSnapshot --> LanguageDocument : arranged for reading
+    LanguageDocument "1" o-- "*" LanguageSection
+```
+
+The two reference tools have no payload and therefore no diagram. That is not an omission: a
+reference tool produces no artifacts, and a model of nothing would be a decoration.
+
+```mermaid
+classDiagram
+    class WordPatternElement {
+        +string name
+        +string symbol
+        +string[] elements
+    }
+    class SpeciesSizeSummary {
+        +string ageCategoryName
+        +number minAge
+        +string heightRange
+        +string weightRange
+    }
+    class SizeMatrix
+    class AgeCategory
+
+    SizeMatrix --> SpeciesSizeSummary : convertMatrixToSummary
+    AgeCategory --> SpeciesSizeSummary : per category
+```
+
+Both are existing types rather than new ones — the only new declaration in this domain outside the
+language kind is `WordPatternElement`, and it is a move rather than an invention.
+
+## Decisions taken here
+
+### 1. The lexicon is stored, not regenerated from the seed
+
+A user who renames one word has edited the language, and 4.2 forbids a seed overruling that.
+Regeneration is what a re-roll does, deliberately and destructively. The size measurement #74 asks
+for still happens and changes what the user is told about quota, not what the payload holds.
+
+### 2. Determinism gets a test even though nothing depends on it for storage
+
+"Regenerate from the seed" is a claim, and the only way to know it holds is to generate twice and
+compare. It is what makes the re-roll trustworthy, and #74 was right to ask for it explicitly.
+
+### 3. #25 does not block #75
+
+The calculator never reads the species table; it computes from a human baseline and says so on the
+page. The placeholder-sizes problem is about data this tool is used to author, not data it consumes.
+Recording that here means the next reader does not re-inherit the assumption.
+
+### 4. The calculator loses its `fantasy` tag and gains one name
+
+The arithmetic is genre-neutral, and a mis-tagged tool vanishes from the projects that need it once
+projects filter by genre. The page title and the catalog label become the same string — the
+catalog's.
+
+### 5. The cheat sheet gets a library, and renders from data rather than an HTML string
+
+The pass's answer to the question #76 raises. The alternative — a spec sentence exempting
+logic-free reference tools — would be used by the next reference page too, and the exemption would
+become the pattern. Rendering from data also makes 6.2 checkable instead of assumed.
+
+## Still open
+
+- **How the language editor handles a lexicon of a few thousand words in a panel.** A searchable
+  table is the design; whether it needs virtualisation is a question for the implementation, and
+  the honest answer is that nobody has measured how long a generated lexicon actually is.
+- **Whether `word_patterns` should be consumed by the word generators as well as documented by the
+  cheat sheet.** It would make the sheet provably current rather than a hand-maintained copy. It is
+  also scope beyond #76, so this document names it and leaves it.

--- a/docs/tool-readiness.md
+++ b/docs/tool-readiness.md
@@ -1,0 +1,503 @@
+# The readiness pass
+
+The remaining twenty-eight tools, taken to Release-ready as one body of work rather than
+twenty-eight unrelated ones.
+
+This is the spine. It settles what every tool in the pass shares — the vocabulary their payloads
+are written in, the modules each one grows, the kind ids, the order the work runs in, and the
+decisions that would otherwise be taken twenty-eight times and differently. The per-tool designs
+live in five documents grouped by catalog domain, because that is how the catalog, the components
+and the routes are already grouped:
+
+| Document                              | Tools                                                                                                                                     |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [Characters](readiness-characters.md) | #48 DCC, #49 SWN, #50 Uncharted Worlds, #51 heraldry, #52 Velgarth Gifts                                                                  |
+| [Factions](readiness-factions.md)     | #53 arms manufacturer, #54 encounter, #55 family, #56 organization, #57 star nation                                                       |
+| [Locations](readiness-locations.md)   | #58 chop shop, #59 dungeon, #60 environment, #61 planet, #62 region, #63 star system                                                      |
+| [Objects](readiness-objects.md)       | #64 drug, #65 equipment lists, #66 equipment, #67 merchant, #68 potion, #69 weapon, #70 treasure hoard, #71 spooky ship, #72 SWN starship |
+| [Utilities](readiness-utilities.md)   | #74 language, #75 species stats, #76 word generator cheat sheet                                                                           |
+
+Measured against [Tool release readiness](workshop.md#tool-release-readiness). The worked examples
+are culture (#40), religion (#41), settlement (#20), the AD&D 2E character
+([docs/adnd-character.md](adnd-character.md)) and the fantasy character
+([docs/fantasy-character.md](fantasy-character.md)); nothing here invents a shape those five
+already have.
+
+**Status:** proposal. The [domain model](#domain-model) has not been reviewed. Implementation of
+any tool in the pass waits on that approval, because the vocabulary in
+[The stored vocabulary](#the-stored-vocabulary) is what the per-tool documents are written against.
+
+## What is already true, for all twenty-eight
+
+Assessed against the code rather than taken from the issues, because several of the issues are
+stale or wrong and it is cheaper to say so once here than to discover it twenty-eight times:
+
+- **1.1 and 1.3 are met everywhere.** Every one of the twenty-eight has a catalog entry with a
+  `kind` and `domain`, and every one is in `TOOL_PANELS` — all thirty-five paths in
+  `src/lib/tools/tool_catalog.ts` appear in `src/lib/workshop/tool_panels.ts`.
+- **7.1, 8.1 and 8.2 are met everywhere that has a library.** Every directory under `src/lib` has
+  a `README.md` and an `index.ts` except `assets` and `styles`, which back no tool, and
+  `scripts/library_coverage_baseline.json` now carries **no entries at all**: ninety-nine
+  libraries, every one at or above 80%. The pass starts with no coverage debt.
+- **1.4 needs no work.** The label collisions the issues describe are already fixed. #68 says the
+  potion generator reads "Fantasy Potion Generator"; the catalog reads `Fantasy Potion`
+  (`tool_catalog.ts`). Every generator label drops the word already.
+- **2.2 fails everywhere.** Every generator in the pass calls `Date.now()` — the arms manufacturer
+  three times, the chop shop, drug, DCC, SWN, Uncharted Worlds, Velgarth, star system and star
+  nation generators twice each, and the rest once. The same seed does not give the same output,
+  which is the defect `adnd_character_roll.ts` fixed for AD&D and `character_roll.ts` fixes for
+  `/character`. **It is the single most common finding in this pass**, and it has to be fixed
+  before a re-roll from provenance means anything.
+- **And the clock is inside the libraries too, which is the half nobody has counted.** Fifteen
+  `getDefault*Config` helpers instantiate `new RNG(Date.now())` as their default RNG:
+  `astronomical_bodies` in four places (`star_systems.ts:31`, `planets.ts:89`, `stars.ts:52`,
+  `moons.ts:95`), `environment` in five, `civilizations` in two, and `culture`, `heraldry`, `adnd`
+  and `dice` once each. A component that threads its seed correctly still gets clock-driven
+  randomness the moment it calls one of these without passing an RNG. The fix pattern already
+  exists and is already commented in `character_generation.ts`: `getDefaultHeraldryGeneratorConfig`
+  takes an RNG, and the character generator passes the seeded one in precisely so the charge count
+  is reproducible. Every helper in that list grows the same parameter.
+- **2.3 fails in three places.** `/arms-manufacturer`, `/chop-shop` and `/language` render no
+  `SeedControls` at all, so the seed is neither shown nor settable. Everywhere else it is present.
+- **6.1 is watched everywhere already.** `/character` and the rest are in `e2e/page_manifest.ts`,
+  so `pages.mobile.spec.ts` renders each at every width in `mobile_viewports.ts` with a pinned
+  seed and fails on horizontal overflow. What that suite cannot see is a control it cannot reach,
+  which is 6.2's business.
+
+So the pass is not twenty-eight assessments of sections 1, 7.1 and 8.1–8.2. It is one determinism
+fix, one vocabulary, twenty-five artifact kinds, twenty-five editors, and the export and test work
+that goes with them.
+
+## Corrections to the issues
+
+Four, each verified in the code, and each changing what the work is:
+
+- **#69 names the wrong library.** It says the fantasy weapon generator is backed by
+  `src/lib/weapons` and asks whether that library's science-fiction path should change the tool's
+  genre tags. `WeaponGenerator.svelte` does not import `$lib/weapons` at all — it imports
+  `$lib/equipment` and `domains` from `$lib/religion`. The only importer of `$lib/weapons`
+  anywhere is `$lib/arms_manufacturer`, which is #53 and is already tagged `scifi`. So the genre
+  question answers itself: nothing science-fictional is reachable from `/fantasy/weapon`, the tag
+  is right as it stands, and `scifi.ts` is not dead code but _the arms manufacturer's_ code.
+- **#68's label complaint is already fixed**, as above. Nothing is owed on 1.4.
+- **#55 asks whether a family diagram is in scope; it is already built.** `getFamilyTreeSVG` in
+  `src/lib/families/graph.ts:365` renders a family tree with `xmlbuilder2`, and
+  `FamilyGenerator.svelte` never calls it. 6.3 there is a download control over a working function,
+  not a rendering pipeline — the cheapest export in the pass rather than the costliest.
+- **#75 names #25 as its blocker, and #25 does not touch it.** The species height and weight
+  calculator never reads the species list: it takes percentages of a human baseline and derives
+  size and age tables from `Sizes.getHumanVariant` and `AgeCategories.getHumanVariant`. The 182
+  species carrying placeholder sizes are data this tool is used to _author_, not data it consumes.
+  See [Utilities](readiness-utilities.md#75--species-height-and-weight-calculator).
+
+## The shape every tool takes
+
+Five modules and one registration, in the shape culture, religion, settlement and the two
+character kinds already have. Named consistently so that a reader who has seen one library has
+seen them all:
+
+| Module                     | What it holds                                                                                                                                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<thing>_snapshot.ts`      | `<Thing>Snapshot`, `to<Thing>Snapshot`. The writing half.                                                                                                                                           |
+| `<thing>_rehydrate.ts`     | `<thing>FromSnapshot`. Split off **only** when reading pulls a heavy dependency the writing side does not — charge art, species tables, archetype equipment. Otherwise it lives beside its partner. |
+| `<thing>_artifact_kind.ts` | `defineArtifactKind` entry: id, display name, icon, `payloadVersion`, `validate`, `migrate`, `nameOf`, deferred `loadCodec`.                                                                        |
+| `<thing>_roll.ts`          | `<Thing>GeneratorConfigRecord`, `read<Thing>GeneratorConfig`, `roll<Thing>`, `roll<Thing>Snapshot`. The one path from a seed, taken by the page and by a re-roll.                                   |
+| `<thing>_editing.ts`       | Pure snapshot-to-snapshot field edits, one per thing a user can change.                                                                                                                             |
+| `<thing>_presentation.ts`  | A `<Thing>Document` of titled sections, empty ones dropped — 6.4 by construction.                                                                                                                   |
+
+Plus, per tool: a `SaveArtifactButton` and any `SavedArtifactPicker`s in the component, an entry in
+`ARTIFACT_KINDS` (`artifact_kind_catalog.ts`) and one in `ARTIFACT_EDITORS`
+(`artifact_editors.ts`), and the export control that renders the presentation document.
+
+**No tool in this pass gets a `*_saved_state.ts`.** That is the per-generator pattern the store
+replaces; the three that exist are legacy, and #51 retires heraldry's.
+
+## The stored vocabulary
+
+Four generators embed characters, three embed organizations, five embed a coat of arms, and two
+embed a creature. Written per tool, that is five copies of "an `Arms` carries a `renderSVG`
+closure" which drift the first time heraldry changes. So the pass declares the stored form of each
+shared concept **once, in the library that owns the concept**, and every payload composes them.
+
+| Stored type                                         | Owner                  | Replaces                                                               | Consumers                                                              |
+| --------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `StoredArms`                                        | `$lib/heraldry`        | `Arms` — charge groups carry `renderSVG`                               | heraldry, character, organization, merchant, region, arms manufacturer |
+| `StoredCharacter`, `StoredArchetype`                | `$lib/characters`      | `Character` — species tables, archetype equipment, arms                | character, family, encounter, organization, settlement, region         |
+| `StoredCreature`                                    | `$lib/creatures`       | `Creature` — embeds a whole `Species`                                  | encounter, dungeon                                                     |
+| `StoredOrganization`, `StoredOrganizationHierarchy` | `$lib/organizations`   | `Organization` — three `Map`s, a `Character` leader, a visual identity | organization, settlement, region                                       |
+| `StoredNameGeneratorPatternSet`                     | `$lib/names`           | `NameGenerator` — closures                                             | culture, family, civilization, region, merchant                        |
+| `StoredVisualIdentity`, `StoredVisualEmblem`        | `$lib/visual_identity` | An emblem that may be heraldry                                         | organization, settlement, merchant                                     |
+
+Three of these already exist in the wrong place: `StoredCharacter`, `StoredArchetype`,
+`StoredOrganization`, `StoredOrganizationHierarchy`, `StoredVisualIdentity` and
+`StoredVisualEmblem` are all declared in `src/lib/settlements/settlement_snapshot.ts`, because a
+settlement was the first payload that needed them. Moving each to the library that owns the
+concept is the first work item of the pass, and
+[docs/fantasy-character.md](fantasy-character.md#storedcharacter-moves-to-libcharacters-and-the-settlement-payload-advances-to-version-2)
+already designs the character half of that move, including the settlement payload's advance to
+version 2 and the migration that comes with it.
+
+**The rest of the move rides on that same version step.** Organization and visual identity change
+shape in the same way and in the same payload, so they migrate in the same step rather than
+driving a version 3 and a version 4 through everyone's stored settlements. One migration, tested
+against one real version 1 payload, is the whole of it.
+
+`StoredCreature` is new: a `Creature` embeds a whole `Species`, exactly as a `Character` does, and
+the encounter and dungeon payloads both need it. It is the character treatment applied one type
+up the hierarchy — species by name, rebuilt on read, unknown names becoming a placeholder.
+
+## Kind ids
+
+Twenty-five kinds for twenty-eight tools. Three are reference tools and register none; two pairs
+share one kind.
+
+| Kind                         | Tools                           | Qualified? |
+| ---------------------------- | ------------------------------- | ---------- |
+| `character.dcc`              | #48                             | system     |
+| `character.swn`              | #49                             | system     |
+| `character.uncharted-worlds` | #50                             | system     |
+| `heraldry`                   | #51 (registered already)        | —          |
+| `velgarth-gifts`             | #52                             | setting    |
+| `arms-manufacturer`          | #53                             | —          |
+| `encounter`                  | #54                             | —          |
+| `family`                     | #55                             | —          |
+| `organization`               | #56                             | —          |
+| `star-nation`                | #57                             | —          |
+| `chop-shop`                  | #58                             | —          |
+| `dungeon`                    | #59                             | —          |
+| `environment`                | #60                             | —          |
+| `planet`                     | #61                             | —          |
+| `region`                     | #62                             | —          |
+| `star-system`                | #63                             | —          |
+| `drug`                       | #64                             | —          |
+| `item`                       | #66 **and** #69                 | —          |
+| `merchant`                   | #67                             | —          |
+| `potion`                     | #68                             | —          |
+| `treasure-hoard`             | #70                             | —          |
+| `spooky-ship`                | #71                             | —          |
+| `starship.swn`               | #72                             | system     |
+| `language`                   | #74                             | —          |
+| _(none)_                     | #65, #75, #76 — reference tools | —          |
+
+Four are system-qualified because their payloads are numbers that mean something only under one
+ruleset, which is the test
+[decision 4](workshop.md#4-kinds-are-system-qualified-when-the-payload-is) sets. Concept first,
+system as a qualifier, so every character sorts together in a vault listing.
+
+`velgarth-gifts` is the one entry that is neither system-qualified nor generic. A Velgarth gift is
+setting-specific fan content rather than a rule, and there is no `setting:` namespace to qualify
+with; naming the setting in the concept is the honest reading, and it keeps the kind from claiming
+to be the generic notion of a psychic gift.
+
+## Decisions taken here
+
+### 1. Every generator in the pass grows a `*_roll.ts`, and the clock leaves it
+
+Twenty-five generators seed from `Date.now()`. The fix is the one `adnd_character_roll.ts` made:
+pressing **Generate** draws a _new seed_ from the page's RNG, and the roll itself is a pure
+function of seed and config. Anything drawn from a second stream — a name, a mark — derives that
+stream from the seed rather than the clock.
+
+It is listed first because everything else in section 3 and section 4 rests on it. Provenance
+records a seed and a config so that a re-roll can reproduce what was rolled; against a
+clock-seeded generator, that record is a lie the moment it is written.
+
+**The fix reaches into the libraries, not just the components.** Every `getDefault*Config` helper
+that defaults its RNG to `new RNG(Date.now())` takes a required `rng` parameter instead. That is
+fifteen call sites across six libraries, it is a one-line change at each, and it is the difference
+between a generator that looks seeded and one that is. A tool's own work item covers the helpers it
+calls; nothing is centralised, because a shared "fix the clock" item would touch six libraries at
+once and block every tool behind one review.
+
+### 2. The stored vocabulary is declared once, by the library that owns the concept
+
+Stated above. The alternative is five spellings of `StoredArms`, and the failure mode is silent:
+each copy keeps working until heraldry adds a field, and then four payloads quietly lose it.
+
+### 3. The equipment generator and the weapon generator share the kind `item`
+
+Both produce an `Item` from `$lib/equipment` — the weapon generator is the same generator with the
+major type fixed and a religion domain steering the enchantment. Two kinds for one payload shape
+would split a user's gear across two vault entries, each openable by only one of the two tools
+that made it. This is the argument [decision 4](adnd-character.md#1-the-kind-is-characteradnd-2e)
+made for the AD&D builder and generator, and it applies here for the same reason.
+
+The provenance's `toolPath` still says which tool made it, which is what a re-roll reads to know
+whether it is rolling a weapon or anything at all.
+
+### 4. Prose generators get a kind, and it holds the prose
+
+`/chop-shop` and `/spooky-ship` each return a single string — `generate(rng)` in their `index.ts`
+is a paragraph assembled from phrase tables. Their payload is `{ text: string }` and nothing else.
+
+That is a real artifact rather than a joke: the thing a user wants to keep is the paragraph, the
+editing view is a textarea, and the re-roll is the whole tool. Giving them a kind each rather than
+one shared `vignette` kind keeps two unrelated tools' output apart in a vault listing, which is
+what a user browsing a project actually needs; the cost is one extra registration.
+
+These two are also the pass's cheapest complete tools, and
+[Locations](readiness-locations.md) and [Objects](readiness-objects.md) put them first for that
+reason: they exercise the whole spec end to end in an afternoon and find the awkward corners of the
+process rather than of a tool.
+
+### 5. Flat payloads get a declared field editor, not twenty-five bespoke components
+
+Section 4 is the expensive half of this pass. Written the obvious way it is twenty-five Svelte
+components, most of which are the same component: a list of labelled inputs bound to the fields of
+a flat object, each edit producing a new snapshot.
+
+So the pass adds one component, `SnapshotFieldEditor`, driven by a **field descriptor** a kind
+declares beside its editing module:
+
+```ts
+type SnapshotFieldDescriptor = {
+  field: string; // key on the snapshot
+  label: string; // what the user sees
+  control: 'text' | 'textarea' | 'number' | 'select' | 'string-list';
+  options?: string[]; // for 'select'
+};
+```
+
+It takes `ArtifactEditorProps` like any other editor and calls `onChange` with a new snapshot. The
+kind supplies the descriptors; nothing in the framework learns what a drug or a star nation is.
+
+**Which tools it serves:** the arms manufacturer, chop shop, spooky ship, drug, Velgarth gifts,
+environment, planet, star nation, star system, potion, item, treasure hoard and merchant — thirteen
+of twenty-five, and every one of them a flat record of strings and numbers with at most a list.
+
+**Which tools it does not:** the three system characters, heraldry, organization, family, encounter,
+dungeon, region and language. Each of those is a structure — a hierarchy, a graph, a device, a
+grid, a lexicon — and a flat list of inputs would be a worse editor than none. They get bespoke
+components, and that is where the section 4 effort in this pass actually goes.
+
+The risk in this decision is the usual one for a declarative layer: a descriptor language that
+grows a case for every kind until it is a framework nobody can read. The guard is the `control`
+union above — four controls and a list. **A kind that needs a fifth control does not get one; it
+gets a bespoke editor.**
+
+### 6. Composition follows the kinds that exist, so the order of the work is part of the design
+
+5.1 binds "where an artifact kind exists for that input", which makes it a function of what has
+already landed. The references this pass creates:
+
+| Consumer         | References                                                           |
+| ---------------- | -------------------------------------------------------------------- |
+| `encounter`      | `environment` (where it happens)                                     |
+| `family`         | `culture` (naming), `heraldry` (arms)                                |
+| `organization`   | `heraldry` (arms), `character` (leader, members), `culture` (naming) |
+| `merchant`       | `culture` (naming), `settlement` (where the shop is)                 |
+| `dungeon`        | `encounter` (room encounters), `environment`                         |
+| `region`         | `settlement`, `culture`, `organization`, `character`, `heraldry`     |
+| `star-system`    | `planet`                                                             |
+| `star-nation`    | `star-system`, `planet`                                              |
+| `treasure-hoard` | `potion`, `item`                                                     |
+| `character.*`    | `culture` (naming), `heraldry` (arms)                                |
+
+Two consequences. **A referenced kind lands before its consumer**, which is what the sequencing
+below is built from. And **5.4 — tolerate reference cycles — is tested once, in whatever walks
+references**, not twenty-five times: a region references settlements which may reference the same
+culture the region does, and the walker is the only thing that can loop.
+
+### 7. Payload size is a design input for exactly three tools
+
+Most payloads here are kilobytes. Three are not, and each gets a stated position rather than a
+discovery in a user's quota warning:
+
+- **The language lexicon** (#74) — the largest payload any tool would store. Stored whole
+  regardless, because a user edits a lexicon and an edited word is not reproducible from a seed.
+  What #74 asks — check it against the quota reporting first — is a measurement in that issue.
+- **The dungeon** (#59) — grid, rooms, doors, keys and encounters. Stored whole; the WebGL scene is
+  not part of it.
+- **The region map** (#62) — `RegionMap` is a plain graph of nodes, edges and corners, so it is
+  storable as it stands, and it is stored. What is _not_ stored is a rendered SVG.
+
+The rule under all three, and the one the per-tool documents apply: **store what a user could have
+edited; regenerate only what is purely derived — and prove the determinism with a test before
+relying on it.** A rendered image is never stored. #56 puts it best: a stored SVG is a fossil,
+because it cannot be re-themed, re-rendered at another size, or re-read by anything but the
+renderer that produced it.
+
+### 8. A reference tool with no logic still gets a library
+
+#76 asks the question directly: `WordGeneratorCheatSheet.svelte` imports nothing from `$lib`, so
+does 8.1/8.2 apply to a tool with no library?
+
+It gets one — `src/lib/word_patterns`, holding the pattern table the page renders as data. Three
+reasons, and none of them is consistency for its own sake: the content is a table rather than
+prose, so it is data sitting in a component; the same table is what the word generators elsewhere
+document, so it has a second reader; and a library is what gives 7.1 something to test, where a
+component full of literals has nothing.
+
+The alternative — a sentence in the spec exempting logic-free reference tools — is worse
+specifically because it would be _used_. The next reference page would keep its content in the
+component too, and the exemption would become the pattern.
+
+### 9. The three reference tools do not queue behind the generators
+
+#65, #75 and #76 need sections 1, 2.1, 2.5, 6, 7.1 and 8 only. No kind, no snapshot, no editor, no
+migration. They are days of work in total, they are independent of everything above, and the two
+table-shaped ones (#65 and #76) are the site's most likely 6.1 failures — wide tables at 320px.
+They run in parallel with the rest of the pass rather than after it.
+
+**#75 carries a caveat the other two do not.** The species height and weight calculator returns
+confident numbers from placeholder data: #25 records that 182 of 239 species carry placeholder
+human sizes. Section 6 polish does not fix that, and this document does not pretend otherwise —
+[Utilities](readiness-utilities.md) says what the tool should do about it in the meantime.
+
+## Domain model
+
+### The vocabulary, and who composes it
+
+```mermaid
+classDiagram
+    class StoredArms {
+        +StoredDevice device
+        +string blazon
+    }
+    class StoredCharacter {
+        +string speciesName
+        +StoredArchetype archetype
+        +StoredArms heraldry
+    }
+    class StoredArchetype {
+        +string name
+        +string[] tags
+    }
+    class StoredCreature {
+        +string speciesName
+        +string name
+        +string description
+    }
+    class StoredOrganization {
+        +string kindId
+        +StoredOrganizationHierarchy hierarchy
+        +StoredCharacter leader
+        +StoredVisualIdentity visualIdentity
+    }
+    class StoredOrganizationHierarchy {
+        +array childToParent
+        +array idToOrder
+        +array roleById
+    }
+    class StoredVisualIdentity {
+        +StoredVisualEmblem emblem
+    }
+    class StoredNameGeneratorPatternSet {
+        +string name
+    }
+
+    StoredCharacter "1" o-- "0..1" StoredArchetype
+    StoredCharacter "1" o-- "0..1" StoredArms
+    StoredOrganization "1" o-- "1" StoredOrganizationHierarchy
+    StoredOrganization "1" o-- "1" StoredCharacter : leader
+    StoredOrganization "1" o-- "*" StoredCharacter : notable members
+    StoredOrganization "1" o-- "1" StoredVisualIdentity
+    StoredVisualIdentity "1" o-- "1" StoredVisualEmblem
+    StoredVisualEmblem "0..1" o-- "1" StoredArms : when heraldic
+    StoredCreature "1" --> "1" StoredCharacter : same species treatment
+```
+
+### What each library contributes
+
+```mermaid
+classDiagram
+    class ArtifactKindEntry {
+        +string kind
+        +number payloadVersion
+        +validate(payload)
+        +migrate(payload, from)
+        +loadCodec()
+    }
+    class RollModule {
+        +readGeneratorConfig(record)
+        +roll(seed, config)
+        +rollSnapshot(seed, config)
+    }
+    class EditingModule {
+        +setField(snapshot, value)
+    }
+    class PresentationModule {
+        +toDocument(snapshot)
+    }
+    class SnapshotFieldDescriptor {
+        +string field
+        +string label
+        +string control
+        +string[] options
+    }
+    class ArtifactEditorEntry {
+        +loadEditor()
+        +loadRoller()
+    }
+    class SnapshotFieldEditor
+
+    ArtifactEditorEntry "1" --> "1" RollModule : roller reads provenance
+    ArtifactEditorEntry "1" --> "1" EditingModule : editor calls
+    SnapshotFieldEditor "1" o-- "*" SnapshotFieldDescriptor : declared by the kind
+    ArtifactEditorEntry "0..1" --> "1" SnapshotFieldEditor : flat kinds mount
+    ArtifactKindEntry "1" --> "1" PresentationModule : 6.3 renders from
+```
+
+### What references what
+
+```mermaid
+graph LR
+  environment --> encounter
+  encounter --> dungeon
+  environment --> dungeon
+  culture --> family
+  culture --> merchant
+  culture --> organization
+  heraldry --> organization
+  heraldry --> family
+  heraldry --> character
+  character --> organization
+  settlement --> merchant
+  settlement --> region
+  culture --> region
+  organization --> region
+  planet --> starSystem[star-system]
+  starSystem --> starNation[star-nation]
+  potion --> treasureHoard[treasure-hoard]
+  item --> treasureHoard
+```
+
+Read as "lands before": an arrow from `environment` to `encounter` says the environment kind has to
+exist before the encounter generator can offer a saved environment as an input.
+
+## The order of the work
+
+Four waves. The boundaries are dependency boundaries, and within a wave nothing blocks anything.
+
+**Wave 0 — the vocabulary.** The stored types move to the libraries that own them, and the
+settlement payload advances to version 2 with one migration covering all of it. Everything else in
+the pass composes what this wave declares, so it is the only strictly serial step.
+
+**Wave 1 — the cheap and the unblocking.** `arms-manufacturer`, `chop-shop`, `spooky-ship`, `drug`,
+`velgarth-gifts`, `environment`, `potion`, `item`, and the three reference tools. Small flat
+payloads, no composition, and between them they prove the `SnapshotFieldEditor` decision before
+thirteen tools depend on it. `environment` is here because two other tools reference it.
+
+**Wave 2 — the structured.** `character.dcc`, `character.swn`, `character.uncharted-worlds`,
+`starship.swn`, `heraldry`'s editor, `encounter`, `family`, `organization`, `merchant`,
+`treasure-hoard`, `planet`, `star-system`, `star-nation`, `language`. Each has either a real
+structure to edit or a composition to offer.
+
+**Wave 3 — the heavy.** `dungeon` and `region`. Both compose most of the kinds above, both are
+payload-size cases, and both touch rendering hard enough to want `verify:all` more than once.
+Region in particular was the reason settlement went first: it is built from saved settlements.
+
+Heraldry's editor is in wave 2 rather than wave 1 despite being described as the shortest run on
+the site, because it is the kind most referenced by others and its editing view is a structured
+device rather than a form — see [Characters](readiness-characters.md).
+
+## What this pass does not do
+
+- **It does not change the readiness spec**, with one exception recorded in decision 8: nothing in
+  `workshop.md` section 8 changes, because the answer to #76 is a library rather than an exemption.
+- **It does not touch the four open issues that overlap it.** #11 (reframe civilizations), #14
+  (Convention Special DCC), #16 and #17 (stellar imagery), #19 and #25 (species sizes) each land on
+  a tool in this pass; each per-tool document says what it assumes and what it defers, and none of
+  them is folded in silently.
+- **It does not raise any tool's `maturity` field until that tool's own work is merged.** The
+  catalog records assessments, not intentions.

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -1811,6 +1811,18 @@ name rather than embedded — and in doing so moves the `StoredCharacter` shape 
 `$lib/settlements`, which is what makes the settlement payload the first here to advance a
 `payloadVersion`.
 
+**Everything else is designed together, in [the readiness pass](tool-readiness.md).** Twenty-eight
+tools remain, and taken one at a time they would answer the same questions twenty-eight times and
+differently: where the stored form of a character lives, whether a rendered image is a payload,
+what a tool that returns a paragraph of prose is worth saving as. The pass settles those once and
+splits the per-tool work across five documents by catalog domain —
+[characters](readiness-characters.md), [factions](readiness-factions.md),
+[locations](readiness-locations.md), [objects](readiness-objects.md) and
+[utilities](readiness-utilities.md). Its most consequential finding is not about any one tool:
+**every remaining generator seeds from the clock**, in the component and often in its library's
+default-config helper too, so requirement 2.2 is failing site-wide and every re-roll from
+provenance depends on fixing it.
+
 The paragraph below refers to the **pre-migration** #45, which was about storage. Issue numbers all
 changed when the forge moved to GitHub, and today's #45 is the character builder above.
 


### PR DESCRIPTION
Design only, docs only — no implementation. Covers all 28 remaining "Take X to Release-ready" issues in `needs-design`.

**Status: proposal.** The domain models need review before any tool starts.

## Shape

One spine plus five per-domain documents, grouped the way the catalog already groups tools:

| Document | Tools |
| --- | --- |
| `docs/tool-readiness.md` | the spine — shared vocabulary, kind ids, waves, cross-cutting decisions |
| `docs/readiness-characters.md` | #48, #49, #50, #51, #52 |
| `docs/readiness-factions.md` | #53, #54, #55, #56, #57 |
| `docs/readiness-locations.md` | #58, #59, #60, #61, #62, #63 |
| `docs/readiness-objects.md` | #64, #65, #66, #67, #68, #69, #70, #71, #72 |
| `docs/readiness-utilities.md` | #74, #75, #76 |

28 issues, 25 artifact kinds (two pairs share one, three reference tools register none).

## The findings worth reading first

- **2.2 is failing site-wide.** Every remaining generator calls `Date.now()`, and — the half nobody had counted — 15 `getDefault*Config` helpers instantiate `new RNG(Date.now())` inside the libraries, so threading a seed through a component is not enough. Every re-roll from provenance depends on this.
- **Four issues are stale or wrong**, each verified in the code: #69 names a library its tool doesn't import (it's the arms manufacturer's), #68's label was fixed already, #55's family-tree SVG is already written and never called, and #75's claimed blocker (#25) concerns data that tool never reads.
- **The stored vocabulary moves once.** `StoredCharacter`, `StoredArchetype`, `StoredOrganization`, its hierarchy and the visual identity types all live in `$lib/settlements` today; they move to the libraries that own them and ride the payload migration #46 already needs.
- **13 flat payloads share one declared field editor** rather than 13 components, with a hard four-control limit — anything richer gets a bespoke editor. This is what makes section 4 across 25 kinds tractable.

## Notes

- #57 (star nation) is sequenced behind #11, which proposes replacing the very stats its payload would be built from. It's the pass's one hard external dependency.
- `npm run verify` is green. Docs only, so no `verify:all` run.
- One structural caveat worth your call: this is a large PR to review in one sitting. The spine is the part that must be right, since the five domain documents are written against it — reviewing that first and the domains separately would work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Acb1bAUwcGdybvjyCsCYJK