### PR TITLE
Mark the readiness pass accepted, for #48-#76

### DIFF
--- a/docs/readiness-characters.md
+++ b/docs/readiness-characters.md
@@ -12,7 +12,7 @@ Part of [the readiness pass](tool-readiness.md); read that first for what all tw
 share — the determinism fix, the stored vocabulary, the kind ids, and the field-editor decision.
 Measured against [Tool release readiness](workshop.md#tool-release-readiness).
 
-**Status:** proposal, with [the pass](tool-readiness.md#domain-model). Not reviewed.
+**Status:** accepted; not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in this document is clear to start.
 
 ## The three system characters
 

--- a/docs/readiness-factions.md
+++ b/docs/readiness-factions.md
@@ -10,7 +10,7 @@ Five tools: the arms manufacturer
 Part of [the readiness pass](tool-readiness.md). Measured against
 [Tool release readiness](workshop.md#tool-release-readiness).
 
-**Status:** proposal, with [the pass](tool-readiness.md#domain-model). Not reviewed.
+**Status:** accepted; not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in this document is clear to start.
 
 This domain holds the pass's easiest tool and its second-hardest. The arms manufacturer is three
 files and a flat payload; the organization generator is the richest generator on the site, with a

--- a/docs/readiness-locations.md
+++ b/docs/readiness-locations.md
@@ -11,7 +11,7 @@ Six tools: the cyberpunk chop shop
 Part of [the readiness pass](tool-readiness.md). Measured against
 [Tool release readiness](workshop.md#tool-release-readiness).
 
-**Status:** proposal, with [the pass](tool-readiness.md#domain-model). Not reviewed.
+**Status:** accepted; not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in this document is clear to start.
 
 The pass's two heaviest tools are here — the dungeon and the region — and so is one of its
 cheapest. The environment generator goes first regardless of size, because two other tools

--- a/docs/readiness-objects.md
+++ b/docs/readiness-objects.md
@@ -14,7 +14,7 @@ Number starship generator ([#72](https://github.com/ironarachne/ironarachne/issu
 Part of [the readiness pass](tool-readiness.md). Measured against
 [Tool release readiness](workshop.md#tool-release-readiness).
 
-**Status:** proposal, with [the pass](tool-readiness.md#domain-model). Not reviewed.
+**Status:** accepted; not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in this document is clear to start.
 
 The largest domain in the pass by count and the smallest by difficulty. Seven of the nine are flat
 payloads that the declared field editor serves; one is a reference tool with no kind at all; and

--- a/docs/readiness-utilities.md
+++ b/docs/readiness-utilities.md
@@ -8,7 +8,7 @@ cheat sheet ([#76](https://github.com/ironarachne/ironarachne/issues/76)).
 Part of [the readiness pass](tool-readiness.md). Measured against
 [Tool release readiness](workshop.md#tool-release-readiness).
 
-**Status:** proposal, with [the pass](tool-readiness.md#domain-model). Not reviewed.
+**Status:** accepted; not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in this document is clear to start.
 
 Two of these are reference tools with no artifact kind at all, which makes them the smallest jobs
 in the pass; they run in parallel with everything else rather than queueing behind it

--- a/docs/tool-readiness.md
+++ b/docs/tool-readiness.md
@@ -23,9 +23,9 @@ are culture (#40), religion (#41), settlement (#20), the AD&D 2E character
 ([docs/fantasy-character.md](fantasy-character.md)); nothing here invents a shape those five
 already have.
 
-**Status:** proposal. The [domain model](#domain-model) has not been reviewed. Implementation of
-any tool in the pass waits on that approval, because the vocabulary in
-[The stored vocabulary](#the-stored-vocabulary) is what the per-tool documents are written against.
+**Status:** accepted; not yet built. The [domain model](#domain-model) was reviewed and approved,
+so the pass is clear to start — beginning with wave 0, because the vocabulary in
+[The stored vocabulary](#the-stored-vocabulary) is what every per-tool document is written against.
 
 ## What is already true, for all twenty-eight
 


### PR DESCRIPTION
Follow-up to #170, docs only. Merging the pass was the approval, so the six documents no longer say their domain models are awaiting review.

- All five domain documents: **Status: accepted; not yet built.**
- `docs/tool-readiness.md`: the same, and it now names where the work starts — wave 0, since every per-tool document is written against the vocabulary that wave declares.

Prettier clean. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Acb1bAUwcGdybvjyCsCYJK