### PR TITLE
Take the fantasy character generator to Release-ready

### DIFF
--- a/docs/fantasy-character.md
+++ b/docs/fantasy-character.md
@@ -10,10 +10,10 @@ against [Tool release readiness](workshop.md#tool-release-readiness). Culture (#
 [docs/adnd-character.md](adnd-character.md)) are the worked examples, and this follows them rather
 than inventing a second shape.
 
-**Status:** accepted; not yet built. The [domain model](#domain-model) was reviewed and approved,
-so [the plan](#the-plan) is clear to start. The one question in [Still open](#still-open) — whether
-the editor lets a saved character's species be changed — is still open, and item 6 of the plan is
-where it has to be answered.
+**Status:** implemented. The [domain model](#domain-model) was reviewed and approved, and
+[the plan](#the-plan) was carried out in one branch rather than eight. The question that was left
+[open](#still-open) — whether the editor lets a saved character's species be changed — was answered
+**no**: species is shown read-only and a re-roll is how a character becomes a different species.
 
 ## The problem
 
@@ -174,18 +174,19 @@ screen against what was read.
 
 Covering every field the generator displays (4.1):
 
-| What                                 | How it is edited                                                        |
-| ------------------------------------ | ----------------------------------------------------------------------- |
-| First and last name                  | Two fields; `name` is rederived by `formatCharacterDisplayName`.        |
-| Description, short description       | Textareas. Rewriting from the character is an explicit command.         |
-| Gender, species name, archetype name | Selects over the build's tables, with the stored value kept if unknown. |
-| Age and age category                 | A number and a select.                                                  |
-| Height, weight, length               | Numbers, in the units the sheet shows.                                  |
-| Personality traits                   | Add, rewrite, remove — one at a time.                                   |
-| Physical traits                      | Name and description per trait, add and remove.                         |
-| Abilities, carried equipment         | Name and description per entry, add and remove.                         |
-| Titles                               | Male and female forms, honorifics, land name, per title.                |
-| Heraldry                             | Shown, and re-rolled or replaced from a saved coat of arms.             |
+| What                           | How it is edited                                                 |
+| ------------------------------ | ---------------------------------------------------------------- |
+| First and last name            | Two fields; `name` is rederived by `formatCharacterDisplayName`. |
+| Description, short description | Textareas. Rewriting from the character is an explicit command.  |
+| Gender, archetype name         | A select and a field, with the stored value kept if unknown.     |
+| Species                        | Read-only. See [Still open](#still-open) for why.                |
+| Age and age category           | A number and a select.                                           |
+| Height, weight, length         | Numbers, in the units the sheet shows.                           |
+| Personality traits             | Add, rewrite, remove — one at a time.                            |
+| Physical traits                | Name and description per trait, add and remove.                  |
+| Abilities, carried equipment   | Name and description per entry, add and remove.                  |
+| Titles                         | Male and female forms, honorifics, land name, per title.         |
+| Heraldry                       | Shown, and re-rolled or replaced from a saved coat of arms.      |
 
 That is 4.4 satisfied by construction: nothing here re-rolls anything else.
 
@@ -537,11 +538,59 @@ already has, and the second is a bug fix that stands on its own whether or not t
 `npm run verify` gates each; `npm run verify:all` runs before merging items 5, 6 and 7, which touch
 components and routes.
 
+**It shipped as one branch rather than eight.** The eight items are still the order the work was
+done in, and the dependency column still says why; what changed is only how it was reviewed.
+
+## What shipped
+
+Assessed section by section against
+[Tool release readiness](workshop.md#tool-release-readiness), not declared.
+
+- **1.** Catalog entry unchanged but for `maturity`, and registered in `TOOL_PANELS` already.
+- **2.** `character_roll.ts` is the single path from a seed, and the clock is out of it: pressing
+  Generate draws a new seed from the page's RNG, seeded once at mount. The name has its own derived
+  stream, so choosing a naming source cannot shift the rest of the character. One defect fell out
+  of writing the roll and is fixed with it: `generate` asked
+  `getFantasyNameGeneratorSet(species.name)` for a noble's land name, which **throws** for the
+  twenty-odd species with no pattern set of their own — a noble aarakocra took the whole page down.
+  It goes through `fantasyHintToNameSetName` now.
+- **3.** `character_snapshot.ts` and `character_rehydrate.ts`, kind `character` at payload version
+  1, `SaveArtifactButton` on the tool's own route, provenance carrying the four selects and the
+  resolved pattern set.
+- **4.** `character_editing.ts` and `CharacterArtifactEditor.svelte`, every displayed field but
+  species, each function returning a new snapshot. Re-roll is the kind's registered roller, and it
+  reports which part of a stale config it had to substitute rather than rolling out of empty tables.
+- **5.** A naming culture through `CharacterNameSection`'s existing opt-in, and a coat of arms
+  through a `SavedArtifactPicker`; both by reference, both opt-in, arms stored as `null`.
+- **6.** Markdown and PDF exports **with their controls**, which is decision 8 honoured.
+- **7.** Round-trip, unknown-species, editing, presentation and roll tests in the library; the
+  settlement version 1 → 2 migration exercised against a real version 1 payload; `e2e/character.spec.ts`
+  for generate, save, reopen, edit across a reload.
+- **8.** `src/lib/characters/README.md` says plainly that this library implements no game system,
+  and where a system's character lives instead.
+
+Two things are worth recording for the kinds that follow.
+
+**The first real `payloadVersion` step was unremarkable to write, and that is the finding.** The
+registry's read path already routed an older payload to `migrate`; the settlement kind supplied one
+step and nothing generic changed. What the step actually cost was a fixture: the migration is only
+worth trusting against a payload of the shape the site really shipped, so the test builds one by
+putting the embedded species _back_ into a generated settlement rather than pasting a captured blob
+that would go stale.
+
+**A shared type is cheaper than a shared shape.** Moving `StoredCharacter` into `$lib/characters`
+cost the migration above and removed a whole `Species` record per notable, which is the bulk of
+what a stored notable was. The alternative, two types with one name, would have been free that day
+and wrong from the first change to either.
+
 ## Still open
 
-- **Whether the editor offers a species change at all.** Changing a saved character's species does
-  not recompute the height, weight or physical traits that species produced, so the result is an
-  elf with a halfling's build unless the user fixes the rest by hand. The table above includes it
-  on the grounds that 4.1 asks for every displayed field; the alternative is to show species as
-  read-only and let a re-roll be the way to change it. This is the one question in this document a
-  reviewer should answer deliberately.
+- ~~**Whether the editor offers a species change at all.**~~ **Answered: it does not.** Changing a
+  saved character's species does not recompute the height, weight or physical traits that species
+  produced, so the result would be an elf with a halfling's build unless the user fixed the rest by
+  hand. Species is shown read-only — including its name when this build no longer has that
+  species — and a re-roll is the way to change it. The field table above is amended accordingly:
+  4.1 asks for every displayed field to be _changeable_, and the honest reading is that a field
+  whose change would silently invalidate five others is better shown than half-edited.
+
+Nothing else in this document is open.

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -1764,8 +1764,8 @@ recorded here because it is what the next kind will meet:
   is a megabyte with its organizations silently hollowed out. Converted by name — entries, charge
   names, archetype names — it is about forty kilobytes and round-trips exactly.
 - **A kind can have more than one legitimate shape.** `enrich_settlement.ts` is opt-in four times
-  over, so sixteen combinations are all current payloads at version 1. That is not a version
-  problem and must not be treated as one: `validate` accepts each optional layer when absent and
+  over, so sixteen combinations are all current payloads at whatever version is current. That is
+  not a version problem and must not be treated as one: `validate` accepts each optional layer when absent and
   checks it when present, which is also what makes a payload written by a build with different
   enrichment defaults readable rather than quarantined (requirement 3.3).
 - **Determinism needs a single roll path, and the page is not it.** The generator built its
@@ -1805,11 +1805,14 @@ recorded as provenance so a hand-built character is reproducible — is what the
 character kind will meet.
 
 The system-neutral **Fantasy Character** generator follows it in
-[The fantasy character artifact](fantasy-character.md), which is accepted and not yet built. It
-takes the same bargain one step further — a species and an archetype stored by
-name rather than embedded — and in doing so moves the `StoredCharacter` shape out of
-`$lib/settlements`, which is what makes the settlement payload the first here to advance a
-`payloadVersion`.
+[The fantasy character artifact](fantasy-character.md), which is **implemented** (#46). It took the
+same bargain one step further — a species and an archetype stored by name rather than embedded —
+and in doing so moved the `StoredCharacter` shape out of `$lib/settlements`, which is what made the
+settlement payload the first here to advance a `payloadVersion`. `SETTLEMENT_PAYLOAD_VERSION` is 2,
+and its migration rewrites every notable's and every organization member's embedded species record
+into a name. The step is unremarkable to write and that is the finding: the registry's read path
+already routed an older payload to `migrate`, so the kind supplied one step and nothing generic
+changed.
 
 **Everything else is designed together, in [the readiness pass](tool-readiness.md).** Twenty-eight
 tools remain, and taken one at a time they would answer the same questions twenty-eight times and

--- a/e2e/character.spec.ts
+++ b/e2e/character.spec.ts
@@ -1,0 +1,211 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `character` kind: generate, save, reopen, edit.
+ *
+ * This is the half no unit test can settle. The library tests prove a character round-trips through
+ * the codec and that each editing function changes one field; what they cannot prove is that a user
+ * can press Generate, keep the result, come back to it in a different page, change something, and
+ * still have the character they saved. Every step of that crosses a boundary the unit tests stub
+ * out — the artifact store, IndexedDB, the editor registry, and a page reload.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+
+const CHARACTER_TITLE = 'Character | Iron Arachne';
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool on this page has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+test.describe('a fantasy character', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'The Marches');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/character', { title: CHARACTER_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a character to keep straight away.
+    await expect(page.getByRole('button', { name: 'Generate', exact: true })).toBeVisible();
+    await saveAs(page, 'Maren Voss');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'Maren Voss');
+
+    // Typed rather than filled: `fill` sets the value in one go, and the point of this assertion is
+    // that the editor's own bindings carry a user's keystrokes through to the snapshot it announces.
+    const description = panel.getByRole('textbox', { name: 'Description', exact: true });
+    await description.click();
+    await description.pressSequentially(' Keeps the tide charts.');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'Maren Voss');
+    await expect(reopened.getByRole('textbox', { name: 'Description', exact: true })).toHaveValue(
+      /Keeps the tide charts\./,
+    );
+  });
+
+  test('renames the character through both halves of the name', async ({ page }) => {
+    await visitRoute(page, '/character', { title: CHARACTER_TITLE });
+    await saveAs(page, 'Someone Unnamed');
+
+    const panel = await openInWorkshop(page, 'Someone Unnamed');
+    await panel.getByRole('textbox', { name: 'First name' }).fill('Perrin');
+    await panel.getByRole('textbox', { name: 'Last name' }).fill('Thistlewood');
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+  });
+
+  test('shows species read-only, because nothing recomputes the build it produced', async ({
+    page,
+  }) => {
+    await visitRoute(page, '/character', { title: CHARACTER_TITLE });
+    await saveAs(page, 'Fixed Species');
+
+    const panel = await openInWorkshop(page, 'Fixed Species');
+    await expect(panel.getByText(/^Species:/)).toBeVisible();
+    await expect(panel.getByRole('combobox', { name: 'Species' })).toHaveCount(0);
+    // Gender is editable, which is what makes the species decision a decision rather than an
+    // omission.
+    await expect(panel.getByRole('combobox', { name: 'Gender' })).toBeVisible();
+  });
+
+  test('reproduces the same character from the same seed', async ({ page }) => {
+    // Requirement 2.2, and the defect `character_roll.ts` was written to fix: the generator used to
+    // reseed from the clock inside every roll and to name from a clock-seeded RNG, so a locked seed
+    // reproduced neither the body nor the name.
+    await visitRoute(page, '/character', { title: CHARACTER_TITLE });
+
+    const heading = page.getByRole('heading', { level: 2 }).first();
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const first = await heading.textContent();
+    const description = await page
+      .getByText(/years old|of \d+ years/)
+      .first()
+      .textContent();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    await expect(heading).toHaveText(first ?? '');
+    await expect(page.getByText(/years old|of \d+ years/).first()).toHaveText(description ?? '');
+
+    // And a different seed is a different person, so the reproduction above is not the page simply
+    // failing to re-roll.
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    await expect(heading).not.toHaveText(first ?? '');
+  });
+
+  test('offers a project culture to name from, and only once there is one', async ({ page }) => {
+    await visitRoute(page, '/character', { title: CHARACTER_TITLE });
+
+    // No cultures in the project, so no offer. An offer with nothing behind it is noise, and
+    // requirement 5.3 is what makes its absence correct rather than a gap: the tool generates its
+    // own names and saves perfectly well without one.
+    await expect(page.getByLabel('Name from a saved culture in this project')).toHaveCount(0);
+
+    await visitRoute(page, '/culture', { title: 'Culture Generator | Iron Arachne' });
+    await saveAs(page, 'The Emberfolk');
+
+    await visitRoute(page, '/character', { title: CHARACTER_TITLE });
+
+    // Composition is opt-in (rule 1): the offer is there and starts unticked.
+    const offer = page.getByLabel('Name from a saved culture in this project');
+    await expect(offer).toBeVisible();
+    await expect(offer).not.toBeChecked();
+  });
+
+  test('offers a saved coat of arms, and only once there is one', async ({ page }) => {
+    await visitRoute(page, '/character', { title: CHARACTER_TITLE });
+    await expect(page.getByLabel('Give this character a saved coat of arms')).toHaveCount(0);
+
+    await visitRoute(page, '/heraldry', { title: 'Heraldry Generator | Iron Arachne' });
+    await saveAs(page, 'Azure, a bend or');
+
+    await visitRoute(page, '/character', { title: CHARACTER_TITLE });
+    const offer = page.getByLabel('Give this character a saved coat of arms');
+    await expect(offer).toBeVisible();
+    await expect(offer).not.toBeChecked();
+  });
+
+  test('downloads a character sheet a user can take to the table', async ({ page }) => {
+    // Requirement 6.3. These are the presentation exports, distinct from artifact export.
+    await visitRoute(page, '/character', { title: CHARACTER_TITLE });
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    expect((await markdown).suggestedFilename()).toMatch(/\.md$/);
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: /Download PDF/ }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/\.pdf$/);
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -25,6 +25,7 @@ const TOOL_PAGES = [
 
 /** The release-ready tools, which must say nothing at all. */
 const SILENT_TOOL_PAGES = [
+  { path: '/character', title: 'Character | Iron Arachne' },
   { path: '/culture', title: 'Culture Generator | Iron Arachne' },
   { path: '/fantasy/settlement', title: 'Settlement Generator | Iron Arachne' },
   { path: '/fantasy/religion', title: 'Religion Generator | Iron Arachne' },
@@ -100,6 +101,9 @@ test('maturity: the tool browser marks every tool that has something to warn abo
   await expect(
     browser.getByRole('button', { name: /^AD&D 2E Character Builder/ }),
   ).not.toContainText('Release-ready');
+  await expect(browser.getByRole('button', { name: /^Fantasy Character/ })).not.toContainText(
+    'Release-ready',
+  );
   await expect(browser.getByRole('button', { name: /^Heraldry/ })).toContainText('Beta');
   await expect(browser.getByRole('button', { name: /^Planet/ })).toContainText('Experimental');
 });

--- a/src/components/characters/CharacterArtifactEditor.svelte
+++ b/src/components/characters/CharacterArtifactEditor.svelte
@@ -1,0 +1,524 @@
+<script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import {
+    addCharacterCarried,
+    addCharacterDescribedEntry,
+    addCharacterPersonalityTrait,
+    addCharacterTitle,
+    characterAgeCategoryOptions,
+    characterGenderOptions,
+    isUnknownSpeciesName,
+    removeCharacterCarried,
+    removeCharacterDescribedEntry,
+    removeCharacterPersonalityTrait,
+    removeCharacterTitle,
+    setCharacterAge,
+    setCharacterAgeCategory,
+    setCharacterArchetypeName,
+    setCharacterCarriedName,
+    setCharacterDescribedEntry,
+    setCharacterGender,
+    setCharacterHeraldry,
+    setCharacterMeasurement,
+    setCharacterNamePart,
+    setCharacterPersonalityTrait,
+    setCharacterText,
+    setCharacterTitleField,
+    validateCharacterSnapshot,
+    type CharacterDescribedListField,
+    type CharacterMeasurementField,
+    type CharacterSnapshot,
+    type CharacterTitleField,
+  } from '$lib/characters';
+  import { armsFromStored, renderDeviceBlazon, toStoredArms } from '$lib/heraldry';
+  import { showHeraldryPersistenceModal } from '$lib/ui';
+
+  /**
+   * The editing view for a saved character.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it, so
+   * what is here is the character's own shape and the calls that change it.
+   *
+   * Every control writes a whole replacement snapshot through `onChange`. The framework compares
+   * that against what it read to decide whether anything needs saving, so typing a character and
+   * deleting it again leaves nothing to save — no bookkeeping here is required to achieve that.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps a character editor from rendering fields
+   * over something that is not a character.
+   */
+  const accepted = $derived(validateCharacterSnapshot(snapshot));
+  const character = $derived<CharacterSnapshot | undefined>(
+    accepted.ok ? accepted.value : undefined,
+  );
+
+  const MEASUREMENTS: { field: CharacterMeasurementField; label: string }[] = [
+    { field: 'height', label: 'Height (cm)' },
+    { field: 'weight', label: 'Weight (kg)' },
+    { field: 'length', label: 'Length (cm)' },
+  ];
+
+  const TITLE_FIELDS: { field: CharacterTitleField; label: string }[] = [
+    { field: 'maleTitle', label: 'Male form' },
+    { field: 'femaleTitle', label: 'Female form' },
+    { field: 'maleHonorific', label: 'Male honorific' },
+    { field: 'femaleHonorific', label: 'Female honorific' },
+    { field: 'landName', label: 'Land' },
+  ];
+
+  const DESCRIBED_LISTS: { list: CharacterDescribedListField; legend: string; noun: string }[] = [
+    { list: 'physicalTraits', legend: 'Physical traits', noun: 'physical trait' },
+    { list: 'abilities', legend: 'Abilities', noun: 'ability' },
+  ];
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: CharacterSnapshot) => CharacterSnapshot): void {
+    if (character === undefined) {
+      return;
+    }
+    onChange(change(character));
+  }
+
+  /**
+   * Draw this character a new coat of arms, through the same modal the generator uses.
+   *
+   * Only offered for a character carrying arms of their own. One wearing a referenced coat of arms
+   * holds a link rather than a copy, and replacing it from here would be editing someone else's
+   * record through a window — the same line `CultureArtifactEditor` draws around a referenced
+   * religion.
+   */
+  async function replaceArms(): Promise<void> {
+    const current = character;
+    if (current === undefined || current.heraldry === undefined || current.heraldry === null) {
+      return;
+    }
+    const result = await showHeraldryPersistenceModal({
+      arms: armsFromStored(current.heraldry),
+      seed: current.id,
+      title: current.name,
+    });
+    if (result.action === 'replaced') {
+      edit((snapshot) => setCharacterHeraldry(snapshot, toStoredArms(result.arms)));
+    }
+  }
+</script>
+
+{#if character === undefined}
+  <Notice tone="danger">
+    These contents are stored as a character but do not read as one, so there is nothing safe to
+    edit here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="character-editor">
+    <fieldset>
+      <legend>Name</legend>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-first-name">First name</label>
+        <input
+          id="{uid}-first-name"
+          type="text"
+          value={character.firstName}
+          oninput={(event) =>
+            edit((current) =>
+              setCharacterNamePart(current, 'firstName', event.currentTarget.value),
+            )}
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-last-name">Last name</label>
+        <input
+          id="{uid}-last-name"
+          type="text"
+          value={character.lastName}
+          oninput={(event) =>
+            edit((current) => setCharacterNamePart(current, 'lastName', event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>What they are</legend>
+
+      <!-- Species is shown and not editable, deliberately. Nothing recomputes the height, weight
+           or physical traits a species produced, so a select here would hand back an elf with a
+           halfling's build; a re-roll is how a character becomes a different species. -->
+      <p class="character-editor__note">
+        Species: {character.speciesName}{isUnknownSpeciesName(character.speciesName)
+          ? ' — this build no longer has that species, so only what was saved is shown.'
+          : ''}
+      </p>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-gender">Gender</label>
+        <select
+          id="{uid}-gender"
+          value={character.gender.name}
+          onchange={(event) =>
+            edit((current) => setCharacterGender(current, event.currentTarget.value))}
+        >
+          <!-- The stored value is kept as an option even when it is not one this build offers, so
+               opening a character never silently changes what they are. -->
+          {#if !characterGenderOptions().some((entry) => entry.name === character.gender.name)}
+            <option value={character.gender.name}>{character.gender.name}</option>
+          {/if}
+          {#each characterGenderOptions() as gender (gender.name)}
+            <option value={gender.name}>{gender.name}</option>
+          {/each}
+        </select>
+      </div>
+
+      {#if character.archetype !== undefined}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-archetype">Archetype</label>
+          <input
+            id="{uid}-archetype"
+            type="text"
+            value={character.archetype.name}
+            oninput={(event) =>
+              edit((current) => setCharacterArchetypeName(current, event.currentTarget.value))}
+            autocomplete="off"
+          />
+        </div>
+      {/if}
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-age">Age</label>
+        <input
+          id="{uid}-age"
+          type="number"
+          value={character.age}
+          oninput={(event) =>
+            edit((current) => setCharacterAge(current, event.currentTarget.valueAsNumber))}
+        />
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-age-category">Age category</label>
+        <select
+          id="{uid}-age-category"
+          value={character.ageCategory.name}
+          onchange={(event) =>
+            edit((current) => setCharacterAgeCategory(current, event.currentTarget.value))}
+        >
+          {#if !characterAgeCategoryOptions().some((entry) => entry.name === character.ageCategory.name)}
+            <option value={character.ageCategory.name}>{character.ageCategory.name}</option>
+          {/if}
+          {#each characterAgeCategoryOptions() as category (category.name)}
+            <option value={category.name}>{category.name}</option>
+          {/each}
+        </select>
+      </div>
+
+      {#each MEASUREMENTS as entry (entry.field)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-{entry.field}">{entry.label}</label>
+          <input
+            id="{uid}-{entry.field}"
+            type="number"
+            value={character[entry.field]}
+            oninput={(event) =>
+              edit((current) =>
+                setCharacterMeasurement(current, entry.field, event.currentTarget.valueAsNumber),
+              )}
+          />
+        </div>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Description</legend>
+
+      <div class="input-group character-editor__stacked">
+        <label for="{uid}-description">Description</label>
+        <textarea
+          id="{uid}-description"
+          rows="4"
+          value={character.description}
+          oninput={(event) =>
+            edit((current) => setCharacterText(current, 'description', event.currentTarget.value))}
+        ></textarea>
+      </div>
+
+      <div class="input-group character-editor__stacked">
+        <label for="{uid}-short-description">Short description</label>
+        <textarea
+          id="{uid}-short-description"
+          rows="2"
+          value={character.shortDescription}
+          oninput={(event) =>
+            edit((current) =>
+              setCharacterText(current, 'shortDescription', event.currentTarget.value),
+            )}
+        ></textarea>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Personality</legend>
+
+      <!-- Keyed by position rather than by value: two traits may read the same, and a key that
+           changed as the user typed would lose focus on every keystroke. -->
+      {#each character.personalityTraits as trait, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-personality-{index}">Trait {index + 1}</label>
+          <input
+            id="{uid}-personality-{index}"
+            type="text"
+            value={trait}
+            oninput={(event) =>
+              edit((current) =>
+                setCharacterPersonalityTrait(current, index, event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+          <BaseButton
+            aria-label="Remove personality trait {index + 1}"
+            onclick={() => edit((current) => removeCharacterPersonalityTrait(current, index))}
+          >
+            Remove
+          </BaseButton>
+        </div>
+      {/each}
+
+      <BaseButton onclick={() => edit((current) => addCharacterPersonalityTrait(current))}>
+        Add a personality trait
+      </BaseButton>
+    </fieldset>
+
+    {#each DESCRIBED_LISTS as list (list.list)}
+      <fieldset>
+        <legend>{list.legend}</legend>
+
+        {#each character[list.list] as entry, index (index)}
+          <div class="input-group input-group--inline">
+            <label for="{uid}-{list.list}-{index}-name">{list.noun} {index + 1} name</label>
+            <input
+              id="{uid}-{list.list}-{index}-name"
+              type="text"
+              value={entry.name}
+              oninput={(event) =>
+                edit((current) =>
+                  setCharacterDescribedEntry(
+                    current,
+                    list.list,
+                    index,
+                    'name',
+                    event.currentTarget.value,
+                  ),
+                )}
+              autocomplete="off"
+            />
+            <BaseButton
+              aria-label="Remove {list.noun} {index + 1}"
+              onclick={() =>
+                edit((current) => removeCharacterDescribedEntry(current, list.list, index))}
+            >
+              Remove
+            </BaseButton>
+          </div>
+          <div class="input-group character-editor__stacked">
+            <label for="{uid}-{list.list}-{index}-description">
+              {list.noun}
+              {index + 1} description
+            </label>
+            <textarea
+              id="{uid}-{list.list}-{index}-description"
+              rows="2"
+              value={entry.description}
+              oninput={(event) =>
+                edit((current) =>
+                  setCharacterDescribedEntry(
+                    current,
+                    list.list,
+                    index,
+                    'description',
+                    event.currentTarget.value,
+                  ),
+                )}
+            ></textarea>
+          </div>
+        {/each}
+
+        <BaseButton
+          onclick={() => edit((current) => addCharacterDescribedEntry(current, list.list))}
+        >
+          Add {list.noun === 'ability' ? 'an' : 'a'}
+          {list.noun}
+        </BaseButton>
+      </fieldset>
+    {/each}
+
+    <fieldset>
+      <legend>Equipment</legend>
+
+      {#each character.carried as item, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-carried-{index}">Item {index + 1}</label>
+          <input
+            id="{uid}-carried-{index}"
+            type="text"
+            value={item.name}
+            oninput={(event) =>
+              edit((current) => setCharacterCarriedName(current, index, event.currentTarget.value))}
+            autocomplete="off"
+          />
+          <BaseButton
+            aria-label="Remove item {index + 1}"
+            onclick={() => edit((current) => removeCharacterCarried(current, index))}
+          >
+            Remove
+          </BaseButton>
+        </div>
+      {/each}
+
+      <BaseButton onclick={() => edit((current) => addCharacterCarried(current))}>
+        Add an item
+      </BaseButton>
+    </fieldset>
+
+    <fieldset>
+      <legend>Titles</legend>
+
+      {#each character.titles ?? [] as title, index (index)}
+        <div class="character-editor__title">
+          {#each TITLE_FIELDS as entry (entry.field)}
+            <div class="input-group input-group--inline">
+              <label for="{uid}-title-{index}-{entry.field}">
+                Title {index + 1}
+                {entry.label}
+              </label>
+              <input
+                id="{uid}-title-{index}-{entry.field}"
+                type="text"
+                value={title[entry.field]}
+                oninput={(event) =>
+                  edit((current) =>
+                    setCharacterTitleField(current, index, entry.field, event.currentTarget.value),
+                  )}
+                autocomplete="off"
+              />
+            </div>
+          {/each}
+          <BaseButton
+            aria-label="Remove title {index + 1}"
+            onclick={() => edit((current) => removeCharacterTitle(current, index))}
+          >
+            Remove title {index + 1}
+          </BaseButton>
+        </div>
+      {/each}
+
+      <BaseButton onclick={() => edit((current) => addCharacterTitle(current))}>
+        Add a title
+      </BaseButton>
+    </fieldset>
+
+    <fieldset>
+      <legend>Heraldry</legend>
+
+      {#if character.heraldry === null}
+        <p class="character-editor__note">
+          This character bears a saved coat of arms of its own, linked above. Editing it there
+          changes it everywhere it is used, including here.
+        </p>
+      {:else if character.heraldry === undefined}
+        <p class="character-editor__note">This character bears no arms.</p>
+      {:else}
+        <p>{renderDeviceBlazon(armsFromStored(character.heraldry).device)}</p>
+        <div class="character-editor__arms-controls">
+          <BaseButton onclick={replaceArms}>Replace coat of arms</BaseButton>
+          <BaseButton onclick={() => edit((current) => setCharacterHeraldry(current, undefined))}>
+            Remove coat of arms
+          </BaseButton>
+        </div>
+      {/if}
+    </fieldset>
+  </div>
+{/if}
+
+<style>
+  .character-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+  }
+
+  .character-editor fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s3);
+    align-items: flex-start;
+    margin: 0;
+    /* No border and no radius, matching the culture editor: a fieldset inside an editor panel was
+       a box inside a box, and the legend and the spacing already group these fields. */
+    padding: var(--s4) 0;
+    min-width: 0;
+  }
+
+  .character-editor legend {
+    padding: 0 var(--s3);
+    color: var(--gold);
+    font-size: var(--t-micro-size);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .character-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  /* Prose wants the width; a label beside a textarea on a 320px screen leaves neither enough room. */
+  .character-editor .character-editor__stacked {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .character-editor input[type='text'],
+  .character-editor input[type='number'],
+  .character-editor textarea {
+    min-width: 0;
+    flex: 1 1 6rem;
+    width: 100%;
+  }
+
+  .character-editor__title {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s2);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .character-editor__arms-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .character-editor__note {
+    font-size: var(--t-small-size);
+    font-style: italic;
+    margin: 0;
+  }
+</style>

--- a/src/components/characters/CharacterGenerator.svelte
+++ b/src/components/characters/CharacterGenerator.svelte
@@ -4,21 +4,32 @@
   import { RNG } from '@ironarachne/rng';
   import * as Measurements from '$lib/measurements';
   import {
-    applyNameGeneratorsToCharacterGenerationConfig,
     buildCharacterNameSource,
-    generate,
-    getDefaultCharacterGenerationConfig,
-    isCustomCharacterNameSource,
-    resolveCharacterNameGeneratorSet,
-    restoreLockedCharacterName,
+    characterFileStem,
+    characterTitleLine,
+    characterToMarkdown,
+    characterToPlainText,
+    CHARACTER_ANY,
+    CHARACTER_ARTIFACT_KIND,
+    formatCharacterDisplayName,
+    nameGeneratorSetForSource,
+    rollCharacter,
     rollCharacterNameForSource,
+    toCharacterSnapshot,
     type Character,
-    type CharacterGenerationConfig,
-    type Title,
+    type CharacterGeneratorConfigRecord,
     loadCulturesForNaming,
   } from '$lib/characters';
-  import type { Arms } from '$lib/heraldry';
-  import { renderDeviceBlazon, renderHeraldryDeviceSvg } from '$lib/heraldry';
+  import type { ArtifactReference } from '$lib/artifacts';
+  import Download from '$lib/download';
+  import { downloadTextPdf } from '$lib/pdf';
+  import {
+    HERALDRY_ARTIFACT_KIND,
+    renderDeviceBlazon,
+    renderHeraldryDeviceSvg,
+    type Arms,
+    type RestoredHeraldry,
+  } from '$lib/heraldry';
   import { showHeraldryPersistenceModal } from '$lib/ui';
   import type { Culture } from '$lib/culture';
   import { sentientSpeciesList } from '$lib/species_sentients';
@@ -28,7 +39,12 @@
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
   import SeedControls from '$components/common/SeedControls.svelte';
   import CharacterNameSection from '$components/characters/CharacterNameSection.svelte';
+  import DownloadPdfButton from '$components/common/DownloadPdfButton.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
+  import SavedArtifactPicker from '$components/common/SavedArtifactPicker.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
+
+  const TOOL_PATH = '/character';
 
   const heraldryWidth = 200;
   const heraldryHeight = 220;
@@ -36,111 +52,189 @@
   const speciesList = sentientSpeciesList;
   const archetypeOptions = getAllFantasyArchetypes().sort((a, b) => a.name.localeCompare(b.name));
   const ageCategories = getCategoryList();
-  const genderOptions = ['Random', 'Male', 'Female'];
+  const genderOptions = [CHARACTER_ANY, 'Male', 'Female'];
 
-  let seed = $state(new RNG(Date.now().toString()).randomString(13));
-  const rng = new RNG(seed);
-  let character = $state<null | Character>(null);
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. That is the whole of requirement 2.2's
+   * fix here: the clock decides where the sequence of seeds *starts*, and everything after it is a
+   * pure function of the seed on screen. This used to reseed from `Date.now()` inside every roll,
+   * so a locked seed reproduced nothing.
+   */
+  const rng = new RNG(Date.now().toString());
+  let seed = $state(rng.randomString(13));
+  let lockSeed = $state(false);
+
+  /**
+   * The rolled character.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every array and object in
+   * the character in a Proxy, and `structuredClone` — what IndexedDB stores with — refuses a Proxy
+   * outright, so saving fails with `could not be cloned`. The same trap is written up in
+   * `$lib/workshop`'s README beside `saveToolArtifact`, and the AD&D generator hit it first.
+   */
+  let character = $state.raw<Character | null>(null);
+  /** The settings the character on screen was actually rolled with. Raw, for the same reason. */
+  let rolledConfig = $state.raw<Record<string, unknown>>({});
 
   let savedCultures = $state<Culture[]>([]);
-  let nameSourceKind = $state<'default' | 'preset' | 'saved_culture'>('default');
+  let nameSourceKind = $state<'default' | 'preset' | 'saved_culture' | 'referenced_culture'>(
+    'default',
+  );
   let presetSetName = $state('human');
   let savedCultureName = $state('');
   let firstName = $state('');
   let lastName = $state('');
   let lockName = $state(false);
+  /** The culture the picker loaded, and the link to record for it. */
+  let referencedCulture = $state<Culture | undefined>();
+  let cultureReference = $state<ArtifactReference | undefined>();
+  /**
+   * The culture link, recorded only when the character on screen was actually named from it.
+   *
+   * Gated on the roll rather than on the picker, as the AD&D generator gates its own: a reference
+   * is a record of what the tool was handed, and one written for a character whose names came from
+   * somewhere else would claim an input that was never used.
+   */
+  let rolledCultureReference = $state.raw<ArtifactReference | undefined>();
+
+  /** Filled in by the arms picker: a saved coat of arms to wear instead of rolling one. */
+  let useReferencedArms = $state(false);
+  let referencedArms = $state<RestoredHeraldry | undefined>();
+  let armsReference = $state<ArtifactReference | undefined>();
+  let armsProblem = $state<string | null>(null);
 
   let selectedSpeciesName = $state('human');
-  let selectedArchetypeName = $state('Random');
-  let selectedGenderName = $state('Random');
-  let selectedAgeCategoryName = $state('Random');
+  let selectedArchetypeName = $state<string>(CHARACTER_ANY);
+  let selectedGenderName = $state<string>(CHARACTER_ANY);
+  let selectedAgeCategoryName = $state<string>(CHARACTER_ANY);
 
-  let lockSeed = $state(false);
-  $effect(() => {
-    if (!lockSeed) {
-      rng.setSeed(seed);
-    }
-  });
+  /**
+   * Whether the character on screen is wearing a referenced coat of arms.
+   *
+   * Gated on the picker having actually loaded one, not on the checkbox: a ticked box whose
+   * artifact has not arrived would otherwise store `heraldry: null` beside no reference at all,
+   * which is a character with a hole where their arms were.
+   */
+  const wearingReferencedArms = $derived(useReferencedArms && referencedArms !== undefined);
 
-  function applyNameGeneratorsForCharacterGeneration(
-    config: CharacterGenerationConfig,
-    speciesName: string,
-  ) {
+  /** The arms to show: the character's own, or the saved ones standing in for them. */
+  const shownArms = $derived<Arms | null>(
+    wearingReferencedArms ? (referencedArms?.arms ?? null) : (character?.heraldry ?? null),
+  );
+
+  /**
+   * The character with the names the page is showing, which is what the sheet and the exports want.
+   *
+   * They differ from the roll's whenever the user has typed a name or locked one, and the display
+   * below already renders it this way. Saving the roll's name instead would keep something the user
+   * can see is not what they asked for.
+   */
+  const namedCharacter = $derived<Character | null>(
+    character === null
+      ? null
+      : {
+          ...character,
+          firstName,
+          lastName,
+          name: formatCharacterDisplayName(firstName, lastName),
+          ...(wearingReferencedArms && referencedArms !== undefined
+            ? { heraldry: referencedArms.arms }
+            : {}),
+        },
+  );
+
+  /**
+   * What a project stores. The generator owns the conversion — it is the `toSnapshot` half of its
+   * own kind — so what reaches the save button is already the payload.
+   *
+   * The referenced-arms flag is passed through because only this page knows whether the arms on
+   * screen came from a picker. Stored as `null` plus a reference, they stay one record that someone
+   * may edit later, rather than a copy forked at the moment of saving.
+   */
+  const characterSnapshot = $derived(
+    namedCharacter === null ? null : toCharacterSnapshot(namedCharacter, wearingReferencedArms),
+  );
+
+  const references = $derived(
+    [rolledCultureReference, wearingReferencedArms ? armsReference : undefined].filter(
+      (entry): entry is ArtifactReference => entry !== undefined,
+    ),
+  );
+
+  const defaultArtifactName = $derived(formatCharacterDisplayName(firstName, lastName));
+
+  /** The settings a roll takes, and the ones provenance records. */
+  function currentConfig(): CharacterGeneratorConfigRecord {
     const source = buildCharacterNameSource(
       nameSourceKind,
       presetSetName,
       savedCultureName,
       savedCultures,
+      referencedCulture,
     );
-    if (isCustomCharacterNameSource(source)) {
-      const nameSet = resolveCharacterNameGeneratorSet(rng, source, speciesName);
-      applyNameGeneratorsToCharacterGenerationConfig(config, nameSet);
-      return;
-    }
-
-    const nameSet = resolveCharacterNameGeneratorSet(rng, { kind: 'default' }, speciesName);
-    applyNameGeneratorsToCharacterGenerationConfig(config, nameSet);
+    const nameGeneratorSet = nameGeneratorSetForSource(source);
+    return {
+      speciesName: selectedSpeciesName,
+      archetypeName: selectedArchetypeName,
+      genderName: selectedGenderName,
+      ageCategoryName: selectedAgeCategoryName,
+      ...(nameGeneratorSet === '' ? {} : { nameGeneratorSet }),
+      namingGender: 'random',
+    };
   }
 
   function generateCharacter() {
     if (!lockSeed) {
-      seed = new RNG(Date.now().toString()).randomString(13);
-      rng.setSeed(seed);
+      seed = rng.randomString(13);
     }
 
     const lockedFirstName = firstName;
     const lockedLastName = lastName;
 
-    const config = getDefaultCharacterGenerationConfig(seed + '-character');
+    const config = currentConfig();
+    const rolled = rollCharacter(seed, config);
+    character = rolled.character;
+    // The resolved set, not the requested one: a set this build has since dropped would otherwise
+    // be recorded as provenance a re-roll could not honour.
+    rolledConfig = { ...config, nameGeneratorSet: rolled.nameGeneratorSet };
+    rolledCultureReference =
+      nameSourceKind === 'referenced_culture' && referencedCulture !== undefined
+        ? cultureReference
+        : undefined;
 
-    const species =
-      sentientSpeciesList.find((s) => s.name === selectedSpeciesName) || sentientSpeciesList[0];
-    config.species = species;
-
-    applyNameGeneratorsForCharacterGeneration(config, species.name);
-
-    if (selectedArchetypeName !== 'Random') {
-      const arch = archetypeOptions.find((a) => a.name === selectedArchetypeName);
-      if (arch) {
-        config.archetypeOptions = [arch];
-      }
-    }
-
-    if (selectedGenderName !== 'Random') {
-      config.allowedGenderNames = [selectedGenderName.toLowerCase()];
-    } else {
-      config.allowedGenderNames = undefined;
-    }
-
-    if (selectedAgeCategoryName !== 'Random') {
-      config.allowedAgeCategoryNames = [selectedAgeCategoryName];
-    } else {
-      config.allowedAgeCategoryNames = undefined;
-    }
-
-    character = generate(seed + '-character', config);
     if (lockName) {
-      restoreLockedCharacterName(character, lockedFirstName, lockedLastName);
+      firstName = lockedFirstName;
+      lastName = lockedLastName;
     } else {
-      firstName = character.firstName;
-      lastName = character.lastName;
+      firstName = rolled.character.firstName;
+      lastName = rolled.character.lastName;
     }
   }
 
+  /**
+   * Another name for the character already on screen.
+   *
+   * An **edit**, not a generation, and so a fresh draw that does not touch the recorded seed:
+   * requirement 4.2 says the payload is what the user kept, and a name they asked for is not
+   * something a seed reproduces. The character itself is untouched — it is raw state, and every
+   * reader already composes the shown names over it.
+   */
   function generateNameOnly() {
     if (lockName) {
       return;
     }
     const speciesName = character?.species.name ?? selectedSpeciesName;
-    const nameRng = new RNG(`${Date.now()}-character-name`);
     const source = buildCharacterNameSource(
       nameSourceKind,
       presetSetName,
       savedCultureName,
       savedCultures,
+      referencedCulture,
     );
     const generated = rollCharacterNameForSource(
-      nameRng,
+      new RNG(`${Date.now()}-character-name`),
       source,
       speciesName,
       'random',
@@ -148,43 +242,45 @@
     );
     firstName = generated.firstName;
     lastName = generated.lastName;
-    if (character) {
-      character = {
-        ...character,
-        firstName: generated.firstName,
-        lastName: generated.lastName,
-        name: `${generated.firstName} ${generated.lastName}`.trim(),
-      };
-    }
   }
 
-  async function openHeraldryModal(
-    arms: Arms,
-    title: string,
-    applyReplacement: (arms: Arms) => void,
-  ) {
+  async function openHeraldryModal(arms: Arms, title: string) {
     const result = await showHeraldryPersistenceModal({ arms, seed, title });
-    if (result.action === 'replaced') {
-      applyReplacement(result.arms);
+    if (result.action === 'replaced' && character !== null) {
+      // A replacement is the character's own arms, whatever they were wearing before: the user has
+      // just made a coat of arms for this person, so the reference is no longer what they are
+      // showing.
+      useReferencedArms = false;
+      character = { ...character, heraldry: result.arms };
     }
   }
 
-  function replaceCharacterHeraldry(arms: Arms) {
-    if (character === null) {
+  function exportMarkdown() {
+    if (namedCharacter === null) {
       return;
     }
-    character = {
-      ...character,
-      heraldry: arms,
-    };
+    const markdown = characterToMarkdown(namedCharacter);
+    const url = URL.createObjectURL(new Blob([markdown], { type: 'text/markdown' }));
+    Download(url, `${characterFileStem(namedCharacter)}.md`);
+    URL.revokeObjectURL(url);
   }
 
-  function getDisplayTitle(title: Title, genderName: string): string {
-    const titleName = genderName.toLowerCase() === 'female' ? title.femaleTitle : title.maleTitle;
-    if (title.hasLands && title.landName) {
-      return `${titleName} of ${title.landName}`;
+  let downloadingPdf = $state(false);
+
+  async function exportPdf() {
+    if (namedCharacter === null || downloadingPdf) {
+      return;
     }
-    return titleName;
+    downloadingPdf = true;
+    try {
+      await downloadTextPdf(
+        namedCharacter.name,
+        characterToPlainText(namedCharacter),
+        `${characterFileStem(namedCharacter)}.pdf`,
+      );
+    } finally {
+      downloadingPdf = false;
+    }
   }
 
   onMount(() => {
@@ -200,7 +296,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/character" title="Character">
+<GeneratorPage toolPath={TOOL_PATH} title="Character">
   {#snippet description()}
     <p>This generator creates random characters.</p>
   {/snippet}
@@ -219,7 +315,7 @@
   <div class="input-group">
     <label for="archetype">Archetype</label>
     <select bind:value={selectedArchetypeName} id="archetype">
-      <option value="Random">Random</option>
+      <option value={CHARACTER_ANY}>{CHARACTER_ANY}</option>
       {#each archetypeOptions as archetype}
         <option value={archetype.name}>{archetype.name}</option>
       {/each}
@@ -238,7 +334,7 @@
   <div class="input-group">
     <label for="age">Age</label>
     <select bind:value={selectedAgeCategoryName} id="age">
-      <option value="Random">Random</option>
+      <option value={CHARACTER_ANY}>{CHARACTER_ANY}</option>
       {#each ageCategories as age}
         <option value={age}>{age}</option>
       {/each}
@@ -246,6 +342,9 @@
   </div>
 
   <CharacterNameSection
+    offerReferencedCulture
+    bind:referencedCulture
+    bind:cultureReference
     bind:nameSourceKind
     bind:presetSetName
     bind:savedCultureName
@@ -256,94 +355,121 @@
     onGenerateName={generateNameOnly}
   />
 
+  <SavedArtifactPicker
+    kind={HERALDRY_ARTIFACT_KIND}
+    role="arms"
+    checkboxLabel="Give this character a saved coat of arms"
+    selectLabel="Coat of arms"
+    bind:enabled={useReferencedArms}
+    bind:value={referencedArms}
+    bind:reference={armsReference}
+    bind:problem={armsProblem}
+  />
+
   <BaseButton onclick={generateCharacter}>Generate</BaseButton>
 
-  {#if character}
-    <h2>{character.name}</h2>
-    {#if character.titles && character.titles.length > 0}
+  <SaveArtifactButton
+    kind={CHARACTER_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={characterSnapshot}
+    {seed}
+    config={rolledConfig}
+    defaultName={defaultArtifactName}
+    {references}
+  />
+
+  {#if namedCharacter}
+    <h2>{namedCharacter.name}</h2>
+
+    <div class="character-exports">
+      <BaseButton onclick={exportMarkdown}>Download Markdown</BaseButton>
+      <DownloadPdfButton onclick={exportPdf} downloading={downloadingPdf} />
+    </div>
+
+    {#if namedCharacter.titles && namedCharacter.titles.length > 0}
       <h3>Titles</h3>
       <ul>
-        {#each character.titles as title}
-          <li>{getDisplayTitle(title, character.gender.name)}</li>
+        {#each namedCharacter.titles as title}
+          <li>{characterTitleLine(title, namedCharacter.gender.name)}</li>
         {/each}
       </ul>
     {/if}
     <StatBlock>
-      <Stat label="Description">{character.description}</Stat>
-      <Stat label="Gender">{character.gender.name}</Stat>
-      <Stat label="Species">{character.species.name}</Stat>
-      {#if character.creatureTypes.length > 0}
-        <Stat label="Type">{character.creatureTypes.join(', ')}</Stat>
+      <Stat label="Description">{namedCharacter.description}</Stat>
+      <Stat label="Gender">{namedCharacter.gender.name}</Stat>
+      <Stat label="Species">{namedCharacter.species.name}</Stat>
+      {#if namedCharacter.creatureTypes.length > 0}
+        <Stat label="Type">{namedCharacter.creatureTypes.join(', ')}</Stat>
       {/if}
-      {#if character.archetype}
-        <Stat label="Archetype">{character.archetype.name}</Stat>
+      {#if namedCharacter.archetype}
+        <Stat label="Archetype">{namedCharacter.archetype.name}</Stat>
       {/if}
-      <Stat label="Age">{character.age} years ({character.ageCategory.name})</Stat>
+      <Stat label="Age">{namedCharacter.age} years ({namedCharacter.ageCategory.name})</Stat>
     </StatBlock>
     <Stat label="Height">
-      {Measurements.inchesToFeetExpression(Measurements.cmToInches(character.height))}
+      {Measurements.inchesToFeetExpression(Measurements.cmToInches(namedCharacter.height))}
     </Stat>
-    {#if character.length > 0}
+    {#if namedCharacter.length > 0}
       <Stat label="Length">
-        {Measurements.inchesToFeetExpression(Measurements.cmToInches(character.length))}
+        {Measurements.inchesToFeetExpression(Measurements.cmToInches(namedCharacter.length))}
       </Stat>
     {/if}
     <StatBlock>
-      <Stat label="Weight">{Measurements.kgToPounds(character.weight)} lbs.</Stat>
+      <Stat label="Weight">{Measurements.kgToPounds(namedCharacter.weight)} lbs.</Stat>
     </StatBlock>
 
-    {#if character.physicalTraits.length > 0}
+    {#if namedCharacter.physicalTraits.length > 0}
       <h3>Physical Traits</h3>
       <ul>
-        {#each character.physicalTraits as trait}
+        {#each namedCharacter.physicalTraits as trait}
           <li><strong>{trait.name}:</strong> {trait.description}</li>
         {/each}
       </ul>
     {/if}
 
-    {#if character.personalityTraits.length > 0}
+    {#if namedCharacter.personalityTraits.length > 0}
       <h3>Personality</h3>
-      <p>{character.personalityTraits.join(', ')}</p>
+      <p>{namedCharacter.personalityTraits.join(', ')}</p>
     {/if}
 
-    {#if character.heraldry}
+    {#if shownArms}
       <h3>Heraldry</h3>
+      {#if wearingReferencedArms}
+        <!-- Named as borrowed, because it is: the character stores a link, not a copy, so editing
+             those arms changes what this character bears. -->
+        <p class="character-referenced-arms">From a saved coat of arms.</p>
+      {/if}
       <button
         type="button"
         class="character-heraldry heraldry-block-target"
-        aria-label="View heraldry for {character.name}"
+        aria-label="View heraldry for {namedCharacter.name}"
         onclick={() => {
-          const current = character;
-          if (current?.heraldry) {
-            void openHeraldryModal(current.heraldry, current.name, replaceCharacterHeraldry);
+          const arms = shownArms;
+          if (arms !== null) {
+            void openHeraldryModal(arms, namedCharacter.name);
           }
         }}
       >
         <!-- Renders app-generated markup (no external or user-supplied input). -->
         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-        {@html renderHeraldryDeviceSvg(
-          character.heraldry.device,
-          heraldryWidth,
-          heraldryHeight,
-          rng,
-        )}
+        {@html renderHeraldryDeviceSvg(shownArms.device, heraldryWidth, heraldryHeight, rng)}
       </button>
-      <p>{renderDeviceBlazon(character.heraldry.device)}</p>
+      <p>{renderDeviceBlazon(shownArms.device)}</p>
     {/if}
 
-    {#if character.abilities.length > 0}
+    {#if namedCharacter.abilities.length > 0}
       <h3>Abilities</h3>
       <ul>
-        {#each character.abilities as ability}
+        {#each namedCharacter.abilities as ability}
           <li><strong>{ability.name}:</strong> {ability.description}</li>
         {/each}
       </ul>
     {/if}
 
-    {#if character.carried.length > 0}
+    {#if namedCharacter.carried.length > 0}
       <h3>Equipment</h3>
       <ul>
-        {#each character.carried as item}
+        {#each namedCharacter.carried as item}
           <li>{item.name}</li>
         {/each}
       </ul>
@@ -352,6 +478,17 @@
 </GeneratorPage>
 
 <style>
+  .character-exports {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .character-referenced-arms {
+    font-style: italic;
+    opacity: 0.9;
+  }
+
   button.character-heraldry {
     width: 200px;
     height: 220px;

--- a/src/lib/characters/README.md
+++ b/src/lib/characters/README.md
@@ -6,7 +6,23 @@ titles they answer to. A `Character` extends `Creature`, so anything that works 
 on characters too.
 
 Generation is seeded — `generate(seed, config)` builds its own `RNG` — so the same seed and config
-always produce the same person.
+always produce the same person. `rollCharacter(seed, config)` is the single path the Fantasy
+Character generator and a re-roll from provenance both take; prefer it over calling `generate`
+directly, because it is where the settings a re-roll reads back are defined.
+
+## This library implements no game system
+
+Deliberately, and it is worth saying plainly (requirement 8.4 of [the readiness
+spec](../../../docs/workshop.md#tool-release-readiness)). A character here has **no levels, no
+classes, no attribute scores, and no derived combat numbers** — an archetype is an occupation and a
+flavour, not a character class, and `combatProfile` is the generic creature default rather than
+anything a ruleset would recognise. A character is a _person_: someone to put behind a counter or at
+the head of a household, usable at any table.
+
+Where a system's character lives instead: `$lib/adnd` (AD&D 2E), `$lib/dcc`, `$lib/swn`, and
+`$lib/unchartedworlds`. That is also why the artifact kind here is `character`, unqualified, and
+theirs are `character.adnd-2e` and the like — see
+[docs/fantasy-character.md](../../../docs/fantasy-character.md), decision 1.
 
 ## Features
 
@@ -26,6 +42,20 @@ always produce the same person.
   that offer "name this character from a saved culture" agree about what the user has saved.
 - **Personality traits** — `allPersonalityTraits` and `getRandomPersonalityTraits`, which respects
   each trait's `conflictingTraits` so a character is not both bold and timid.
+- **Rolling** — `rollCharacter` and `rollCharacterSnapshot`, with
+  `CharacterGeneratorConfigRecord` and `readCharacterGeneratorConfig` — the typed boundary where an
+  artifact's untyped provenance becomes settings a roll can take. A roll reports the pattern set it
+  actually used and any part of the recorded config this build could no longer supply.
+- **Storing** — `toCharacterSnapshot` and `toStoredCharacter` write a character with its species,
+  archetype, and arms as names; `characterFromSnapshot`, `characterFromStored`,
+  `speciesFromStoredName` and `isUnknownSpeciesName` read one back. `StoredCharacter` lives here
+  rather than in `$lib/settlements`, which embeds it for its notables.
+- **The artifact kind** — `characterArtifactKind`, `CHARACTER_ARTIFACT_KIND`,
+  `validateCharacterSnapshot`, `migrateCharacterSnapshot`.
+- **Editing a saved character** — `character_editing.ts`: one function per field, each taking a
+  snapshot and returning a new one. Species is not among them; see the module comment for why.
+- **Presentation** — `characterToDocument`, `characterToMarkdown`, `characterToPlainText`,
+  `characterFileStem`, and `characterTitleLine`, for the Markdown and PDF exports.
 - **Titles** — `getStandardNobleTitles`, `getNobleTitleByName`, `getTitle`, `getHonorific`,
   `getTitleForGender`, `createTitleFromCore`, and the precedence helpers
   (`hasHigherPrecedenceThan`, `hasLowerPrecedenceThan`, `getHighestPrecedenceTitle`).

--- a/src/lib/characters/character_artifact_kind.test.ts
+++ b/src/lib/characters/character_artifact_kind.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  characterArtifactKind,
+  CHARACTER_ARTIFACT_KIND,
+  CHARACTER_PAYLOAD_VERSION,
+  migrateCharacterSnapshot,
+  validateCharacterSnapshot,
+} from './character_artifact_kind.js';
+import { rollCharacter } from './character_roll.js';
+import { toCharacterSnapshot, type CharacterSnapshot } from './character_snapshot.js';
+
+function snapshot(config: Parameters<typeof rollCharacter>[1] = {}): CharacterSnapshot {
+  return toCharacterSnapshot(rollCharacter('kind-fixture', config).character);
+}
+
+describe('the character artifact kind', () => {
+  it('is registered unqualified, and does not collide with a system-qualified character', () => {
+    expect(CHARACTER_ARTIFACT_KIND).toBe('character');
+    expect(characterArtifactKind.kind).toBe('character');
+    expect(characterArtifactKind.payloadVersion).toBe(CHARACTER_PAYLOAD_VERSION);
+    expect(characterArtifactKind.icon).not.toBe('');
+  });
+
+  it('names an artifact after the character', () => {
+    const rolled = snapshot();
+
+    expect(characterArtifactKind.nameOf(rolled)).toBe(rolled.name);
+  });
+
+  it('falls back to what a nameless character is', () => {
+    const base = snapshot();
+
+    expect(
+      characterArtifactKind.nameOf({
+        ...base,
+        name: '   ',
+        speciesName: 'elf',
+        archetype: { ...(base.archetype ?? { tags: [] }), name: 'noble' } as typeof base.archetype,
+      }),
+    ).toBe('elf noble');
+  });
+
+  it('round-trips through the codec the registry loads', async () => {
+    const codec = await characterArtifactKind.loadCodec();
+    const { character } = rollCharacter('codec-fixture');
+    const stored = codec.toSnapshot(character) as CharacterSnapshot;
+
+    expect(validateCharacterSnapshot(stored).ok).toBe(true);
+    expect((codec.fromSnapshot(stored, undefined as never) as typeof character).name).toBe(
+      character.name,
+    );
+  });
+});
+
+describe('validating a character payload', () => {
+  it('accepts what the generator writes', () => {
+    expect(validateCharacterSnapshot(snapshot()).ok).toBe(true);
+    expect(validateCharacterSnapshot(snapshot({ archetypeName: 'noble' })).ok).toBe(true);
+  });
+
+  it('accepts a character whose arms are a referenced artifact', () => {
+    const rolled = toCharacterSnapshot(
+      rollCharacter('referenced', { archetypeName: 'noble' }).character,
+      true,
+    );
+
+    expect(rolled.heraldry).toBeNull();
+    expect(validateCharacterSnapshot(rolled).ok).toBe(true);
+  });
+
+  it('rejects something that is not an object', () => {
+    const result = validateCharacterSnapshot('a character, honestly');
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? '' : result.reason).toBe('invalid-payload');
+  });
+
+  it('rejects a payload with no species name to resolve', () => {
+    const { speciesName: _dropped, ...rest } = snapshot();
+
+    expect(validateCharacterSnapshot(rest).ok).toBe(false);
+  });
+
+  it('rejects a payload whose build is not numbers', () => {
+    expect(validateCharacterSnapshot({ ...snapshot(), height: 'tallish' }).ok).toBe(false);
+  });
+
+  it('rejects a gender with no name, which the description prose reads', () => {
+    expect(validateCharacterSnapshot({ ...snapshot(), gender: { pronouns: {} } }).ok).toBe(false);
+  });
+
+  it('rejects arms with no blazon to print', () => {
+    expect(validateCharacterSnapshot({ ...snapshot(), heraldry: { device: {} } }).ok).toBe(false);
+  });
+
+  /**
+   * A species this build no longer has is not a corrupt record. Quarantining over the lookup would
+   * retire a saved character permanently; `character_rehydrate.ts` gives it a placeholder instead.
+   */
+  it('accepts a species name this build does not have', () => {
+    expect(validateCharacterSnapshot({ ...snapshot(), speciesName: 'Thrennish' }).ok).toBe(true);
+  });
+});
+
+describe('migrating a character payload', () => {
+  it('rejects, because version 1 is the only shape there has been', () => {
+    const result = migrateCharacterSnapshot(snapshot(), 0);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? '' : result.reason).toBe('unsupported-version');
+  });
+});

--- a/src/lib/characters/character_artifact_kind.ts
+++ b/src/lib/characters/character_artifact_kind.ts
@@ -1,0 +1,272 @@
+import human from '$lib/assets/icons/set3/human.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  isStringArray,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import type { CharacterSnapshot } from './character_snapshot';
+import type { Character } from './character_types';
+
+/**
+ * Stable artifact kind id — unqualified, and deliberately so.
+ *
+ * A character from this generator is a *person*: a name, a species, an occupation, a build and some
+ * traits. It is not a set of numbers that mean something only under one ruleset, which is the test
+ * decision 4 of docs/workshop.md sets for whether a kind is system-qualified. So the qualifier would
+ * be a lie about what the payload is.
+ *
+ * It leaves `character.adnd-2e` — registered — and `character.dcc`, `character.swn` and
+ * `character.uncharted-worlds` — not yet — free, and sorts with them in a vault listing: concept
+ * first, system as the qualifier, with the unqualified one as the generic.
+ *
+ * A character saved from `/character` and one saved from `/fantasy/adnd/character` are different
+ * kinds on purpose. They are not the same payload, and one editor cannot open both.
+ */
+export const CHARACTER_ARTIFACT_KIND = 'character' as const;
+
+/** Version 1. The first shape a fantasy character has been stored in. */
+export const CHARACTER_PAYLOAD_VERSION = 1 as const;
+
+const CHARACTER_STRING_FIELDS = [
+  'id',
+  'name',
+  'firstName',
+  'lastName',
+  'description',
+  'shortDescription',
+  'speciesName',
+];
+
+const CHARACTER_NUMBER_FIELDS = ['age', 'height', 'weight', 'length'];
+
+function hasNumberFields(record: Record<string, unknown>, keys: string[]): boolean {
+  return keys.every((key) => Number.isFinite(record[key]));
+}
+
+function isNamedObjectArray(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.every((entry) => {
+      const record = asRecord(entry);
+      return record !== null && typeof record.name === 'string';
+    })
+  );
+}
+
+function validateNamedList(value: unknown, field: string): PayloadResult<unknown> {
+  if (value === undefined || isNamedObjectArray(value)) {
+    return acceptedPayload(value);
+  }
+  return rejectedPayload('invalid-payload', `character ${field} is not a list of named entries`);
+}
+
+function validateNamedRecord(value: unknown, field: string): PayloadResult<unknown> {
+  const record = asRecord(value);
+  if (record === null || typeof record.name !== 'string') {
+    return rejectedPayload('invalid-payload', `character ${field} is not an object with a name`);
+  }
+  return acceptedPayload(record);
+}
+
+/**
+ * The archetype, when there is one.
+ *
+ * Absent is ordinary rather than a fault: infants and children never get one, and neither does an
+ * adult whose filtered archetype list came back empty. Present, it is checked for a name and its
+ * tags — a name because that is what the sheet prints and what the equipment tables are rebuilt
+ * from, and tags because a character's own tag list was extended from them.
+ */
+function validateStoredArchetype(value: unknown): PayloadResult<unknown> {
+  if (value === undefined) {
+    return acceptedPayload(value);
+  }
+  const archetype = asRecord(value);
+  if (archetype === null || typeof archetype.name !== 'string') {
+    return rejectedPayload('invalid-payload', 'character archetype is not an object with a name');
+  }
+  if (!isStringArray(archetype.tags)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'character archetype tags is not an array of strings',
+    );
+  }
+  return acceptedPayload(archetype);
+}
+
+/**
+ * A coat of arms is optional twice over: absent for a character with none, `null` for one whose
+ * arms are a referenced artifact, and stored parts for one carrying its own.
+ *
+ * `null` has to be accepted rather than rejected, and that is not leniency: it is the value a
+ * composed character is *written* with, so a validator that turned it away would make a character
+ * unreadable by the very build that saved it. The reference beside the payload says which arms.
+ */
+function validateStoredHeraldry(value: unknown): PayloadResult<unknown> {
+  if (value === undefined || value === null) {
+    return acceptedPayload(value);
+  }
+  const arms = asRecord(value);
+  if (arms === null || typeof arms.blazon !== 'string') {
+    return rejectedPayload('invalid-payload', 'character heraldry has no blazon');
+  }
+  const device = asRecord(arms.device);
+  if (
+    device === null ||
+    typeof device.fieldName !== 'string' ||
+    !Array.isArray(device.chargeGroups)
+  ) {
+    return rejectedPayload(
+      'invalid-payload',
+      'character heraldry device is not a named field with charge groups',
+    );
+  }
+  return acceptedPayload(arms);
+}
+
+/**
+ * Titles, when the character holds any.
+ *
+ * Only the two forms of the title itself are checked. A title carries eight more fields, and a
+ * validator that listed all of them would be a second copy of `Title` living in a module that does
+ * not own it — and the copy is the half that goes stale. What reading depends on is having
+ * something to print.
+ */
+function validateTitles(value: unknown): PayloadResult<unknown> {
+  if (value === undefined) {
+    return acceptedPayload(value);
+  }
+  if (
+    !Array.isArray(value) ||
+    !value.every((entry) => {
+      const title = asRecord(entry);
+      return title !== null && hasStringFields(title, ['maleTitle', 'femaleTitle']);
+    })
+  ) {
+    return rejectedPayload(
+      'invalid-payload',
+      'character titles is not a list of titles with a male and female form',
+    );
+  }
+  return acceptedPayload(value);
+}
+
+/**
+ * Checks what `characterFromSnapshot` depends on: the fields it copies straight through, and the
+ * names it resolves species, archetype, and arms from.
+ *
+ * `speciesName` is checked as a string and nothing more, deliberately. Whether this build still has
+ * that species is not a question about the payload's validity — a species that was removed is not a
+ * corrupt record — and answering it here would quarantine a character over a lookup that nothing
+ * brings back. `character_rehydrate.ts` resolves it and falls back to an inert placeholder, which
+ * keeps the character readable and printable.
+ */
+export function validateCharacterSnapshot(payload: unknown): PayloadResult<CharacterSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'character payload is not an object');
+  }
+  if (!hasStringFields(record, CHARACTER_STRING_FIELDS)) {
+    return rejectedPayload(
+      'invalid-payload',
+      `character payload needs string ${CHARACTER_STRING_FIELDS.join(', ')}`,
+    );
+  }
+  if (!hasNumberFields(record, CHARACTER_NUMBER_FIELDS)) {
+    return rejectedPayload(
+      'invalid-payload',
+      `character payload needs numeric ${CHARACTER_NUMBER_FIELDS.join(', ')}`,
+    );
+  }
+  if (!isStringArray(record.personalityTraits)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'character personalityTraits is not an array of strings',
+    );
+  }
+  if (!isStringArray(record.tags)) {
+    return rejectedPayload('invalid-payload', 'character tags is not an array of strings');
+  }
+
+  const checks: PayloadResult<unknown>[] = [
+    validateNamedRecord(record.gender, 'gender'),
+    validateNamedRecord(record.ageCategory, 'ageCategory'),
+    validateNamedList(record.physicalTraits, 'physicalTraits'),
+    validateNamedList(record.abilities, 'abilities'),
+    validateNamedList(record.carried, 'carried'),
+    validateStoredArchetype(record.archetype),
+    validateStoredHeraldry(record.heraldry),
+    validateTitles(record.titles),
+  ];
+  const failed = checks.find((check) => !check.ok);
+  if (failed !== undefined) {
+    return failed as PayloadResult<CharacterSnapshot>;
+  }
+
+  return acceptedPayload(record as unknown as CharacterSnapshot);
+}
+
+/**
+ * Characters have only ever been stored at version 1, so there is nothing older to bring forward
+ * and this rejects rather than pretending. It is here because the contract requires it, and it is
+ * where the step goes the day the shape changes — a kind without one looks complete right up until
+ * it silently drops someone's work, and local-only means there is no server-side migration to fall
+ * back on.
+ */
+export function migrateCharacterSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<CharacterSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `character has no migration from payload version ${from}; version ${CHARACTER_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/** What to call a character that was saved without a name: what they are, which they always have. */
+function characterName(snapshot: CharacterSnapshot): string {
+  const given = snapshot.name.trim();
+  if (given !== '') {
+    return given;
+  }
+  const described = `${snapshot.speciesName} ${snapshot.archetype?.name ?? ''}`.trim();
+  return described === '' ? 'Character' : described;
+}
+
+/**
+ * A fantasy character as an artifact.
+ *
+ * The live value is the `Character` the library works with, and the snapshot is that character with
+ * its species, archetype, and arms written as names — see `character_snapshot.ts`. The codec's two
+ * halves come from two modules because reading is much the more expensive one: it reaches the
+ * archetype tables, the species list, and the 18 MB charge library, none of which validating or
+ * listing a character touches.
+ */
+export const characterArtifactKind = defineArtifactKind<Character, CharacterSnapshot>({
+  kind: CHARACTER_ARTIFACT_KIND,
+  displayName: 'Character',
+  icon: human,
+  payloadVersion: CHARACTER_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const [{ toCharacterSnapshot }, { characterFromSnapshot }] = await Promise.all([
+      import('./character_snapshot.js'),
+      import('./character_rehydrate.js'),
+    ]);
+    return {
+      // The referenced-arms flag is the generator's to set: it knows whether the arms on screen
+      // came from a picker. Everything reaching the codec generically — export, a project copy —
+      // has a snapshot already and passes through the payload's own `heraldry`.
+      toSnapshot: (character: Character) => toCharacterSnapshot(character),
+      // The RNG the contract hands every codec. A character rebuilds from names alone, so there is
+      // nothing here for it to do.
+      fromSnapshot: (snapshot: CharacterSnapshot) => characterFromSnapshot(snapshot),
+    };
+  },
+  nameOf: characterName,
+  validate: validateCharacterSnapshot,
+  migrate: migrateCharacterSnapshot,
+});

--- a/src/lib/characters/character_editing.test.ts
+++ b/src/lib/characters/character_editing.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addCharacterCarried,
+  addCharacterDescribedEntry,
+  addCharacterPersonalityTrait,
+  addCharacterTitle,
+  removeCharacterCarried,
+  removeCharacterDescribedEntry,
+  removeCharacterPersonalityTrait,
+  removeCharacterTitle,
+  setCharacterAge,
+  setCharacterAgeCategory,
+  setCharacterArchetypeName,
+  setCharacterCarriedName,
+  setCharacterDescribedEntry,
+  setCharacterGender,
+  setCharacterHeraldry,
+  setCharacterMeasurement,
+  setCharacterNamePart,
+  setCharacterPersonalityTrait,
+  setCharacterText,
+  setCharacterTitleField,
+} from './character_editing.js';
+import { validateCharacterSnapshot } from './character_artifact_kind.js';
+import { rollCharacter } from './character_roll.js';
+import { toCharacterSnapshot, type CharacterSnapshot } from './character_snapshot.js';
+
+function noble(): CharacterSnapshot {
+  for (let seed = 0; seed < 200; seed += 1) {
+    const { character } = rollCharacter(`editing-${seed}`, { archetypeName: 'noble' });
+    if (character.archetype !== undefined && (character.titles?.length ?? 0) > 0) {
+      return toCharacterSnapshot(character);
+    }
+  }
+  throw new Error('no seed in the sweep produced a titled noble');
+}
+
+const fixture = noble();
+
+describe('editing a character', () => {
+  it('rederives the display name when a half of it changes', () => {
+    const after = setCharacterNamePart(
+      setCharacterNamePart(fixture, 'firstName', 'Maren'),
+      'lastName',
+      'Voss',
+    );
+
+    expect(after.firstName).toBe('Maren');
+    expect(after.lastName).toBe('Voss');
+    expect(after.name).toBe('Maren Voss');
+  });
+
+  /** Requirement 4.4: one field at a time, and nothing else disturbed. */
+  it('leaves everything else alone', () => {
+    const after = setCharacterText(fixture, 'description', 'Rewritten by hand.');
+
+    expect(after.description).toBe('Rewritten by hand.');
+    expect({ ...after, description: fixture.description }).toEqual(fixture);
+  });
+
+  it('changes nothing in place', () => {
+    const before = structuredClone(fixture);
+    setCharacterNamePart(fixture, 'firstName', 'Someone');
+    addCharacterPersonalityTrait(fixture, 'restless');
+
+    expect(fixture).toEqual(before);
+  });
+
+  it('takes a gender whole, so the pronouns follow the label', () => {
+    const after = setCharacterGender(fixture, 'female');
+
+    expect(after.gender.name).toBe('female');
+    expect(after.gender.pronouns.subjective).toBe('she');
+  });
+
+  it('ignores a gender the build does not offer, rather than storing a name with no pronouns', () => {
+    expect(setCharacterGender(fixture, 'a-gender-nobody-has')).toBe(fixture);
+  });
+
+  it('takes an age category whole, and refuses one it does not have', () => {
+    expect(setCharacterAgeCategory(fixture, 'elderly').ageCategory.name).toBe('elderly');
+    expect(setCharacterAgeCategory(fixture, 'ancient-and-terrible')).toBe(fixture);
+  });
+
+  /**
+   * An emptied number field arrives as `NaN`. Stored, it is a payload that fails its own kind's
+   * validation, which the user meets as a broken artifact rather than as a rejected keystroke.
+   */
+  it('refuses a measurement that is not a number', () => {
+    expect(setCharacterMeasurement(fixture, 'height', Number.NaN)).toBe(fixture);
+    expect(setCharacterAge(fixture, Number.NaN)).toBe(fixture);
+    expect(setCharacterMeasurement(fixture, 'height', 168).height).toBe(168);
+    expect(setCharacterAge(fixture, 41).age).toBe(41);
+  });
+
+  it('renames an archetype without inventing one for a character who has none', () => {
+    expect(setCharacterArchetypeName(fixture, 'harbourmaster').archetype?.name).toBe(
+      'harbourmaster',
+    );
+
+    const { archetype: _none, ...unemployed } = fixture;
+    expect(setCharacterArchetypeName(unemployed, 'harbourmaster')).toBe(unemployed);
+  });
+});
+
+describe('editing a character’s lists', () => {
+  it('rewrites, adds and removes a personality trait', () => {
+    const rewritten = setCharacterPersonalityTrait(fixture, 0, 'brooding');
+    expect(rewritten.personalityTraits[0]).toBe('brooding');
+    expect(rewritten.personalityTraits.slice(1)).toEqual(fixture.personalityTraits.slice(1));
+
+    const added = addCharacterPersonalityTrait(fixture, 'restless');
+    expect(added.personalityTraits.at(-1)).toBe('restless');
+
+    expect(removeCharacterPersonalityTrait(added, added.personalityTraits.length - 1)).toEqual(
+      fixture,
+    );
+  });
+
+  it('does nothing at an index nothing lives at', () => {
+    expect(setCharacterPersonalityTrait(fixture, 99, 'nowhere')).toBe(fixture);
+    expect(removeCharacterPersonalityTrait(fixture, -1)).toBe(fixture);
+    expect(setCharacterCarriedName(fixture, 99, 'nowhere')).toBe(fixture);
+    expect(setCharacterTitleField(fixture, 99, 'landName', 'nowhere')).toBe(fixture);
+  });
+
+  it('edits physical traits and abilities through the one pair of functions', () => {
+    for (const list of ['physicalTraits', 'abilities'] as const) {
+      const added = addCharacterDescribedEntry(fixture, list);
+      const index = added[list].length - 1;
+      const named = setCharacterDescribedEntry(added, list, index, 'name', 'A scar');
+      const described = setCharacterDescribedEntry(named, list, index, 'description', 'Old.');
+
+      expect(described[list][index]?.name).toBe('A scar');
+      expect(described[list][index]?.description).toBe('Old.');
+      expect(removeCharacterDescribedEntry(described, list, index)).toEqual(fixture);
+    }
+  });
+
+  it('adds, renames and removes a carried item, and the result still validates', () => {
+    const added = addCharacterCarried(fixture);
+    const named = setCharacterCarriedName(added, added.carried.length - 1, 'A bent key');
+
+    expect(named.carried.at(-1)?.name).toBe('A bent key');
+    expect(validateCharacterSnapshot(named).ok).toBe(true);
+    expect(removeCharacterCarried(named, named.carried.length - 1)).toEqual(fixture);
+  });
+
+  it('rewrites one part of one title', () => {
+    const after = setCharacterTitleField(fixture, 0, 'landName', 'Ashmere');
+
+    expect(after.titles?.[0]?.landName).toBe('Ashmere');
+    expect(after.titles?.[0]?.maleTitle).toBe(fixture.titles?.[0]?.maleTitle);
+  });
+
+  it('adds and removes a title, and the result still validates', () => {
+    const added = addCharacterTitle(fixture);
+
+    expect(added.titles).toHaveLength((fixture.titles?.length ?? 0) + 1);
+    expect(validateCharacterSnapshot(added).ok).toBe(true);
+    expect(removeCharacterTitle(added, added.titles!.length - 1)).toEqual(fixture);
+  });
+});
+
+describe('a character’s coat of arms', () => {
+  it('is removed by dropping the field entirely, not by storing null', () => {
+    const after = setCharacterHeraldry(fixture, undefined);
+
+    expect(after).not.toHaveProperty('heraldry');
+    expect(validateCharacterSnapshot(after).ok).toBe(true);
+  });
+
+  /** `null` says the arms are a record of their own; see requirement 5.2. */
+  it('is stored as null when a saved coat of arms supplies it', () => {
+    expect(setCharacterHeraldry(fixture, null).heraldry).toBeNull();
+  });
+
+  it('is replaced whole', () => {
+    const replacement = { device: fixture.heraldry!.device, blazon: 'Party per pale, a new thing' };
+
+    expect(setCharacterHeraldry(fixture, replacement).heraldry?.blazon).toBe(
+      'Party per pale, a new thing',
+    );
+  });
+});

--- a/src/lib/characters/character_editing.ts
+++ b/src/lib/characters/character_editing.ts
@@ -1,0 +1,328 @@
+/**
+ * Editing a stored character, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction — renaming a character must not
+ * disturb their traits, and rewriting one trait must not re-roll the rest — and it is what lets the
+ * editing framework compare what is on screen against what was read to decide whether anything
+ * needs saving.
+ *
+ * They work on the **snapshot**, not a live `Character`, because the snapshot is what is stored and
+ * what the kind's `validate` speaks. An editor working on live values would run the codec both ways
+ * on every keystroke and hand back a payload one conversion further from what the user kept.
+ *
+ * **Species is not among them.** Changing a saved character's species does not recompute the
+ * height, weight or physical traits that species produced, so the result would be an elf with a
+ * halfling's build until the user fixed the rest by hand. It is shown read-only and a re-roll is
+ * how a character becomes a different species — the question docs/fantasy-character.md left open,
+ * answered that way deliberately.
+ */
+
+import { humanStandard, type AgeCategory } from '$lib/age';
+import type { Ability } from '$lib/abilities';
+import type { Item } from '$lib/equipment';
+import { traditional, type Gender } from '$lib/gender';
+import type { StoredArms } from '$lib/heraldry';
+import type { PhysicalTrait } from '$lib/physical_traits';
+
+import { formatCharacterDisplayName } from './character_name_generation.js';
+import type { CharacterSnapshot } from './character_snapshot.js';
+import type { Title } from './character_types.js';
+
+/** The prose fields an editing view puts in a textarea each. */
+export type CharacterTextField = 'description' | 'shortDescription';
+
+/** The measurements the sheet shows, in the units it shows them in. */
+export type CharacterMeasurementField = 'height' | 'weight' | 'length';
+
+/** A named-and-described entry: a physical trait, or an ability. Both edit identically. */
+export type CharacterDescribedListField = 'physicalTraits' | 'abilities';
+
+/** The parts of a title a user may rewrite. Everything else about one is precedence and flags. */
+export type CharacterTitleField =
+  | 'maleTitle'
+  | 'femaleTitle'
+  | 'maleHonorific'
+  | 'femaleHonorific'
+  | 'landName';
+
+/** The genders an editor offers. The build's standard set, since a placeholder species has none. */
+export function characterGenderOptions(): Gender[] {
+  return traditional();
+}
+
+/** The age categories an editor offers, for the same reason {@link characterGenderOptions} exists. */
+export function characterAgeCategoryOptions(): AgeCategory[] {
+  return humanStandard();
+}
+
+/**
+ * Rewrite a name part, and the display name with it.
+ *
+ * The two go together on purpose: `name` is derived from the other two everywhere else in the
+ * library, and an editor that let them drift would produce a character whose heading and whose
+ * name fields disagreed. It is the same helper the roll uses, which is what keeps them in step.
+ */
+export function setCharacterNamePart(
+  snapshot: CharacterSnapshot,
+  part: 'firstName' | 'lastName',
+  value: string,
+): CharacterSnapshot {
+  const firstName = part === 'firstName' ? value : snapshot.firstName;
+  const lastName = part === 'lastName' ? value : snapshot.lastName;
+  return {
+    ...snapshot,
+    firstName,
+    lastName,
+    name: formatCharacterDisplayName(firstName, lastName),
+  };
+}
+
+export function setCharacterText(
+  snapshot: CharacterSnapshot,
+  field: CharacterTextField,
+  value: string,
+): CharacterSnapshot {
+  return { ...snapshot, [field]: value };
+}
+
+/**
+ * A measurement, as a number.
+ *
+ * A field the user has emptied arrives as `NaN` and is refused rather than stored: a character with
+ * a height of `NaN` is a payload that fails its own kind's validation, which the user would meet as
+ * a broken artifact rather than as a rejected keystroke.
+ */
+export function setCharacterMeasurement(
+  snapshot: CharacterSnapshot,
+  field: CharacterMeasurementField,
+  value: number,
+): CharacterSnapshot {
+  return Number.isFinite(value) ? { ...snapshot, [field]: value } : snapshot;
+}
+
+export function setCharacterAge(snapshot: CharacterSnapshot, age: number): CharacterSnapshot {
+  return Number.isFinite(age) ? { ...snapshot, age } : snapshot;
+}
+
+/**
+ * The character's gender, taken whole from the offered set.
+ *
+ * Whole because a gender carries its pronouns, and the description prose reads them. Setting the
+ * name alone would leave a character described as "she" and labelled male.
+ */
+export function setCharacterGender(snapshot: CharacterSnapshot, name: string): CharacterSnapshot {
+  const gender = characterGenderOptions().find((entry) => entry.name === name);
+  return gender === undefined ? snapshot : { ...snapshot, gender };
+}
+
+/** The age category, likewise taken whole: the noun on it is what the short description reads. */
+export function setCharacterAgeCategory(
+  snapshot: CharacterSnapshot,
+  name: string,
+): CharacterSnapshot {
+  const ageCategory = characterAgeCategoryOptions().find((entry) => entry.name === name);
+  return ageCategory === undefined ? snapshot : { ...snapshot, ageCategory };
+}
+
+/**
+ * The archetype's name, leaving its tags and abilities as they are.
+ *
+ * A character with no archetype gains none here — an occupation is something a re-roll gives, and
+ * inventing an empty one from a text field would put a nameless archetype on the sheet.
+ */
+export function setCharacterArchetypeName(
+  snapshot: CharacterSnapshot,
+  name: string,
+): CharacterSnapshot {
+  return snapshot.archetype === undefined
+    ? snapshot
+    : { ...snapshot, archetype: { ...snapshot.archetype, name } };
+}
+
+function hasIndex(length: number, index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < length;
+}
+
+function replaceAt<T>(list: T[], index: number, value: T): T[] {
+  return list.map((entry, position) => (position === index ? value : entry));
+}
+
+function removeAt<T>(list: T[], index: number): T[] {
+  return list.filter((_entry, position) => position !== index);
+}
+
+export function setCharacterPersonalityTrait(
+  snapshot: CharacterSnapshot,
+  index: number,
+  value: string,
+): CharacterSnapshot {
+  return hasIndex(snapshot.personalityTraits.length, index)
+    ? { ...snapshot, personalityTraits: replaceAt(snapshot.personalityTraits, index, value) }
+    : snapshot;
+}
+
+export function addCharacterPersonalityTrait(
+  snapshot: CharacterSnapshot,
+  value = '',
+): CharacterSnapshot {
+  return { ...snapshot, personalityTraits: [...snapshot.personalityTraits, value] };
+}
+
+export function removeCharacterPersonalityTrait(
+  snapshot: CharacterSnapshot,
+  index: number,
+): CharacterSnapshot {
+  return hasIndex(snapshot.personalityTraits.length, index)
+    ? { ...snapshot, personalityTraits: removeAt(snapshot.personalityTraits, index) }
+    : snapshot;
+}
+
+/**
+ * One field of one physical trait or ability.
+ *
+ * The two lists share these three functions because they are the same shape and behave the same
+ * way. Three pairs of near-identical functions is how the pair that gets fixed and the pair that
+ * does not come to differ.
+ */
+export function setCharacterDescribedEntry(
+  snapshot: CharacterSnapshot,
+  list: CharacterDescribedListField,
+  index: number,
+  field: 'name' | 'description',
+  value: string,
+): CharacterSnapshot {
+  const entries = snapshot[list];
+  if (!hasIndex(entries.length, index)) {
+    return snapshot;
+  }
+  const updated = { ...entries[index], [field]: value };
+  return {
+    ...snapshot,
+    [list]: replaceAt(entries as (PhysicalTrait | Ability)[], index, updated),
+  } as CharacterSnapshot;
+}
+
+export function addCharacterDescribedEntry(
+  snapshot: CharacterSnapshot,
+  list: CharacterDescribedListField,
+): CharacterSnapshot {
+  const entry = { name: '', description: '', category: '', tags: [] };
+  return { ...snapshot, [list]: [...snapshot[list], entry] } as CharacterSnapshot;
+}
+
+export function removeCharacterDescribedEntry(
+  snapshot: CharacterSnapshot,
+  list: CharacterDescribedListField,
+  index: number,
+): CharacterSnapshot {
+  const entries = snapshot[list];
+  return hasIndex(entries.length, index)
+    ? ({ ...snapshot, [list]: removeAt(entries as unknown[], index) } as CharacterSnapshot)
+    : snapshot;
+}
+
+export function setCharacterCarriedName(
+  snapshot: CharacterSnapshot,
+  index: number,
+  name: string,
+): CharacterSnapshot {
+  return hasIndex(snapshot.carried.length, index)
+    ? {
+        ...snapshot,
+        carried: replaceAt(snapshot.carried, index, { ...snapshot.carried[index], name }),
+      }
+    : snapshot;
+}
+
+/**
+ * A blank item, for something a character picked up that no generator gave them.
+ *
+ * The fields beyond name and description are what a generator rolled the item *from* — its
+ * material, rarity, value, weight — and they are set to the neutral end of each rather than
+ * guessed. An item a user typed has no provenance, and inventing some would put numbers on the
+ * sheet that nothing stands behind.
+ */
+export function addCharacterCarried(snapshot: CharacterSnapshot): CharacterSnapshot {
+  const item: Item = {
+    id: '',
+    name: '',
+    description: '',
+    itemMajorType: '',
+    value: 0,
+    rarity: 'common',
+    densityCategory: 'standard',
+    weight: 0,
+    properties: [],
+  };
+  return { ...snapshot, carried: [...snapshot.carried, item] };
+}
+
+export function removeCharacterCarried(
+  snapshot: CharacterSnapshot,
+  index: number,
+): CharacterSnapshot {
+  return hasIndex(snapshot.carried.length, index)
+    ? { ...snapshot, carried: removeAt(snapshot.carried, index) }
+    : snapshot;
+}
+
+export function setCharacterTitleField(
+  snapshot: CharacterSnapshot,
+  index: number,
+  field: CharacterTitleField,
+  value: string,
+): CharacterSnapshot {
+  const titles = snapshot.titles ?? [];
+  if (!hasIndex(titles.length, index)) {
+    return snapshot;
+  }
+  return { ...snapshot, titles: replaceAt(titles, index, { ...titles[index], [field]: value }) };
+}
+
+export function removeCharacterTitle(
+  snapshot: CharacterSnapshot,
+  index: number,
+): CharacterSnapshot {
+  const titles = snapshot.titles ?? [];
+  return hasIndex(titles.length, index)
+    ? { ...snapshot, titles: removeAt(titles, index) }
+    : snapshot;
+}
+
+/** An empty title, for a character who has come into one the generator did not give them. */
+export function addCharacterTitle(snapshot: CharacterSnapshot): CharacterSnapshot {
+  const title: Title = {
+    maleTitle: '',
+    femaleTitle: '',
+    maleHonorific: '',
+    femaleHonorific: '',
+    hasLands: false,
+    isHereditary: false,
+    isNoble: true,
+    isRoyal: false,
+    landName: '',
+    precedence: 0,
+    tags: [],
+  };
+  return { ...snapshot, titles: [...(snapshot.titles ?? []), title] };
+}
+
+/**
+ * The character's coat of arms: their own, none, or a referenced artifact's.
+ *
+ * `null` is what says the arms belong to a saved coat of arms rather than to this character — the
+ * shape `culture` uses for a referenced religion, and what requirement 5.2 asks for. Copying the
+ * arms in instead would fork them at the moment of saving, so an edit to that coat of arms would
+ * never reach the character wearing it.
+ */
+export function setCharacterHeraldry(
+  snapshot: CharacterSnapshot,
+  arms: StoredArms | null | undefined,
+): CharacterSnapshot {
+  if (arms === undefined) {
+    const { heraldry: _heraldry, ...rest } = snapshot;
+    return rest;
+  }
+  return { ...snapshot, heraldry: arms };
+}

--- a/src/lib/characters/character_generation.ts
+++ b/src/lib/characters/character_generation.ts
@@ -13,6 +13,7 @@ import { getAllFantasyArchetypes, type Archetype } from '$lib/archetypes';
 import { human } from '$lib/species_sentients';
 import { getFantasyNameGeneratorSet, type NameGeneratorSet } from '$lib/names';
 import { generateHeraldry, getDefaultHeraldryGeneratorConfig } from '$lib/heraldry';
+import { fantasyHintToNameSetName } from './character_name_generation';
 import { getStandardNobleTitles } from './titles';
 import { applyTagFilter } from '$lib/tags';
 
@@ -152,8 +153,11 @@ export function generate(seed: string, config: CharacterGenerationConfig): Chara
 
     const possibleTitles = getStandardNobleTitles();
     const title = rng.item(possibleTitles);
+    /* Through the hint rather than straight off the species name: `getFantasyNameGeneratorSet`
+       throws for a set it does not have, and most of `sentientSpeciesList` — aarakocra, tabaxi,
+       tortle — has no patterns of its own, so a noble of one used to take the whole roll down. */
     title.landName = getFantasyNameGeneratorSet(
-      config.species.name.toLowerCase() || 'human',
+      fantasyHintToNameSetName(config.species.name),
       rng,
     ).country.generate(1)[0];
     titles.push(title);

--- a/src/lib/characters/character_presentation.test.ts
+++ b/src/lib/characters/character_presentation.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  characterFileStem,
+  characterTitleLine,
+  characterToDocument,
+  characterToMarkdown,
+  characterToPlainText,
+} from './character_presentation.js';
+import { rollCharacter } from './character_roll.js';
+import type { Character } from './character_types.js';
+
+function rollMatching(
+  predicate: (character: Character) => boolean,
+  config: Parameters<typeof rollCharacter>[1] = {},
+): Character {
+  for (let seed = 0; seed < 200; seed += 1) {
+    const { character } = rollCharacter(`presentation-${seed}`, config);
+    if (predicate(character)) {
+      return character;
+    }
+  }
+  throw new Error('no seed in the sweep produced a character of that shape');
+}
+
+const titled = rollMatching(
+  (character) => (character.titles?.length ?? 0) > 0 && character.heraldry !== undefined,
+  { archetypeName: 'noble' },
+);
+
+function headings(character: Character): string[] {
+  return characterToDocument(character).sections.map((entry) => entry.heading);
+}
+
+describe('a character as a document', () => {
+  it('is titled with the character’s name', () => {
+    expect(characterToDocument(titled).title).toBe(titled.name);
+  });
+
+  it('prints what the sheet shows', () => {
+    expect(headings(titled)).toEqual(
+      expect.arrayContaining(['Description', 'At a Glance', 'Build', 'Titles', 'Heraldry']),
+    );
+  });
+
+  /**
+   * Requirement 6.4, and the reason the document model exists rather than two renderers each
+   * remembering to skip an empty list: a character with nothing to say about a thing prints no
+   * heading for it.
+   */
+  it('drops every section it has nothing for', () => {
+    const bare: Character = {
+      ...titled,
+      titles: [],
+      carried: [],
+      abilities: [],
+      physicalTraits: [],
+      personalityTraits: [],
+      heraldry: undefined,
+    };
+
+    expect(headings(bare)).not.toContain('Titles');
+    expect(headings(bare)).not.toContain('Equipment');
+    expect(headings(bare)).not.toContain('Abilities');
+    expect(headings(bare)).not.toContain('Physical Traits');
+    expect(headings(bare)).not.toContain('Personality');
+    expect(headings(bare)).not.toContain('Heraldry');
+  });
+
+  it('leaves out a length nobody has', () => {
+    const upright = characterToDocument({ ...titled, length: 0 });
+    const build = upright.sections.find((entry) => entry.heading === 'Build');
+
+    expect(build?.items.some((line) => line.startsWith('Length'))).toBe(false);
+  });
+
+  it('names a title for the person wearing it, and their lands with it', () => {
+    const title = {
+      ...titled.titles![0]!,
+      maleTitle: 'Duke',
+      femaleTitle: 'Duchess',
+      hasLands: true,
+      landName: 'Ashmere',
+    };
+
+    expect(characterTitleLine(title, 'female')).toBe('Duchess of Ashmere');
+    expect(characterTitleLine(title, 'male')).toBe('Duke of Ashmere');
+    expect(characterTitleLine({ ...title, hasLands: false }, 'male')).toBe('Duke');
+  });
+});
+
+describe('a character as a file', () => {
+  it('writes Markdown with a heading per section', () => {
+    const markdown = characterToMarkdown(titled);
+
+    expect(markdown.startsWith(`# ${titled.name}`)).toBe(true);
+    expect(markdown).toContain('## Build');
+    expect(markdown).toContain(`- Species: ${titled.species.name}`);
+  });
+
+  /** The PDF gets plain text: `#` and `-` are punctuation on a page, not formatting. */
+  it('writes plain text with no Markdown punctuation', () => {
+    const text = characterToPlainText(titled);
+
+    expect(text).toContain('BUILD');
+    expect(text).not.toContain('## ');
+    expect(text).not.toContain('- Species');
+  });
+
+  it('reduces a name to something a filesystem takes', () => {
+    expect(characterFileStem({ ...titled, name: 'Maren Voss' })).toBe('maren-voss');
+    expect(characterFileStem({ ...titled, name: '  ' })).toBe('character');
+  });
+});

--- a/src/lib/characters/character_presentation.ts
+++ b/src/lib/characters/character_presentation.ts
@@ -1,0 +1,169 @@
+/**
+ * A character arranged for reading, and the two formats it is written in.
+ *
+ * Requirement 6.3 in docs/workshop.md wants a presentation export a user can take to the table,
+ * which is a different thing from artifact export: this is the character as a page, not as a
+ * payload. The document model sits between the character and the formats so that requirement
+ * 6.4 — no stray blank sections — is a property of the model rather than something two renderers
+ * have to remember separately. A character with no titles, no equipment and no arms prints no
+ * headings for them; it does not print empty ones.
+ *
+ * The export controls ship with this module rather than after it. `settlement_presentation.ts`
+ * built the document model and wired no control to it, so nothing on the site renders it and 6.3 is
+ * met there only on paper — see decision 8 of docs/fantasy-character.md, which is that mistake
+ * named so as not to be repeated.
+ */
+
+import * as Measurements from '$lib/measurements';
+
+import type { Character, Title } from './character_types.js';
+
+/** One heading and what sits under it. A section with neither prose nor items is not printed. */
+export type CharacterSection = {
+  heading: string;
+  paragraphs: string[];
+  items: string[];
+};
+
+/** A character arranged for reading, independent of the format it is finally written in. */
+export type CharacterDocument = {
+  title: string;
+  sections: CharacterSection[];
+};
+
+function section(heading: string, paragraphs: string[], items: string[] = []): CharacterSection {
+  return { heading, paragraphs: paragraphs.filter(isPrintable), items: items.filter(isPrintable) };
+}
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+function hasContent(entry: CharacterSection): boolean {
+  return entry.paragraphs.length > 0 || entry.items.length > 0;
+}
+
+/** A title as it is worn, which depends on who is wearing it. */
+export function characterTitleLine(title: Title, genderName: string): string {
+  const worn = genderName.toLowerCase() === 'female' ? title.femaleTitle : title.maleTitle;
+  return title.hasLands && isPrintable(title.landName) ? `${worn} of ${title.landName}` : worn;
+}
+
+/**
+ * Height, weight and length in both the units the sheet shows.
+ *
+ * Both, because the screen shows both and an export that dropped one would be a different document
+ * from the one the user was looking at. Length only when there is one: it is zero for every upright
+ * species, and a line reading "Length: 0 ft." is exactly the stray content 6.4 is about.
+ */
+function buildLines(character: Character): string[] {
+  const feet = Measurements.inchesToFeetExpression(Measurements.cmToInches(character.height));
+  const pounds = Math.round(Measurements.kgToPounds(character.weight));
+  return [
+    `Height: ${feet} (${character.height} cm)`,
+    `Weight: ${pounds} lb. (${character.weight} kg)`,
+    character.length > 0
+      ? `Length: ${Measurements.inchesToFeetExpression(Measurements.cmToInches(character.length))}`
+      : '',
+  ];
+}
+
+/**
+ * What the character is, in the terms the stat block on screen uses.
+ *
+ * The archetype line is omitted rather than written as "Archetype: none": most characters this
+ * generator makes are ordinary people, and a sheet that announced the absence of an occupation for
+ * every child in a village would be noise.
+ */
+function identityLines(character: Character): string[] {
+  return [
+    `Species: ${character.species.name}`,
+    `Gender: ${character.gender.name}`,
+    `Age: ${character.age} years (${character.ageCategory.name})`,
+    character.archetype === undefined ? '' : `Archetype: ${character.archetype.name}`,
+    character.creatureTypes.length === 0 ? '' : `Type: ${character.creatureTypes.join(', ')}`,
+  ];
+}
+
+/** Arrange a character for reading. Every empty section is dropped here, once. */
+export function characterToDocument(character: Character): CharacterDocument {
+  const sections = [
+    section('Description', [character.description]),
+    section('At a Glance', [], identityLines(character)),
+    section('Build', [], buildLines(character)),
+    section(
+      'Titles',
+      [],
+      (character.titles ?? []).map((title) => characterTitleLine(title, character.gender.name)),
+    ),
+    section(
+      'Physical Traits',
+      [],
+      character.physicalTraits.map((trait) => `${trait.name}: ${trait.description}`),
+    ),
+    section('Personality', [], character.personalityTraits),
+    section(
+      'Abilities',
+      [],
+      character.abilities.map((ability) => `${ability.name}: ${ability.description}`),
+    ),
+    section(
+      'Equipment',
+      [],
+      character.carried.map((item) => item.name),
+    ),
+    // The blazon rather than the drawing: this is a text document, and a coat of arms written in
+    // the language heralds use is the form of it a page can carry. The SVG is the generator's own
+    // download.
+    section('Heraldry', [character.heraldry?.blazon ?? '']),
+  ];
+
+  return {
+    title: isPrintable(character.name) ? character.name : 'Character',
+    sections: sections.filter(hasContent),
+  };
+}
+
+/** A character as Markdown, for a user who wants them in their own notes. */
+export function characterToMarkdown(character: Character): string {
+  const document = characterToDocument(character);
+  const blocks = [`# ${document.title}`];
+
+  for (const entry of document.sections) {
+    blocks.push(`## ${entry.heading}`);
+    blocks.push(...entry.paragraphs);
+    if (entry.items.length > 0) {
+      blocks.push(entry.items.map((item) => `- ${item}`).join('\n'));
+    }
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/**
+ * A character as plain text, for the PDF export.
+ *
+ * Separate from the Markdown because `#` and `-` are punctuation a PDF reader has to see past
+ * rather than formatting it renders — the same content, written for a page instead of an editor.
+ */
+export function characterToPlainText(character: Character): string {
+  const document = characterToDocument(character);
+  const blocks: string[] = [];
+
+  for (const entry of document.sections) {
+    blocks.push(entry.heading.toUpperCase());
+    blocks.push(...entry.paragraphs);
+    blocks.push(...entry.items);
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** A filename stem for an exported character: their name, reduced to something a filesystem takes. */
+export function characterFileStem(character: Character): string {
+  const stem = character.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' ? 'character' : stem;
+}

--- a/src/lib/characters/character_rehydrate.ts
+++ b/src/lib/characters/character_rehydrate.ts
@@ -1,0 +1,121 @@
+/**
+ * Rebuilding a character from a snapshot, kept apart from `character_snapshot.ts` because of what
+ * it costs. Restoring an archetype's equipment tables reaches `$lib/archetypes`, restoring a
+ * species reaches `$lib/species_sentients`, and restoring a coat of arms resolves charge names
+ * against `$lib/charges` — 18 MB of glyph art, measured. Writing a snapshot needs none of them, and
+ * the kind registry validates one without touching any, so the two directions do not belong in the
+ * same file.
+ *
+ * **Nothing here is recomputed.** Height, weight, the description prose, the personality traits,
+ * the land a title is named for: all of it comes back exactly as it was stored, per requirement 4.2
+ * in docs/workshop.md. Species and archetype are resolved by name only so the sheet can say what
+ * they were.
+ */
+
+import { getAllFantasyArchetypes, type Archetype } from '$lib/archetypes';
+import { armsFromStored } from '$lib/heraldry';
+import type { Species } from '$lib/species';
+import { sentientSpeciesList } from '$lib/species_sentients';
+
+import type { CharacterSnapshot, StoredArchetype, StoredCharacter } from './character_snapshot.js';
+import type { Character } from './character_types.js';
+
+/**
+ * The equipment tables each archetype was rolled from, by archetype name.
+ *
+ * Built once. `getAllFantasyArchetypes` returns a shared array that must not be mutated, and this
+ * only ever reads from it.
+ */
+const equipmentConfigsByArchetypeName = new Map(
+  getAllFantasyArchetypes().map((archetype) => [
+    archetype.name,
+    archetype.equipmentGenerationConfigs,
+  ]),
+);
+
+/**
+ * An archetype with its equipment tables put back.
+ *
+ * An archetype this build no longer has comes back with no tables rather than throwing. That is
+ * requirement 3.3 applied one level down: the tables are what a character would be *re-equipped*
+ * from, which reading a saved character never does, so a character whose blacksmith archetype was
+ * renamed in some later release is still every bit the character the user saved.
+ */
+export function archetypeFromStored(stored: StoredArchetype): Archetype {
+  return {
+    ...stored,
+    equipmentGenerationConfigs: equipmentConfigsByArchetypeName.get(stored.name) ?? [],
+  };
+}
+
+/**
+ * A species this build does not have, carrying nothing but the name it was stored under.
+ *
+ * The point of it is that it is inert. Every number a character needs — height, weight, age,
+ * physical traits, abilities — is already in the payload, so a placeholder never has to produce
+ * one; what it has to do is let the sheet say `a weary Thrennish smith` and the export render,
+ * rather than losing the character to a lookup that missed. Quarantining instead would retire a
+ * saved character permanently over a name nothing ever brings back.
+ *
+ * The adjective and plural are derived from the name because that is what the description prose
+ * reads, and a blank adjective would print a sentence with a hole in it. The tables are empty
+ * because a placeholder that answered questions about a species this build cannot describe would
+ * be inventing one — see {@link isUnknownSpeciesName}, which is how a re-roll is kept from doing
+ * exactly that.
+ */
+export function placeholderSpecies(name: string): Species {
+  return {
+    name,
+    pluralName: `${name}s`,
+    adjective: name,
+    breedType: '',
+    environments: [],
+    creatureTypes: [],
+    physicalTraitGeneratorConfigs: [],
+    ageCategories: [],
+    sizeGeneratorConfigMatrix: [],
+    abilities: [],
+    baseThreatLevel: 0,
+    genders: [],
+    commonality: 0,
+    tags: [],
+  };
+}
+
+/** Whether a stored species name came back as a placeholder rather than a table this build has. */
+export function isUnknownSpeciesName(name: string): boolean {
+  return !sentientSpeciesList.some((species) => species.name === name);
+}
+
+/** The species a stored name refers to, or an inert stand-in carrying that name. */
+export function speciesFromStoredName(name: string): Species {
+  return sentientSpeciesList.find((species) => species.name === name) ?? placeholderSpecies(name);
+}
+
+/**
+ * A stored character, live again.
+ *
+ * A character whose arms are `null` comes back with none of its own, which is the whole point of
+ * that value: the arms are a referenced artifact, and the caller that holds the reference is the
+ * one that can resolve it.
+ */
+export function characterFromStored(stored: StoredCharacter): Character {
+  const { speciesName, archetype, heraldry, ...rest } = stored;
+  return {
+    ...rest,
+    species: speciesFromStoredName(speciesName),
+    ...(archetype === undefined ? {} : { archetype: archetypeFromStored(archetype) }),
+    ...(heraldry === undefined || heraldry === null ? {} : { heraldry: armsFromStored(heraldry) }),
+  };
+}
+
+/**
+ * The codec's reading half, with the signature the kind registry hands it.
+ *
+ * The RNG is unused, and that is the correct amount of use for it. It exists for kinds that rebuild
+ * name generators; a character is finished when it is stored, and drawing anything from a seed on
+ * the way back would be regenerating over the user's edits — the one thing requirement 4.2 forbids.
+ */
+export function characterFromSnapshot(snapshot: CharacterSnapshot): Character {
+  return characterFromStored(snapshot);
+}

--- a/src/lib/characters/character_roll.test.ts
+++ b/src/lib/characters/character_roll.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  readCharacterGeneratorConfig,
+  rollCharacter,
+  rollCharacterSnapshot,
+  CHARACTER_ANY,
+} from './character_roll.js';
+
+describe('reading a recorded config', () => {
+  it('takes the fields it recognises', () => {
+    expect(
+      readCharacterGeneratorConfig({
+        speciesName: 'elf',
+        archetypeName: 'noble',
+        genderName: 'Female',
+        ageCategoryName: 'adult',
+        nameGeneratorSet: 'dwarf',
+        namingGender: 'male',
+      }),
+    ).toEqual({
+      speciesName: 'elf',
+      archetypeName: 'noble',
+      genderName: 'Female',
+      ageCategoryName: 'adult',
+      nameGeneratorSet: 'dwarf',
+      namingGender: 'male',
+    });
+  });
+
+  /**
+   * Anything unrecognisable is dropped rather than coerced. A config written by a build that
+   * spelled these differently should fall back to the defaults, not roll a character from a field
+   * it misread.
+   */
+  it('drops what it does not recognise', () => {
+    expect(
+      readCharacterGeneratorConfig({
+        speciesName: 42,
+        archetypeName: '',
+        namingGender: 'neither',
+        somethingElse: 'ignored',
+      }),
+    ).toEqual({});
+  });
+});
+
+describe('rolling a character', () => {
+  /** Requirement 2.2, and the defect this module exists to fix: the clock is out of the roll. */
+  it('gives the same character for the same seed and settings', () => {
+    const config = { speciesName: 'elf', archetypeName: 'noble', genderName: 'female' };
+    const first = rollCharacter('a-fixed-seed', config);
+    const second = rollCharacter('a-fixed-seed', config);
+
+    expect(second.character).toEqual(first.character);
+    expect(second.nameGeneratorSet).toBe(first.nameGeneratorSet);
+  });
+
+  it('gives a different character for a different seed', () => {
+    expect(rollCharacter('seed-one').character.name).not.toBe(
+      rollCharacter('seed-two').character.name,
+    );
+  });
+
+  /**
+   * The name has a stream of its own, so choosing where names come from cannot shift the rest of
+   * the character. Without it, "same seed, same character" holds only for one naming source.
+   */
+  it('does not let the naming source move the character’s body', () => {
+    const plain = rollCharacter('shared-seed', { speciesName: 'human' });
+    const named = rollCharacter('shared-seed', { speciesName: 'human', nameGeneratorSet: 'dwarf' });
+
+    expect(named.character.height).toBe(plain.character.height);
+    expect(named.character.weight).toBe(plain.character.weight);
+    expect(named.character.physicalTraits).toEqual(plain.character.physicalTraits);
+    expect(named.character.name).not.toBe(plain.character.name);
+  });
+
+  it('honours the species, archetype and gender it was asked for', () => {
+    const { character } = rollCharacter('asked-for', {
+      speciesName: 'dwarf',
+      archetypeName: 'noble',
+      genderName: 'female',
+    });
+
+    expect(character.species.name).toBe('dwarf');
+    expect(character.archetype?.name).toBe('noble');
+    expect(character.gender.name).toBe('female');
+  });
+
+  it('treats the generator’s own “Random” as no choice at all', () => {
+    const { character } = rollCharacter('any-of-them', {
+      speciesName: CHARACTER_ANY,
+      archetypeName: CHARACTER_ANY,
+      genderName: CHARACTER_ANY,
+      ageCategoryName: CHARACTER_ANY,
+    });
+
+    expect(character.name).not.toBe('');
+  });
+
+  it('keeps the displayed name in step with its two halves', () => {
+    const { character } = rollCharacter('in-step');
+
+    expect(character.name).toBe(`${character.firstName} ${character.lastName}`);
+  });
+
+  it('reports the pattern set it actually used, not the one that was asked for', () => {
+    const { nameGeneratorSet, substitutions } = rollCharacter('resolved', {
+      speciesName: 'human',
+      nameGeneratorSet: 'a-set-nobody-has',
+    });
+
+    expect(nameGeneratorSet).toBe('human');
+    expect(substitutions).toContain('nameGeneratorSet');
+  });
+
+  /**
+   * Decision 3 of docs/fantasy-character.md. A placeholder species has empty tables, so rolling
+   * from one would produce a character out of nothing; the roll falls back and says which part it
+   * substituted, which is what the editing surface tells the user after a re-roll.
+   */
+  it('falls back to the default species rather than rolling out of empty tables', () => {
+    const { character, substitutions } = rollCharacter('gone', { speciesName: 'Thrennish' });
+
+    expect(character.species.name).toBe('human');
+    expect(substitutions).toContain('species');
+  });
+
+  it('widens back to every archetype when the recorded one has gone', () => {
+    const { substitutions } = rollCharacter('gone-too', { archetypeName: 'lamplighter-royal' });
+
+    expect(substitutions).toContain('archetype');
+  });
+
+  it('rolls a snapshot by the same path', () => {
+    const config = { speciesName: 'halfling' };
+
+    expect(rollCharacterSnapshot('paths-agree', config).name).toBe(
+      rollCharacter('paths-agree', config).character.name,
+    );
+  });
+
+  /**
+   * Every species in the list, because `generate` reaches for a name pattern set to name a noble's
+   * lands and most species have none of their own. A noble aarakocra used to take the whole roll
+   * down with an unavailable-pattern-set error.
+   */
+  it('rolls a noble of every species without throwing', () => {
+    const speciesNames = ['aarakocra', 'tabaxi', 'tortle', 'human', 'elf', 'dwarf'];
+
+    for (const speciesName of speciesNames) {
+      expect(() =>
+        rollCharacter(`noble-${speciesName}`, { speciesName, archetypeName: 'noble' }),
+      ).not.toThrow();
+    }
+  });
+});

--- a/src/lib/characters/character_roll.ts
+++ b/src/lib/characters/character_roll.ts
@@ -1,0 +1,259 @@
+/**
+ * The single path from a seed to a fantasy character, and the record of how it was rolled.
+ *
+ * Modelled on `adnd_character_roll.ts` and `settlement_roll.ts`, and here for the same reason:
+ * requirement 2.2 in docs/workshop.md wants the same seed and configuration to give the same
+ * character, and a generator whose configuration is assembled inline in a Svelte component
+ * satisfies that only for as long as nobody edits the component. Once an artifact can be
+ * re-rolled, "reproduce this" also needs somewhere to read the settings back from.
+ *
+ * **The clock leaves the generation path here.** `CharacterGenerator.svelte` used to reseed from
+ * `Date.now()` inside the roll, and to name from `` `${Date.now()}-character-name` ``, so the same
+ * seed did not in fact produce the same character — 2.2 was already failing before anything was
+ * saved. Pressing Generate now draws a *new seed* from the page's own RNG and the roll itself is a
+ * pure function of seed and config.
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import { getAllFantasyArchetypes, type Archetype } from '$lib/archetypes';
+import { getCategoryList } from '$lib/age';
+import { getFantasyNameGeneratorSet, getFantasyNameGeneratorSetNames } from '$lib/names';
+import { human, sentientSpeciesList } from '$lib/species_sentients';
+import type { Species } from '$lib/species';
+
+import { generate } from './character_generation.js';
+import {
+  applyGeneratedCharacterName,
+  generateCharacterName,
+  peopleNameGeneratorsFromNameSet,
+  type NamingGender,
+} from './character_name_generation.js';
+import { toCharacterSnapshot, type CharacterSnapshot } from './character_snapshot.js';
+import type { Character } from './character_types.js';
+
+/** The generator's own value for "let the seed choose", in every select that has one. */
+export const CHARACTER_ANY = 'Random' as const;
+
+/**
+ * What the character generator records about how it rolled, and what a re-roll reads back.
+ *
+ * It is exactly what the page's four selects and its naming section say, stated as a type rather
+ * than read field by field at the call site, so the two ends — what the generator writes and what a
+ * re-roll expects — are in one place and drift loudly instead of quietly.
+ */
+export type CharacterGeneratorConfigRecord = {
+  /** The species to roll, or absent for whichever one the page's default names. */
+  speciesName?: string;
+  /** A single archetype to roll from, or absent to draw from all of them. */
+  archetypeName?: string;
+  /** `male` or `female` to fix the character's gender, or absent to let the seed choose. */
+  genderName?: string;
+  /** An age category by name, or absent to let the seed choose. */
+  ageCategoryName?: string;
+  /**
+   * The name pattern set the character's names were built from.
+   *
+   * A character named from a culture records that culture's own pattern set here rather than the
+   * culture's id, so a re-roll produces names of the same tongue without reaching back into the
+   * store for an artifact it has no way to ask for. The link to the culture is an artifact
+   * reference and lives beside the payload, not in this record.
+   */
+  nameGeneratorSet?: string;
+  /** Which name to draw. `random` follows the character's own gender, as the page does. */
+  namingGender?: NamingGender;
+};
+
+/** A part of the roll that the recorded config asked for and this build could not supply. */
+export type CharacterRollSubstitution = 'species' | 'archetype' | 'nameGeneratorSet';
+
+/**
+ * A rolled character, and what the roll actually used.
+ *
+ * The resolved values travel back out because provenance has to record what was *used* rather than
+ * what was asked for: a pattern set this build has since dropped, recorded as it was requested, is
+ * provenance a re-roll cannot honour.
+ *
+ * `substitutions` is what the editing surface tells the user about after a re-roll. A character
+ * whose species was removed between saving and re-rolling is not re-rolled out of empty tables —
+ * it falls back to the default and says which part it substituted.
+ */
+export type CharacterRoll = {
+  character: Character;
+  nameGeneratorSet: string;
+  substitutions: CharacterRollSubstitution[];
+};
+
+const NAMING_GENDERS: NamingGender[] = ['male', 'female', 'random'];
+
+function readString(value: unknown, key: string): Record<string, string> {
+  return typeof value === 'string' && value !== '' ? { [key]: value } : {};
+}
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Provenance is `Record<string, unknown>` because the store cannot know what any tool puts in it,
+ * so this is the boundary where that becomes typed. Anything unrecognisable is dropped rather than
+ * coerced: a config written by a build that spelled these differently should fall back to the
+ * defaults, not roll a character from a field it misread.
+ */
+export function readCharacterGeneratorConfig(
+  config: Record<string, unknown>,
+): CharacterGeneratorConfigRecord {
+  return {
+    ...readString(config.speciesName, 'speciesName'),
+    ...readString(config.archetypeName, 'archetypeName'),
+    ...readString(config.genderName, 'genderName'),
+    ...readString(config.ageCategoryName, 'ageCategoryName'),
+    ...readString(config.nameGeneratorSet, 'nameGeneratorSet'),
+    ...(NAMING_GENDERS.includes(config.namingGender as NamingGender)
+      ? { namingGender: config.namingGender as NamingGender }
+      : {}),
+  };
+}
+
+/**
+ * The species a roll should use.
+ *
+ * A name this build no longer has falls back to the default rather than to the placeholder
+ * `character_rehydrate.ts` builds. The placeholder exists so a *saved* character stays readable —
+ * every number it needs is already in the payload — but a roll would be drawing height, age and
+ * traits out of its empty tables, which is not a character anyone asked for.
+ */
+function resolveSpecies(requested: string | undefined): {
+  species: Species;
+  substituted: boolean;
+} {
+  if (requested === undefined || requested === CHARACTER_ANY) {
+    return { species: human, substituted: false };
+  }
+  const found = sentientSpeciesList.find((species) => species.name === requested);
+  return found === undefined
+    ? { species: human, substituted: true }
+    : { species: found, substituted: false };
+}
+
+/**
+ * The archetypes a roll may draw from: all of them, or the single one that was asked for.
+ *
+ * An archetype this build no longer has widens back to all of them rather than leaving the list
+ * empty, because an empty list is how a character silently comes back with no occupation at all.
+ */
+function resolveArchetypes(requested: string | undefined): {
+  archetypes: Archetype[];
+  substituted: boolean;
+} {
+  const all = getAllFantasyArchetypes();
+  if (requested === undefined || requested === CHARACTER_ANY) {
+    return { archetypes: all, substituted: false };
+  }
+  const found = all.find((archetype) => archetype.name === requested);
+  return found === undefined
+    ? { archetypes: all, substituted: true }
+    : { archetypes: [found], substituted: false };
+}
+
+/**
+ * The pattern set a roll should name from.
+ *
+ * Absent means "the one that suits this species", which is what the page does when the user has not
+ * chosen a naming source — `character_generation.ts` has always derived a hint from the species
+ * name. A set this build no longer has lands in the same place and is reported as a substitution,
+ * because names in a tongue nobody asked for are worth saying out loud.
+ */
+function resolveNameGeneratorSet(
+  requested: string | undefined,
+  speciesName: string,
+): { name: string; substituted: boolean } {
+  const fallback = fantasyNameSetForSpecies(speciesName);
+  if (requested === undefined || requested === '') {
+    return { name: fallback, substituted: false };
+  }
+  return getFantasyNameGeneratorSetNames().includes(requested)
+    ? { name: requested, substituted: false }
+    : { name: fallback, substituted: true };
+}
+
+/** The build's name set for a species, or `human` for one it has no patterns for. */
+function fantasyNameSetForSpecies(speciesName: string): string {
+  const normalized = speciesName.toLowerCase();
+  return getFantasyNameGeneratorSetNames().includes(normalized) ? normalized : 'human';
+}
+
+/**
+ * Roll a character from a seed and a set of options — the one path the generator page and a
+ * re-roll both take.
+ *
+ * The name is drawn from a stream of its own, `` `${seed}-character-name` ``, rather than off the
+ * character's. Two reasons, and both matter. Names drawn from the main stream would shift every
+ * roll after them, so choosing a naming source explicitly and having one chosen would produce
+ * different *characters*. And the displayed name is written through `applyGeneratedCharacterName`
+ * so `firstName`, `lastName` and the derived `name` cannot fall out of step, which is the same
+ * helper the editor uses.
+ */
+export function rollCharacter(
+  seed: string,
+  config: CharacterGeneratorConfigRecord = {},
+): CharacterRoll {
+  const substitutions: CharacterRollSubstitution[] = [];
+
+  const species = resolveSpecies(config.speciesName);
+  if (species.substituted) {
+    substitutions.push('species');
+  }
+  const archetypes = resolveArchetypes(config.archetypeName);
+  if (archetypes.substituted) {
+    substitutions.push('archetype');
+  }
+  const nameSetName = resolveNameGeneratorSet(config.nameGeneratorSet, species.species.name);
+  if (nameSetName.substituted) {
+    substitutions.push('nameGeneratorSet');
+  }
+
+  const nameRng = new RNG(`${seed}-character-name`);
+  const nameSet = getFantasyNameGeneratorSet(nameSetName.name, nameRng);
+
+  const character = generate(seed, {
+    species: species.species,
+    archetypeOptions: archetypes.archetypes,
+    maleFirstNameGenerator: nameSet.male,
+    femaleFirstNameGenerator: nameSet.female,
+    familyNameGenerator: nameSet.family,
+    ...(config.genderName === undefined || config.genderName === CHARACTER_ANY
+      ? {}
+      : { allowedGenderNames: [config.genderName.toLowerCase()] }),
+    ...(config.ageCategoryName === undefined || config.ageCategoryName === CHARACTER_ANY
+      ? {}
+      : { allowedAgeCategoryNames: [config.ageCategoryName] }),
+  });
+
+  applyGeneratedCharacterName(
+    character,
+    generateCharacterName(
+      nameRng,
+      peopleNameGeneratorsFromNameSet(nameSet),
+      config.namingGender ?? 'random',
+      character.gender.name,
+    ),
+  );
+
+  return { character, nameGeneratorSet: nameSetName.name, substitutions };
+}
+
+/**
+ * Roll a fresh character snapshot from a seed and the settings it was first made with — the
+ * destructive half of editing (requirement 4.3), and what `ARTIFACT_EDITORS` registers as this
+ * kind's roller.
+ */
+export function rollCharacterSnapshot(
+  seed: string,
+  config: CharacterGeneratorConfigRecord = {},
+): CharacterSnapshot {
+  return toCharacterSnapshot(rollCharacter(seed, config).character);
+}
+
+/** The age categories the generator's own select offers, for the editor to offer the same list. */
+export function characterAgeCategoryNames(): string[] {
+  return getCategoryList();
+}

--- a/src/lib/characters/character_snapshot.test.ts
+++ b/src/lib/characters/character_snapshot.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  characterFromSnapshot,
+  isUnknownSpeciesName,
+  placeholderSpecies,
+  speciesFromStoredName,
+} from './character_rehydrate.js';
+import { rollCharacter } from './character_roll.js';
+import { toCharacterSnapshot, toStoredCharacter } from './character_snapshot.js';
+import type { Character } from './character_types.js';
+
+/**
+ * A generated character of a given shape, found by sweeping seeds.
+ *
+ * Sweeping rather than hand-building, because the point of a round-trip test is that a character
+ * the generator actually produces survives, and a hand-built one only proves the fields the test
+ * author remembered to set.
+ */
+function rollMatching(
+  predicate: (character: Character) => boolean,
+  config: Parameters<typeof rollCharacter>[1] = {},
+): Character {
+  for (let seed = 0; seed < 200; seed += 1) {
+    const { character } = rollCharacter(`roundtrip-${seed}`, config);
+    if (predicate(character)) {
+      return character;
+    }
+  }
+  throw new Error('no seed in the sweep produced a character of that shape');
+}
+
+describe('character snapshot', () => {
+  /** Requirement 7.2: the snapshot is lossless for everything the sheet shows. */
+  it('round-trips a generated character', () => {
+    const character = rollMatching(() => true);
+    const restored = characterFromSnapshot(toCharacterSnapshot(character));
+
+    expect(restored.name).toBe(character.name);
+    expect(restored.firstName).toBe(character.firstName);
+    expect(restored.lastName).toBe(character.lastName);
+    expect(restored.description).toBe(character.description);
+    expect(restored.shortDescription).toBe(character.shortDescription);
+    expect(restored.age).toBe(character.age);
+    expect(restored.height).toBe(character.height);
+    expect(restored.weight).toBe(character.weight);
+    expect(restored.length).toBe(character.length);
+    expect(restored.gender).toEqual(character.gender);
+    expect(restored.ageCategory).toEqual(character.ageCategory);
+    expect(restored.personalityTraits).toEqual(character.personalityTraits);
+    expect(restored.physicalTraits).toEqual(character.physicalTraits);
+    expect(restored.abilities).toEqual(character.abilities);
+    expect(restored.carried).toEqual(character.carried);
+    expect(restored.tags).toEqual(character.tags);
+  });
+
+  it('resolves the species back from its name, tables and all', () => {
+    const character = rollMatching((rolled) => rolled.species.name === 'human');
+    const restored = characterFromSnapshot(toCharacterSnapshot(character));
+
+    expect(restored.species).toEqual(character.species);
+  });
+
+  it('gives an archetype its equipment tables back', () => {
+    const character = rollMatching(
+      (rolled) => (rolled.archetype?.equipmentGenerationConfigs.length ?? 0) > 0,
+    );
+    const snapshot = toCharacterSnapshot(character);
+    const restored = characterFromSnapshot(snapshot);
+
+    // Dropped on the way out — they are what the character was rolled *from*, and 66 KB of it.
+    expect(snapshot.archetype).not.toHaveProperty('equipmentGenerationConfigs');
+    expect(restored.archetype).toEqual(character.archetype);
+  });
+
+  it('redraws a noble’s arms from the names of their parts', () => {
+    const character = rollMatching((rolled) => rolled.heraldry !== undefined, {
+      archetypeName: 'noble',
+    });
+    const restored = characterFromSnapshot(toCharacterSnapshot(character));
+
+    expect(restored.heraldry?.blazon).toBe(character.heraldry?.blazon);
+    expect(restored.heraldry?.device.field.name).toBe(character.heraldry?.device.field.name);
+    expect(restored.heraldry?.device.chargeGroups.map((group) => group.charge.name)).toEqual(
+      character.heraldry?.device.chargeGroups.map((group) => group.charge.name),
+    );
+  });
+
+  /**
+   * The value that says "these arms are a record of their own". Requirement 5.2, and decision 4 of
+   * docs/fantasy-character.md: copying them in would fork them at the moment of saving.
+   */
+  it('stores referenced arms as null rather than as a copy', () => {
+    const character = rollMatching((rolled) => rolled.heraldry !== undefined, {
+      archetypeName: 'noble',
+    });
+    const snapshot = toCharacterSnapshot(character, true);
+
+    expect(snapshot.heraldry).toBeNull();
+    expect(characterFromSnapshot(snapshot).heraldry).toBeUndefined();
+  });
+
+  it('is free of the functions IndexedDB refuses', () => {
+    const character = rollMatching((rolled) => rolled.heraldry !== undefined, {
+      archetypeName: 'noble',
+    });
+
+    expect(() => structuredClone(toCharacterSnapshot(character))).not.toThrow();
+  });
+
+  it('leaves a character with no arms carrying none', () => {
+    const character = rollMatching((rolled) => rolled.heraldry === undefined);
+    const snapshot = toStoredCharacter(character);
+
+    expect(snapshot).not.toHaveProperty('heraldry');
+  });
+});
+
+describe('an unknown species', () => {
+  /**
+   * Decision 3 of docs/fantasy-character.md: a name this build no longer has becomes a placeholder
+   * rather than retiring the character. Everything the sheet prints is already in the payload.
+   */
+  it('comes back as an inert placeholder carrying the stored name', () => {
+    const species = speciesFromStoredName('Thrennish');
+
+    expect(species.name).toBe('Thrennish');
+    expect(species.adjective).toBe('Thrennish');
+    expect(species.ageCategories).toEqual([]);
+    expect(species.sizeGeneratorConfigMatrix).toEqual([]);
+    expect(placeholderSpecies('Thrennish')).toEqual(species);
+  });
+
+  it('is reported as unknown, so a re-roll can decline to use it', () => {
+    expect(isUnknownSpeciesName('Thrennish')).toBe(true);
+    expect(isUnknownSpeciesName('human')).toBe(false);
+  });
+
+  it('keeps every number the character was saved with', () => {
+    const character = rollMatching(() => true);
+    const restored = characterFromSnapshot({
+      ...toCharacterSnapshot(character),
+      speciesName: 'Thrennish',
+    });
+
+    expect(restored.species.name).toBe('Thrennish');
+    expect(restored.height).toBe(character.height);
+    expect(restored.weight).toBe(character.weight);
+    expect(restored.physicalTraits).toEqual(character.physicalTraits);
+  });
+});

--- a/src/lib/characters/character_snapshot.ts
+++ b/src/lib/characters/character_snapshot.ts
@@ -1,0 +1,107 @@
+/**
+ * Writing a character snapshot, and the shapes one is made of. Reading one back is
+ * `character_rehydrate.ts`, split off for the reason settlement's and heraldry's are: resolving an
+ * archetype's equipment tables reaches `$lib/archetypes`, and rebuilding a coat of arms reaches
+ * `$lib/charges` — 18 MB of glyph art, measured. Nothing that merely stores, lists, or validates a
+ * character needs either.
+ *
+ * Most of a character's bulk is the shared table data it was rolled *from* rather than anything
+ * about the character, and requirement 3.2 in docs/workshop.md asks for such values to be stripped
+ * **or reconstructed explicitly**. Three are reconstructed here, by name:
+ *
+ * - **A species is a whole set of generator tables.** Age categories, a size matrix, physical-trait
+ *   configs, abilities — none of it is about this person, and every number it produced is already
+ *   in the payload. `Species` has no id, so the key is its `name`.
+ * - **An archetype carries its own equipment tables.** `equipmentGenerationConfigs` measured 66 KB
+ *   per character when the settlement snapshot was designed. A party of six, stored whole, is a
+ *   storage-quota problem.
+ * - **A coat of arms carries a render function.** `arrangement.renderSVG` is a function on every
+ *   charge group, which `structuredClone` — what IndexedDB stores with — refuses outright. Arms
+ *   travel the way the heraldry kind stores them, by the names of their parts.
+ *
+ * The final `stripFunctionValuesDeep` is a net rather than the mechanism, as it is for a
+ * settlement: everything this module knows to be a function has already been converted by name, and
+ * the strip is what keeps a closure grown somewhere new from turning a save into a `DataCloneError`
+ * the user meets instead of a character.
+ */
+
+import type { Archetype } from '$lib/archetypes';
+import { toStoredArms, type StoredArms } from '$lib/heraldry';
+import { stripFunctionValuesDeep } from '$lib/persistent_save';
+
+import type { Character } from './character_types.js';
+
+/**
+ * An archetype without the equipment tables it was rolled from. See the module comment: they are
+ * generator input, not content, and they are rebuilt from the archetype's name on the way back.
+ */
+export type StoredArchetype = Omit<Archetype, 'equipmentGenerationConfigs'>;
+
+/**
+ * A character with the three parts of it that are not this person's own stored as names.
+ *
+ * Declared here rather than in `$lib/settlements`, which is where it lived until #46. A settlement's
+ * notables are characters, and one shape in the library that owns the concept beats two types with
+ * one name drifting apart the first time either changes. The move is what
+ * `SETTLEMENT_PAYLOAD_VERSION` 2 migrates.
+ */
+export type StoredCharacter = Omit<Character, 'species' | 'archetype' | 'heraldry'> & {
+  speciesName: string;
+  archetype?: StoredArchetype;
+  /**
+   * `undefined` for a character with no arms, a value for one carrying its own, and `null` for one
+   * whose arms are a referenced artifact. `null` is a statement rather than a gap: it says the arms
+   * are a record of their own that someone may edit later, and the artifact reference beside the
+   * payload says which.
+   */
+  heraldry?: StoredArms | null;
+};
+
+/**
+ * A character as an artifact payload.
+ *
+ * Identical to {@link StoredCharacter} today, and named separately all the same: this is the
+ * artifact's payload shape, which the kind's `validate` and `migrate` speak, where `StoredCharacter`
+ * is what a settlement embeds. They are free to diverge, and the day one does the other should not
+ * follow it silently.
+ */
+export type CharacterSnapshot = StoredCharacter;
+
+export function toStoredArchetype(archetype: Archetype): StoredArchetype {
+  const { equipmentGenerationConfigs: _configs, ...rest } = archetype;
+  return rest;
+}
+
+/**
+ * A character with its species, archetype, and arms written as names.
+ *
+ * No strip here: this is the conversion a settlement composes into a much larger one, and running
+ * the net over each notable separately would walk the same tree once per person. `toCharacterSnapshot`
+ * below is where a character stored on its own gets it.
+ */
+export function toStoredCharacter(character: Character): StoredCharacter {
+  const { species, archetype, heraldry, ...rest } = character;
+  return {
+    ...rest,
+    speciesName: species.name,
+    ...(archetype === undefined ? {} : { archetype: toStoredArchetype(archetype) }),
+    ...(heraldry === undefined ? {} : { heraldry: toStoredArms(heraldry) }),
+  };
+}
+
+/**
+ * A character as an artifact payload.
+ *
+ * `referencedArms` says that this character's coat of arms is a saved artifact rather than its own.
+ * The payload then stores `heraldry: null` and the reference beside it says which — copying the arms
+ * in would fork them at the moment of saving, so an edit to that coat of arms would never reach the
+ * character wearing it, which is the opposite of what composition is for.
+ */
+export function toCharacterSnapshot(
+  character: Character,
+  referencedArms = false,
+): CharacterSnapshot {
+  const stored = toStoredCharacter(character);
+  const converted: CharacterSnapshot = referencedArms ? { ...stored, heraldry: null } : stored;
+  return stripFunctionValuesDeep(converted) as CharacterSnapshot;
+}

--- a/src/lib/characters/index.ts
+++ b/src/lib/characters/index.ts
@@ -1,7 +1,13 @@
 export type * from './character_types';
+export * from './character_artifact_kind';
 export * from './character_culture_sources';
+export * from './character_editing';
 export * from './character_generation';
 export * from './character_name_generation';
+export * from './character_presentation';
+export * from './character_rehydrate';
+export * from './character_roll';
+export * from './character_snapshot';
 export * from './personality_traits';
 export * from './titles';
 

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -58,6 +58,10 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // it the registry chunk goes from 25.4 KB to 50.2 KB — it very nearly doubles, and every page
   // that lists what a project contains pays the difference.
   '$lib/adnd/adnd_character_artifact_kind',
+  // The sixth, and the same reason again: `$lib/characters`'s entry point reaches
+  // `character_generation`, and from there the sentient species tables, the fantasy archetypes and
+  // the heraldry generator. The kind module holds metadata and validation only.
+  '$lib/characters/character_artifact_kind',
 ]);
 
 /**

--- a/src/lib/settlements/settlement_artifact_kind.test.ts
+++ b/src/lib/settlements/settlement_artifact_kind.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { readArtifactPayload, type AnyArtifactKindEntry } from '$lib/artifact_kinds';
+import { sentientSpeciesList } from '$lib/species_sentients';
 
 import {
   migrateSettlementSnapshot,
@@ -114,11 +115,127 @@ describe('validateSettlementSnapshot', () => {
   });
 });
 
+/**
+ * A settlement as version 1 wrote it: every notable's and every organization member's character
+ * carrying the whole `Species` record that version 2 stores as a name.
+ *
+ * Built by putting the species back rather than by pasting a captured payload, so the fixture stays
+ * a *real* settlement of the shape the site actually shipped — every other field is exactly what
+ * the generator produces — instead of a hand-typed approximation that goes stale.
+ */
+function version1Snapshot(seed: string): Record<string, unknown> {
+  const snapshot = storedSnapshot(seed, {
+    size: 'large',
+    includeOrganizations: true,
+    includeNotables: true,
+  });
+
+  const embed = (value: unknown): unknown => {
+    const character = value as Record<string, unknown>;
+    const { speciesName, ...rest } = character;
+    const species = sentientSpeciesList.find((entry) => entry.name === speciesName);
+    return { ...rest, species: JSON.parse(JSON.stringify(species)) as unknown };
+  };
+
+  return {
+    ...snapshot,
+    importantPeople: (snapshot.importantPeople as Record<string, unknown>[]).map((notable) => ({
+      ...notable,
+      character: embed(notable.character),
+    })),
+    organizations: (snapshot.organizations as Record<string, unknown>[]).map((organization) => ({
+      ...organization,
+      leader: embed(organization.leader),
+      notableMembers: (organization.notableMembers as unknown[]).map(embed),
+    })),
+  };
+}
+
 describe('migrateSettlementSnapshot', () => {
-  it('rejects, because version 1 is the only shape there has been', () => {
+  /**
+   * Requirement 7.3, and the site's first real payload step. Every settlement saved before this
+   * release keeps every notable it had.
+   */
+  it('brings a version 1 settlement’s notables forward, species and all', () => {
+    const result = migrateSettlementSnapshot(version1Snapshot('greyhaven'), 1);
+
+    expect(result.ok).toBe(true);
+    const notables = result.ok ? (result.value.importantPeople ?? []) : [];
+    expect(notables.length).toBeGreaterThan(0);
+    for (const notable of notables) {
+      expect(notable.character.speciesName).not.toBe('');
+      expect(notable.character).not.toHaveProperty('species');
+      // The species is resolvable, which is what makes the migrated character a whole one again.
+      expect(sentientSpeciesList.some((s) => s.name === notable.character.speciesName)).toBe(true);
+    }
+  });
+
+  it('brings an organization’s leader and members forward too', () => {
+    const result = migrateSettlementSnapshot(version1Snapshot('greyhaven'), 1);
+
+    expect(result.ok).toBe(true);
+    const organizations = result.ok ? (result.value.organizations ?? []) : [];
+    expect(organizations.length).toBeGreaterThan(0);
+    for (const organization of organizations) {
+      expect(organization.leader.speciesName).not.toBe('');
+      for (const member of organization.notableMembers) {
+        expect(member.speciesName).not.toBe('');
+      }
+    }
+  });
+
+  it('leaves the rest of the settlement exactly as it was', () => {
+    const before = version1Snapshot('greyhaven');
+    const result = migrateSettlementSnapshot(before, 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.name).toBe(before.name);
+      expect(result.value.population).toBe(before.population);
+      expect(result.value.acuteProblems).toEqual(before.acuteProblems);
+    }
+  });
+
+  /**
+   * Enrichment is opt-in four times over, so a version 1 settlement may have neither notables nor
+   * organizations. One that has neither migrates by having nothing to do.
+   */
+  it('migrates an unenriched settlement by leaving it alone', () => {
+    const plain = storedSnapshot('greyhaven');
+    const result = migrateSettlementSnapshot(plain, 1);
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.value.name).toBe(plain.name);
+  });
+
+  it('does not lose a settlement over one malformed notable', () => {
+    const broken = version1Snapshot('greyhaven');
+    const notables = broken.importantPeople as Record<string, unknown>[];
+    notables[0] = {
+      ...notables[0],
+      character: { ...(notables[0].character as Record<string, unknown>), species: 'not a record' },
+    };
+    const result = migrateSettlementSnapshot(broken, 1);
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.value.importantPeople?.[0]?.character.speciesName).toBe('');
+  });
+
+  it('rejects a version it has no step from', () => {
     const result = migrateSettlementSnapshot({}, 0);
     expect(result.ok).toBe(false);
     expect(result.ok === false && result.reason).toBe('unsupported-version');
+  });
+
+  it('rejects something that is not a settlement at all', () => {
+    expect(migrateSettlementSnapshot('a town, honestly', 1).ok).toBe(false);
+  });
+
+  /** The registry's own path: an older payload reaches `migrate` and comes back current. */
+  it('is reached by the registry when a stored payload is older than this build', () => {
+    const entry = settlementArtifactKind as unknown as AnyArtifactKindEntry;
+
+    expect(readArtifactPayload(entry, version1Snapshot('greyhaven'), 1).ok).toBe(true);
   });
 });
 

--- a/src/lib/settlements/settlement_artifact_kind.ts
+++ b/src/lib/settlements/settlement_artifact_kind.ts
@@ -18,8 +18,19 @@ import type { Settlement } from './settlement_types';
  */
 export const SETTLEMENT_ARTIFACT_KIND = 'settlement' as const;
 
-/** Version 1. The first shape a settlement has been stored in. */
-export const SETTLEMENT_PAYLOAD_VERSION = 1 as const;
+/**
+ * Version 2: a notable's character stores `speciesName` where version 1 embedded a whole `Species`.
+ *
+ * The site's first real payload step, and it exists because `StoredCharacter` moved to
+ * `$lib/characters` for #46 — one shape in the library that owns the concept, rather than two types
+ * with one name drifting apart. The shape change is not free: a settlement written by an older
+ * build carries the embedded record, and reading it as a version 2 payload would leave every
+ * notable without a species. {@link migrateSettlementSnapshot} is what stops that.
+ *
+ * It also drops a whole `Species` record per notable, which was the bulk of what a stored notable
+ * was.
+ */
+export const SETTLEMENT_PAYLOAD_VERSION = 2 as const;
 
 const SETTLEMENT_STRING_FIELDS = ['name', 'description', 'economicRole'];
 
@@ -210,19 +221,88 @@ export function validateSettlementSnapshot(payload: unknown): PayloadResult<Sett
 }
 
 /**
- * Settlements have only ever been stored at version 1, so there is nothing older to bring forward
- * and this rejects rather than pretending. It is here because the contract requires it, and it is
- * where the step goes the day the shape changes — a kind without one looks complete right up
- * until it silently drops someone's work.
+ * A version 1 character: whatever it held, plus the embedded species record.
+ *
+ * Typed as loosely as the data actually is. A migration is handed a payload written by a build this
+ * one has never seen, so anything it assumes beyond "an object, possibly with a species that has a
+ * name" is an assumption that can be wrong on someone's real data.
+ */
+function migratedCharacter(value: unknown): unknown {
+  const character = asRecord(value);
+  if (character === null) {
+    return value;
+  }
+  const { species, ...rest } = character;
+  const speciesRecord = asRecord(species);
+  return {
+    ...rest,
+    // The name off the embedded record, or an empty one. A version 1 settlement with a malformed
+    // species is still a settlement; `character_rehydrate.ts` turns an unresolvable name into an
+    // inert placeholder, and losing the whole town over one notable would be the worse trade.
+    speciesName: typeof speciesRecord?.name === 'string' ? speciesRecord.name : '',
+  };
+}
+
+function migratedNotable(value: unknown): unknown {
+  const notable = asRecord(value);
+  if (notable === null) {
+    return value;
+  }
+  return { ...notable, character: migratedCharacter(notable.character) };
+}
+
+function migratedOrganization(value: unknown): unknown {
+  const organization = asRecord(value);
+  if (organization === null) {
+    return value;
+  }
+  return {
+    ...organization,
+    ...(organization.leader === undefined
+      ? {}
+      : { leader: migratedCharacter(organization.leader) }),
+    ...(Array.isArray(organization.notableMembers)
+      ? { notableMembers: organization.notableMembers.map(migratedCharacter) }
+      : {}),
+  };
+}
+
+/**
+ * Bring a settlement written before {@link SETTLEMENT_PAYLOAD_VERSION} 2 forward.
+ *
+ * Every notable and every organization member is rewritten so its embedded species becomes a
+ * `speciesName`; nothing else about the settlement is touched. Enrichment is opt-in four times
+ * over, so a settlement may have neither notables nor organizations, and one that has neither
+ * migrates by having nothing to do rather than by being rejected.
+ *
+ * The result goes back through `validateSettlementSnapshot` rather than being trusted: a migration
+ * that produced something unreadable should say so here, where the reason reaches the user as a
+ * quarantine message, instead of one field at a time somewhere downstream.
  */
 export function migrateSettlementSnapshot(
-  _payload: unknown,
+  payload: unknown,
   from: number,
 ): PayloadResult<SettlementSnapshot> {
-  return rejectedPayload(
-    'unsupported-version',
-    `settlement has no migration from payload version ${from}; version ${SETTLEMENT_PAYLOAD_VERSION} is the only shape there has been`,
-  );
+  if (from !== 1) {
+    return rejectedPayload(
+      'unsupported-version',
+      `settlement has no migration from payload version ${from}; version 1 is the only older shape there has been`,
+    );
+  }
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'settlement payload is not an object');
+  }
+
+  return validateSettlementSnapshot({
+    ...record,
+    ...(Array.isArray(record.importantPeople)
+      ? { importantPeople: record.importantPeople.map(migratedNotable) }
+      : {}),
+    ...(Array.isArray(record.organizations)
+      ? { organizations: record.organizations.map(migratedOrganization) }
+      : {}),
+  });
 }
 
 /**

--- a/src/lib/settlements/settlement_editing.test.ts
+++ b/src/lib/settlements/settlement_editing.test.ts
@@ -212,8 +212,8 @@ describe('settlement notables', () => {
     expect(after.importantPeople?.[0]?.character.firstName).toBe('Maren');
     expect(after.importantPeople?.[0]?.character.lastName).toBe('Voss');
     // The rest of the character record is untouched; a rename is a rename.
-    expect(after.importantPeople?.[0]?.character.species).toEqual(
-      enriched().importantPeople?.[0]?.character.species,
+    expect(after.importantPeople?.[0]?.character.speciesName).toEqual(
+      enriched().importantPeople?.[0]?.character.speciesName,
     );
   });
 

--- a/src/lib/settlements/settlement_rehydrate.ts
+++ b/src/lib/settlements/settlement_rehydrate.ts
@@ -1,64 +1,29 @@
 /**
  * Rebuilding a settlement from a snapshot, kept apart from `settlement_snapshot.ts` because of
  * what it costs. Restoring an organization's emblem resolves charge names against
- * `$lib/charges` — 18 MB of glyph art, measured — and restoring a character's archetype reaches
- * the fantasy archetype tables. Writing a snapshot needs neither, and the kind registry validates
- * one without touching either module, so the two directions do not belong in the same file.
+ * `$lib/charges` — 18 MB of glyph art, measured — and restoring a character's archetype and species
+ * reaches the fantasy archetype tables and the sentient species list. Writing a snapshot needs
+ * none of it, and the kind registry validates one without touching those modules, so the two
+ * directions do not belong in the same file.
+ *
+ * A stored character comes back through `$lib/characters`, which owns that shape since #46. What
+ * is left here is what a settlement itself borrows: hierarchies, emblems, and the notables and
+ * members those characters hang off.
  */
 
-import { getAllFantasyArchetypes, type Archetype } from '$lib/archetypes';
-import type { Character } from '$lib/characters';
+import { characterFromStored } from '$lib/characters';
 import { armsFromStored } from '$lib/heraldry';
 import type { OrganizationHierarchy, Organization } from '$lib/organizations';
 import type { VisualIdentity } from '$lib/visual_identity';
 
 import type {
   SettlementSnapshot,
-  StoredArchetype,
-  StoredCharacter,
   StoredOrganization,
   StoredOrganizationHierarchy,
   StoredSettlementNotable,
   StoredVisualIdentity,
 } from './settlement_snapshot.js';
 import type { Settlement, SettlementImportantPerson } from './settlement_types.js';
-
-/**
- * The equipment tables each archetype was rolled from, by archetype name.
- *
- * Built once. `getAllFantasyArchetypes` returns a shared array that must not be mutated, and this
- * only ever reads from it.
- */
-const equipmentConfigsByArchetypeName = new Map(
-  getAllFantasyArchetypes().map((archetype) => [
-    archetype.name,
-    archetype.equipmentGenerationConfigs,
-  ]),
-);
-
-/**
- * An archetype with its equipment tables put back.
- *
- * An archetype this build no longer has comes back with no tables rather than throwing. That is
- * requirement 3.3 applied one level down: the tables are what a character would be *re-equipped*
- * from, which a saved settlement never does, so a settlement whose blacksmith archetype was
- * renamed in some later release is still every bit the settlement the user saved.
- */
-function archetypeFromStored(stored: StoredArchetype): Archetype {
-  return {
-    ...stored,
-    equipmentGenerationConfigs: equipmentConfigsByArchetypeName.get(stored.name) ?? [],
-  };
-}
-
-function characterFromStored(stored: StoredCharacter): Character {
-  const { archetype, heraldry, ...rest } = stored;
-  return {
-    ...rest,
-    ...(archetype === undefined ? {} : { archetype: archetypeFromStored(archetype) }),
-    ...(heraldry === undefined ? {} : { heraldry: armsFromStored(heraldry) }),
-  };
-}
 
 function notableFromStored(stored: StoredSettlementNotable): SettlementImportantPerson {
   return { ...stored, character: characterFromStored(stored.character) };

--- a/src/lib/settlements/settlement_snapshot.ts
+++ b/src/lib/settlements/settlement_snapshot.ts
@@ -5,7 +5,7 @@
  * stores, lists, or validates a settlement needs it.
  *
  * A settlement is the first artifact payload on the site built against the kind contract from
- * scratch rather than retrofitted, and three things in it are not plain data. Each is handled
+ * scratch rather than retrofitted, and four things in it are not plain data. Each is handled
  * explicitly here rather than left to a blanket strip, because requirement 3.2 in
  * docs/workshop.md asks for exactly that — stripped *or reconstructed*, and named either way:
  *
@@ -20,10 +20,13 @@
  *   about the character. Kept, one enriched settlement is a megabyte and a campaign's worth is a
  *   storage-quota problem; dropped and rebuilt from the archetype's name, the same settlement is
  *   about forty kilobytes. That is the trade the heraldry kind already makes with charge names.
+ * - **A character embeds a whole species.** Age categories, a size matrix, physical-trait configs
+ *   and abilities, none of it about this person and all of it repeated per notable. Stored by name
+ *   since payload version 2; see `migrateSettlementSnapshot`, which is what brings a version 1
+ *   settlement's notables forward.
  */
 
-import type { Archetype } from '$lib/archetypes';
-import type { Character } from '$lib/characters';
+import { toStoredCharacter, type StoredCharacter } from '$lib/characters';
 import { toStoredArms, type StoredArms } from '$lib/heraldry';
 import type { OrganizationHierarchy, Organization, RoleId, RoleInfo } from '$lib/organizations';
 import { stripFunctionValuesDeep } from '$lib/persistent_save';
@@ -32,16 +35,13 @@ import type { VisualEmblem, VisualIdentity } from '$lib/visual_identity';
 import type { Settlement, SettlementImportantPerson } from './settlement_types.js';
 
 /**
- * An archetype without the equipment tables it was rolled from. See the module comment: they are
- * generator input, not content, and they are rebuilt from the archetype's name on the way back.
+ * The two shapes a stored character is made of now live in `$lib/characters`, which is the library
+ * that owns the concept. They were declared here until #46, because a settlement's notables were
+ * the first characters anything stored — and the day the fantasy character generator needed the
+ * same shape, one of the two copies would have started drifting. Re-exported so the settlement
+ * kind's own consumers keep importing them from where they always did.
  */
-export type StoredArchetype = Omit<Archetype, 'equipmentGenerationConfigs'>;
-
-/** A character with the two parts of it that are not plain data stored as names. */
-export type StoredCharacter = Omit<Character, 'archetype' | 'heraldry'> & {
-  archetype?: StoredArchetype;
-  heraldry?: StoredArms;
-};
+export type { StoredArchetype, StoredCharacter } from '$lib/characters';
 
 export type StoredSettlementNotable = Omit<SettlementImportantPerson, 'character'> & {
   character: StoredCharacter;
@@ -82,20 +82,6 @@ export type SettlementSnapshot = Omit<Settlement, 'importantPeople' | 'organizat
   importantPeople?: StoredSettlementNotable[];
   organizations?: StoredOrganization[];
 };
-
-function toStoredArchetype(archetype: Archetype): StoredArchetype {
-  const { equipmentGenerationConfigs: _configs, ...rest } = archetype;
-  return rest;
-}
-
-function toStoredCharacter(character: Character): StoredCharacter {
-  const { archetype, heraldry, ...rest } = character;
-  return {
-    ...rest,
-    ...(archetype === undefined ? {} : { archetype: toStoredArchetype(archetype) }),
-    ...(heraldry === undefined ? {} : { heraldry: toStoredArms(heraldry) }),
-  };
-}
 
 function toStoredNotable(notable: SettlementImportantPerson): StoredSettlementNotable {
   return { ...notable, character: toStoredCharacter(notable.character) };

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -111,6 +111,7 @@ describe('TOOL_CATALOG', () => {
     // change that earns it. That is the point — a level should not be able to rise as a side
     // effect of editing a catalog entry for some other reason.
     const assessedHigher = [
+      '/character',
       '/culture',
       '/fantasy/religion',
       '/fantasy/settlement',
@@ -210,6 +211,7 @@ describe('toolsWithMaturity', () => {
     const releaseReady = toolsWithMaturity('release-ready');
 
     expect(releaseReady.map((tool) => tool.path).sort()).toEqual([
+      '/character',
       '/culture',
       '/fantasy/adnd/character',
       '/fantasy/adnd/character/build',
@@ -261,6 +263,7 @@ describe('filterTools', () => {
 
     expect(durableFantasy.map((tool) => tool.path)).toEqual([
       '/fantasy/adnd/character/build',
+      '/character',
       '/fantasy/adnd/character',
       '/culture',
       '/fantasy/religion',

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -38,7 +38,12 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     label: 'Fantasy Character',
     kind: 'generator',
     domain: 'characters',
-    maturity: 'experimental',
+    // Release-ready, assessed section by section against docs/workshop.md and recorded in
+    // docs/fantasy-character.md (#46). It saves as the unqualified `character` kind, has an editor
+    // in `ARTIFACT_EDITORS`, composes a naming culture and a coat of arms by reference, and exports
+    // Markdown and PDF. Its roll is deterministic from the seed — the clock left the generation
+    // path with `character_roll.ts`, which is what 2.2 was failing on before.
+    maturity: 'release-ready',
     genres: ['fantasy'],
     tags: ['character'],
   }),

--- a/src/lib/workshop/README.md
+++ b/src/lib/workshop/README.md
@@ -223,8 +223,8 @@ artifact does not restamp contents nobody changed.
 ## Artifact editors
 
 `ARTIFACT_EDITORS` maps a kind to the component that edits it, alongside an optional roller.
-**Culture, religion, and settlement are the entries**, and most kinds having none is the shipped
-state: #39
+**Culture, religion, settlement, the AD&D 2E character and the fantasy character are the
+entries**, and most kinds having none is the shipped state: #39
 built the frame, and an editing view for a particular kind is part of taking that tool to
 Release-ready (docs/workshop.md, section 4). A kind with no entry opens read-only — the stored
 snapshot, rendered honestly — which is a state the surface draws rather than an error it reports.

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -74,6 +74,15 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         rollSettlementSnapshot(provenance.seed, readSettlementGeneratorConfig(provenance.config));
     },
   },
+  character: {
+    loadEditor: () => import('$components/characters/CharacterArtifactEditor.svelte'),
+    loadRoller: async () => {
+      const { readCharacterGeneratorConfig, rollCharacterSnapshot } =
+        await import('$lib/characters/character_roll.js');
+      return (provenance) =>
+        rollCharacterSnapshot(provenance.seed, readCharacterGeneratorConfig(provenance.config));
+    },
+  },
   /**
    * The first kind whose editor is a tool rather than a component written for the purpose.
    *

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -16,6 +16,7 @@ describe('artifact kind catalog', () => {
       'religion',
       'settlement',
       'character.adnd-2e',
+      'character',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -16,6 +16,7 @@ import {
 // so much as lists what a project contains. Settlement is the sharpest case of the four: its entry
 // point reaches `$lib/organizations`, and from there the heraldry generator and the charge library.
 import { adndCharacterArtifactKind } from '$lib/adnd/adnd_character_artifact_kind';
+import { characterArtifactKind } from '$lib/characters/character_artifact_kind';
 import { cultureArtifactKind } from '$lib/culture/culture_artifact_kind';
 import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
 import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
@@ -37,6 +38,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, religionArtifactKind);
   registerArtifactKind(registry, settlementArtifactKind);
   registerArtifactKind(registry, adndCharacterArtifactKind);
+  registerArtifactKind(registry, characterArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Implements [docs/fantasy-character.md](https://github.com/ironarachne/ironarachne/blob/main/docs/fantasy-character.md), all eight items of its plan, in one branch rather than eight. Closes #46.

`/character` now reads `maturity: 'release-ready'`, assessed section by section against the readiness spec rather than declared; the assessment is in the design document under **What shipped**.

## The four things worth reviewing

**The kind is `character`, unqualified.** A character from this generator is a person, not a set of numbers that mean something under one ruleset — the test decision 4 of `docs/workshop.md` sets. It sorts with `character.adnd-2e` and leaves the three unbuilt system-qualified ids free.

**`StoredCharacter` moved into `$lib/characters`, and the settlement payload advanced to version 2.** A settlement's notables are characters, so the shape already existed in the wrong library. The migration rewrites every notable's and every organization member's embedded `Species` record into a `speciesName`. This is the site's first real `payloadVersion` step; it is exercised against a version 1 payload built by putting the species *back* into a generated settlement, so the fixture stays a real settlement rather than a captured blob.

**Requirement 2.2 was failing before anything was saved.** The generator reseeded from `Date.now()` inside every roll and named from a clock-seeded RNG, so a locked seed reproduced neither the body nor the name. `character_roll.ts` is the single path from a seed now. A crash fell out of writing it and is fixed with it: `generate` asked `getFantasyNameGeneratorSet(species.name)` for a noble's land name, which **throws** for the twenty-odd species with no pattern set of their own — a noble aarakocra took the whole page down.

**Species is editable only by re-rolling**, which is the question the design document left open. Nothing recomputes the height, weight or physical traits a species produced, so a select would hand back an elf with a halfling's build. Everything else the generator displays is editable in `CharacterArtifactEditor`.

## Also here

- Composition by reference, both opt-in: a naming culture through `CharacterNameSection`'s existing opt-in, and a coat of arms through a `SavedArtifactPicker`. Referenced arms are stored as `heraldry: null` beside the link rather than copied.
- Markdown and PDF exports **with their controls** — decision 8, which is settlement's document-model-and-no-button mistake named so as not to be repeated.
- `e2e/character.spec.ts`: generate, save, reopen, edit across a reload, plus determinism, the two offers, and both downloads.
- `src/lib/characters/README.md` says plainly that this library implements no game system, and where a system's character lives instead (8.4).

## Verification

`npm run verify` green — 4548 tests, 0 svelte-check errors, coverage gate passed with no new baseline entries.

`npm run verify:all` ran the browser suite: **464 passed, 2 failed**, both in the new spec and both the same strict-mode locator fault (`Generate` also matches `Generate name`). Fixed, and the affected specs re-run on their own: `e2e/character.spec.ts` 7 passed; `tool_maturity`, `workshop` and `vault` 91 passed together. The full suite has not been run again since that one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRkjYVaTcuxkQaGkzgaP4r
