### PR TITLE
Take the DCC character generator to Release-ready

### DIFF
--- a/docs/readiness-characters.md
+++ b/docs/readiness-characters.md
@@ -12,7 +12,9 @@ Part of [the readiness pass](tool-readiness.md); read that first for what all tw
 share — the determinism fix, the stored vocabulary, the kind ids, and the field-editor decision.
 Measured against [Tool release readiness](workshop.md#tool-release-readiness).
 
-**Status:** accepted; not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in this document is clear to start.
+**Status:** accepted; [#48](#48--dungeon-crawl-classics) is **implemented**, the other four are not
+yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in
+this document is clear to start.
 
 ## The three system characters
 
@@ -71,6 +73,36 @@ one press of **Save** writes more than one artifact, and it is worth the special
 
 **8.4** — the README says DCC as published in the core rulebook, that the funnel implements
 zero-level characters only, and that levelled advancement is deliberately out of scope.
+
+#### What shipped, and the one place it departs from the shape above
+
+**The rule objects travel as the rows the character drew, minus `apply`, rather than as bare
+names.** `StoredDccOccupation = Omit<DCCOccupation, 'apply'>` and the lucky-sign equivalent; the
+handler is put back by name on read, and an inert one stands in when the name resolves to nothing.
+The design's `occupationName` / `luckyRollName` shape came from AD&D, where a race and a class are
+table rows the character merely points at. In DCC they are not, in two ways that were only visible
+in the code:
+
+- **A drawn row carries per-character data.** `randomLuckyRoll` copies its row and overwrites
+  `modifier` with the character's own Luck modifier, so the table's row is not the character's row.
+  Rebuilt from the name, every saved character's lucky sign would read `+0`.
+- **An `apply` handler may rewrite the row's own name.** The human farmer replaces its
+  `occupation.name` with the crop it rolled (`human_occupation_data.ts:372`), so a `potato farmer`
+  matches nothing in any table — and resolving by name would lose the pitchfork and the hen with it.
+
+Storing the row keeps the payload authoritative (4.2) and still keeps every closure out of it, which
+is what the by-name rule was protecting. The name lookup is kept for the one thing it is good for.
+The same question is worth asking of #49 and #50 before their snapshots are written: _does anything
+write to the row after it is drawn?_
+
+Two things beyond the design, both small:
+
+- **Generate is disabled when all four occupation tables are switched off.** The page could always
+  reach that state, and `randomOccupation` would have been drawing from an empty list. The provenance
+  reader drops such a config rather than storing an empty list a re-roll could not honour.
+- **A Markdown export beside the PDF.** The drawn PDF sheet is what a player writes on and it is
+  unchanged; `dcc_presentation.ts` is the character as _text_, and it is where 6.4 lives — a peasant
+  who cannot cast prints no Spellcasting heading rather than one reading "No spellcasting possible".
 
 ### #49 — Stars Without Number
 

--- a/e2e/dcc_character.spec.ts
+++ b/e2e/dcc_character.spec.ts
@@ -1,0 +1,223 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `character.dcc` kind: generate, save, reopen, edit.
+ *
+ * This is the half no unit test can settle. The library tests prove a character round-trips through
+ * the codec and that each editing function changes one field; what they cannot prove is that a user
+ * can press Generate, keep the result, come back to it in a different page, change something, and
+ * still have the character they saved. Every step of that crosses a boundary the unit tests stub
+ * out — the artifact store, IndexedDB, the editor registry, and a page reload.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+
+const DCC_TITLE = 'Dungeon Crawl Classics Character Generator | Iron Arachne';
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool on this page has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+test.describe('a DCC zero-level character', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'The Funnel');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a character to keep straight away.
+    await expect(page.getByRole('heading', { name: 'Attributes' })).toBeVisible();
+    await saveAs(page, 'Yorik Bramble');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'Yorik Bramble');
+
+    // Typed rather than filled: `fill` sets the value in one go, and the point of this assertion is
+    // that the editor's own bindings carry a user's keystrokes through to the snapshot it announces.
+    const alignment = panel.getByRole('textbox', { name: 'Alignment' });
+    await alignment.fill('');
+    await alignment.pressSequentially('Chaos');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'Yorik Bramble');
+    await expect(reopened.getByRole('textbox', { name: 'Alignment' })).toHaveValue('Chaos');
+  });
+
+  test('offers the derived arithmetic as a command rather than doing it silently', async ({
+    page,
+  }) => {
+    // Requirement 4.2: a judge who adjusts a save has made a decision no recomputation may
+    // overrule. The button is how they ask for the arithmetic back.
+    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+    await saveAs(page, 'Bess Tanner');
+
+    const panel = await openInWorkshop(page, 'Bess Tanner');
+    const fortitude = panel.getByRole('spinbutton', { name: 'Fortitude save' });
+    await fortitude.fill('7');
+    await expect(fortitude).toHaveValue('7');
+
+    await panel.getByRole('spinbutton', { name: 'stamina score' }).fill('18');
+    // Unmoved: changing the score did not touch the save.
+    await expect(fortitude).toHaveValue('7');
+
+    await panel
+      .getByRole('button', { name: 'Recalculate modifiers and saves from the scores' })
+      .click();
+    await expect(fortitude).not.toHaveValue('7');
+  });
+
+  test('reproduces the same character from the same seed', async ({ page }) => {
+    // Requirement 2.2, and the defect `dcc_character_roll.ts` was written to fix: the page drew
+    // three separate values off an RNG it reseeded each press, so the seed described only part of
+    // what it produced.
+    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+
+    const heading = page.getByRole('heading', { level: 2 }).first();
+    const occupation = page.locator('p', { hasText: /^A level 0 / }).first();
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const first = await heading.textContent();
+    const firstOccupation = await occupation.textContent();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    await expect(heading).toHaveText(first ?? '');
+    await expect(occupation).toHaveText(firstOccupation ?? '');
+
+    // And a different seed is a different peasant, so the reproduction above is not the page simply
+    // failing to re-roll.
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    await expect(occupation).not.toHaveText(firstOccupation ?? '');
+  });
+
+  test('refuses to roll from no table at all', async ({ page }) => {
+    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+
+    for (const label of ['Allow Dwarves', 'Allow Elves', 'Allow Halflings', 'Allow Humans']) {
+      await page.getByLabel(label).uncheck();
+    }
+
+    await expect(page.getByRole('button', { name: 'Generate', exact: true })).toBeDisabled();
+    await expect(page.getByText('Allow at least one kind of occupation.')).toBeVisible();
+
+    await page.getByLabel('Allow Humans').check();
+    await expect(page.getByRole('button', { name: 'Generate', exact: true })).toBeEnabled();
+  });
+
+  test('offers a project culture to name from, and only once there is one', async ({ page }) => {
+    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+
+    // No cultures in the project, so no offer. An offer with nothing behind it is noise, and
+    // requirement 5.3 is what makes its absence correct rather than a gap: the tool generates its
+    // own names and saves perfectly well without one.
+    await expect(page.getByLabel('Name from a saved culture in this project')).toHaveCount(0);
+
+    await visitRoute(page, '/culture', { title: 'Culture Generator | Iron Arachne' });
+    await saveAs(page, 'The Emberfolk');
+
+    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+
+    // Composition is opt-in (rule 1): the offer is there and starts unticked.
+    const offer = page.getByLabel('Name from a saved culture in this project');
+    await expect(offer).toBeVisible();
+    await expect(offer).not.toBeChecked();
+  });
+
+  test('downloads a character sheet a judge can take to the table', async ({ page }) => {
+    // Requirement 6.3. Two exports, and they are different things: the PDF is the drawn sheet a
+    // player writes on, the Markdown is the character as text for a judge's notes.
+    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    expect((await markdown).suggestedFilename()).toMatch(/\.md$/);
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: /Download PDF/ }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/\.pdf$/);
+  });
+
+  /**
+   * Decision 1 of docs/readiness-characters.md, tested where it actually matters: two characters
+   * saved from a funnel are two artifacts, each openable and renamable on its own.
+   */
+  test('saves each character as an artifact of its own', async ({ page }) => {
+    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+
+    await saveAs(page, 'Yorik Bramble');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    await saveAs(page, 'Bess Tanner');
+
+    await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+    await expect(vaultRow(page, 'Yorik Bramble')).toBeVisible();
+    await expect(vaultRow(page, 'Bess Tanner')).toBeVisible();
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -26,6 +26,10 @@ const TOOL_PAGES = [
 /** The release-ready tools, which must say nothing at all. */
 const SILENT_TOOL_PAGES = [
   { path: '/character', title: 'Character | Iron Arachne' },
+  {
+    path: '/fantasy/dcc/character',
+    title: 'Dungeon Crawl Classics Character Generator | Iron Arachne',
+  },
   { path: '/culture', title: 'Culture Generator | Iron Arachne' },
   { path: '/fantasy/settlement', title: 'Settlement Generator | Iron Arachne' },
   { path: '/fantasy/religion', title: 'Religion Generator | Iron Arachne' },
@@ -104,6 +108,9 @@ test('maturity: the tool browser marks every tool that has something to warn abo
   await expect(browser.getByRole('button', { name: /^Fantasy Character/ })).not.toContainText(
     'Release-ready',
   );
+  await expect(
+    browser.getByRole('button', { name: /^Dungeon Crawl Classics Character/ }),
+  ).not.toContainText('Release-ready');
   await expect(browser.getByRole('button', { name: /^Heraldry/ })).toContainText('Beta');
   await expect(browser.getByRole('button', { name: /^Planet/ })).toContainText('Experimental');
 });

--- a/src/components/characters/DccCharacterArtifactEditor.svelte
+++ b/src/components/characters/DccCharacterArtifactEditor.svelte
@@ -1,0 +1,451 @@
+<script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import {
+    addDccCharacterEquipment,
+    addDccCharacterListEntry,
+    addDccCharacterWeapon,
+    dccDerivedFromAttributes,
+    DCC_ATTRIBUTE_FIELDS,
+    DCC_NUMBER_FIELDS,
+    isUnknownDccOccupationName,
+    removeDccCharacterEquipment,
+    removeDccCharacterListEntry,
+    removeDccCharacterWeapon,
+    setDccCharacterAttribute,
+    setDccCharacterCurrency,
+    setDccCharacterEquipmentName,
+    setDccCharacterListEntry,
+    setDccCharacterLuckyRollModifier,
+    setDccCharacterLuckyRollText,
+    setDccCharacterNumber,
+    setDccCharacterOccupationName,
+    setDccCharacterText,
+    setDccCharacterWeaponField,
+    validateDccCharacterSnapshot,
+    type DccCharacterListField,
+    type DccCharacterNumberField,
+    type DccCharacterSnapshot,
+    type DccCharacterTextField,
+    type DccWeaponField,
+  } from '$lib/dcc';
+
+  /**
+   * The editing view for a saved DCC zero-level character.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it, so
+   * what is here is the character's own shape and the calls that change it.
+   *
+   * Every control writes a whole replacement snapshot through `onChange`. The framework compares
+   * that against what it read to decide whether anything needs saving, so typing a character and
+   * deleting it again leaves nothing to save.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps a DCC editor from rendering fields over
+   * something that is not a DCC character.
+   */
+  const accepted = $derived(validateDccCharacterSnapshot(snapshot));
+  const character = $derived<DccCharacterSnapshot | undefined>(
+    accepted.ok ? accepted.value : undefined,
+  );
+
+  const TEXT_FIELDS: { field: DccCharacterTextField; label: string }[] = [
+    { field: 'firstName', label: 'First name' },
+    { field: 'lastName', label: 'Last name' },
+    { field: 'gender', label: 'Gender' },
+    { field: 'alignment', label: 'Alignment' },
+  ];
+
+  /** The numbers, in the order the sheet reads, with the labels the sheet prints. */
+  const NUMBER_LABELS: Record<DccCharacterNumberField, string> = {
+    level: 'Level',
+    xp: 'XP',
+    hp: 'HP',
+    speed: 'Speed (ft.)',
+    age: 'Age',
+    armorClass: 'Armor class',
+    attackModifier: 'Attack modifier',
+    baseSave: 'Base save',
+    fortitudeSave: 'Fortitude save',
+    reflexSave: 'Reflex save',
+    willpowerSave: 'Willpower save',
+    spellsKnown: 'Spells known',
+    wizardMaxSpellLevel: 'Wizard max spell level',
+    clericMaxSpellLevel: 'Cleric max spell level',
+    numberOfLanguages: 'Number of languages',
+  };
+
+  const LISTS: { list: DccCharacterListField; legend: string; noun: string }[] = [
+    { list: 'specialRules', legend: 'Special rules', noun: 'special rule' },
+    { list: 'languages', legend: 'Languages', noun: 'language' },
+  ];
+
+  const WEAPON_FIELDS: { field: DccWeaponField; label: string }[] = [
+    { field: 'name', label: 'name' },
+    { field: 'damage', label: 'damage' },
+    { field: 'range', label: 'range' },
+  ];
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: DccCharacterSnapshot) => DccCharacterSnapshot): void {
+    if (character === undefined) {
+      return;
+    }
+    onChange(change(character));
+  }
+</script>
+
+{#if character === undefined}
+  <Notice tone="danger">
+    These contents are stored as a DCC character but do not read as one, so there is nothing safe to
+    edit here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="dcc-editor">
+    <fieldset>
+      <legend>Who they are</legend>
+
+      {#each TEXT_FIELDS as entry (entry.field)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-{entry.field}">{entry.label}</label>
+          <input
+            id="{uid}-{entry.field}"
+            type="text"
+            value={character[entry.field]}
+            oninput={(event) =>
+              edit((current) =>
+                setDccCharacterText(current, entry.field, event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+        </div>
+      {/each}
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-occupation">Occupation</label>
+        <input
+          id="{uid}-occupation"
+          type="text"
+          value={character.occupation.name}
+          oninput={(event) =>
+            edit((current) => setDccCharacterOccupationName(current, event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+
+      <!-- Said rather than hidden. A great many perfectly good characters carry a name no table
+           ever had — the human farmer's own handler rewrites it to the crop they rolled — so this
+           is information, not a fault. -->
+      {#if isUnknownDccOccupationName(character.occupation.name)}
+        <p class="dcc-editor__note">
+          No occupation table in this build has that name, so the trained weapon and trade goods it
+          would have supplied come from the payload alone. That is the ordinary state for a farmer.
+        </p>
+      {/if}
+    </fieldset>
+
+    <fieldset>
+      <legend>Attributes</legend>
+
+      {#each DCC_ATTRIBUTE_FIELDS as field (field)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-{field}-value">{field} score</label>
+          <input
+            id="{uid}-{field}-value"
+            type="number"
+            value={character[field].value}
+            oninput={(event) =>
+              edit((current) =>
+                setDccCharacterAttribute(
+                  current,
+                  field,
+                  'value',
+                  event.currentTarget.valueAsNumber,
+                ),
+              )}
+          />
+          <label for="{uid}-{field}-modifier">{field} modifier</label>
+          <input
+            id="{uid}-{field}-modifier"
+            type="number"
+            value={character[field].modifier}
+            oninput={(event) =>
+              edit((current) =>
+                setDccCharacterAttribute(
+                  current,
+                  field,
+                  'modifier',
+                  event.currentTarget.valueAsNumber,
+                ),
+              )}
+          />
+        </div>
+      {/each}
+
+      <!-- Offered rather than done automatically: a judge who adjusted a save has made a decision,
+           and a form that silently corrected the four numbers derived from an attribute would
+           overrule them four times. -->
+      <BaseButton onclick={() => edit(dccDerivedFromAttributes)}>
+        Recalculate modifiers and saves from the scores
+      </BaseButton>
+    </fieldset>
+
+    <fieldset>
+      <legend>The numbers</legend>
+
+      {#each DCC_NUMBER_FIELDS as field (field)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-number-{field}">{NUMBER_LABELS[field]}</label>
+          <input
+            id="{uid}-number-{field}"
+            type="number"
+            value={character[field]}
+            oninput={(event) =>
+              edit((current) =>
+                setDccCharacterNumber(current, field, event.currentTarget.valueAsNumber),
+              )}
+          />
+        </div>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Lucky sign</legend>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-lucky-name">Sign</label>
+        <input
+          id="{uid}-lucky-name"
+          type="text"
+          value={character.luckyRoll.name}
+          oninput={(event) =>
+            edit((current) =>
+              setDccCharacterLuckyRollText(current, 'name', event.currentTarget.value),
+            )}
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-lucky-description">Applies to</label>
+        <input
+          id="{uid}-lucky-description"
+          type="text"
+          value={character.luckyRoll.description}
+          oninput={(event) =>
+            edit((current) =>
+              setDccCharacterLuckyRollText(current, 'description', event.currentTarget.value),
+            )}
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-lucky-modifier">Lucky modifier</label>
+        <input
+          id="{uid}-lucky-modifier"
+          type="number"
+          value={character.luckyRoll.modifier}
+          oninput={(event) =>
+            edit((current) =>
+              setDccCharacterLuckyRollModifier(current, event.currentTarget.valueAsNumber),
+            )}
+        />
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Money</legend>
+
+      {#each Object.keys(character.currency) as coin (coin)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-currency-{coin}">{coin}</label>
+          <input
+            id="{uid}-currency-{coin}"
+            type="number"
+            value={character.currency[coin]}
+            oninput={(event) =>
+              edit((current) =>
+                setDccCharacterCurrency(current, coin, event.currentTarget.valueAsNumber),
+              )}
+          />
+        </div>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Weapons</legend>
+
+      <!-- Keyed by position rather than by value: two entries may read the same, and a key that
+           changed as the user typed would lose focus on every keystroke. -->
+      {#each character.weapons as weapon, index (index)}
+        <div class="dcc-editor__row">
+          {#each WEAPON_FIELDS as entry (entry.field)}
+            <div class="input-group input-group--inline">
+              <label for="{uid}-weapon-{index}-{entry.field}">
+                Weapon {index + 1}
+                {entry.label}
+              </label>
+              <input
+                id="{uid}-weapon-{index}-{entry.field}"
+                type="text"
+                value={weapon[entry.field]}
+                oninput={(event) =>
+                  edit((current) =>
+                    setDccCharacterWeaponField(
+                      current,
+                      index,
+                      entry.field,
+                      event.currentTarget.value,
+                    ),
+                  )}
+                autocomplete="off"
+              />
+            </div>
+          {/each}
+          <BaseButton
+            aria-label="Remove weapon {index + 1}"
+            onclick={() => edit((current) => removeDccCharacterWeapon(current, index))}
+          >
+            Remove weapon {index + 1}
+          </BaseButton>
+        </div>
+      {/each}
+
+      <BaseButton onclick={() => edit(addDccCharacterWeapon)}>Add a weapon</BaseButton>
+    </fieldset>
+
+    <fieldset>
+      <legend>Equipment</legend>
+
+      {#each character.equipment as item, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-equipment-{index}">Item {index + 1}</label>
+          <input
+            id="{uid}-equipment-{index}"
+            type="text"
+            value={item.name}
+            oninput={(event) =>
+              edit((current) =>
+                setDccCharacterEquipmentName(current, index, event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+          <BaseButton
+            aria-label="Remove item {index + 1}"
+            onclick={() => edit((current) => removeDccCharacterEquipment(current, index))}
+          >
+            Remove
+          </BaseButton>
+        </div>
+      {/each}
+
+      <BaseButton onclick={() => edit(addDccCharacterEquipment)}>Add an item</BaseButton>
+    </fieldset>
+
+    {#each LISTS as entry (entry.list)}
+      <fieldset>
+        <legend>{entry.legend}</legend>
+
+        {#each character[entry.list] as value, index (index)}
+          <div class="input-group input-group--inline">
+            <label for="{uid}-{entry.list}-{index}">{entry.noun} {index + 1}</label>
+            <input
+              id="{uid}-{entry.list}-{index}"
+              type="text"
+              {value}
+              oninput={(event) =>
+                edit((current) =>
+                  setDccCharacterListEntry(current, entry.list, index, event.currentTarget.value),
+                )}
+              autocomplete="off"
+            />
+            <BaseButton
+              aria-label="Remove {entry.noun} {index + 1}"
+              onclick={() =>
+                edit((current) => removeDccCharacterListEntry(current, entry.list, index))}
+            >
+              Remove
+            </BaseButton>
+          </div>
+        {/each}
+
+        <BaseButton
+          onclick={() => edit((current) => addDccCharacterListEntry(current, entry.list))}
+        >
+          Add {entry.noun === 'ability' ? 'an' : 'a'}
+          {entry.noun}
+        </BaseButton>
+      </fieldset>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .dcc-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+  }
+
+  .dcc-editor fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s3);
+    align-items: flex-start;
+    margin: 0;
+    /* No border and no radius, matching the culture and character editors: a fieldset inside an
+       editor panel was a box inside a box, and the legend and the spacing already group these. */
+    padding: var(--s4) 0;
+    min-width: 0;
+  }
+
+  .dcc-editor legend {
+    padding: 0 var(--s3);
+    color: var(--gold);
+    font-size: var(--t-micro-size);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .dcc-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .dcc-editor input[type='text'],
+  .dcc-editor input[type='number'] {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+
+  .dcc-editor__row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s2);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .dcc-editor__note {
+    font-size: var(--t-small-size);
+    font-style: italic;
+    margin: 0;
+  }
+</style>

--- a/src/components/characters/DccCharacterGenerator.svelte
+++ b/src/components/characters/DccCharacterGenerator.svelte
@@ -4,29 +4,37 @@
   import { RNG } from '@ironarachne/rng';
   import {
     buildCharacterNameSource,
-    isCustomCharacterNameSource,
-    restoreLockedCharacterName,
-    resolveCharacterNameGeneratorSet,
-    rollCharacterNameForSource,
     dccOccupationToNameSetHint,
+    nameGeneratorSetForSource,
+    rollCharacterNameForSource,
     loadCulturesForNaming,
   } from '$lib/characters';
+  import type { ArtifactReference } from '$lib/artifacts';
   import type { Culture } from '$lib/culture';
+  import Download from '$lib/download';
   import * as DCC from '$lib/dcc';
-  import type { DCCCharacter } from '$lib/dcc';
+  import type { DccAncestry, DCCCharacter, DccCharacterGeneratorConfigRecord } from '$lib/dcc';
   import { onMount } from 'svelte';
   import CheckboxField from '$components/common/CheckboxField.svelte';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
   import SeedControls from '$components/common/SeedControls.svelte';
   import CharacterNameSection from '$components/characters/CharacterNameSection.svelte';
   import DownloadPdfButton from '$components/common/DownloadPdfButton.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
 
+  const TOOL_PATH = '/fantasy/dcc/character';
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. That is the whole of requirement 2.2's
+   * fix here: the clock decides where the sequence of seeds *starts*, and everything after it is a
+   * pure function of the seed on screen. This page used to draw three separate values off an RNG it
+   * reseeded from the seed box each press, so the seed described only part of what it produced.
+   */
   const rng = new RNG(Date.now().toString());
   let seed = $state(rng.randomString(13));
-  $effect(() => {
-    rng.setSeed(seed);
-  });
   let lockSeed = $state(false);
 
   let allowDwarves = $state(true);
@@ -35,93 +43,137 @@
   let allowHumans = $state(true);
 
   let savedCultures = $state<Culture[]>([]);
-  let nameSourceKind = $state<'default' | 'preset' | 'saved_culture'>('default');
+  let nameSourceKind = $state<'default' | 'preset' | 'saved_culture' | 'referenced_culture'>(
+    'default',
+  );
   let presetSetName = $state('human');
   let savedCultureName = $state('');
   let firstName = $state('');
   let lastName = $state('');
   let lockName = $state(false);
+  /** The culture the picker loaded, and the link to record for it. */
+  let referencedCulture = $state<Culture | undefined>();
+  let cultureReference = $state<ArtifactReference | undefined>();
+  /**
+   * The link, recorded only when the character on screen was actually named from that culture.
+   *
+   * Gated on the roll rather than on the picker, as the AD&D generator gates its own: a reference is
+   * a record of what the tool was handed, and one written for a character whose names came from
+   * somewhere else would claim an input that was never used.
+   */
+  let rolledCultureReference = $state.raw<ArtifactReference | undefined>();
 
-  const genConfig = DCC.getDefaultDCCCharacterGeneratorConfig(rng.randomString(13));
-  let character: DCCCharacter | null = $state(null);
-  let spellsKnown = $state('');
+  /**
+   * The rolled character.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every array and object in
+   * the character in a Proxy, and `structuredClone` — what IndexedDB stores with — refuses a Proxy
+   * outright, so saving fails with `could not be cloned`. The same trap is written up in
+   * `$lib/workshop`'s README beside `saveToolArtifact`.
+   */
+  let character = $state.raw<DCCCharacter | null>(null);
+  /** The settings the character on screen was actually rolled with. Raw, for the same reason. */
+  let rolledConfig = $state.raw<Record<string, unknown>>({});
   let downloadingPdf = $state(false);
 
-  function resolveCustomNameGeneratorSet() {
-    if (!character) return undefined;
+  const allowedOccupations = $derived<DccAncestry[]>(
+    [
+      allowDwarves ? ('dwarf' as const) : undefined,
+      allowElves ? ('elf' as const) : undefined,
+      allowHalflings ? ('halfling' as const) : undefined,
+      allowHumans ? ('human' as const) : undefined,
+    ].filter((entry): entry is DccAncestry => entry !== undefined),
+  );
+
+  /**
+   * Every table switched off is a setting the generator cannot honour — it would be drawing an
+   * occupation from an empty list — so Generate is disabled rather than left to fail.
+   */
+  const noTablesChosen = $derived(allowedOccupations.length === 0);
+
+  /** The character with the names the page is showing, which is what the sheet and exports want. */
+  const namedCharacter = $derived<DCCCharacter | null>(
+    character === null ? null : { ...character, firstName, lastName },
+  );
+
+  const characterSnapshot = $derived(
+    namedCharacter === null ? null : DCC.toDccCharacterSnapshot(namedCharacter),
+  );
+
+  const defaultArtifactName = $derived(`${firstName} ${lastName}`.trim());
+
+  const spellsKnown = $derived(
+    namedCharacter === null ? '' : DCC.formatDccSpellsKnown(namedCharacter.spellsKnown),
+  );
+
+  /** The settings a roll takes, and the ones provenance records. */
+  function currentConfig(): DccCharacterGeneratorConfigRecord {
     const source = buildCharacterNameSource(
       nameSourceKind,
       presetSetName,
       savedCultureName,
       savedCultures,
+      referencedCulture,
     );
-    if (!isCustomCharacterNameSource(source)) {
-      return undefined;
-    }
-    return resolveCharacterNameGeneratorSet(
-      rng,
-      source,
-      dccOccupationToNameSetHint(character.occupation.name),
-    );
+    const nameGeneratorSet = nameGeneratorSetForSource(source);
+    return {
+      allowedOccupations,
+      ...(nameGeneratorSet === '' ? {} : { nameGeneratorSet }),
+    };
   }
 
   function generate() {
+    if (noTablesChosen) {
+      return;
+    }
     if (!lockSeed) {
       seed = rng.randomString(13);
     }
-    rng.setSeed(seed);
 
     const lockedFirstName = firstName;
     const lockedLastName = lastName;
 
-    const allowedOccupations: string[] = [];
+    const config = currentConfig();
+    const rolled = DCC.rollDccCharacter(seed, config);
+    character = rolled.character;
+    // The resolved set, not the requested one: a set this build has since dropped would otherwise
+    // be recorded as provenance a re-roll could not honour.
+    rolledConfig = { ...config, nameGeneratorSet: rolled.nameGeneratorSet };
+    rolledCultureReference =
+      nameSourceKind === 'referenced_culture' && referencedCulture !== undefined
+        ? cultureReference
+        : undefined;
 
-    if (allowDwarves) {
-      allowedOccupations.push('dwarf');
-    }
-
-    if (allowElves) {
-      allowedOccupations.push('elf');
-    }
-
-    if (allowHalflings) {
-      allowedOccupations.push('halfling');
-    }
-
-    if (allowHumans) {
-      allowedOccupations.push('human');
-    }
-
-    genConfig.allowedOccupations = allowedOccupations;
-
-    const customNameGeneratorSet = resolveCustomNameGeneratorSet();
-    character = DCC.generateRandomDCCCharacter(
-      rng.randomString(13),
-      genConfig,
-      customNameGeneratorSet,
-    );
     if (lockName) {
-      restoreLockedCharacterName(character, lockedFirstName, lockedLastName);
+      firstName = lockedFirstName;
+      lastName = lockedLastName;
     } else {
-      firstName = character.firstName;
-      lastName = character.lastName;
+      firstName = rolled.character.firstName;
+      lastName = rolled.character.lastName;
     }
-    spellsKnown = DCC.formatDccSpellsKnown(character.spellsKnown);
   }
 
+  /**
+   * Another name for the character already on screen.
+   *
+   * An **edit**, not a generation, and so a fresh draw that does not touch the recorded seed:
+   * requirement 4.2 says the payload is what the user kept, and a name they asked for is not
+   * something a seed reproduces. The character itself is untouched — it is raw state, and every
+   * reader already composes the shown names over it.
+   */
   function generateNameOnly() {
-    if (lockName || !character) {
+    if (lockName || character === null) {
       return;
     }
-    const nameRng = new RNG(`${Date.now()}-dcc-name`);
     const source = buildCharacterNameSource(
       nameSourceKind,
       presetSetName,
       savedCultureName,
       savedCultures,
+      referencedCulture,
     );
     const generated = rollCharacterNameForSource(
-      nameRng,
+      new RNG(`${Date.now()}-dcc-name`),
       source,
       dccOccupationToNameSetHint(character.occupation.name),
       'random',
@@ -129,24 +181,29 @@
     );
     firstName = generated.firstName;
     lastName = generated.lastName;
-    character = {
-      ...character,
-      firstName: generated.firstName,
-      lastName: generated.lastName,
-    };
   }
 
   async function downloadPdf() {
-    if (downloadingPdf || !character) {
+    if (downloadingPdf || namedCharacter === null) {
       return;
     }
 
     downloadingPdf = true;
     try {
-      await DCC.downloadDccCharacterPdf(character);
+      await DCC.downloadDccCharacterPdf(namedCharacter);
     } finally {
       downloadingPdf = false;
     }
+  }
+
+  function exportMarkdown() {
+    if (namedCharacter === null) {
+      return;
+    }
+    const markdown = DCC.dccCharacterToMarkdown(namedCharacter);
+    const url = URL.createObjectURL(new Blob([markdown], { type: 'text/markdown' }));
+    Download(url, `${DCC.dccCharacterFileStem(namedCharacter)}.md`);
+    URL.revokeObjectURL(url);
   }
 
   onMount(() => {
@@ -162,7 +219,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/dcc/character" title="Dungeon Crawl Classics Character Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Dungeon Crawl Classics Character Generator">
   {#snippet description()}
     <p>This is a DCC 0-level character generator.</p>
   {/snippet}
@@ -178,6 +235,9 @@
   <CheckboxField id="allowHumans" label="Allow Humans" bind:checked={allowHumans} />
 
   <CharacterNameSection
+    offerReferencedCulture
+    bind:referencedCulture
+    bind:cultureReference
     bind:nameSourceKind
     bind:presetSetName
     bind:savedCultureName
@@ -188,71 +248,96 @@
     onGenerateName={generateNameOnly}
   />
 
-  <BaseButton onclick={generate}>Generate</BaseButton>
-  <DownloadPdfButton onclick={downloadPdf} downloading={downloadingPdf} />
+  <BaseButton onclick={generate} disabled={noTablesChosen}>Generate</BaseButton>
 
-  {#if character}
-    <h2>{character.firstName} {character.lastName}</h2>
+  {#if noTablesChosen}
+    <p class="dcc-no-tables">
+      Allow at least one kind of occupation. With all four switched off there is no table to roll a
+      villager from.
+    </p>
+  {/if}
 
-    <p>A level {character.level} {character.occupation.name}</p>
+  <SaveArtifactButton
+    kind={DCC.DCC_CHARACTER_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={characterSnapshot}
+    {seed}
+    config={rolledConfig}
+    defaultName={defaultArtifactName}
+    references={rolledCultureReference === undefined ? [] : [rolledCultureReference]}
+  />
+
+  {#if namedCharacter}
+    <h2>{namedCharacter.firstName} {namedCharacter.lastName}</h2>
+
+    <p>A level {namedCharacter.level} {namedCharacter.occupation.name}</p>
+
+    <div class="dcc-exports">
+      <BaseButton onclick={exportMarkdown}>Download Markdown</BaseButton>
+      <DownloadPdfButton onclick={downloadPdf} downloading={downloadingPdf} />
+    </div>
 
     <StatBlock>
-      <Stat label="XP">{character.xp}</Stat>
-      <Stat label="HP">{character.hp}</Stat>
-      <Stat label="AC">{character.armorClass}</Stat>
-      <Stat label="Currency">{DCC.formatDccCurrency(character.currency)}</Stat>
-      <Stat label="Alignment">{character.alignment}</Stat>
-      <Stat label="Gender">{character.gender}</Stat>
-      <Stat label="Speed">{character.speed}'</Stat>
+      <Stat label="XP">{namedCharacter.xp}</Stat>
+      <Stat label="HP">{namedCharacter.hp}</Stat>
+      <Stat label="AC">{namedCharacter.armorClass}</Stat>
+      <Stat label="Currency">{DCC.formatDccCurrency(namedCharacter.currency)}</Stat>
+      <Stat label="Alignment">{namedCharacter.alignment}</Stat>
+      <Stat label="Gender">{namedCharacter.gender}</Stat>
+      <Stat label="Speed">{namedCharacter.speed}'</Stat>
     </StatBlock>
 
     <h3>Attributes</h3>
 
     <Stat label="Strength">
-      {character.strength.value} ({DCC.formatDccModifier(character.strength.modifier)})
+      {namedCharacter.strength.value} ({DCC.formatDccModifier(namedCharacter.strength.modifier)})
     </Stat>
     <Stat label="Agility">
-      {character.agility.value} ({DCC.formatDccModifier(character.agility.modifier)})
+      {namedCharacter.agility.value} ({DCC.formatDccModifier(namedCharacter.agility.modifier)})
     </Stat>
     <Stat label="Stamina">
-      {character.stamina.value} ({DCC.formatDccModifier(character.stamina.modifier)})
+      {namedCharacter.stamina.value} ({DCC.formatDccModifier(namedCharacter.stamina.modifier)})
     </Stat>
     <Stat label="Personality">
-      {character.personality.value} ({DCC.formatDccModifier(character.personality.modifier)})
+      {namedCharacter.personality.value} ({DCC.formatDccModifier(
+        namedCharacter.personality.modifier,
+      )})
     </Stat>
     <Stat label="Intelligence">
-      {character.intelligence.value} ({DCC.formatDccModifier(character.intelligence.modifier)})
+      {namedCharacter.intelligence.value} ({DCC.formatDccModifier(
+        namedCharacter.intelligence.modifier,
+      )})
     </Stat>
     <Stat label="Luck">
-      {character.luck.value} ({DCC.formatDccModifier(character.luck.modifier)})
+      {namedCharacter.luck.value} ({DCC.formatDccModifier(namedCharacter.luck.modifier)})
     </Stat>
 
     <h3>Other Stats</h3>
 
     <Stat label="Lucky Roll">
-      {DCC.formatDccLuckySign(character.luckyRoll)}
+      {DCC.formatDccLuckySign(namedCharacter.luckyRoll)}
     </Stat>
 
     <h3>Saving Throws</h3>
 
     <StatBlock>
-      <Stat label="Fortitude">{DCC.formatDccModifier(character.fortitudeSave)}</Stat>
-      <Stat label="Reflex">{DCC.formatDccModifier(character.reflexSave)}</Stat>
-      <Stat label="Willpower">{DCC.formatDccModifier(character.willpowerSave)}</Stat>
+      <Stat label="Fortitude">{DCC.formatDccModifier(namedCharacter.fortitudeSave)}</Stat>
+      <Stat label="Reflex">{DCC.formatDccModifier(namedCharacter.reflexSave)}</Stat>
+      <Stat label="Willpower">{DCC.formatDccModifier(namedCharacter.willpowerSave)}</Stat>
     </StatBlock>
 
     <h3>Spellcasting</h3>
 
     <StatBlock>
       <Stat label="Spells Known">{spellsKnown}</Stat>
-      <Stat label="Wizard Max Spell Level">{character.wizardMaxSpellLevel}</Stat>
-      <Stat label="Cleric Max Spell Level">{character.clericMaxSpellLevel}</Stat>
+      <Stat label="Wizard Max Spell Level">{namedCharacter.wizardMaxSpellLevel}</Stat>
+      <Stat label="Cleric Max Spell Level">{namedCharacter.clericMaxSpellLevel}</Stat>
     </StatBlock>
 
     <h3>Weapons</h3>
 
     <ul>
-      {#each character.weapons as weapon}
+      {#each namedCharacter.weapons as weapon}
         <li>{weapon.name}: {weapon.damage} dmg, {weapon.range} range</li>
       {/each}
     </ul>
@@ -260,7 +345,7 @@
     <h3>Languages</h3>
 
     <ul>
-      {#each character.languages as language}
+      {#each namedCharacter.languages as language}
         <li>{language}</li>
       {/each}
     </ul>
@@ -268,7 +353,7 @@
     <h3>Equipment</h3>
 
     <ul>
-      {#each character.equipment as item}
+      {#each namedCharacter.equipment as item}
         <li>{item.name}</li>
       {/each}
     </ul>
@@ -276,9 +361,23 @@
     <h3>Special Rules</h3>
 
     <ul>
-      {#each character.specialRules as rule}
+      {#each namedCharacter.specialRules as rule}
         <li>{rule}</li>
       {/each}
     </ul>
   {/if}
 </GeneratorPage>
+
+<style>
+  .dcc-exports {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .dcc-no-tables {
+    font-size: var(--t-small-size);
+    font-style: italic;
+    margin: 0;
+  }
+</style>

--- a/src/lib/dcc/README.md
+++ b/src/lib/dcc/README.md
@@ -4,6 +4,31 @@ This library implements character generation for **Dungeon Crawl Classics**, who
 level-0 funnel: a player brings several ordinary people with an occupation, whatever that occupation
 left them carrying, and a lucky sign, and most of them do not survive to level 1.
 
+`rollDccCharacter(seed, config)` is the single path from a seed to a character; prefer it over
+calling `generateRandomDCCCharacter` directly, because it is where the settings a re-roll reads back
+are defined.
+
+## Which edition, and what is deliberately absent
+
+This is **Dungeon Crawl Classics as published in the core rulebook**, and only the part of it a
+zero-level character needs: the six attributes, the birth augur (lucky sign), the occupation tables
+for the four ancestries, starting equipment and coin, languages, and the four saves.
+
+What is **not** here, and is out of scope rather than missing:
+
+- **Levelled advancement.** Every character this library makes is level 0. There are no classes, no
+  class tables, no Mighty Deeds, no crit or fumble tables, and no spell lists — a zero-level
+  character has none of them, and a character who survives the funnel picks a class at a table
+  rather than in a generator.
+- **The published attribute-modifier table.** `getAttributeModifier` is the d20-style
+  `floor((value - 10) / 2)`, which differs from DCC's own table at the extremes. It is what this
+  library has always used and what every saved character was rolled with; changing it is a change
+  to the generator, not to the sheet.
+- **Anything from the third-party or licensed material.** Occupations, lucky signs and languages
+  come from the core tables only.
+
+Iron Arachne is unaffiliated with Goodman Games.
+
 ## Features
 
 - **Generation** — `generateRandomDCCCharacter` with `getDefaultDCCCharacterGeneratorConfig(seed)`.
@@ -13,6 +38,21 @@ left them carrying, and a lucky sign, and most of them do not survive to level 1
 - **Formatting** — the `formatDcc*` helpers (modifiers, currency, starting funds, weapon lines,
   lucky sign, notes) and `slugifyDccCharacterFilename`.
 - **PDF** — `buildDccCharacterPdf` returns a `Blob`; `downloadDccCharacterPdf` saves it.
+- **Rolling** — `rollDccCharacter` and `rollDccCharacterSnapshot`, with
+  `DccCharacterGeneratorConfigRecord` and `readDccCharacterGeneratorConfig` — the typed boundary
+  where an artifact's untyped provenance becomes settings a roll can take.
+- **Storing** — `toDccCharacterSnapshot` and `dccCharacterFromSnapshot`. The occupation and the
+  lucky sign travel as the rows the character drew, minus their `apply` handler, which is put back
+  by name on read; `isUnknownDccOccupationName` and `isUnknownDccLuckyRollName` say when it could
+  not be.
+- **The artifact kind** — `dccCharacterArtifactKind`, `DCC_CHARACTER_ARTIFACT_KIND`
+  (`character.dcc`), `validateDccCharacterSnapshot`, `migrateDccCharacterSnapshot`. One artifact is
+  one character: a funnel saves several.
+- **Editing a saved character** — `dcc_character_editing.ts`: one function per field, each taking a
+  snapshot and returning a new one. Nothing recomputes anything; `dccDerivedFromAttributes` offers
+  the arithmetic as an explicit command.
+- **Presentation** — `dccCharacterToDocument`, `dccCharacterToMarkdown`, `dccCharacterFileStem`,
+  for the Markdown export beside the drawn PDF sheet.
 
 ## Usage
 

--- a/src/lib/dcc/dcc_character_artifact_kind.test.ts
+++ b/src/lib/dcc/dcc_character_artifact_kind.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import { readArtifactPayload, type AnyArtifactKindEntry } from '$lib/artifact_kinds';
+
+import {
+  dccCharacterArtifactKind,
+  DCC_CHARACTER_ARTIFACT_KIND,
+  DCC_CHARACTER_PAYLOAD_VERSION,
+  migrateDccCharacterSnapshot,
+  validateDccCharacterSnapshot,
+} from './dcc_character_artifact_kind.js';
+import { rollDccCharacter, rollDccCharacterSnapshot } from './dcc_character_roll.js';
+import type { DccCharacterSnapshot } from './dcc_character_snapshot.js';
+
+/** A stored payload, as anything reading one actually receives it. */
+function storedSnapshot(seed = 'kind-fixture'): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(rollDccCharacterSnapshot(seed))) as Record<string, unknown>;
+}
+
+const snapshot = storedSnapshot();
+
+describe('the DCC character artifact kind', () => {
+  it('is registered system-qualified, concept first', () => {
+    expect(DCC_CHARACTER_ARTIFACT_KIND).toBe('character.dcc');
+    expect(dccCharacterArtifactKind.kind).toBe('character.dcc');
+    expect(dccCharacterArtifactKind.displayName).toBe('DCC Character');
+    expect(dccCharacterArtifactKind.payloadVersion).toBe(DCC_CHARACTER_PAYLOAD_VERSION);
+    expect(dccCharacterArtifactKind.icon).not.toBe('');
+  });
+
+  it('names an artifact after the character', () => {
+    const named = snapshot as unknown as DccCharacterSnapshot;
+
+    expect(dccCharacterArtifactKind.nameOf(named)).toBe(
+      `${named.firstName} ${named.lastName}`.trim(),
+    );
+  });
+
+  /** A funnel peasant who was never named is still findable by what they did for a living. */
+  it('falls back to the occupation for a character with no name', () => {
+    const unnamed = {
+      ...snapshot,
+      firstName: '',
+      lastName: '  ',
+    } as unknown as DccCharacterSnapshot;
+
+    expect(dccCharacterArtifactKind.nameOf(unnamed)).toBe(unnamed.occupation.name);
+  });
+
+  it('falls back again for a character with neither', () => {
+    const nothing = {
+      ...snapshot,
+      firstName: '',
+      lastName: '',
+      occupation: { name: '', trainedWeapon: null, tradeGoods: null, commonality: 0 },
+    } as unknown as DccCharacterSnapshot;
+
+    expect(dccCharacterArtifactKind.nameOf(nothing)).toBe('DCC Character');
+  });
+
+  it('round-trips through the codec the registry loads', async () => {
+    const codec = await dccCharacterArtifactKind.loadCodec();
+    const { character } = rollDccCharacter('codec-fixture');
+    const stored = codec.toSnapshot(character) as DccCharacterSnapshot;
+
+    expect(validateDccCharacterSnapshot(stored).ok).toBe(true);
+    const restored = codec.fromSnapshot(stored, undefined as never) as typeof character;
+    expect(restored.occupation.name).toBe(character.occupation.name);
+    expect(restored.hp).toBe(character.hp);
+  });
+
+  it('reads a current-version payload and refuses one from a newer build', () => {
+    // The erased form the registry hands every consumer back.
+    const entry = dccCharacterArtifactKind as unknown as AnyArtifactKindEntry;
+
+    expect(readArtifactPayload(entry, snapshot, DCC_CHARACTER_PAYLOAD_VERSION).ok).toBe(true);
+    const ahead = readArtifactPayload(entry, snapshot, DCC_CHARACTER_PAYLOAD_VERSION + 1);
+    expect(ahead.ok).toBe(false);
+    expect(ahead.ok === false && ahead.reason).toBe('unsupported-version');
+  });
+});
+
+describe('validating a DCC character payload', () => {
+  it('accepts what the generator writes, from every table', () => {
+    for (const ancestry of ['dwarf', 'elf', 'halfling', 'human'] as const) {
+      const rolled = JSON.parse(
+        JSON.stringify(
+          rollDccCharacterSnapshot(`validate-${ancestry}`, {
+            allowedOccupations: [ancestry],
+          }),
+        ),
+      ) as unknown;
+      expect(validateDccCharacterSnapshot(rolled).ok).toBe(true);
+    }
+  });
+
+  it('rejects something that is not an object', () => {
+    const result = validateDccCharacterSnapshot('a peasant, honestly');
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? '' : result.reason).toBe('invalid-payload');
+  });
+
+  it('rejects a payload with no alignment to print', () => {
+    const { alignment: _dropped, ...rest } = snapshot;
+
+    expect(validateDccCharacterSnapshot(rest).ok).toBe(false);
+  });
+
+  it('rejects a payload whose hit points are not a number', () => {
+    expect(validateDccCharacterSnapshot({ ...snapshot, hp: 'a few' }).ok).toBe(false);
+  });
+
+  /**
+   * Both halves of an attribute are checked because both are stored and both are shown. The
+   * modifier is derivable, which is exactly why it must be validated rather than recomputed.
+   */
+  it('rejects an attribute missing its modifier', () => {
+    const result = validateDccCharacterSnapshot({ ...snapshot, luck: { value: 12 } });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? '' : result.message).toContain('luck');
+  });
+
+  it('rejects a lucky sign with no modifier', () => {
+    expect(
+      validateDccCharacterSnapshot({
+        ...snapshot,
+        luckyRoll: { name: 'The bull', description: 'Strength' },
+      }).ok,
+    ).toBe(false);
+  });
+
+  it('rejects an occupation with no name', () => {
+    expect(validateDccCharacterSnapshot({ ...snapshot, occupation: {} }).ok).toBe(false);
+  });
+
+  /**
+   * A name no table has is not a corrupt record — the human farmer's own handler produces one every
+   * time it runs — so the validator says nothing about it.
+   */
+  it('accepts an occupation name no table has', () => {
+    expect(
+      validateDccCharacterSnapshot({
+        ...snapshot,
+        occupation: { ...(snapshot.occupation as object), name: 'potato farmer' },
+      }).ok,
+    ).toBe(true);
+  });
+});
+
+describe('migrating a DCC character payload', () => {
+  it('rejects, because version 1 is the only shape there has been', () => {
+    const result = migrateDccCharacterSnapshot(snapshot, 0);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? '' : result.reason).toBe('unsupported-version');
+  });
+});

--- a/src/lib/dcc/dcc_character_artifact_kind.ts
+++ b/src/lib/dcc/dcc_character_artifact_kind.ts
@@ -1,0 +1,243 @@
+import scythe from '$lib/assets/icons/set3/scythe.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  isStringArray,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import type { DccCharacterSnapshot } from './dcc_character_snapshot';
+import type { DCCCharacter } from './dcc_types';
+
+/**
+ * Stable artifact kind id.
+ *
+ * Concept first, system as the qualifier, so every character kind sorts together in a vault
+ * listing. A DCC zero-level character is a set of numbers that mean something only under that
+ * ruleset — a lucky sign modifier and a Mighty Deed die are not portable — so it is
+ * system-qualified per decision 4 of docs/workshop.md, alongside `character.adnd-2e`.
+ *
+ * **One artifact is one character.** A funnel is a way of rolling, not a thing in the world: the
+ * four peasants who walk into the dungeon are four characters, three of them about to die, and the
+ * survivor is a character a player keeps for a year. A payload holding all four would make that
+ * survivor unopenable on their own, un-renamable, and impossible to reference from anything else,
+ * and requirement 3.5 — name on save, rename after — is unanswerable for a bundle. See decision 1
+ * of docs/readiness-characters.md; it is what makes #14 small.
+ */
+export const DCC_CHARACTER_ARTIFACT_KIND = 'character.dcc' as const;
+
+/** Version 1. The first shape a DCC character has been stored in. */
+export const DCC_CHARACTER_PAYLOAD_VERSION = 1 as const;
+
+const CHARACTER_STRING_FIELDS = ['firstName', 'lastName', 'gender', 'alignment'];
+
+/**
+ * The numbers a character sheet cannot be read without.
+ *
+ * Not every number on the character. The derived block runs to a dozen more — the spell levels, the
+ * attack modifier, the speed — and a validator listing all of them would be a second copy of
+ * `DCCCharacter` living in a module that does not own it, and the copy is the half that goes stale.
+ * What a validator owes is what reading depends on: the level that says this is a zero-level
+ * character, and the two numbers every DCC sheet is read from the top of.
+ */
+const CHARACTER_NUMBER_FIELDS = ['level', 'hp', 'armorClass'];
+
+const ATTRIBUTES = [
+  'strength',
+  'agility',
+  'stamina',
+  'personality',
+  'intelligence',
+  'luck',
+] as const;
+
+function hasNumberFields(record: Record<string, unknown>, keys: readonly string[]): boolean {
+  return keys.every((key) => Number.isFinite(record[key]));
+}
+
+/**
+ * The six attributes, each a value and the modifier derived from it.
+ *
+ * Both numbers are checked because both are stored and both are shown. The modifier is derivable
+ * from the value, which is exactly why it must be validated rather than recomputed: a judge who has
+ * adjusted one has made a decision, and a reader that quietly recalculated it would overrule them.
+ */
+function validateAttributes(record: Record<string, unknown>): PayloadResult<unknown> {
+  for (const name of ATTRIBUTES) {
+    const attribute = asRecord(record[name]);
+    if (attribute === null || !hasNumberFields(attribute, ['value', 'modifier'])) {
+      return rejectedPayload(
+        'invalid-payload',
+        `DCC character ${name} is not an attribute with a numeric value and modifier`,
+      );
+    }
+  }
+  return acceptedPayload(record);
+}
+
+/**
+ * The occupation, as the row the character drew.
+ *
+ * Checked for a name and nothing more. Whether this build still has an occupation of that name is
+ * not a question about the payload's validity — a table that was renamed is not a corrupt record,
+ * and the human farmer's own `apply` handler rewrites its name to the crop it rolled, so a great
+ * many perfectly good characters carry a name no table ever had.
+ */
+function validateStoredOccupation(value: unknown): PayloadResult<unknown> {
+  const occupation = asRecord(value);
+  if (occupation === null || typeof occupation.name !== 'string') {
+    return rejectedPayload('invalid-payload', 'DCC character occupation has no name');
+  }
+  return acceptedPayload(occupation);
+}
+
+/** The lucky sign, which the sheet prints as a name, a description, and the character's modifier. */
+function validateStoredLuckyRoll(value: unknown): PayloadResult<unknown> {
+  const luckyRoll = asRecord(value);
+  if (
+    luckyRoll === null ||
+    !hasStringFields(luckyRoll, ['name', 'description']) ||
+    !Number.isFinite(luckyRoll.modifier)
+  ) {
+    return rejectedPayload(
+      'invalid-payload',
+      'DCC character luckyRoll is not a named sign with a description and a modifier',
+    );
+  }
+  return acceptedPayload(luckyRoll);
+}
+
+function isNamedObjectArray(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.every((entry) => {
+      const record = asRecord(entry);
+      return record !== null && typeof record.name === 'string';
+    })
+  );
+}
+
+function validateNamedList(value: unknown, field: string): PayloadResult<unknown> {
+  if (value === undefined || isNamedObjectArray(value)) {
+    return acceptedPayload(value);
+  }
+  return rejectedPayload(
+    'invalid-payload',
+    `DCC character ${field} is not a list of named entries`,
+  );
+}
+
+/** Coins by denomination. Absent is accepted; present, every entry has to be a number. */
+function validateCurrency(value: unknown): PayloadResult<unknown> {
+  if (value === undefined) {
+    return acceptedPayload(value);
+  }
+  const currency = asRecord(value);
+  if (currency === null || !Object.values(currency).every((amount) => Number.isFinite(amount))) {
+    return rejectedPayload('invalid-payload', 'DCC character currency is not amounts by coin');
+  }
+  return acceptedPayload(currency);
+}
+
+function validateStringListField(value: unknown, field: string): PayloadResult<unknown> {
+  if (value === undefined || isStringArray(value)) {
+    return acceptedPayload(value);
+  }
+  return rejectedPayload('invalid-payload', `DCC character ${field} is not an array of strings`);
+}
+
+/** Checks what `dccCharacterFromSnapshot` depends on, and what a sheet is printed from. */
+export function validateDccCharacterSnapshot(
+  payload: unknown,
+): PayloadResult<DccCharacterSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'DCC character payload is not an object');
+  }
+  if (!hasStringFields(record, CHARACTER_STRING_FIELDS)) {
+    return rejectedPayload(
+      'invalid-payload',
+      `DCC character payload needs string ${CHARACTER_STRING_FIELDS.join(', ')}`,
+    );
+  }
+  if (!hasNumberFields(record, CHARACTER_NUMBER_FIELDS)) {
+    return rejectedPayload(
+      'invalid-payload',
+      `DCC character payload needs numeric ${CHARACTER_NUMBER_FIELDS.join(', ')}`,
+    );
+  }
+
+  const checks: PayloadResult<unknown>[] = [
+    validateAttributes(record),
+    validateStoredOccupation(record.occupation),
+    validateStoredLuckyRoll(record.luckyRoll),
+    validateNamedList(record.equipment, 'equipment'),
+    validateNamedList(record.weapons, 'weapons'),
+    validateCurrency(record.currency),
+    validateStringListField(record.specialRules, 'specialRules'),
+    validateStringListField(record.languages, 'languages'),
+  ];
+  const failed = checks.find((check) => !check.ok);
+  if (failed !== undefined) {
+    return failed as PayloadResult<DccCharacterSnapshot>;
+  }
+
+  return acceptedPayload(record as unknown as DccCharacterSnapshot);
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day the
+ * shape changes. A kind without one looks complete right up until it silently drops someone's work
+ * — and local-only means there is no server-side migration to fall back on.
+ */
+export function migrateDccCharacterSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<DccCharacterSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `DCC character has no migration from payload version ${from}; version ${DCC_CHARACTER_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/** What to call a character that was saved unnamed: their occupation, which they always have. */
+function dccCharacterName(snapshot: DccCharacterSnapshot): string {
+  const given = `${snapshot.firstName} ${snapshot.lastName}`.trim();
+  if (given !== '') {
+    return given;
+  }
+  const occupation = snapshot.occupation.name.trim();
+  return occupation === '' ? 'DCC Character' : occupation;
+}
+
+/**
+ * A DCC zero-level character as an artifact.
+ *
+ * The codec is cheap on both sides — the character is nearly all plain data, and the two rule
+ * objects resolve against tables already in this library — so unlike settlement or heraldry there
+ * is no expensive half to keep out of the chunk that merely lists a project. It is still loaded on
+ * demand, because the contract is the same for every kind and a codec that happens to be cheap
+ * today is not a reason to wire it differently from its neighbours.
+ */
+export const dccCharacterArtifactKind = defineArtifactKind<DCCCharacter, DccCharacterSnapshot>({
+  kind: DCC_CHARACTER_ARTIFACT_KIND,
+  displayName: 'DCC Character',
+  icon: scythe,
+  payloadVersion: DCC_CHARACTER_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { dccCharacterFromSnapshotWithRng, toDccCharacterSnapshot } =
+      await import('./dcc_character_snapshot.js');
+    return {
+      toSnapshot: toDccCharacterSnapshot,
+      fromSnapshot: dccCharacterFromSnapshotWithRng,
+    };
+  },
+  nameOf: dccCharacterName,
+  validate: validateDccCharacterSnapshot,
+  migrate: migrateDccCharacterSnapshot,
+});

--- a/src/lib/dcc/dcc_character_editing.test.ts
+++ b/src/lib/dcc/dcc_character_editing.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateDccCharacterSnapshot } from './dcc_character_artifact_kind.js';
+import {
+  addDccCharacterEquipment,
+  addDccCharacterListEntry,
+  addDccCharacterWeapon,
+  dccDerivedFromAttributes,
+  removeDccCharacterEquipment,
+  removeDccCharacterListEntry,
+  removeDccCharacterWeapon,
+  setDccCharacterAttribute,
+  setDccCharacterCurrency,
+  setDccCharacterEquipmentName,
+  setDccCharacterListEntry,
+  setDccCharacterLuckyRollModifier,
+  setDccCharacterLuckyRollText,
+  setDccCharacterNumber,
+  setDccCharacterOccupationName,
+  setDccCharacterText,
+  setDccCharacterWeaponField,
+} from './dcc_character_editing.js';
+import { rollDccCharacterSnapshot } from './dcc_character_roll.js';
+import type { DccCharacterSnapshot } from './dcc_character_snapshot.js';
+
+/** A character with something in every list the editor offers. */
+function armed(): DccCharacterSnapshot {
+  for (let seed = 0; seed < 300; seed += 1) {
+    const snapshot = rollDccCharacterSnapshot(`editing-${seed}`);
+    if (snapshot.weapons.length > 0 && snapshot.specialRules.length > 0) {
+      return snapshot;
+    }
+  }
+  throw new Error('no seed in the sweep produced an armed character with a special rule');
+}
+
+const fixture = armed();
+
+describe('editing a DCC character', () => {
+  it('rewrites one text field and leaves everything else alone', () => {
+    const after = setDccCharacterText(fixture, 'alignment', 'Chaos');
+
+    expect(after.alignment).toBe('Chaos');
+    expect({ ...after, alignment: fixture.alignment }).toEqual(fixture);
+  });
+
+  it('changes nothing in place', () => {
+    const before = structuredClone(fixture);
+    setDccCharacterText(fixture, 'firstName', 'Someone');
+    addDccCharacterWeapon(fixture);
+    setDccCharacterAttribute(fixture, 'luck', 'value', 18);
+
+    expect(fixture).toEqual(before);
+  });
+
+  /**
+   * An emptied number field arrives as `NaN`. Stored, it is a payload that fails its own kind's
+   * validation, which the user would meet as a broken artifact rather than a rejected keystroke.
+   */
+  it('refuses anything that is not a number', () => {
+    expect(setDccCharacterNumber(fixture, 'hp', Number.NaN)).toBe(fixture);
+    expect(setDccCharacterAttribute(fixture, 'luck', 'value', Number.NaN)).toBe(fixture);
+    expect(setDccCharacterLuckyRollModifier(fixture, Number.NaN)).toBe(fixture);
+    expect(setDccCharacterCurrency(fixture, 'cp', Number.NaN)).toBe(fixture);
+    expect(setDccCharacterNumber(fixture, 'hp', 4).hp).toBe(4);
+  });
+
+  /**
+   * Requirement 4.2 taken seriously: a judge who adjusted one number has made a decision, and a
+   * form that corrected the four derived from it would overrule them four times.
+   */
+  it('does not move a save when the attribute behind it changes', () => {
+    const after = setDccCharacterAttribute(fixture, 'stamina', 'value', 18);
+
+    expect(after.stamina.value).toBe(18);
+    expect(after.stamina.modifier).toBe(fixture.stamina.modifier);
+    expect(after.fortitudeSave).toBe(fixture.fortitudeSave);
+  });
+
+  it('offers that arithmetic as an explicit command instead', () => {
+    const raised = setDccCharacterAttribute(fixture, 'stamina', 'value', 18);
+    const after = dccDerivedFromAttributes(raised);
+
+    // 4, not the +3 the DCC table gives an 18: `getAttributeModifier` is the d20-style
+    // `floor((value - 10) / 2)` this library has always used. Whether that should be the published
+    // table is a question about the generator, not about this command, which exists to apply
+    // whatever the library's own arithmetic is.
+    expect(after.stamina.modifier).toBe(4);
+    expect(after.fortitudeSave).toBe(after.baseSave + 4);
+    expect(after.reflexSave).toBe(after.baseSave + after.agility.modifier);
+    expect(after.willpowerSave).toBe(after.baseSave + after.personality.modifier);
+  });
+
+  it('leaves what the dice decided alone when it recalculates', () => {
+    const after = dccDerivedFromAttributes(fixture);
+
+    expect(after.hp).toBe(fixture.hp);
+    expect(after.armorClass).toBe(fixture.armorClass);
+    expect(after.specialRules).toEqual(fixture.specialRules);
+    expect(after.luckyRoll).toEqual(fixture.luckyRoll);
+  });
+
+  it('renames the occupation without touching what it gave the character', () => {
+    const after = setDccCharacterOccupationName(fixture, 'turnip farmer');
+
+    expect(after.occupation.name).toBe('turnip farmer');
+    expect(after.occupation.trainedWeapon).toEqual(fixture.occupation.trainedWeapon);
+    expect(after.equipment).toEqual(fixture.equipment);
+  });
+
+  it('rewrites the lucky sign, name, description and modifier apart', () => {
+    const named = setDccCharacterLuckyRollText(fixture, 'name', 'Bountiful harvest');
+    const described = setDccCharacterLuckyRollText(named, 'description', 'All healing');
+    const after = setDccCharacterLuckyRollModifier(described, 3);
+
+    expect(after.luckyRoll).toEqual({
+      name: 'Bountiful harvest',
+      description: 'All healing',
+      modifier: 3,
+    });
+  });
+
+  it('sets one coin without disturbing the purse', () => {
+    const after = setDccCharacterCurrency(fixture, 'gp', 2);
+
+    expect(after.currency.gp).toBe(2);
+    expect(after.currency.cp).toBe(fixture.currency.cp);
+  });
+});
+
+describe('editing a DCC character’s lists', () => {
+  it('rewrites, adds and removes a special rule', () => {
+    const rewritten = setDccCharacterListEntry(fixture, 'specialRules', 0, 'Reads the weather');
+    expect(rewritten.specialRules[0]).toBe('Reads the weather');
+    expect(rewritten.specialRules.slice(1)).toEqual(fixture.specialRules.slice(1));
+
+    const added = addDccCharacterListEntry(fixture, 'specialRules', 'Fears geese');
+    expect(added.specialRules.at(-1)).toBe('Fears geese');
+    expect(
+      removeDccCharacterListEntry(added, 'specialRules', added.specialRules.length - 1),
+    ).toEqual(fixture);
+  });
+
+  it('does nothing at an index nothing lives at', () => {
+    expect(setDccCharacterListEntry(fixture, 'languages', 99, 'nowhere')).toBe(fixture);
+    expect(removeDccCharacterListEntry(fixture, 'languages', -1)).toBe(fixture);
+    expect(setDccCharacterEquipmentName(fixture, 99, 'nowhere')).toBe(fixture);
+    expect(setDccCharacterWeaponField(fixture, 99, 'name', 'nowhere')).toBe(fixture);
+    expect(removeDccCharacterWeapon(fixture, 99)).toBe(fixture);
+  });
+
+  it('adds, renames and removes an item, and the result still validates', () => {
+    const added = addDccCharacterEquipment(fixture);
+    const named = setDccCharacterEquipmentName(added, added.equipment.length - 1, 'a bent nail');
+
+    expect(named.equipment.at(-1)?.name).toBe('a bent nail');
+    expect(validateDccCharacterSnapshot(named).ok).toBe(true);
+    expect(removeDccCharacterEquipment(named, named.equipment.length - 1)).toEqual(fixture);
+  });
+
+  it('edits each part of a weapon’s line', () => {
+    const named = setDccCharacterWeaponField(fixture, 0, 'name', 'scythe');
+    const damaged = setDccCharacterWeaponField(named, 0, 'damage', '1d8');
+    const after = setDccCharacterWeaponField(damaged, 0, 'range', 'melee');
+
+    expect(after.weapons[0]?.name).toBe('scythe');
+    expect(after.weapons[0]?.damage).toBe('1d8');
+    expect(after.weapons[0]?.range).toBe('melee');
+    expect(validateDccCharacterSnapshot(after).ok).toBe(true);
+  });
+
+  /**
+   * A trained weapon is pushed onto both lists, and editing one does not reach into the other:
+   * guessing which entries were meant to be the same object would be guessing.
+   */
+  it('keeps the two equipment lists independent', () => {
+    const after = setDccCharacterWeaponField(fixture, 0, 'name', 'scythe');
+
+    expect(after.equipment).toEqual(fixture.equipment);
+  });
+
+  it('adds and removes a weapon, and the result still validates', () => {
+    const added = addDccCharacterWeapon(fixture);
+
+    expect(added.weapons).toHaveLength(fixture.weapons.length + 1);
+    expect(validateDccCharacterSnapshot(added).ok).toBe(true);
+    expect(removeDccCharacterWeapon(added, added.weapons.length - 1)).toEqual(fixture);
+  });
+});

--- a/src/lib/dcc/dcc_character_editing.ts
+++ b/src/lib/dcc/dcc_character_editing.ts
@@ -1,0 +1,277 @@
+/**
+ * Editing a stored DCC character, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction — renaming a character must not
+ * disturb their attributes, and correcting one save must not re-roll the rest — and it is what lets
+ * the editing framework compare what is on screen against what was read to decide whether anything
+ * needs saving.
+ *
+ * They work on the **snapshot**, not a live `DCCCharacter`, because the snapshot is what is stored
+ * and what the kind's `validate` speaks. An editor working on live values would run the codec both
+ * ways on every keystroke and hand back a payload one conversion further from what the user kept.
+ *
+ * **Nothing here recomputes anything.** Editing Stamina does not move Fortitude, and editing Luck
+ * does not move the lucky sign's modifier. That is requirement 4.2 taken seriously rather than a
+ * gap: a judge who has adjusted one number has made a decision, and a form that quietly corrected
+ * the four numbers derived from it would overrule them four times. `dccDerivedFromAttributes`
+ * exists for a caller that wants the arithmetic offered as an explicit command — see the editor,
+ * where it is a button.
+ */
+
+import { getAttributeModifier } from './dcc_characters.js';
+import type { DccCharacterSnapshot } from './dcc_character_snapshot.js';
+import type { DCCAttribute, DCCItem, DCCWeapon } from './dcc_types.js';
+
+/** The six attributes, in the order every DCC sheet prints them. */
+export const DCC_ATTRIBUTE_FIELDS = [
+  'strength',
+  'agility',
+  'stamina',
+  'personality',
+  'intelligence',
+  'luck',
+] as const;
+
+export type DccAttributeField = (typeof DCC_ATTRIBUTE_FIELDS)[number];
+
+/** The identity fields a user may rewrite. */
+export type DccCharacterTextField = 'firstName' | 'lastName' | 'gender' | 'alignment';
+
+/** The whole-number fields the sheet shows beside the attributes. */
+export const DCC_NUMBER_FIELDS = [
+  'level',
+  'xp',
+  'hp',
+  'speed',
+  'age',
+  'armorClass',
+  'attackModifier',
+  'baseSave',
+  'fortitudeSave',
+  'reflexSave',
+  'willpowerSave',
+  'spellsKnown',
+  'wizardMaxSpellLevel',
+  'clericMaxSpellLevel',
+  'numberOfLanguages',
+] as const;
+
+export type DccCharacterNumberField = (typeof DCC_NUMBER_FIELDS)[number];
+
+/** The string lists the sheet prints as bullets. */
+export type DccCharacterListField = 'specialRules' | 'languages';
+
+export function setDccCharacterText(
+  snapshot: DccCharacterSnapshot,
+  field: DccCharacterTextField,
+  value: string,
+): DccCharacterSnapshot {
+  return { ...snapshot, [field]: value };
+}
+
+/**
+ * A whole number on the sheet.
+ *
+ * A field the user has emptied arrives as `NaN` and is refused rather than stored: a character with
+ * an armour class of `NaN` is a payload that fails its own kind's validation, which the user would
+ * meet as a broken artifact rather than as a rejected keystroke.
+ */
+export function setDccCharacterNumber(
+  snapshot: DccCharacterSnapshot,
+  field: DccCharacterNumberField,
+  value: number,
+): DccCharacterSnapshot {
+  return Number.isFinite(value) ? { ...snapshot, [field]: value } : snapshot;
+}
+
+/**
+ * One half of one attribute.
+ *
+ * The value and the modifier are edited separately and neither follows the other, for the reason in
+ * the module comment. A user who wants the standard arithmetic asks for it.
+ */
+export function setDccCharacterAttribute(
+  snapshot: DccCharacterSnapshot,
+  field: DccAttributeField,
+  part: keyof DCCAttribute,
+  value: number,
+): DccCharacterSnapshot {
+  if (!Number.isFinite(value)) {
+    return snapshot;
+  }
+  const attribute: DCCAttribute = { ...snapshot[field], [part]: value };
+  return { ...snapshot, [field]: attribute };
+}
+
+/**
+ * The six modifiers and the four saves as the rules would derive them from the attribute values.
+ *
+ * Offered as a command rather than run whenever a value changes — the destructive kind of helpful,
+ * kept explicit. It touches nothing else: hit points, armour class, the spell levels and the
+ * character's own special rules are left exactly as they are, because those took dice and choices
+ * that this cannot reconstruct.
+ */
+export function dccDerivedFromAttributes(snapshot: DccCharacterSnapshot): DccCharacterSnapshot {
+  const derived = { ...snapshot };
+  for (const field of DCC_ATTRIBUTE_FIELDS) {
+    derived[field] = { ...snapshot[field], modifier: getAttributeModifier(snapshot[field].value) };
+  }
+  derived.fortitudeSave = derived.baseSave + derived.stamina.modifier;
+  derived.reflexSave = derived.baseSave + derived.agility.modifier;
+  derived.willpowerSave = derived.baseSave + derived.personality.modifier;
+  return derived;
+}
+
+/** The occupation's name, which the sheet prints and the lookup for its handler uses. */
+export function setDccCharacterOccupationName(
+  snapshot: DccCharacterSnapshot,
+  name: string,
+): DccCharacterSnapshot {
+  return { ...snapshot, occupation: { ...snapshot.occupation, name } };
+}
+
+/** The lucky sign: its name, the description the sheet prints, and the character's own modifier. */
+export function setDccCharacterLuckyRollText(
+  snapshot: DccCharacterSnapshot,
+  field: 'name' | 'description',
+  value: string,
+): DccCharacterSnapshot {
+  return { ...snapshot, luckyRoll: { ...snapshot.luckyRoll, [field]: value } };
+}
+
+export function setDccCharacterLuckyRollModifier(
+  snapshot: DccCharacterSnapshot,
+  modifier: number,
+): DccCharacterSnapshot {
+  return Number.isFinite(modifier)
+    ? { ...snapshot, luckyRoll: { ...snapshot.luckyRoll, modifier } }
+    : snapshot;
+}
+
+/** One coin denomination. An amount that is not a number leaves the purse alone. */
+export function setDccCharacterCurrency(
+  snapshot: DccCharacterSnapshot,
+  coin: string,
+  amount: number,
+): DccCharacterSnapshot {
+  return Number.isFinite(amount)
+    ? { ...snapshot, currency: { ...snapshot.currency, [coin]: amount } }
+    : snapshot;
+}
+
+function hasIndex(length: number, index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < length;
+}
+
+function replaceAt<T>(list: T[], index: number, value: T): T[] {
+  return list.map((entry, position) => (position === index ? value : entry));
+}
+
+function removeAt<T>(list: T[], index: number): T[] {
+  return list.filter((_entry, position) => position !== index);
+}
+
+export function setDccCharacterListEntry(
+  snapshot: DccCharacterSnapshot,
+  list: DccCharacterListField,
+  index: number,
+  value: string,
+): DccCharacterSnapshot {
+  return hasIndex(snapshot[list].length, index)
+    ? { ...snapshot, [list]: replaceAt(snapshot[list], index, value) }
+    : snapshot;
+}
+
+export function addDccCharacterListEntry(
+  snapshot: DccCharacterSnapshot,
+  list: DccCharacterListField,
+  value = '',
+): DccCharacterSnapshot {
+  return { ...snapshot, [list]: [...snapshot[list], value] };
+}
+
+export function removeDccCharacterListEntry(
+  snapshot: DccCharacterSnapshot,
+  list: DccCharacterListField,
+  index: number,
+): DccCharacterSnapshot {
+  return hasIndex(snapshot[list].length, index)
+    ? { ...snapshot, [list]: removeAt(snapshot[list], index) }
+    : snapshot;
+}
+
+/**
+ * A piece of equipment's name.
+ *
+ * `equipment` and `weapons` overlap — a trained weapon is pushed onto both — and editing one does
+ * **not** reach into the other. They are two lists on the sheet and a user who renames a pitchfork
+ * in their pack has not said anything about the pitchfork in their hands; guessing which entries
+ * were meant to be the same object would be guessing.
+ */
+export function setDccCharacterEquipmentName(
+  snapshot: DccCharacterSnapshot,
+  index: number,
+  name: string,
+): DccCharacterSnapshot {
+  return hasIndex(snapshot.equipment.length, index)
+    ? {
+        ...snapshot,
+        equipment: replaceAt(snapshot.equipment, index, {
+          ...snapshot.equipment[index],
+          name,
+        }),
+      }
+    : snapshot;
+}
+
+export function addDccCharacterEquipment(snapshot: DccCharacterSnapshot): DccCharacterSnapshot {
+  const item: DCCItem = { name: '', value: 0 };
+  return { ...snapshot, equipment: [...snapshot.equipment, item] };
+}
+
+export function removeDccCharacterEquipment(
+  snapshot: DccCharacterSnapshot,
+  index: number,
+): DccCharacterSnapshot {
+  return hasIndex(snapshot.equipment.length, index)
+    ? { ...snapshot, equipment: removeAt(snapshot.equipment, index) }
+    : snapshot;
+}
+
+/** The parts of a weapon the sheet prints on its line. */
+export type DccWeaponField = 'name' | 'damage' | 'range';
+
+export function setDccCharacterWeaponField(
+  snapshot: DccCharacterSnapshot,
+  index: number,
+  field: DccWeaponField,
+  value: string,
+): DccCharacterSnapshot {
+  return hasIndex(snapshot.weapons.length, index)
+    ? {
+        ...snapshot,
+        weapons: replaceAt(snapshot.weapons, index, {
+          ...snapshot.weapons[index],
+          [field]: value,
+        }),
+      }
+    : snapshot;
+}
+
+export function addDccCharacterWeapon(snapshot: DccCharacterSnapshot): DccCharacterSnapshot {
+  // A blank line rather than a guessed one. Every other field on a weapon describes what the
+  // occupation table gave it, and inventing a classification and a value would put numbers on the
+  // sheet that nothing stands behind.
+  const weapon: DCCWeapon = { name: '', value: 0, classification: '', damage: '', range: '' };
+  return { ...snapshot, weapons: [...snapshot.weapons, weapon] };
+}
+
+export function removeDccCharacterWeapon(
+  snapshot: DccCharacterSnapshot,
+  index: number,
+): DccCharacterSnapshot {
+  return hasIndex(snapshot.weapons.length, index)
+    ? { ...snapshot, weapons: removeAt(snapshot.weapons, index) }
+    : snapshot;
+}

--- a/src/lib/dcc/dcc_character_roll.test.ts
+++ b/src/lib/dcc/dcc_character_roll.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  readDccCharacterGeneratorConfig,
+  resolveDccNameGeneratorSet,
+  rollDccCharacter,
+  rollDccCharacterSnapshot,
+} from './dcc_character_roll.js';
+
+describe('reading a recorded config', () => {
+  it('takes the fields it recognises', () => {
+    expect(
+      readDccCharacterGeneratorConfig({
+        allowedOccupations: ['dwarf', 'human'],
+        nameGeneratorSet: 'elf',
+      }),
+    ).toEqual({ allowedOccupations: ['dwarf', 'human'], nameGeneratorSet: 'elf' });
+  });
+
+  /**
+   * Anything unrecognisable is dropped rather than coerced. A config written by a build that spelled
+   * these differently should fall back to the defaults, not roll a character from a field it
+   * misread.
+   */
+  it('drops what it does not recognise', () => {
+    expect(
+      readDccCharacterGeneratorConfig({
+        allowedOccupations: ['dwarf', 'gnome', 7],
+        nameGeneratorSet: 42,
+        namingGender: 'male',
+      }),
+    ).toEqual({ allowedOccupations: ['dwarf'] });
+  });
+
+  /**
+   * Every table off is a setting the page cannot produce and the generator cannot honour, so it
+   * reads as no preference rather than as an empty list a roll would then draw nothing from.
+   */
+  it('drops an allowed-occupations list that filters down to nothing', () => {
+    expect(readDccCharacterGeneratorConfig({ allowedOccupations: ['gnome'] })).toEqual({});
+    expect(readDccCharacterGeneratorConfig({ allowedOccupations: [] })).toEqual({});
+    expect(readDccCharacterGeneratorConfig({})).toEqual({});
+  });
+});
+
+describe('resolving the pattern set', () => {
+  it('keeps a set this build has, and drops one it does not', () => {
+    expect(resolveDccNameGeneratorSet('dwarf')).toBe('dwarf');
+    expect(resolveDccNameGeneratorSet('a-set-nobody-has')).toBe('');
+    expect(resolveDccNameGeneratorSet(undefined)).toBe('');
+    expect(resolveDccNameGeneratorSet('')).toBe('');
+  });
+});
+
+describe('rolling a DCC character', () => {
+  /** Requirement 2.2, and the defect this module exists to fix: the clock is out of the roll. */
+  it('gives the same character for the same seed and settings', () => {
+    const config = { allowedOccupations: ['human' as const] };
+    const first = rollDccCharacter('a-fixed-seed', config);
+    const second = rollDccCharacter('a-fixed-seed', config);
+
+    expect(second.character).toEqual(first.character);
+    expect(second.nameGeneratorSet).toBe(first.nameGeneratorSet);
+  });
+
+  it('gives a different character for a different seed', () => {
+    const first = rollDccCharacter('seed-one').character;
+    const second = rollDccCharacter('seed-two').character;
+
+    expect(`${second.firstName} ${second.lastName}`).not.toBe(
+      `${first.firstName} ${first.lastName}`,
+    );
+  });
+
+  /**
+   * The name is drawn from a stream derived from the seed, so a naming choice cannot move the dice.
+   * Without it, "same seed, same character" would hold only for one naming source.
+   */
+  it('does not let the naming source move the character’s dice', () => {
+    const plain = rollDccCharacter('shared-seed', { allowedOccupations: ['human'] });
+    const named = rollDccCharacter('shared-seed', {
+      allowedOccupations: ['human'],
+      nameGeneratorSet: 'dwarf',
+    });
+
+    expect(named.character.strength).toEqual(plain.character.strength);
+    expect(named.character.hp).toBe(plain.character.hp);
+    expect(named.character.occupation.name).toBe(plain.character.occupation.name);
+    expect(named.character.luckyRoll.name).toBe(plain.character.luckyRoll.name);
+  });
+
+  it('rolls from only the tables it was given', () => {
+    for (let seed = 0; seed < 20; seed += 1) {
+      const { character } = rollDccCharacter(`dwarves-only-${seed}`, {
+        allowedOccupations: ['dwarf'],
+      });
+      expect(character.occupation.name).toContain('dwarven');
+    }
+  });
+
+  it('rolls from every table when it was given none', () => {
+    const names = new Set(
+      Array.from({ length: 40 }, (_entry, index) => rollDccCharacter(`any-${index}`).character)
+        .map((character) => character.occupation.name)
+        .filter((name) => !name.includes('dwarven') && !name.includes('elven')),
+    );
+
+    expect(names.size).toBeGreaterThan(0);
+  });
+
+  it('reports the pattern set it actually used, not the one that was asked for', () => {
+    expect(
+      rollDccCharacter('resolved', { nameGeneratorSet: 'a-set-nobody-has' }).nameGeneratorSet,
+    ).toBe('');
+    expect(rollDccCharacter('resolved', { nameGeneratorSet: 'elf' }).nameGeneratorSet).toBe('elf');
+  });
+
+  it('makes a zero-level character with at least one hit point', () => {
+    for (let seed = 0; seed < 30; seed += 1) {
+      const { character } = rollDccCharacter(`zero-level-${seed}`);
+      expect(character.level).toBe(0);
+      expect(character.hp).toBeGreaterThanOrEqual(1);
+      expect(character.languages).toContain('Common');
+    }
+  });
+
+  it('rolls a snapshot by the same path', () => {
+    const config = { allowedOccupations: ['halfling' as const] };
+
+    expect(rollDccCharacterSnapshot('paths-agree', config).occupation.name).toBe(
+      rollDccCharacter('paths-agree', config).character.occupation.name,
+    );
+  });
+});

--- a/src/lib/dcc/dcc_character_roll.ts
+++ b/src/lib/dcc/dcc_character_roll.ts
@@ -1,0 +1,153 @@
+/**
+ * The single path from a seed to a DCC zero-level character, and the record of how it was rolled.
+ *
+ * Decision 1 of docs/tool-readiness.md, applied here: pressing **Generate** draws a _new seed_ from
+ * the page's RNG, and the roll itself is a pure function of seed and config. What it replaces is a
+ * component that drew three separate `rng.randomString(13)` values per press off an RNG it reseeded
+ * from the seed box, and built its generator config once at module scope — so the seed on screen
+ * described only part of what produced the character, and the "generate a name" button reached for
+ * `Date.now()` outright.
+ *
+ * The two derived streams are derived from the seed rather than drawn off a shared RNG, which is
+ * what makes the settings independent of each other: turning halflings off cannot change which
+ * lucky sign the same seed draws.
+ */
+
+import { resolveCharacterNameGeneratorSet } from '$lib/characters';
+import { getFantasyNameGeneratorSetNames } from '$lib/names';
+import { RNG } from '@ironarachne/rng';
+
+import {
+  generateRandomDCCCharacter,
+  getDefaultDCCCharacterGeneratorConfig,
+} from './dcc_characters.js';
+import { toDccCharacterSnapshot, type DccCharacterSnapshot } from './dcc_character_snapshot.js';
+import type { DCCCharacter } from './dcc_types.js';
+
+/** The four ancestries whose occupation tables the generator draws from. */
+export const DCC_ANCESTRIES = ['dwarf', 'elf', 'halfling', 'human'] as const;
+
+export type DccAncestry = (typeof DCC_ANCESTRIES)[number];
+
+/**
+ * What the generator records about how it rolled, and what a re-roll reads back.
+ *
+ * Stated as a type rather than read field by field at the call site so the two ends — what is
+ * written as provenance and what a re-roll expects to find — are in one place and drift loudly
+ * instead of quietly.
+ *
+ * There is no naming-gender field, because this page has no naming-gender control: a DCC character
+ * is named for the gender the dice gave them. Recording a setting the tool cannot express would be
+ * provenance describing a page that does not exist.
+ */
+export type DccCharacterGeneratorConfigRecord = {
+  /** The occupation tables in play, as the page's four checkboxes say. */
+  allowedOccupations?: DccAncestry[];
+  /**
+   * The name pattern set the character was named from.
+   *
+   * A character named from a culture records that culture's own pattern set here rather than the
+   * culture's id, so a re-roll produces names of the same tongue without reaching back into the
+   * store for an artifact it has no way to ask for. The link to the culture is an artifact
+   * reference and lives beside the payload, not in this record.
+   *
+   * Absent means "the set the occupation implies", which is what the generator does when the user
+   * has chosen no naming source: a dwarven apothecarist is named as a dwarf.
+   */
+  nameGeneratorSet?: string;
+};
+
+/**
+ * A rolled character and the pattern set its name actually came from.
+ *
+ * The resolved set travels back out because provenance has to record what was *used* rather than
+ * what was asked for: a set this build has since dropped, recorded as it was requested, is
+ * provenance a re-roll cannot honour. `''` means the occupation decided, which is the ordinary case
+ * and not a failure.
+ */
+export type DccCharacterRoll = {
+  character: DCCCharacter;
+  nameGeneratorSet: string;
+};
+
+function isAncestry(value: unknown): value is DccAncestry {
+  return DCC_ANCESTRIES.includes(value as DccAncestry);
+}
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Provenance is `Record<string, unknown>` because the store cannot know what any tool puts in it,
+ * so this is the boundary where that becomes typed. Anything unrecognisable is dropped rather than
+ * coerced: a config written by a build that spelled these differently should fall back to the
+ * defaults, not roll a character from a field it misread.
+ *
+ * An `allowedOccupations` that survives filtering as an empty list is dropped rather than kept.
+ * Every table switched off is a setting the page cannot produce and the generator cannot honour —
+ * `randomOccupation` would be drawing from nothing — so it reads as "no preference recorded".
+ */
+export function readDccCharacterGeneratorConfig(
+  config: Record<string, unknown>,
+): DccCharacterGeneratorConfigRecord {
+  const allowed = Array.isArray(config.allowedOccupations)
+    ? config.allowedOccupations.filter(isAncestry)
+    : [];
+  return {
+    ...(allowed.length > 0 ? { allowedOccupations: allowed } : {}),
+    ...(typeof config.nameGeneratorSet === 'string' && config.nameGeneratorSet !== ''
+      ? { nameGeneratorSet: config.nameGeneratorSet }
+      : {}),
+  };
+}
+
+/**
+ * The pattern set a roll should name from, or `''` for "let the occupation decide".
+ *
+ * A set this build no longer has lands on `''` too, and is dropped rather than substituted: naming
+ * a character in a tongue nobody asked for is worse than letting their occupation name them, which
+ * is what the generator does by default anyway.
+ */
+export function resolveDccNameGeneratorSet(requested: string | undefined): string {
+  if (requested === undefined || requested === '') {
+    return '';
+  }
+  return getFantasyNameGeneratorSetNames().includes(requested) ? requested : '';
+}
+
+/**
+ * Roll a character from a seed and a set of options — the one path the generator page and a re-roll
+ * both take.
+ */
+export function rollDccCharacter(
+  seed: string,
+  config: DccCharacterGeneratorConfigRecord = {},
+): DccCharacterRoll {
+  const generatorConfig = getDefaultDCCCharacterGeneratorConfig(`${seed}-dcc-config`);
+  generatorConfig.allowedOccupations = [...(config.allowedOccupations ?? DCC_ANCESTRIES)];
+
+  const nameGeneratorSet = resolveDccNameGeneratorSet(config.nameGeneratorSet);
+  const nameSet =
+    nameGeneratorSet === ''
+      ? undefined
+      : resolveCharacterNameGeneratorSet(new RNG(`${seed}-dcc-name`), {
+          kind: 'preset',
+          setName: nameGeneratorSet,
+        });
+
+  return {
+    character: generateRandomDCCCharacter(seed, generatorConfig, nameSet),
+    nameGeneratorSet,
+  };
+}
+
+/**
+ * Roll a fresh character snapshot from a seed and the settings it was first made with — the
+ * destructive half of editing (requirement 4.3), and what `ARTIFACT_EDITORS` registers as this
+ * kind's roller.
+ */
+export function rollDccCharacterSnapshot(
+  seed: string,
+  config: DccCharacterGeneratorConfigRecord = {},
+): DccCharacterSnapshot {
+  return toDccCharacterSnapshot(rollDccCharacter(seed, config).character);
+}

--- a/src/lib/dcc/dcc_character_snapshot.test.ts
+++ b/src/lib/dcc/dcc_character_snapshot.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  dccCharacterFromSnapshot,
+  isUnknownDccLuckyRollName,
+  isUnknownDccOccupationName,
+  toDccCharacterSnapshot,
+} from './dcc_character_snapshot.js';
+import { rollDccCharacter } from './dcc_character_roll.js';
+import type { DCCCharacter } from './dcc_types.js';
+
+/**
+ * A generated character of a given shape, found by sweeping seeds.
+ *
+ * Sweeping rather than hand-building, because the point of a round-trip test is that a character the
+ * generator actually produces survives, and a hand-built one only proves the fields the test author
+ * remembered to set.
+ */
+function rollMatching(
+  predicate: (character: DCCCharacter) => boolean,
+  config: Parameters<typeof rollDccCharacter>[1] = {},
+): DCCCharacter {
+  for (let seed = 0; seed < 300; seed += 1) {
+    const { character } = rollDccCharacter(`roundtrip-${seed}`, config);
+    if (predicate(character)) {
+      return character;
+    }
+  }
+  throw new Error('no seed in the sweep produced a character of that shape');
+}
+
+const character = rollMatching(() => true);
+
+describe('the DCC character snapshot', () => {
+  /** Requirement 7.2: lossless for everything the sheet shows. */
+  it('round-trips a generated character', () => {
+    const restored = dccCharacterFromSnapshot(toDccCharacterSnapshot(character));
+
+    // Compared whole, with the two handlers set aside — they are functions, and functions are the
+    // one thing a snapshot is allowed to lose.
+    expect({ ...restored, occupation: null, luckyRoll: null }).toEqual({
+      ...character,
+      occupation: null,
+      luckyRoll: null,
+    });
+  });
+
+  it('keeps every derived number rather than recomputing it', () => {
+    const restored = dccCharacterFromSnapshot(toDccCharacterSnapshot(character));
+
+    expect(restored.fortitudeSave).toBe(character.fortitudeSave);
+    expect(restored.reflexSave).toBe(character.reflexSave);
+    expect(restored.willpowerSave).toBe(character.willpowerSave);
+    expect(restored.attackModifier).toBe(character.attackModifier);
+    expect(restored.armorClass).toBe(character.armorClass);
+    expect(restored.spellsKnown).toBe(character.spellsKnown);
+  });
+
+  it('is free of the functions IndexedDB refuses', () => {
+    expect(() => structuredClone(toDccCharacterSnapshot(character))).not.toThrow();
+  });
+
+  /**
+   * The reason the row travels whole rather than as a name. `randomLuckyRoll` overwrites the drawn
+   * row's modifier with the character's own luck modifier, so rebuilding from the table would give
+   * every saved character a lucky sign reading `+0`.
+   */
+  it('keeps the lucky sign’s per-character modifier', () => {
+    const lucky = rollMatching((rolled) => rolled.luck.modifier !== 0);
+    const restored = dccCharacterFromSnapshot(toDccCharacterSnapshot(lucky));
+
+    expect(restored.luckyRoll.modifier).toBe(lucky.luckyRoll.modifier);
+    expect(restored.luckyRoll.modifier).toBe(lucky.luck.modifier);
+  });
+
+  /**
+   * The other reason. The human farmer's own handler rewrites `occupation.name` to the crop it
+   * rolled, so a `potato farmer` matches no row in any table — and resolving by name alone would
+   * lose the pitchfork and the hen the table gave them.
+   */
+  it('keeps an occupation whose own handler renamed it, trained weapon and all', () => {
+    const farmer = rollMatching((rolled) => rolled.occupation.name.endsWith(' farmer'), {
+      allowedOccupations: ['human'],
+    });
+    const restored = dccCharacterFromSnapshot(toDccCharacterSnapshot(farmer));
+
+    expect(isUnknownDccOccupationName(farmer.occupation.name)).toBe(true);
+    expect(restored.occupation.name).toBe(farmer.occupation.name);
+    expect(restored.occupation.trainedWeapon).toEqual(farmer.occupation.trainedWeapon);
+    expect(restored.occupation.tradeGoods).toEqual(farmer.occupation.tradeGoods);
+  });
+
+  it('puts a handler back on a row the tables still have', () => {
+    const known = rollMatching((rolled) => !isUnknownDccOccupationName(rolled.occupation.name));
+    const restored = dccCharacterFromSnapshot(toDccCharacterSnapshot(known));
+
+    expect(typeof restored.occupation.apply).toBe('function');
+    expect(typeof restored.luckyRoll.apply).toBe('function');
+  });
+
+  /**
+   * Requirement 3.3: a name this build no longer has is not a corrupt record. The handler comes back
+   * inert rather than missing, so nothing that reads a saved character has to check for it.
+   */
+  it('gives an unknown occupation an inert handler rather than throwing', () => {
+    const snapshot = toDccCharacterSnapshot(character);
+    const restored = dccCharacterFromSnapshot({
+      ...snapshot,
+      occupation: { ...snapshot.occupation, name: 'lamplighter-royal' },
+      luckyRoll: { ...snapshot.luckyRoll, name: 'Struck by a passing comet' },
+    });
+
+    expect(isUnknownDccOccupationName('lamplighter-royal')).toBe(true);
+    expect(isUnknownDccLuckyRollName('Struck by a passing comet')).toBe(true);
+    // `apply` is a domain method on the row, not `Function.prototype.apply`.
+    // eslint-disable-next-line prefer-spread
+    expect(restored.occupation.apply(restored, undefined as never)).toBe(restored);
+    expect(restored.luckyRoll.apply(restored)).toBe(restored);
+  });
+
+  it('reports a name the tables do have as known', () => {
+    expect(isUnknownDccLuckyRollName(character.luckyRoll.name)).toBe(false);
+  });
+});

--- a/src/lib/dcc/dcc_character_snapshot.ts
+++ b/src/lib/dcc/dcc_character_snapshot.ts
@@ -1,0 +1,132 @@
+/**
+ * Writing a DCC character snapshot, and reading one back.
+ *
+ * A DCC character is almost entirely plain data already: six attributes as `{ value, modifier }`,
+ * four saves, `specialRules: string[]`, `currency`, and arrays of items and weapons. Exactly two
+ * fields are not storable, and `dcc_types.ts` names them: `DCCOccupation.apply` and
+ * `DCCLuckyRoll.apply` are functions held in data.
+ *
+ * So the conversion is narrow — the two rule objects travel without their handler, and everything
+ * else travels as it is. Requirement 3.2 in docs/workshop.md asks for non-serialisable values to be
+ * stripped **or reconstructed explicitly**, and this is the second: the handler is put back on read
+ * by resolving the row's name against the tables.
+ *
+ * **Why the whole row rather than just its name.** `docs/readiness-characters.md` proposed storing
+ * `occupationName` and `luckyRollName` alone, in the shape AD&D stores its race and class. That is
+ * lossy here, in two ways AD&D does not have:
+ *
+ * - **A drawn row carries per-character data.** `randomLuckyRoll` copies its row and overwrites
+ *   `modifier` with the character's own luck modifier, so the table's row is not the character's
+ *   row. Rebuilt from the name, every saved character's lucky sign would come back reading `+0`.
+ * - **An `apply` handler may rewrite the row's own name.** The human farmer replaces its
+ *   `occupation.name` with the crop it rolled (`human_occupation_data.ts:372`), so the stored name
+ *   of a `potato farmer` matches nothing in the table, and resolving it would lose the pitchfork
+ *   and the hen with it.
+ *
+ * Storing the row minus its handler keeps the payload authoritative (4.2) and still keeps every
+ * closure out of it, which is what the design was actually protecting. The name lookup is retained
+ * for the one thing it is good for: putting the handler back, and saying so when it cannot.
+ *
+ * **Every derived number stays in the payload.** The saves, the spell levels, the attack modifier,
+ * the armour class — all of it, even though all of it could be recomputed from six attributes. A
+ * judge who edits a save has made a decision no recomputation may overrule, and a character saved
+ * under one printing of the tables must still be that character after the tables change.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+
+import type { DCCCharacter, DCCLuckyRoll, DCCOccupation } from './dcc_types.js';
+import * as DwarfOccupations from './dwarf_occupations.js';
+import * as ElfOccupations from './elf_occupations.js';
+import * as HalflingOccupations from './halfling_occupations.js';
+import * as HumanOccupations from './human_occupations.js';
+import * as LuckyRolls from './lucky_rolls.js';
+
+/** An occupation as it is stored: the row the character drew, without its handler. */
+export type StoredDccOccupation = Omit<DCCOccupation, 'apply'>;
+
+/** A lucky sign as it is stored, carrying the character's own modifier rather than the table's. */
+export type StoredDccLuckyRoll = Omit<DCCLuckyRoll, 'apply'>;
+
+/** A DCC character as it is stored. */
+export type DccCharacterSnapshot = Omit<DCCCharacter, 'occupation' | 'luckyRoll'> & {
+  occupation: StoredDccOccupation;
+  luckyRoll: StoredDccLuckyRoll;
+};
+
+/** Every occupation this build has, across all four ancestries. Built on demand, never mutated. */
+function allOccupations(): DCCOccupation[] {
+  return [
+    ...DwarfOccupations.all(),
+    ...ElfOccupations.all(),
+    ...HalflingOccupations.all(),
+    ...HumanOccupations.all(),
+  ];
+}
+
+/**
+ * The handler an occupation of this name carries, or one that does nothing.
+ *
+ * Inert rather than absent, and inert rather than a throw. A handler is what *made* this character
+ * — it already ran, and its results are in the payload — so re-running it is never something
+ * reading a saved character does. What the field is for is a re-roll, and a re-roll draws a fresh
+ * row from the table rather than reaching through a rehydrated one.
+ *
+ * The identity function is therefore the honest value for a name this build no longer has, and for
+ * a name an `apply` handler rewrote on its way past — `potato farmer` matches no row, and never
+ * did.
+ */
+function occupationApplyFor(name: string): DCCOccupation['apply'] {
+  return allOccupations().find((row) => row.name === name)?.apply ?? ((character) => character);
+}
+
+function luckyRollApplyFor(name: string): DCCLuckyRoll['apply'] {
+  return LuckyRolls.all().find((row) => row.name === name)?.apply ?? ((character) => character);
+}
+
+/** Whether a stored occupation name is one this build's tables still have. */
+export function isUnknownDccOccupationName(name: string): boolean {
+  return !allOccupations().some((row) => row.name === name);
+}
+
+/** Whether a stored lucky sign is one this build's table still has. */
+export function isUnknownDccLuckyRollName(name: string): boolean {
+  return !LuckyRolls.all().some((row) => row.name === name);
+}
+
+export function toDccCharacterSnapshot(character: DCCCharacter): DccCharacterSnapshot {
+  const { occupation, luckyRoll, ...rest } = character;
+  const { apply: _occupationApply, ...storedOccupation } = occupation;
+  const { apply: _luckyApply, ...storedLuckyRoll } = luckyRoll;
+  return { ...rest, occupation: storedOccupation, luckyRoll: storedLuckyRoll };
+}
+
+/**
+ * A stored character back into the live one the library works with.
+ *
+ * Nothing is recomputed and nothing is re-rolled: every number comes back as it was stored, and the
+ * only thing added is the two handlers, resolved by name. The payload is the truth, per
+ * docs/workshop.md.
+ */
+export function dccCharacterFromSnapshot(snapshot: DccCharacterSnapshot): DCCCharacter {
+  const { occupation, luckyRoll, ...rest } = snapshot;
+  return {
+    ...rest,
+    occupation: { ...occupation, apply: occupationApplyFor(occupation.name) },
+    luckyRoll: { ...luckyRoll, apply: luckyRollApplyFor(luckyRoll.name) },
+  };
+}
+
+/**
+ * The codec's reading half, with the signature the registry hands it.
+ *
+ * The RNG is unused, and that is the correct amount of use for it. It exists for kinds that rebuild
+ * name generators; a character is finished when it is stored, and drawing anything from a seed on
+ * the way back would be regenerating over the user's edits.
+ */
+export function dccCharacterFromSnapshotWithRng(
+  snapshot: DccCharacterSnapshot,
+  _rng: RNG,
+): DCCCharacter {
+  return dccCharacterFromSnapshot(snapshot);
+}

--- a/src/lib/dcc/dcc_presentation.test.ts
+++ b/src/lib/dcc/dcc_presentation.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  dccCharacterDisplayName,
+  dccCharacterFileStem,
+  dccCharacterToDocument,
+  dccCharacterToMarkdown,
+} from './dcc_presentation.js';
+import { rollDccCharacter } from './dcc_character_roll.js';
+import type { DCCCharacter } from './dcc_types.js';
+
+function rollMatching(predicate: (character: DCCCharacter) => boolean): DCCCharacter {
+  for (let seed = 0; seed < 300; seed += 1) {
+    const { character } = rollDccCharacter(`presentation-${seed}`);
+    if (predicate(character)) {
+      return character;
+    }
+  }
+  throw new Error('no seed in the sweep produced a character of that shape');
+}
+
+const character = rollMatching((rolled) => rolled.weapons.length > 0);
+
+function headings(subject: DCCCharacter): string[] {
+  return dccCharacterToDocument(subject).sections.map((entry) => entry.heading);
+}
+
+describe('a DCC character as a document', () => {
+  it('is titled with the character’s name', () => {
+    expect(dccCharacterToDocument(character).title).toBe(
+      `${character.firstName} ${character.lastName}`,
+    );
+  });
+
+  it('prints what the sheet shows', () => {
+    expect(headings(character)).toEqual(
+      expect.arrayContaining(['At a Glance', 'Attributes', 'Combat', 'Lucky Sign', 'Weapons']),
+    );
+  });
+
+  it('prints each attribute with its modifier', () => {
+    const attributes = dccCharacterToDocument(character).sections.find(
+      (entry) => entry.heading === 'Attributes',
+    );
+
+    expect(attributes?.items).toHaveLength(6);
+    expect(attributes?.items[0]).toBe(
+      `Strength: ${character.strength.value} (${character.strength.modifier >= 0 ? '+' : ''}${character.strength.modifier})`,
+    );
+  });
+
+  /**
+   * Requirement 6.4, and why the document model exists rather than each renderer remembering to
+   * skip an empty list.
+   */
+  it('drops every section it has nothing for', () => {
+    const bare: DCCCharacter = {
+      ...character,
+      weapons: [],
+      equipment: [],
+      languages: [],
+      specialRules: [],
+      currency: { cp: 0, sp: 0, gp: 0, ep: 0, pp: 0 },
+    };
+
+    expect(headings(bare)).not.toContain('Weapons');
+    expect(headings(bare)).not.toContain('Equipment');
+    expect(headings(bare)).not.toContain('Languages');
+    expect(headings(bare)).not.toContain('Special Rules');
+    expect(headings(bare)).not.toContain('Money');
+  });
+
+  /**
+   * A peasant's sheet should be silent on spells rather than announce that they have none — a
+   * heading over the line "No spellcasting possible" is exactly the stray content 6.4 is about.
+   */
+  it('says nothing about spellcasting for a character who cannot cast', () => {
+    expect(headings({ ...character, spellsKnown: -9 })).not.toContain('Spellcasting');
+    expect(headings({ ...character, spellsKnown: 1 })).toContain('Spellcasting');
+  });
+
+  it('falls back to the occupation for a character with no name', () => {
+    const unnamed = { ...character, firstName: '', lastName: '  ' };
+
+    expect(dccCharacterDisplayName(unnamed)).toBe(character.occupation.name);
+    expect(dccCharacterToDocument(unnamed).title).toBe(character.occupation.name);
+  });
+
+  it('falls back again for a character with neither', () => {
+    const nothing = {
+      ...character,
+      firstName: '',
+      lastName: '',
+      occupation: { ...character.occupation, name: '' },
+    };
+
+    expect(dccCharacterDisplayName(nothing)).toBe('DCC Character');
+  });
+});
+
+describe('a DCC character as a file', () => {
+  it('writes Markdown with a heading per section', () => {
+    const markdown = dccCharacterToMarkdown(character);
+
+    expect(markdown.startsWith(`# ${dccCharacterDisplayName(character)}`)).toBe(true);
+    expect(markdown).toContain('## Attributes');
+    expect(markdown).toContain(`- Occupation: ${character.occupation.name}`);
+  });
+
+  it('reduces a name to something a filesystem takes', () => {
+    expect(dccCharacterFileStem({ ...character, firstName: 'Maren', lastName: 'Voss' })).toBe(
+      'dcc-maren-voss',
+    );
+  });
+});

--- a/src/lib/dcc/dcc_presentation.ts
+++ b/src/lib/dcc/dcc_presentation.ts
@@ -1,0 +1,166 @@
+/**
+ * A DCC character arranged for reading, and the Markdown export written from it.
+ *
+ * The library already renders a **character sheet** as a PDF (`render_dcc_character_pdf.ts`) — a
+ * drawn form with boxes, alignment markers and rules, which is what a player wants at the table.
+ * That is 6.3 satisfied for the sheet, and this module does not replace it: a document model
+ * underneath a drawn form would be a worse form.
+ *
+ * What was missing is the other half of 6.3 — the character as *text*, for a judge's notes and a
+ * funnel's four peasants in one file — and 6.4 with it: no stray blank sections. The document model
+ * is where a section with neither prose nor items is dropped, once, rather than in each renderer.
+ */
+
+import {
+  formatDccCurrency,
+  formatDccLuckySign,
+  formatDccModifier,
+  formatDccSpellsKnown,
+  formatDccWeaponLine,
+} from './dcc_format.js';
+import type { DCCAttribute, DCCCharacter } from './dcc_types.js';
+
+/** One heading and what sits under it. A section with neither prose nor items is not printed. */
+export type DccCharacterSection = {
+  heading: string;
+  paragraphs: string[];
+  items: string[];
+};
+
+/** A DCC character arranged for reading, independent of the format it is finally written in. */
+export type DccCharacterDocument = {
+  title: string;
+  sections: DccCharacterSection[];
+};
+
+function section(heading: string, paragraphs: string[], items: string[] = []): DccCharacterSection {
+  return { heading, paragraphs: paragraphs.filter(isPrintable), items: items.filter(isPrintable) };
+}
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+function hasContent(entry: DccCharacterSection): boolean {
+  return entry.paragraphs.length > 0 || entry.items.length > 0;
+}
+
+function attributeLine(label: string, attribute: DCCAttribute): string {
+  return `${label}: ${attribute.value} (${formatDccModifier(attribute.modifier)})`;
+}
+
+/** What the character is, in the terms the top of a DCC sheet uses. */
+function identityLines(character: DCCCharacter): string[] {
+  return [
+    `Occupation: ${character.occupation.name}`,
+    `Level: ${character.level}`,
+    `Alignment: ${character.alignment}`,
+    `Gender: ${character.gender}`,
+    `Age: ${character.age}`,
+    `Speed: ${character.speed} ft.`,
+  ];
+}
+
+function combatLines(character: DCCCharacter): string[] {
+  return [
+    `HP: ${character.hp}`,
+    `AC: ${character.armorClass}`,
+    `Attack modifier: ${formatDccModifier(character.attackModifier)}`,
+    `Fortitude: ${formatDccModifier(character.fortitudeSave)}`,
+    `Reflex: ${formatDccModifier(character.reflexSave)}`,
+    `Willpower: ${formatDccModifier(character.willpowerSave)}`,
+  ];
+}
+
+/**
+ * Spellcasting, which most zero-level characters have none of.
+ *
+ * Dropped entirely when the character cannot cast — `formatDccSpellsKnown` renders that state as
+ * "No spellcasting possible", and a section saying so under a heading is the stray content 6.4 is
+ * about. A peasant's sheet should be silent on spells.
+ */
+function spellcastingLines(character: DCCCharacter): string[] {
+  if (character.spellsKnown === -9) {
+    return [];
+  }
+  return [
+    `Spells known: ${formatDccSpellsKnown(character.spellsKnown)}`,
+    `Wizard max spell level: ${character.wizardMaxSpellLevel}`,
+    `Cleric max spell level: ${character.clericMaxSpellLevel}`,
+  ];
+}
+
+/** Arrange a character for reading. Every empty section is dropped here, once. */
+export function dccCharacterToDocument(character: DCCCharacter): DccCharacterDocument {
+  const sections = [
+    section('At a Glance', [], identityLines(character)),
+    section(
+      'Attributes',
+      [],
+      [
+        attributeLine('Strength', character.strength),
+        attributeLine('Agility', character.agility),
+        attributeLine('Stamina', character.stamina),
+        attributeLine('Personality', character.personality),
+        attributeLine('Intelligence', character.intelligence),
+        attributeLine('Luck', character.luck),
+      ],
+    ),
+    section('Combat', [], combatLines(character)),
+    section('Lucky Sign', [formatDccLuckySign(character.luckyRoll)]),
+    section('Spellcasting', [], spellcastingLines(character)),
+    section(
+      'Weapons',
+      [],
+      character.weapons.map((weapon) => formatDccWeaponLine(weapon, character.attackModifier)),
+    ),
+    section(
+      'Equipment',
+      [],
+      character.equipment.map((item) => item.name),
+    ),
+    section('Money', [formatDccCurrency(character.currency)]),
+    section('Languages', [], character.languages),
+    section('Special Rules', [], character.specialRules),
+  ];
+
+  return {
+    title: dccCharacterDisplayName(character),
+    sections: sections.filter(hasContent),
+  };
+}
+
+/** What to head the document with: the character's name, or what they are when they have none. */
+export function dccCharacterDisplayName(character: DCCCharacter): string {
+  const given = `${character.firstName} ${character.lastName}`.trim();
+  if (isPrintable(given)) {
+    return given;
+  }
+  const occupation = character.occupation.name.trim();
+  return occupation === '' ? 'DCC Character' : occupation;
+}
+
+/** A DCC character as Markdown, for a judge who wants them in their own notes. */
+export function dccCharacterToMarkdown(character: DCCCharacter): string {
+  const document = dccCharacterToDocument(character);
+  const blocks = [`# ${document.title}`];
+
+  for (const entry of document.sections) {
+    blocks.push(`## ${entry.heading}`);
+    blocks.push(...entry.paragraphs);
+    if (entry.items.length > 0) {
+      blocks.push(entry.items.map((item) => `- ${item}`).join('\n'));
+    }
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** A filename stem for an exported character: their name, reduced to something a filesystem takes. */
+export function dccCharacterFileStem(character: DCCCharacter): string {
+  const stem = dccCharacterDisplayName(character)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' ? 'dcc-character' : `dcc-${stem}`;
+}

--- a/src/lib/dcc/index.ts
+++ b/src/lib/dcc/index.ts
@@ -1,5 +1,10 @@
 export type * from './dcc_types';
+export * from './dcc_character_artifact_kind';
+export * from './dcc_character_editing';
+export * from './dcc_character_roll';
+export * from './dcc_character_snapshot';
 export * from './dcc_characters';
 export * from './dcc_format';
+export * from './dcc_presentation';
 export * from './render_dcc_character_pdf';
 export * as HumanOccupations from './human_occupations';

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -62,6 +62,9 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // `character_generation`, and from there the sentient species tables, the fantasy archetypes and
   // the heraldry generator. The kind module holds metadata and validation only.
   '$lib/characters/character_artifact_kind',
+  // The seventh. `$lib/dcc`'s entry point re-exports the PDF renderer, and from there jsPDF, along
+  // with four occupation tables and the lucky-sign table.
+  '$lib/dcc/dcc_character_artifact_kind',
 ]);
 
 /**

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -113,6 +113,7 @@ describe('TOOL_CATALOG', () => {
     const assessedHigher = [
       '/character',
       '/culture',
+      '/fantasy/dcc/character',
       '/fantasy/religion',
       '/fantasy/settlement',
       '/heraldry',
@@ -215,6 +216,7 @@ describe('toolsWithMaturity', () => {
       '/culture',
       '/fantasy/adnd/character',
       '/fantasy/adnd/character/build',
+      '/fantasy/dcc/character',
       '/fantasy/religion',
       '/fantasy/settlement',
     ]);
@@ -265,6 +267,7 @@ describe('filterTools', () => {
       '/fantasy/adnd/character/build',
       '/character',
       '/fantasy/adnd/character',
+      '/fantasy/dcc/character',
       '/culture',
       '/fantasy/religion',
       '/fantasy/settlement',

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -63,7 +63,12 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     label: 'Dungeon Crawl Classics Character',
     kind: 'generator',
     domain: 'characters',
-    maturity: 'experimental',
+    // Release-ready, assessed section by section against docs/workshop.md and recorded in
+    // docs/readiness-characters.md (#48). It saves as `character.dcc` — one artifact per
+    // character, which is what makes a funnel survivor openable on their own — has an editor in
+    // `ARTIFACT_EDITORS`, composes a naming culture by reference, and exports a PDF sheet and
+    // Markdown. Its roll is deterministic from the seed via `dcc_character_roll.ts`.
+    maturity: 'release-ready',
     genres: ['fantasy'],
     systems: ['dcc'],
     tags: ['character'],

--- a/src/lib/workshop/README.md
+++ b/src/lib/workshop/README.md
@@ -223,8 +223,8 @@ artifact does not restamp contents nobody changed.
 ## Artifact editors
 
 `ARTIFACT_EDITORS` maps a kind to the component that edits it, alongside an optional roller.
-**Culture, religion, settlement, the AD&D 2E character and the fantasy character are the
-entries**, and most kinds having none is the shipped state: #39
+**Culture, religion, settlement, and the AD&D 2E, fantasy and DCC characters are the entries**, and
+most kinds having none is the shipped state: #39
 built the frame, and an editing view for a particular kind is part of taking that tool to
 Release-ready (docs/workshop.md, section 4). A kind with no entry opens read-only — the stored
 snapshot, rendered honestly — which is a state the surface draws rather than an error it reports.

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -83,6 +83,18 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         rollCharacterSnapshot(provenance.seed, readCharacterGeneratorConfig(provenance.config));
     },
   },
+  'character.dcc': {
+    loadEditor: () => import('$components/characters/DccCharacterArtifactEditor.svelte'),
+    loadRoller: async () => {
+      const { readDccCharacterGeneratorConfig, rollDccCharacterSnapshot } =
+        await import('$lib/dcc/dcc_character_roll.js');
+      return (provenance) =>
+        rollDccCharacterSnapshot(
+          provenance.seed,
+          readDccCharacterGeneratorConfig(provenance.config),
+        );
+    },
+  },
   /**
    * The first kind whose editor is a tool rather than a component written for the purpose.
    *

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -17,6 +17,7 @@ describe('artifact kind catalog', () => {
       'settlement',
       'character.adnd-2e',
       'character',
+      'character.dcc',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -18,6 +18,7 @@ import {
 import { adndCharacterArtifactKind } from '$lib/adnd/adnd_character_artifact_kind';
 import { characterArtifactKind } from '$lib/characters/character_artifact_kind';
 import { cultureArtifactKind } from '$lib/culture/culture_artifact_kind';
+import { dccCharacterArtifactKind } from '$lib/dcc/dcc_character_artifact_kind';
 import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
 import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
 import { settlementArtifactKind } from '$lib/settlements/settlement_artifact_kind';
@@ -39,6 +40,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, settlementArtifactKind);
   registerArtifactKind(registry, adndCharacterArtifactKind);
   registerArtifactKind(registry, characterArtifactKind);
+  registerArtifactKind(registry, dccCharacterArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Implements the [#48 section](https://github.com/ironarachne/ironarachne/blob/main/docs/readiness-characters.md#48--dungeon-crawl-classics) of the characters readiness document, part of [the readiness pass](https://github.com/ironarachne/ironarachne/blob/main/docs/tool-readiness.md). Closes #48. Wave 2 of the pass; wave 0's character half landed with #46, which is all this tool needed from it.

`/fantasy/dcc/character` now reads `maturity: 'release-ready'`, assessed section by section rather than declared. The assessment is in the design document under **What shipped**.

## The one departure from the approved shape

**The rule objects travel as the rows the character drew, minus `apply`, not as bare names.** Worth reading before #49 and #50 write their snapshots.

The design proposed `occupationName` / `luckyRollName`, carried over from AD&D, where a race and a class are table rows a character merely points at. In DCC they are not, in two ways only visible in the code:

- `randomLuckyRoll` copies its row and **overwrites `modifier` with the character's own Luck modifier**, so the table's row is not the character's row. Rebuilt from the name, every saved character's lucky sign would read `+0`.
- The human farmer's own `apply` handler **rewrites `occupation.name`** to the crop it rolled (`human_occupation_data.ts:372`), so a `potato farmer` matches nothing in any table — and resolving by name would lose the pitchfork and the hen with it.

Storing the row keeps the payload authoritative (4.2) and still keeps every closure out of it, which is what the by-name rule was protecting. The name lookup is kept for the one thing it is good for: putting the handler back, and standing in an inert one when it cannot. **The question worth asking of the next two snapshots is the same: does anything write to the row after it is drawn?**

## The rest

**Kind `character.dcc`, one artifact per character** — decision 1 of the design. A funnel is a way of rolling, not a thing in the world; a bundle would make the survivor unopenable, un-renamable and unreferenceable, and 3.5 is unanswerable for one. An e2e test saves two characters in a row and checks the vault holds two.

**2.2 was failing in three places.** The page drew three separate `rng.randomString(13)` values per press off an RNG it reseeded from the seed box, built its generator config once at module scope, and named from `` `${Date.now()}-dcc-name` ``. `dcc_character_roll.ts` is the single path from a seed now, with the config and the name on streams derived from it — so turning halflings off cannot change which lucky sign the same seed draws.

**The editor recomputes nothing.** Editing Stamina does not move Fortitude: a judge who adjusted a save has made a decision, and a form that corrected the four numbers derived from an attribute would overrule them four times. The arithmetic is a button instead.

Two things beyond the design, both small:

- **Generate is disabled with all four occupation tables off.** The page could always reach that state and `randomOccupation` would have been drawing from an empty list. The provenance reader drops such a config rather than storing an empty list a re-roll could not honour.
- **A Markdown export beside the PDF.** The drawn sheet is unchanged and is what a player writes on; `dcc_presentation.ts` is the character as text, and it is where 6.4 lives — a peasant who cannot cast prints no Spellcasting heading rather than one reading "No spellcasting possible".

Also: a culture reference for naming through `CharacterNameSection`'s existing opt-in, `e2e/dcc_character.spec.ts` (generate, save, reopen, edit across a reload), and the README's 8.4 section — DCC as published in the core rulebook, zero-level only, no classes or advancement, and a note that `getAttributeModifier` is the d20-style formula rather than DCC's own table.

## Verification

`npm run verify` green — 0 svelte-check errors, coverage gate passed with no new baseline entries.

Full `npm run test:e2e` green: **474 passed**, including seven new DCC tests that passed first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRkjYVaTcuxkQaGkzgaP4r
