### PR TITLE
Take the SWN character generator to Release-ready

### DIFF
--- a/docs/readiness-characters.md
+++ b/docs/readiness-characters.md
@@ -12,8 +12,8 @@ Part of [the readiness pass](tool-readiness.md); read that first for what all tw
 share — the determinism fix, the stored vocabulary, the kind ids, and the field-editor decision.
 Measured against [Tool release readiness](workshop.md#tool-release-readiness).
 
-**Status:** accepted; [#48](#48--dungeon-crawl-classics) is **implemented**, the other four are not
-yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in
+**Status:** accepted; [#48](#48--dungeon-crawl-classics) and
+[#49](#49--stars-without-number) are **implemented**, the other three are not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in
 this document is clear to start.
 
 ## The three system characters
@@ -124,6 +124,14 @@ finding: a user decision that was never recorded as data, only as its consequenc
 
 **6.3 is largely in hand** — `render_swn_character_pdf.ts` already exists. What it needs is the
 presentation document beneath it so the PDF and any Markdown export cannot disagree.
+
+**As built, only the psychic half of `picks` exists.** `SWNCharacter` grew `psychicPicks`, because
+a discipline resolves into `abilities` as prose — `"Psychic Succor-1: …"` and one randomly drawn
+ability — and prose is not a decision an editor can offer back. It grew no focus-pick list: a
+`Focus` on `character.focuses` already carries its own `name` and `currentLevel`, so the row _is_
+the pick, and a second list of the same two fields is a copy that can disagree with the one the
+sheet prints. The question this leaves for [#50](#50--uncharted-worlds) is the same one #48 left:
+is the decision recoverable from the row that was drawn, or only from its consequence?
 
 ### #50 — Uncharted Worlds
 
@@ -258,19 +266,22 @@ classDiagram
         +Stat[] stats
         +Skill[] skills
         +Focus[] focuses
+        +PsychicPick[] psychicPicks
         +ClassAbility[] abilities
         +number hitPoints
     }
     class SwnCharacterSnapshot {
         +Stat[] stats
         +Skill[] skills
-        +FocusPick[] picks
+        +Focus[] focuses
+        +PsychicPick[] psychicPicks
         +ClassAbility[] abilities
         +number hitPoints
     }
-    class FocusPick {
-        +string focusName
+    class PsychicPick {
+        +string disciplineName
         +number level
+        +string abilityName
     }
     class UWCharacter {
         +StatBlock stats
@@ -291,7 +302,7 @@ classDiagram
     DCCCharacter "1" o-- "1" DCCLuckyRoll
     DCCCharacter --> DccCharacterSnapshot : rule objects by name
     SWNCharacter --> SwnCharacterSnapshot : picks recorded beside effects
-    SwnCharacterSnapshot "1" o-- "*" FocusPick
+    SwnCharacterSnapshot "1" o-- "*" PsychicPick
     UWCharacter --> UwCharacterSnapshot : identity, descriptions derived on read
 ```
 

--- a/e2e/swn_character.spec.ts
+++ b/e2e/swn_character.spec.ts
@@ -3,7 +3,7 @@ import { expect, test, type Page } from '@playwright/test';
 import { visitRoute } from './helpers';
 
 /**
- * Requirement 7.4 for the `character.dcc` kind: generate, save, reopen, edit.
+ * Requirement 7.4 for the `character.swn` kind: generate, save, reopen, edit.
  *
  * This is the half no unit test can settle. The library tests prove a character round-trips through
  * the codec and that each editing function changes one field; what they cannot prove is that a user
@@ -21,7 +21,7 @@ const vault = (page: Page) => page.locator('section.vault');
 const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
 const saveArtifact = (page: Page) => page.locator('.save-artifact');
 
-const DCC_TITLE = 'Dungeon Crawl Classics Character Generator | Iron Arachne';
+const SWN_TITLE = 'Stars Without Number Character Generator | Iron Arachne';
 
 async function openEmpty(page: Page): Promise<void> {
   await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
@@ -77,106 +77,92 @@ async function openInWorkshop(page: Page, name: string) {
   return panel;
 }
 
-test.describe('a DCC zero-level character', () => {
+test.describe('a Stars Without Number character', () => {
   test.beforeEach(async ({ page }) => {
     await openEmpty(page);
-    await createProject(page, 'The Funnel');
+    await createProject(page, 'The Sector');
   });
 
   test('is generated, saved, reopened, and edited', async ({ page }) => {
-    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+    await visitRoute(page, '/swn/character', { title: SWN_TITLE });
 
     // The generator rolls on mount (2.4), so there is a character to keep straight away.
-    await expect(page.getByRole('heading', { name: 'Attributes' })).toBeVisible();
-    await saveAs(page, 'Yorik Bramble');
+    await expect(page.getByRole('heading', { name: 'Stats' })).toBeVisible();
+    await saveAs(page, 'Vex Calloway');
 
     // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
     // rather than a state test.
-    const panel = await openInWorkshop(page, 'Yorik Bramble');
+    const panel = await openInWorkshop(page, 'Vex Calloway');
 
     // Typed rather than filled: `fill` sets the value in one go, and the point of this assertion is
     // that the editor's own bindings carry a user's keystrokes through to the snapshot it announces.
-    // A value no character can already have. `Chaos` is one of the three the generator rolls, so a
-    // peasant who was already chaotic left the snapshot unchanged and nothing to save — a flake
-    // that fired on roughly one run in three.
-    const alignment = panel.getByRole('textbox', { name: 'Alignment' });
-    await alignment.fill('');
-    await alignment.pressSequentially('Chaos, mostly');
+    const background = panel.getByRole('textbox', { name: 'Background', exact: true });
+    await background.fill('');
+    // A value no character can already have: `Dilettante` is one of the backgrounds the generator
+    // rolls, and typing what is already there would leave nothing to save.
+    await background.pressSequentially('Dilettante of Vega');
     await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
     await panel.getByRole('button', { name: 'Save changes' }).click();
     await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
 
     // And it survived the round trip through IndexedDB, which is the whole claim.
     await page.reload({ waitUntil: 'load' });
-    const reopened = await openInWorkshop(page, 'Yorik Bramble');
-    await expect(reopened.getByRole('textbox', { name: 'Alignment' })).toHaveValue('Chaos, mostly');
+    const reopened = await openInWorkshop(page, 'Vex Calloway');
+    await expect(reopened.getByRole('textbox', { name: 'Background', exact: true })).toHaveValue(
+      'Dilettante of Vega',
+    );
   });
 
   test('offers the derived arithmetic as a command rather than doing it silently', async ({
     page,
   }) => {
-    // Requirement 4.2: a judge who adjusts a save has made a decision no recomputation may
+    // Requirement 4.2: a referee who adjusts a save has made a decision no recomputation may
     // overrule. The button is how they ask for the arithmetic back.
-    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
-    await saveAs(page, 'Bess Tanner');
+    await visitRoute(page, '/swn/character', { title: SWN_TITLE });
+    await saveAs(page, 'Juno Marek');
 
-    const panel = await openInWorkshop(page, 'Bess Tanner');
-    const fortitude = panel.getByRole('spinbutton', { name: 'Fortitude save' });
-    await fortitude.fill('7');
-    await expect(fortitude).toHaveValue('7');
+    const panel = await openInWorkshop(page, 'Juno Marek');
+    const physical = panel.getByRole('spinbutton', { name: 'Physical save' });
+    await physical.fill('7');
+    await expect(physical).toHaveValue('7');
 
-    await panel.getByRole('spinbutton', { name: 'stamina score' }).fill('18');
+    await panel.getByRole('spinbutton', { name: 'strength score' }).fill('18');
     // Unmoved: changing the score did not touch the save.
-    await expect(fortitude).toHaveValue('7');
+    await expect(physical).toHaveValue('7');
 
     await panel
       .getByRole('button', { name: 'Recalculate modifiers and saves from the scores' })
       .click();
-    await expect(fortitude).not.toHaveValue('7');
+    await expect(physical).not.toHaveValue('7');
   });
 
-  test('reproduces the same character from the same seed', async ({ page }) => {
-    // Requirement 2.2, and the defect `dcc_character_roll.ts` was written to fix: the page drew
-    // three separate values off an RNG it reseeded each press, so the seed described only part of
-    // what it produced.
-    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+  test('reproduces the same character, name included, from the same seed', async ({ page }) => {
+    // Requirement 2.2, and the defect `swn_character_roll.ts` was written to fix: the page named
+    // from the clock, so the same seed reproduced a body and never the person wearing it.
+    await visitRoute(page, '/swn/character', { title: SWN_TITLE });
 
     const heading = page.getByRole('heading', { level: 2 }).first();
-    const occupation = page.locator('p', { hasText: /^A level 0 / }).first();
+    const what = page.locator('p', { hasText: /^A / }).first();
 
     await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
     await page.getByLabel('Lock Seed').check();
     await page.getByRole('button', { name: 'Generate', exact: true }).click();
     const first = await heading.textContent();
-    const firstOccupation = await occupation.textContent();
+    const firstWhat = await what.textContent();
 
     await page.getByRole('button', { name: 'Generate', exact: true }).click();
     await expect(heading).toHaveText(first ?? '');
-    await expect(occupation).toHaveText(firstOccupation ?? '');
+    await expect(what).toHaveText(firstWhat ?? '');
 
-    // And a different seed is a different peasant, so the reproduction above is not the page simply
-    // failing to re-roll.
+    // And a different seed is a different character, so the reproduction above is not the page
+    // simply failing to re-roll.
     await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
     await page.getByRole('button', { name: 'Generate', exact: true }).click();
-    await expect(occupation).not.toHaveText(firstOccupation ?? '');
-  });
-
-  test('refuses to roll from no table at all', async ({ page }) => {
-    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
-
-    for (const label of ['Allow Dwarves', 'Allow Elves', 'Allow Halflings', 'Allow Humans']) {
-      await page.getByLabel(label).uncheck();
-    }
-
-    await expect(page.getByRole('button', { name: 'Generate', exact: true })).toBeDisabled();
-    await expect(page.getByText('Allow at least one kind of occupation.')).toBeVisible();
-
-    await page.getByLabel('Allow Humans').check();
-    await expect(page.getByRole('button', { name: 'Generate', exact: true })).toBeEnabled();
+    await expect(heading).not.toHaveText(first ?? '');
   });
 
   test('offers a project culture to name from, and only once there is one', async ({ page }) => {
-    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+    await visitRoute(page, '/swn/character', { title: SWN_TITLE });
 
     // No cultures in the project, so no offer. An offer with nothing behind it is noise, and
     // requirement 5.3 is what makes its absence correct rather than a gap: the tool generates its
@@ -184,9 +170,9 @@ test.describe('a DCC zero-level character', () => {
     await expect(page.getByLabel('Name from a saved culture in this project')).toHaveCount(0);
 
     await visitRoute(page, '/culture', { title: 'Culture Generator | Iron Arachne' });
-    await saveAs(page, 'The Emberfolk');
+    await saveAs(page, 'The Vaskaari');
 
-    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+    await visitRoute(page, '/swn/character', { title: SWN_TITLE });
 
     // Composition is opt-in (rule 1): the offer is there and starts unticked.
     const offer = page.getByLabel('Name from a saved culture in this project');
@@ -194,10 +180,10 @@ test.describe('a DCC zero-level character', () => {
     await expect(offer).not.toBeChecked();
   });
 
-  test('downloads a character sheet a judge can take to the table', async ({ page }) => {
+  test('downloads a character sheet a player can take to the table', async ({ page }) => {
     // Requirement 6.3. Two exports, and they are different things: the PDF is the drawn sheet a
-    // player writes on, the Markdown is the character as text for a judge's notes.
-    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
+    // player writes on, the Markdown is the character as text for a referee's notes.
+    await visitRoute(page, '/swn/character', { title: SWN_TITLE });
 
     const markdown = page.waitForEvent('download');
     await page.getByRole('button', { name: 'Download Markdown' }).click();
@@ -206,21 +192,5 @@ test.describe('a DCC zero-level character', () => {
     const pdf = page.waitForEvent('download');
     await page.getByRole('button', { name: /Download PDF/ }).click();
     expect((await pdf).suggestedFilename()).toMatch(/\.pdf$/);
-  });
-
-  /**
-   * Decision 1 of docs/readiness-characters.md, tested where it actually matters: two characters
-   * saved from a funnel are two artifacts, each openable and renamable on its own.
-   */
-  test('saves each character as an artifact of its own', async ({ page }) => {
-    await visitRoute(page, '/fantasy/dcc/character', { title: DCC_TITLE });
-
-    await saveAs(page, 'Yorik Bramble');
-    await page.getByRole('button', { name: 'Generate', exact: true }).click();
-    await saveAs(page, 'Bess Tanner');
-
-    await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
-    await expect(vaultRow(page, 'Yorik Bramble')).toBeVisible();
-    await expect(vaultRow(page, 'Bess Tanner')).toBeVisible();
   });
 });

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -31,6 +31,10 @@ const SILENT_TOOL_PAGES = [
     title: 'Dungeon Crawl Classics Character Generator | Iron Arachne',
   },
   { path: '/culture', title: 'Culture Generator | Iron Arachne' },
+  {
+    path: '/swn/character',
+    title: 'Stars Without Number Character Generator | Iron Arachne',
+  },
   { path: '/fantasy/settlement', title: 'Settlement Generator | Iron Arachne' },
   { path: '/fantasy/religion', title: 'Religion Generator | Iron Arachne' },
   { path: '/fantasy/adnd/character', title: 'AD&D 2e Character Generator | Iron Arachne' },
@@ -110,6 +114,9 @@ test('maturity: the tool browser marks every tool that has something to warn abo
   );
   await expect(
     browser.getByRole('button', { name: /^Dungeon Crawl Classics Character/ }),
+  ).not.toContainText('Release-ready');
+  await expect(
+    browser.getByRole('button', { name: /^Stars Without Number Character/ }),
   ).not.toContainText('Release-ready');
   await expect(browser.getByRole('button', { name: /^Heraldry/ })).toContainText('Beta');
   await expect(browser.getByRole('button', { name: /^Planet/ })).toContainText('Experimental');

--- a/src/components/characters/SwnCharacterArtifactEditor.svelte
+++ b/src/components/characters/SwnCharacterArtifactEditor.svelte
@@ -1,0 +1,491 @@
+<script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import {
+    addSwnCharacterAbility,
+    addSwnCharacterArmor,
+    addSwnCharacterEquipment,
+    addSwnCharacterSkill,
+    addSwnCharacterWeapon,
+    removeSwnCharacterAbility,
+    removeSwnCharacterArmor,
+    removeSwnCharacterEquipment,
+    removeSwnCharacterFocus,
+    removeSwnCharacterSkill,
+    removeSwnCharacterWeapon,
+    setSwnCharacterAbilityDescription,
+    setSwnCharacterArmorClass,
+    setSwnCharacterArmorName,
+    setSwnCharacterBackgroundName,
+    setSwnCharacterClassName,
+    setSwnCharacterEquipmentName,
+    setSwnCharacterFocusLevel,
+    setSwnCharacterFocusName,
+    setSwnCharacterNumber,
+    setSwnCharacterSkillLevel,
+    setSwnCharacterSkillName,
+    setSwnCharacterStat,
+    setSwnCharacterText,
+    setSwnCharacterWeaponField,
+    swnDerivedFromStats,
+    validateSwnCharacterSnapshot,
+    SWN_NUMBER_FIELDS,
+    type SwnCharacterNumberField,
+    type SwnCharacterSnapshot,
+    type SwnCharacterTextField,
+    type SwnWeaponField,
+    type SwnWeaponList,
+  } from '$lib/swn';
+
+  /**
+   * The editing view for a saved Stars Without Number character.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it, so
+   * what is here is the character's own shape and the calls that change it.
+   *
+   * Every control writes a whole replacement snapshot through `onChange`. The framework compares
+   * that against what it read to decide whether anything needs saving, so typing a character and
+   * deleting it again leaves nothing to save.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps a SWN editor from rendering fields over
+   * something that is not a SWN character.
+   */
+  const accepted = $derived(validateSwnCharacterSnapshot(snapshot));
+  const character = $derived<SwnCharacterSnapshot | undefined>(
+    accepted.ok ? accepted.value : undefined,
+  );
+
+  const TEXT_FIELDS: { field: SwnCharacterTextField; label: string }[] = [
+    { field: 'firstName', label: 'First name' },
+    { field: 'lastName', label: 'Last name' },
+  ];
+
+  /** The numbers, in the order the sheet reads, with the labels the sheet prints. */
+  const NUMBER_LABELS: Record<SwnCharacterNumberField, string> = {
+    currentLevel: 'Level',
+    hitPoints: 'Hit points',
+    effort: 'Effort',
+    attackBonus: 'Base attack bonus',
+    meleeAttackBonus: 'Melee attack bonus',
+    rangedAttackBonus: 'Ranged attack bonus',
+    armorClassBase: 'Armor class (base)',
+    armorClassUnequipped: 'Armor class (unarmored)',
+    armorClassEquipped: 'Armor class (armored)',
+    credits: 'Credits',
+    savingThrowMental: 'Mental save',
+    savingThrowEvasion: 'Evasion save',
+    savingThrowPhysical: 'Physical save',
+  };
+
+  const WEAPON_LISTS: { list: SwnWeaponList; legend: string; noun: string }[] = [
+    { list: 'rangedWeapons', legend: 'Ranged weapons', noun: 'ranged weapon' },
+    { list: 'meleeWeapons', legend: 'Melee weapons', noun: 'melee weapon' },
+  ];
+
+  const WEAPON_FIELDS: { field: SwnWeaponField; label: string }[] = [
+    { field: 'name', label: 'name' },
+    { field: 'damage', label: 'damage' },
+    { field: 'range', label: 'range' },
+  ];
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: SwnCharacterSnapshot) => SwnCharacterSnapshot): void {
+    if (character === undefined) {
+      return;
+    }
+    onChange(change(character));
+  }
+</script>
+
+{#if character === undefined}
+  <Notice tone="danger">
+    These contents are stored as a Stars Without Number character but do not read as one, so there
+    is nothing safe to edit here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="swn-editor">
+    <fieldset>
+      <legend>Who they are</legend>
+
+      {#each TEXT_FIELDS as entry (entry.field)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-{entry.field}">{entry.label}</label>
+          <input
+            id="{uid}-{entry.field}"
+            type="text"
+            value={character[entry.field]}
+            oninput={(event) =>
+              edit((current) =>
+                setSwnCharacterText(current, entry.field, event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+        </div>
+      {/each}
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-background">Background</label>
+        <input
+          id="{uid}-background"
+          type="text"
+          value={character.background.name}
+          oninput={(event) =>
+            edit((current) => setSwnCharacterBackgroundName(current, event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-class">Class</label>
+        <input
+          id="{uid}-class"
+          type="text"
+          value={character.characterClass.name}
+          oninput={(event) =>
+            edit((current) => setSwnCharacterClassName(current, event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Stats</legend>
+
+      {#each character.stats as stat, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-stat-{index}-score">{stat.name} score</label>
+          <input
+            id="{uid}-stat-{index}-score"
+            type="number"
+            value={stat.score}
+            oninput={(event) =>
+              edit((current) =>
+                setSwnCharacterStat(current, index, 'score', event.currentTarget.valueAsNumber),
+              )}
+          />
+          <label for="{uid}-stat-{index}-modifier">{stat.name} modifier</label>
+          <input
+            id="{uid}-stat-{index}-modifier"
+            type="number"
+            value={stat.modifier}
+            oninput={(event) =>
+              edit((current) =>
+                setSwnCharacterStat(current, index, 'modifier', event.currentTarget.valueAsNumber),
+              )}
+          />
+        </div>
+      {/each}
+
+      <!-- Offered rather than done automatically: a referee who adjusted a save has made a
+           decision, and a form that silently corrected everything derived from a score would
+           overrule them several times over. -->
+      <BaseButton onclick={() => edit(swnDerivedFromStats)}>
+        Recalculate modifiers and saves from the scores
+      </BaseButton>
+    </fieldset>
+
+    <fieldset>
+      <legend>The numbers</legend>
+
+      {#each SWN_NUMBER_FIELDS as field (field)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-number-{field}">{NUMBER_LABELS[field]}</label>
+          <input
+            id="{uid}-number-{field}"
+            type="number"
+            value={character[field]}
+            oninput={(event) =>
+              edit((current) =>
+                setSwnCharacterNumber(current, field, event.currentTarget.valueAsNumber),
+              )}
+          />
+        </div>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Skills</legend>
+
+      <!-- Keyed by position rather than by value: two entries may read the same, and a key that
+           changed as the user typed would lose focus on every keystroke. -->
+      {#each character.skills as skill, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-skill-{index}-name">Skill {index + 1} name</label>
+          <input
+            id="{uid}-skill-{index}-name"
+            type="text"
+            value={skill.name}
+            oninput={(event) =>
+              edit((current) =>
+                setSwnCharacterSkillName(current, index, event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+          <label for="{uid}-skill-{index}-level">Skill {index + 1} level</label>
+          <input
+            id="{uid}-skill-{index}-level"
+            type="number"
+            value={skill.level}
+            oninput={(event) =>
+              edit((current) =>
+                setSwnCharacterSkillLevel(current, index, event.currentTarget.valueAsNumber),
+              )}
+          />
+          <BaseButton
+            aria-label="Remove skill {index + 1}"
+            onclick={() => edit((current) => removeSwnCharacterSkill(current, index))}
+          >
+            Remove
+          </BaseButton>
+        </div>
+      {/each}
+
+      <BaseButton onclick={() => edit(addSwnCharacterSkill)}>Add a skill</BaseButton>
+    </fieldset>
+
+    <fieldset>
+      <legend>Foci</legend>
+
+      <!-- The row is the pick. A focus carries its own name and the level the character holds it
+           at, so this is where a user corrects what they took; the rulebook text under it is not
+           theirs to rewrite and is not offered. -->
+      {#each character.focuses as focus, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-focus-{index}-name">Focus {index + 1} name</label>
+          <input
+            id="{uid}-focus-{index}-name"
+            type="text"
+            value={focus.name}
+            oninput={(event) =>
+              edit((current) =>
+                setSwnCharacterFocusName(current, index, event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+          <label for="{uid}-focus-{index}-level">Focus {index + 1} level</label>
+          <input
+            id="{uid}-focus-{index}-level"
+            type="number"
+            value={focus.currentLevel}
+            oninput={(event) =>
+              edit((current) =>
+                setSwnCharacterFocusLevel(current, index, event.currentTarget.valueAsNumber),
+              )}
+          />
+          <BaseButton
+            aria-label="Remove focus {index + 1}"
+            onclick={() => edit((current) => removeSwnCharacterFocus(current, index))}
+          >
+            Remove
+          </BaseButton>
+        </div>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Abilities</legend>
+
+      {#each character.abilities as ability, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-ability-{index}">Ability {index + 1}</label>
+          <textarea
+            id="{uid}-ability-{index}"
+            rows="3"
+            value={ability.description}
+            oninput={(event) =>
+              edit((current) =>
+                setSwnCharacterAbilityDescription(current, index, event.currentTarget.value),
+              )}
+          ></textarea>
+          <BaseButton
+            aria-label="Remove ability {index + 1}"
+            onclick={() => edit((current) => removeSwnCharacterAbility(current, index))}
+          >
+            Remove
+          </BaseButton>
+        </div>
+      {/each}
+
+      <BaseButton onclick={() => edit(addSwnCharacterAbility)}>Add an ability</BaseButton>
+    </fieldset>
+
+    {#each WEAPON_LISTS as entry (entry.list)}
+      <fieldset>
+        <legend>{entry.legend}</legend>
+
+        {#each character[entry.list] as weapon, index (index)}
+          <div class="swn-editor__row">
+            {#each WEAPON_FIELDS as part (part.field)}
+              <div class="input-group input-group--inline">
+                <label for="{uid}-{entry.list}-{index}-{part.field}">
+                  {entry.noun}
+                  {index + 1}
+                  {part.label}
+                </label>
+                <input
+                  id="{uid}-{entry.list}-{index}-{part.field}"
+                  type="text"
+                  value={weapon[part.field]}
+                  oninput={(event) =>
+                    edit((current) =>
+                      setSwnCharacterWeaponField(
+                        current,
+                        entry.list,
+                        index,
+                        part.field,
+                        event.currentTarget.value,
+                      ),
+                    )}
+                  autocomplete="off"
+                />
+              </div>
+            {/each}
+            <BaseButton
+              aria-label="Remove {entry.noun} {index + 1}"
+              onclick={() =>
+                edit((current) => removeSwnCharacterWeapon(current, entry.list, index))}
+            >
+              Remove {entry.noun}
+              {index + 1}
+            </BaseButton>
+          </div>
+        {/each}
+
+        <BaseButton onclick={() => edit((current) => addSwnCharacterWeapon(current, entry.list))}>
+          Add a {entry.noun}
+        </BaseButton>
+      </fieldset>
+    {/each}
+
+    <fieldset>
+      <legend>Armor</legend>
+
+      {#each character.armor as item, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-armor-{index}-name">Armor {index + 1} name</label>
+          <input
+            id="{uid}-armor-{index}-name"
+            type="text"
+            value={item.name}
+            oninput={(event) =>
+              edit((current) =>
+                setSwnCharacterArmorName(current, index, event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+          <label for="{uid}-armor-{index}-ac">Armor {index + 1} AC</label>
+          <input
+            id="{uid}-armor-{index}-ac"
+            type="number"
+            value={item.ac}
+            oninput={(event) =>
+              edit((current) =>
+                setSwnCharacterArmorClass(current, index, event.currentTarget.valueAsNumber),
+              )}
+          />
+          <BaseButton
+            aria-label="Remove armor {index + 1}"
+            onclick={() => edit((current) => removeSwnCharacterArmor(current, index))}
+          >
+            Remove
+          </BaseButton>
+        </div>
+      {/each}
+
+      <BaseButton onclick={() => edit(addSwnCharacterArmor)}>Add armor</BaseButton>
+    </fieldset>
+
+    <fieldset>
+      <legend>Equipment</legend>
+
+      {#each character.equipment as item, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-equipment-{index}">Item {index + 1}</label>
+          <input
+            id="{uid}-equipment-{index}"
+            type="text"
+            value={item.name}
+            oninput={(event) =>
+              edit((current) =>
+                setSwnCharacterEquipmentName(current, index, event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+          <BaseButton
+            aria-label="Remove item {index + 1}"
+            onclick={() => edit((current) => removeSwnCharacterEquipment(current, index))}
+          >
+            Remove
+          </BaseButton>
+        </div>
+      {/each}
+
+      <BaseButton onclick={() => edit(addSwnCharacterEquipment)}>Add an item</BaseButton>
+    </fieldset>
+  </div>
+{/if}
+
+<style>
+  .swn-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+  }
+
+  .swn-editor fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s3);
+    align-items: flex-start;
+    margin: 0;
+    /* No border and no radius, matching the culture, character and DCC editors: a fieldset inside
+       an editor panel was a box inside a box, and the legend and the spacing already group these. */
+    padding: var(--s4) 0;
+    min-width: 0;
+  }
+
+  .swn-editor legend {
+    padding: 0 var(--s3);
+    color: var(--gold);
+    font-size: var(--t-micro-size);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .swn-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .swn-editor input[type='text'],
+  .swn-editor input[type='number'],
+  .swn-editor textarea {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+
+  .swn-editor__row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s2);
+    width: 100%;
+    min-width: 0;
+  }
+</style>

--- a/src/components/characters/SwnCharacterGenerator.svelte
+++ b/src/components/characters/SwnCharacterGenerator.svelte
@@ -1,135 +1,176 @@
 <script lang="ts">
   import Stat from '$components/common/Stat.svelte';
   import StatBlock from '$components/common/StatBlock.svelte';
-  import * as RNG from '@ironarachne/rng';
-  import { characters as CharGen, downloadSwnCharacterPdf } from '$lib/swn';
+  import { RNG } from '@ironarachne/rng';
+  import * as SWN from '$lib/swn';
   import type { SWNCharacter } from '$lib/swn';
   import {
     buildCharacterNameSource,
-    isCustomCharacterNameSource,
-    restoreLockedCharacterName,
+    nameGeneratorSetForSource,
     rollCharacterNameForSource,
     loadCulturesForNaming,
   } from '$lib/characters';
+  import type { ArtifactReference } from '$lib/artifacts';
   import type { Culture } from '$lib/culture';
+  import Download from '$lib/download';
   import { onMount } from 'svelte';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
   import SeedControls from '$components/common/SeedControls.svelte';
   import CharacterNameSection from '$components/characters/CharacterNameSection.svelte';
   import DownloadPdfButton from '$components/common/DownloadPdfButton.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
 
-  const rng = new RNG.RNG(Date.now().toString());
+  const TOOL_PATH = '/swn/character';
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. That is the whole of requirement 2.2's
+   * fix here: the clock decides where the sequence of seeds *starts*, and everything after it is a
+   * pure function of the seed on screen. The names in particular used to come from
+   * `` `${Date.now()}-swn-name` ``, so the same seed reproduced a body and never the person.
+   */
+  const rng = new RNG(Date.now().toString());
   let seed = $state(rng.randomString(13));
   let lockSeed = $state(false);
-  $effect(() => {
-    rng.setSeed(seed);
-  });
-  let character: SWNCharacter | null = $state(null);
-  let downloadingPdf = $state(false);
 
   let savedCultures = $state<Culture[]>([]);
-  let nameSourceKind = $state<'default' | 'preset' | 'saved_culture'>('default');
+  let nameSourceKind = $state<'default' | 'preset' | 'saved_culture' | 'referenced_culture'>(
+    'default',
+  );
   let presetSetName = $state('human');
   let savedCultureName = $state('');
   let firstName = $state('');
   let lastName = $state('');
   let lockName = $state(false);
   let namingGender = $state<'male' | 'female' | 'random'>('random');
+  /** The culture the picker loaded, and the link to record for it. */
+  let referencedCulture = $state<Culture | undefined>();
+  let cultureReference = $state<ArtifactReference | undefined>();
+  /**
+   * The link, recorded only when the character on screen was actually named from that culture.
+   *
+   * Gated on the roll rather than on the picker, as the AD&D and DCC generators gate their own: a
+   * reference is a record of what the tool was handed, and one written for a character whose names
+   * came from somewhere else would claim an input that was never used.
+   */
+  let rolledCultureReference = $state.raw<ArtifactReference | undefined>();
 
-  function applyNamesToCharacter(target: CharGen.SWNCharacter) {
-    target.firstName = firstName;
-    target.lastName = lastName;
-  }
+  /**
+   * The rolled character.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every array and object in
+   * the character in a Proxy, and `structuredClone` — what IndexedDB stores with — refuses a Proxy
+   * outright, so saving fails with `could not be cloned`. The same trap is written up in
+   * `$lib/workshop`'s README beside `saveToolArtifact`.
+   */
+  let character = $state.raw<SWNCharacter | null>(null);
+  /** The settings the character on screen was actually rolled with. Raw, for the same reason. */
+  let rolledConfig = $state.raw<Record<string, unknown>>({});
+  let downloadingPdf = $state(false);
 
-  function rollNamesForCurrentSource() {
-    const source = buildCharacterNameSource(
+  /** The character with the names the page is showing, which is what the sheet and exports want. */
+  const namedCharacter = $derived<SWNCharacter | null>(
+    character === null ? null : { ...character, firstName, lastName },
+  );
+
+  const characterSnapshot = $derived(
+    namedCharacter === null ? null : SWN.toSwnCharacterSnapshot(namedCharacter),
+  );
+
+  const defaultArtifactName = $derived(`${firstName} ${lastName}`.trim());
+
+  function currentNameSource() {
+    return buildCharacterNameSource(
       nameSourceKind,
       presetSetName,
       savedCultureName,
       savedCultures,
+      referencedCulture,
     );
-    const nameRng = new RNG.RNG(`${Date.now()}-swn-name`);
-    return rollCharacterNameForSource(nameRng, source, 'human', namingGender);
   }
 
-  function applyGeneratedNamesFromSource(target: CharGen.SWNCharacter) {
-    const source = buildCharacterNameSource(
-      nameSourceKind,
-      presetSetName,
-      savedCultureName,
-      savedCultures,
-    );
-    if (!isCustomCharacterNameSource(source)) {
-      target.firstName = '';
-      target.lastName = '';
-      firstName = '';
-      lastName = '';
-      return;
-    }
-
-    const generated = rollNamesForCurrentSource();
-    target.firstName = generated.firstName;
-    target.lastName = generated.lastName;
-    firstName = generated.firstName;
-    lastName = generated.lastName;
+  /** The settings a roll takes, and the ones provenance records. */
+  function currentConfig(): SWN.SwnCharacterGeneratorConfigRecord {
+    const nameGeneratorSet = nameGeneratorSetForSource(currentNameSource());
+    return {
+      namingGender,
+      ...(nameGeneratorSet === '' ? {} : { nameGeneratorSet }),
+    };
   }
 
   function generate() {
     if (!lockSeed) {
       seed = rng.randomString(13);
     }
-    rng.setSeed(seed);
 
     const lockedFirstName = firstName;
     const lockedLastName = lastName;
 
-    character = CharGen.generate(rng);
+    const config = currentConfig();
+    const rolled = SWN.rollSwnCharacter(seed, config);
+    character = rolled.character;
+    // The resolved set, not the requested one: a set this build has since dropped would otherwise
+    // be recorded as provenance a re-roll could not honour.
+    rolledConfig = { ...config, nameGeneratorSet: rolled.nameGeneratorSet };
+    rolledCultureReference =
+      nameSourceKind === 'referenced_culture' && referencedCulture !== undefined
+        ? cultureReference
+        : undefined;
+
     if (lockName) {
-      restoreLockedCharacterName(character, lockedFirstName, lockedLastName);
+      firstName = lockedFirstName;
+      lastName = lockedLastName;
     } else {
-      applyGeneratedNamesFromSource(character);
+      firstName = rolled.character.firstName;
+      lastName = rolled.character.lastName;
     }
   }
 
+  /**
+   * Another name for the character already on screen.
+   *
+   * An **edit**, not a generation, and so a fresh draw that does not touch the recorded seed:
+   * requirement 4.2 says the payload is what the user kept, and a name they asked for is not
+   * something a seed reproduces. This is also the one path that names from a chosen culture's own
+   * generators rather than from the pattern set recorded beside it.
+   */
   function generateNameOnly() {
-    if (lockName) {
+    if (lockName || character === null) {
       return;
     }
-    const generated = rollNamesForCurrentSource();
+    const generated = rollCharacterNameForSource(
+      new RNG(`${Date.now()}-swn-name`),
+      currentNameSource(),
+      'human',
+      namingGender,
+    );
     firstName = generated.firstName;
     lastName = generated.lastName;
-    if (character) {
-      character.firstName = generated.firstName;
-      character.lastName = generated.lastName;
-    }
-  }
-
-  function save() {
-    if (!character) return;
-    applyNamesToCharacter(character);
-    const saveData = CharGen.formatAsText(character);
-
-    const blob = new Blob([saveData], { type: 'text/plain' });
-    const link = document.createElement('a');
-    link.href = window.URL.createObjectURL(blob);
-    link.download = 'swn-character.txt';
-    link.click();
-    URL.revokeObjectURL(link.href);
   }
 
   async function downloadPdf() {
-    if (downloadingPdf || !character) {
+    if (downloadingPdf || namedCharacter === null) {
       return;
     }
 
-    applyNamesToCharacter(character);
     downloadingPdf = true;
     try {
-      await downloadSwnCharacterPdf(character);
+      await SWN.downloadSwnCharacterPdf(namedCharacter);
     } finally {
       downloadingPdf = false;
     }
+  }
+
+  function exportMarkdown() {
+    if (namedCharacter === null) {
+      return;
+    }
+    const markdown = SWN.swnCharacterToMarkdown(namedCharacter);
+    const url = URL.createObjectURL(new Blob([markdown], { type: 'text/markdown' }));
+    Download(url, `${SWN.swnCharacterFileStem(namedCharacter)}.md`);
+    URL.revokeObjectURL(url);
   }
 
   onMount(() => {
@@ -145,10 +186,17 @@
   });
 </script>
 
-<GeneratorPage toolPath="/swn/character" title="Stars Without Number Character Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Stars Without Number Character Generator">
+  {#snippet description()}
+    <p>This is a first-level Stars Without Number character generator.</p>
+  {/snippet}
+
   <SeedControls bind:seed bind:lockSeed />
 
   <CharacterNameSection
+    offerReferencedCulture
+    bind:referencedCulture
+    bind:cultureReference
     bind:nameSourceKind
     bind:presetSetName
     bind:savedCultureName
@@ -162,35 +210,50 @@
   />
 
   <BaseButton onclick={generate}>Generate</BaseButton>
-  <BaseButton onclick={save}>Save</BaseButton>
-  <DownloadPdfButton onclick={downloadPdf} downloading={downloadingPdf} />
 
-  <h2>{firstName || lastName ? `${firstName} ${lastName}`.trim() : 'Character'}</h2>
+  <SaveArtifactButton
+    kind={SWN.SWN_CHARACTER_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={characterSnapshot}
+    {seed}
+    config={rolledConfig}
+    defaultName={defaultArtifactName}
+    references={rolledCultureReference === undefined ? [] : [rolledCultureReference]}
+  />
 
-  {#if character}
+  {#if namedCharacter}
+    <h2>{SWN.swnCharacterDisplayName(namedCharacter)}</h2>
+
+    <p>A {namedCharacter.background.name} {namedCharacter.characterClass.name}</p>
+
+    <div class="swn-exports">
+      <BaseButton onclick={exportMarkdown}>Download Markdown</BaseButton>
+      <DownloadPdfButton onclick={downloadPdf} downloading={downloadingPdf} />
+    </div>
+
     <StatBlock>
-      <Stat label="Background">{character.background.name}</Stat>
-      <Stat label="Class">{character.characterClass.name}</Stat>
-      <Stat label="Hit Points">{character.hitPoints}</Stat>
-      {#if character.effort > 0}
-        <Stat label="Effort">{character.effort}</Stat>
+      <Stat label="Background">{namedCharacter.background.name}</Stat>
+      <Stat label="Class">{namedCharacter.characterClass.name}</Stat>
+      <Stat label="Hit Points">{namedCharacter.hitPoints}</Stat>
+      {#if namedCharacter.effort > 0}
+        <Stat label="Effort">{namedCharacter.effort}</Stat>
       {/if}
-      <Stat label="Base Attack Bonus">+{character.attackBonus}</Stat>
-      <Stat label="Armor Class">{character.armorClassEquipped}</Stat>
-      <Stat label="Credits">{character.credits}</Stat>
+      <Stat label="Base Attack Bonus">{SWN.formatSwnModifier(namedCharacter.attackBonus)}</Stat>
+      <Stat label="Armor Class">{namedCharacter.armorClassEquipped}</Stat>
+      <Stat label="Credits">{namedCharacter.credits}</Stat>
     </StatBlock>
 
     <h3>Saving Throws</h3>
 
     <StatBlock>
-      <Stat label="Evasion">{character.savingThrowEvasion}</Stat>
-      <Stat label="Mental">{character.savingThrowMental}</Stat>
-      <Stat label="Physical">{character.savingThrowPhysical}</Stat>
+      <Stat label="Evasion">{namedCharacter.savingThrowEvasion}</Stat>
+      <Stat label="Mental">{namedCharacter.savingThrowMental}</Stat>
+      <Stat label="Physical">{namedCharacter.savingThrowPhysical}</Stat>
     </StatBlock>
 
     <h3>Focuses</h3>
 
-    {#each character.focuses as focus}
+    {#each namedCharacter.focuses as focus}
       <div>
         <strong>{focus.name}</strong>, Level {focus.currentLevel}
       </div>
@@ -199,10 +262,10 @@
     <h3>Stats</h3>
 
     <div class="stats">
-      {#each character.stats as stat}
+      {#each namedCharacter.stats as stat}
         <div>
           <strong>{stat.abbreviation}:</strong>
-          <span>{stat.score} ({stat.modifier})</span>
+          <span>{stat.score} ({SWN.formatSwnModifier(stat.modifier)})</span>
         </div>
       {/each}
     </div>
@@ -210,9 +273,9 @@
     <h3>Skills</h3>
 
     <div class="skills">
-      {#each character.skills as skill}
+      {#each namedCharacter.skills as skill}
         <div>
-          {skill.name}-{skill.level}
+          {SWN.formatSwnSkill(skill)}
         </div>
       {/each}
     </div>
@@ -220,7 +283,7 @@
     <h3>Abilities</h3>
 
     <div class="abilities">
-      {#each character.abilities as ability}
+      {#each namedCharacter.abilities as ability}
         <div>
           {ability.description}
         </div>
@@ -230,14 +293,14 @@
     <h3>Weapons</h3>
 
     <div class="weapons">
-      {#each character.rangedWeapons as weapon}
+      {#each namedCharacter.rangedWeapons as weapon}
         <div>
-          {weapon.name}: {weapon.damage}, ATK +{character.rangedAttackBonus} (rng)
+          {SWN.formatSwnWeaponLine(weapon, namedCharacter.rangedAttackBonus)}
         </div>
       {/each}
-      {#each character.meleeWeapons as weapon}
+      {#each namedCharacter.meleeWeapons as weapon}
         <div>
-          {weapon.name}: {weapon.damage}, ATK +{character.meleeAttackBonus} (mel)
+          {SWN.formatSwnWeaponLine(weapon, namedCharacter.meleeAttackBonus)}
         </div>
       {/each}
     </div>
@@ -245,7 +308,7 @@
     <h3>Armor</h3>
 
     <div class="armor">
-      {#each character.armor as item}
+      {#each namedCharacter.armor as item}
         <div>{item.name}: AC {item.ac}</div>
       {/each}
     </div>
@@ -253,7 +316,7 @@
     <h3>Equipment</h3>
 
     <div class="equipment">
-      {#each character.equipment as item}
+      {#each namedCharacter.equipment as item}
         <div>{item.name}</div>
       {/each}
     </div>
@@ -261,6 +324,12 @@
 </GeneratorPage>
 
 <style>
+  .swn-exports {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
   .stats,
   .skills,
   .abilities,

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -65,6 +65,9 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // The seventh. `$lib/dcc`'s entry point re-exports the PDF renderer, and from there jsPDF, along
   // with four occupation tables and the lucky-sign table.
   '$lib/dcc/dcc_character_artifact_kind',
+  // The eighth. `$lib/swn`'s entry point re-exports the PDF renderer, and jsPDF with it, along with
+  // the focus, psychic, and starship tables. The kind module holds metadata and validation only.
+  '$lib/swn/swn_character_artifact_kind',
 ]);
 
 /**

--- a/src/lib/swn/README.md
+++ b/src/lib/swn/README.md
@@ -8,6 +8,19 @@ Characters and starships are namespaced rather than starred (`characters.generat
 `starships.generate`) because both modules export `generate`, `Weapon`, and `formatAsText`. The
 components consume them the same way: `import { characters as CharGen } from '$lib/swn'`.
 
+## The edition, and what is not here
+
+The character generator implements **Stars Without Number: Revised Edition**, and only what a
+first-level character needs: the twenty-one backgrounds and their quick skills, the three classes
+and the three adventurer combinations with their abilities, the focus table, the six psychic disciplines with their level-0 and level-1
+powers, stats, skills, the equipment package a background hands out, and the numbers derived from
+all of it.
+
+Deliberately absent: advancement past level 1, transhuman options, cyberware, factions, and the
+maturities and tags that only matter to a campaign in play. A character generated here is a
+starting character; a referee who levels one up edits the saved artifact rather than asking the
+tool for level 4. This is unofficial and unaffiliated with Sine Nomine Publishing.
+
 ## How effects work
 
 Backgrounds, classes, and foci do not write directly into a character. Each contributes an
@@ -44,6 +57,27 @@ fitting it keeps, so the fittings on its sheet are its own and editing them cann
 the next ship is offered. `OWNER_TYPES` is the exception that cannot be copied — its entries carry
 naming closures, which `structuredClone` refuses — so an owner type reaching `starship.ownerType`
 really is the shared one, and mutating it would affect every later ship.
+
+## Saving a character
+
+The character generator is Release-ready (issue #49), which means everything it produces can be
+kept:
+
+- `swn_character_snapshot.ts` — the stored form. It is the identity function, because a
+  `SWNCharacter` carries no closures; the module says so explicitly rather than leaving a reader
+  to wonder what was stripped.
+- `swn_character_artifact_kind.ts` — the `character.swn` kind: validation, the payload version,
+  and what to call an artifact whose character was never named.
+- `swn_character_roll.ts` — the single path from a seed to a character, names included. Both the
+  generator page and a re-roll from the vault go through it.
+- `swn_character_editing.ts` — one function per field, each returning a new snapshot. Nothing
+  recomputes anything; `swnDerivedFromStats` is the arithmetic offered as an explicit command.
+- `swn_presentation.ts` — the character as a document, and the Markdown export written from it.
+  Empty sections are dropped here rather than in each renderer.
+
+`psychicPicks` on a character is the decision beside its effect: a discipline resolves into
+`abilities` as prose, and prose is not something an editor can offer back as a choice. The foci
+need no equivalent — a `Focus` already carries its own name and level, so the row _is_ the pick.
 
 ## Usage
 

--- a/src/lib/swn/character.ts
+++ b/src/lib/swn/character.ts
@@ -50,6 +50,31 @@ export type SWNCharacter = {
   savingThrowPhysical: number;
   firstName: string;
   lastName: string;
+  /**
+   * Which psychic disciplines the character has, and the ability each one drew.
+   *
+   * The decision, beside the effect it had. `applyPsychicDiscipline` resolves a discipline into
+   * `abilities` as prose — `"Psychic Succor-1: …"` and one randomly drawn ability — and prose is
+   * not something an editor can offer back as a choice, nor something levelling the character can
+   * read. Recording the pick is decision 2 of docs/readiness-characters.md, and the same finding
+   * the AD&D character had with its thief skills: a user decision that existed only as its
+   * consequence.
+   *
+   * The foci need no equivalent field. A `Focus` on `character.focuses` already carries its own
+   * name and `currentLevel`, so the pick is the row; a second list saying the same two things is a
+   * copy that can disagree with the one the sheet prints.
+   */
+  psychicPicks: PsychicPick[];
+};
+
+/** One psychic discipline the character has, at the level it was resolved at. */
+export type PsychicPick = {
+  /** The psychic skill's name, e.g. `Telepathy`. */
+  disciplineName: string;
+  /** The skill level the discipline's powers were granted at: 0 or 1 at character creation. */
+  level: number;
+  /** The ability drawn from that discipline at level 1, or `''` when the level granted none. */
+  abilityName: string;
 };
 
 export function createSwnCharacter(rng: RNG.RNG): SWNCharacter {
@@ -79,6 +104,7 @@ export function createSwnCharacter(rng: RNG.RNG): SWNCharacter {
     savingThrowPhysical: 0,
     firstName: '',
     lastName: '',
+    psychicPicks: [],
   };
 }
 
@@ -130,6 +156,7 @@ function applyPsychicDiscipline(character: SWNCharacter, skill: Skill, rng: RNG.
 
   if (skill.level === 0) {
     character.abilities.push(createSpecialAbility(power.levelZero));
+    character.psychicPicks.push({ disciplineName: skill.name, level: 0, abilityName: '' });
 
     return;
   }
@@ -147,6 +174,11 @@ function applyPsychicDiscipline(character: SWNCharacter, skill: Skill, rng: RNG.
   const ability = randomPsionicAbilityOfDiscipline(skill.name, rng);
 
   character.abilities.push(createSpecialAbility(`${ability.name}: ${ability.description}`));
+  character.psychicPicks.push({
+    disciplineName: skill.name,
+    level: 1,
+    abilityName: ability.name,
+  });
 }
 
 export function generate(rng: RNG.RNG): SWNCharacter {
@@ -490,6 +522,21 @@ export type Stat = {
   modifier: number;
 };
 
+/**
+ * The modifier a score gives, by the table every SWN stat is read from.
+ *
+ * Exported because two callers need the same table: the generator, which rolls the scores, and
+ * `swn_character_editing.ts`, where a user who has rewritten a score can ask for the arithmetic
+ * back. A second copy of the thresholds is a second copy to get wrong.
+ */
+export function statModifierForScore(score: number): number {
+  if (score < 4) return -2;
+  if (score < 8) return -1;
+  if (score < 14) return 0;
+  if (score < 18) return 1;
+  return 2;
+}
+
 export function createStat(
   name: string,
   abbreviation: string,
@@ -530,17 +577,7 @@ function randomStats(rng: RNG.RNG) {
   }
 
   for (let i = 0; i < stats.length; i++) {
-    if (stats[i].score < 4) {
-      stats[i].modifier = -2;
-    } else if (stats[i].score < 8) {
-      stats[i].modifier = -1;
-    } else if (stats[i].score < 14) {
-      stats[i].modifier = 0;
-    } else if (stats[i].score < 18) {
-      stats[i].modifier = 1;
-    } else {
-      stats[i].modifier = 2;
-    }
+    stats[i].modifier = statModifierForScore(stats[i].score);
   }
 
   return stats;

--- a/src/lib/swn/index.ts
+++ b/src/lib/swn/index.ts
@@ -4,8 +4,13 @@
 export * as characters from './character';
 export * as starships from './starship';
 export * from './render_swn_character_pdf';
+export * from './swn_character_artifact_kind';
+export * from './swn_character_editing';
+export * from './swn_character_roll';
+export * from './swn_character_snapshot';
+export * from './swn_presentation';
 
 // Named for the same reason: starring the types would re-collide the names the namespaces exist to
 // keep apart.
-export type { SWNCharacter } from './character';
+export type { Focus, PsychicPick, SWNCharacter } from './character';
 export type { SWNStarship } from './starship';

--- a/src/lib/swn/swn_character_artifact_kind.test.ts
+++ b/src/lib/swn/swn_character_artifact_kind.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import { readArtifactPayload, type AnyArtifactKindEntry } from '$lib/artifact_kinds';
+
+import {
+  migrateSwnCharacterSnapshot,
+  swnCharacterArtifactKind,
+  SWN_CHARACTER_ARTIFACT_KIND,
+  SWN_CHARACTER_PAYLOAD_VERSION,
+  validateSwnCharacterSnapshot,
+} from './swn_character_artifact_kind.js';
+import { rollSwnCharacterSnapshot } from './swn_character_roll.js';
+import type { SwnCharacterSnapshot } from './swn_character_snapshot.js';
+
+/** A stored payload, as anything reading one actually receives it. */
+function storedSnapshot(seed = 'kind-fixture'): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(rollSwnCharacterSnapshot(seed))) as Record<string, unknown>;
+}
+
+const snapshot = storedSnapshot();
+
+describe('the SWN character artifact kind', () => {
+  it('is registered system-qualified, concept first', () => {
+    expect(SWN_CHARACTER_ARTIFACT_KIND).toBe('character.swn');
+    expect(swnCharacterArtifactKind.kind).toBe('character.swn');
+    expect(swnCharacterArtifactKind.displayName).toBe('SWN Character');
+    expect(swnCharacterArtifactKind.payloadVersion).toBe(SWN_CHARACTER_PAYLOAD_VERSION);
+    expect(swnCharacterArtifactKind.icon).not.toBe('');
+  });
+
+  it('names an artifact after the character', () => {
+    const named = snapshot as unknown as SwnCharacterSnapshot;
+
+    expect(swnCharacterArtifactKind.nameOf(named)).toBe(
+      `${named.firstName} ${named.lastName}`.trim(),
+    );
+  });
+
+  /** A character saved unnamed is still findable by what they are. */
+  it('falls back to the background and class for a character with no name', () => {
+    const unnamed = {
+      ...snapshot,
+      firstName: '',
+      lastName: '  ',
+    } as unknown as SwnCharacterSnapshot;
+
+    expect(swnCharacterArtifactKind.nameOf(unnamed)).toBe(
+      `${unnamed.background.name} ${unnamed.characterClass.name}`,
+    );
+  });
+
+  it('falls back again for a character with neither', () => {
+    const anonymous = {
+      ...snapshot,
+      firstName: '',
+      lastName: '',
+      background: { name: '' },
+      characterClass: { name: '' },
+    } as unknown as SwnCharacterSnapshot;
+
+    expect(swnCharacterArtifactKind.nameOf(anonymous)).toBe('SWN Character');
+  });
+
+  it('accepts a payload the generator produced', () => {
+    expect(validateSwnCharacterSnapshot(snapshot).ok).toBe(true);
+  });
+
+  it('rejects something that is not an object at all', () => {
+    for (const payload of [null, 'a character', 42, ['stats']]) {
+      const result = validateSwnCharacterSnapshot(payload);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toBe('invalid-payload');
+    }
+  });
+
+  it('rejects a payload missing the numbers a sheet is read from', () => {
+    const { hitPoints: _dropped, ...rest } = snapshot;
+
+    expect(validateSwnCharacterSnapshot(rest).ok).toBe(false);
+  });
+
+  it('rejects stats that are not scores with modifiers', () => {
+    expect(validateSwnCharacterSnapshot({ ...snapshot, stats: [{ name: 'strength' }] }).ok).toBe(
+      false,
+    );
+  });
+
+  it('rejects skills without a level, which is half of what a skill is', () => {
+    expect(validateSwnCharacterSnapshot({ ...snapshot, skills: [{ name: 'Shoot' }] }).ok).toBe(
+      false,
+    );
+  });
+
+  it('rejects a focus with no level, because the level is the pick', () => {
+    expect(validateSwnCharacterSnapshot({ ...snapshot, focuses: [{ name: 'Alert' }] }).ok).toBe(
+      false,
+    );
+  });
+
+  it('rejects abilities with nothing to print', () => {
+    expect(
+      validateSwnCharacterSnapshot({ ...snapshot, abilities: [{ kind: 'specialAbility' }] }).ok,
+    ).toBe(false);
+  });
+
+  it('rejects a background or a class with no name', () => {
+    expect(validateSwnCharacterSnapshot({ ...snapshot, background: { equipment: 1 } }).ok).toBe(
+      false,
+    );
+    expect(validateSwnCharacterSnapshot({ ...snapshot, characterClass: {} }).ok).toBe(false);
+  });
+
+  /** Absent picks are a character who has none, not a corrupt record. */
+  it('accepts a payload with no psychic picks and rejects malformed ones', () => {
+    const { psychicPicks: _dropped, ...older } = snapshot;
+
+    expect(validateSwnCharacterSnapshot(older).ok).toBe(true);
+    expect(
+      validateSwnCharacterSnapshot({ ...snapshot, psychicPicks: [{ disciplineName: 'Telepathy' }] })
+        .ok,
+    ).toBe(false);
+  });
+
+  it('has no migration to offer, and says so rather than guessing', () => {
+    const result = migrateSwnCharacterSnapshot(snapshot, 0);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toBe('unsupported-version');
+  });
+
+  /** The whole read path, as the store runs it. */
+  it('reads a stored payload of its own version', () => {
+    const result = readArtifactPayload(
+      swnCharacterArtifactKind as AnyArtifactKindEntry,
+      snapshot,
+      SWN_CHARACTER_PAYLOAD_VERSION,
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('quarantines a payload from a version it has no step for', () => {
+    const result = readArtifactPayload(
+      swnCharacterArtifactKind as AnyArtifactKindEntry,
+      snapshot,
+      SWN_CHARACTER_PAYLOAD_VERSION + 1,
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('loads a codec that round-trips the payload', async () => {
+    const codec = await swnCharacterArtifactKind.loadCodec();
+    const accepted = validateSwnCharacterSnapshot(snapshot);
+
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) {
+      return;
+    }
+    const { RNG } = await import('@ironarachne/rng');
+    const live = codec.fromSnapshot(accepted.value, new RNG('unused'));
+
+    expect(codec.toSnapshot(live)).toEqual(accepted.value);
+  });
+});

--- a/src/lib/swn/swn_character_artifact_kind.ts
+++ b/src/lib/swn/swn_character_artifact_kind.ts
@@ -1,0 +1,270 @@
+import pistol from '$lib/assets/icons/set3/gun-pistol.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import type { SWNCharacter } from './character';
+import type { SwnCharacterSnapshot } from './swn_character_snapshot';
+
+/**
+ * Stable artifact kind id.
+ *
+ * Concept first, system as the qualifier, so every character kind sorts together in a vault
+ * listing. A Stars Without Number character is a set of numbers that mean something only under that
+ * ruleset — skill levels that cap at the class, saving throws counted downwards, Effort — so it is
+ * system-qualified per decision 4 of docs/workshop.md, alongside `character.adnd-2e` and
+ * `character.dcc`.
+ */
+export const SWN_CHARACTER_ARTIFACT_KIND = 'character.swn' as const;
+
+/** Version 1. The first shape a SWN character has been stored in. */
+export const SWN_CHARACTER_PAYLOAD_VERSION = 1 as const;
+
+/**
+ * The numbers a character sheet cannot be read without.
+ *
+ * Not every number on the character. The stored block runs to a dozen more — the three armour
+ * classes, the two attack bonuses, Effort, credits — and a validator listing all of them would be a
+ * second copy of `SWNCharacter` living in a module that does not own it, and the copy is the half
+ * that goes stale. What a validator owes is what reading depends on.
+ */
+const CHARACTER_NUMBER_FIELDS = [
+  'currentLevel',
+  'hitPoints',
+  'armorClassEquipped',
+  'savingThrowMental',
+  'savingThrowEvasion',
+  'savingThrowPhysical',
+];
+
+function hasNumberFields(record: Record<string, unknown>, keys: readonly string[]): boolean {
+  return keys.every((key) => Number.isFinite(record[key]));
+}
+
+/** A named row, which is what most of a SWN character is made of. */
+function isNamedObjectArray(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.every((entry) => {
+      const record = asRecord(entry);
+      return record !== null && typeof record.name === 'string';
+    })
+  );
+}
+
+function validateNamedList(value: unknown, field: string): PayloadResult<unknown> {
+  if (value === undefined || isNamedObjectArray(value)) {
+    return acceptedPayload(value);
+  }
+  return rejectedPayload(
+    'invalid-payload',
+    `SWN character ${field} is not a list of named entries`,
+  );
+}
+
+/**
+ * The six stats, each a score and the modifier derived from it.
+ *
+ * Both numbers are checked because both are stored and both are shown. The modifier is derivable
+ * from the score, which is exactly why it must be validated rather than recomputed: a referee who
+ * has adjusted one has made a decision, and a reader that quietly recalculated it would overrule
+ * them.
+ */
+function validateStats(value: unknown): PayloadResult<unknown> {
+  if (
+    !Array.isArray(value) ||
+    !value.every((entry) => {
+      const stat = asRecord(entry);
+      return (
+        stat !== null &&
+        hasStringFields(stat, ['name', 'abbreviation']) &&
+        hasNumberFields(stat, ['score', 'modifier'])
+      );
+    })
+  ) {
+    return rejectedPayload(
+      'invalid-payload',
+      'SWN character stats are not named scores with modifiers',
+    );
+  }
+  return acceptedPayload(value);
+}
+
+/** Skills, which the sheet prints as `Shoot-1` and an editor offers a level for. */
+function validateSkills(value: unknown): PayloadResult<unknown> {
+  if (
+    !Array.isArray(value) ||
+    !value.every((entry) => {
+      const skill = asRecord(entry);
+      return skill !== null && typeof skill.name === 'string' && Number.isFinite(skill.level);
+    })
+  ) {
+    return rejectedPayload('invalid-payload', 'SWN character skills are not named levels');
+  }
+  return acceptedPayload(value);
+}
+
+/** Foci, which carry their own level: the pick and its level are the row itself. */
+function validateFocuses(value: unknown): PayloadResult<unknown> {
+  if (
+    !Array.isArray(value) ||
+    !value.every((entry) => {
+      const focus = asRecord(entry);
+      return (
+        focus !== null && typeof focus.name === 'string' && Number.isFinite(focus.currentLevel)
+      );
+    })
+  ) {
+    return rejectedPayload('invalid-payload', 'SWN character focuses are not named levels');
+  }
+  return acceptedPayload(value);
+}
+
+/** Class abilities, every one of which the sheet prints by its description. */
+function validateAbilities(value: unknown): PayloadResult<unknown> {
+  if (
+    !Array.isArray(value) ||
+    !value.every((entry) => {
+      const ability = asRecord(entry);
+      return ability !== null && typeof ability.description === 'string';
+    })
+  ) {
+    return rejectedPayload('invalid-payload', 'SWN character abilities are not described entries');
+  }
+  return acceptedPayload(value);
+}
+
+/**
+ * The psychic picks, when there are any.
+ *
+ * Absent is accepted, and deliberately: a character with no psychic skill has no picks to record,
+ * and a payload written before the field existed is a character whose disciplines were never
+ * recorded as decisions — not a corrupt one. `swnCharacterFromSnapshot` supplies the empty list.
+ */
+function validatePsychicPicks(value: unknown): PayloadResult<unknown> {
+  if (
+    value !== undefined &&
+    (!Array.isArray(value) ||
+      !value.every((entry) => {
+        const pick = asRecord(entry);
+        return (
+          pick !== null &&
+          hasStringFields(pick, ['disciplineName', 'abilityName']) &&
+          Number.isFinite(pick.level)
+        );
+      }))
+  ) {
+    return rejectedPayload(
+      'invalid-payload',
+      'SWN character psychicPicks are not disciplines drawn at a level',
+    );
+  }
+  return acceptedPayload(value);
+}
+
+/** A background or a character class: a named row the sheet reads the character from. */
+function validateNamedRow(value: unknown, field: string): PayloadResult<unknown> {
+  const record = asRecord(value);
+  if (record === null || typeof record.name !== 'string') {
+    return rejectedPayload('invalid-payload', `SWN character ${field} has no name`);
+  }
+  return acceptedPayload(record);
+}
+
+/** Checks what `swnCharacterFromSnapshot` depends on, and what a sheet is printed from. */
+export function validateSwnCharacterSnapshot(
+  payload: unknown,
+): PayloadResult<SwnCharacterSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'SWN character payload is not an object');
+  }
+  if (!hasStringFields(record, ['firstName', 'lastName'])) {
+    return rejectedPayload('invalid-payload', 'SWN character payload needs string names');
+  }
+  if (!hasNumberFields(record, CHARACTER_NUMBER_FIELDS)) {
+    return rejectedPayload(
+      'invalid-payload',
+      `SWN character payload needs numeric ${CHARACTER_NUMBER_FIELDS.join(', ')}`,
+    );
+  }
+
+  const checks: PayloadResult<unknown>[] = [
+    validateNamedRow(record.background, 'background'),
+    validateNamedRow(record.characterClass, 'characterClass'),
+    validateStats(record.stats),
+    validateSkills(record.skills),
+    validateFocuses(record.focuses),
+    validateAbilities(record.abilities),
+    validatePsychicPicks(record.psychicPicks),
+    validateNamedList(record.equipment, 'equipment'),
+    validateNamedList(record.rangedWeapons, 'rangedWeapons'),
+    validateNamedList(record.meleeWeapons, 'meleeWeapons'),
+    validateNamedList(record.armor, 'armor'),
+  ];
+  const failed = checks.find((check) => !check.ok);
+  if (failed !== undefined) {
+    return failed as PayloadResult<SwnCharacterSnapshot>;
+  }
+
+  return acceptedPayload(record as unknown as SwnCharacterSnapshot);
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day the
+ * shape changes. A kind without one looks complete right up until it silently drops someone's work
+ * — and local-only means there is no server-side migration to fall back on.
+ */
+export function migrateSwnCharacterSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<SwnCharacterSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `SWN character has no migration from payload version ${from}; version ${SWN_CHARACTER_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/** What to call a character saved unnamed: what they are, which they always have. */
+function swnCharacterName(snapshot: SwnCharacterSnapshot): string {
+  const given = `${snapshot.firstName} ${snapshot.lastName}`.trim();
+  if (given !== '') {
+    return given;
+  }
+  const what = `${snapshot.background.name} ${snapshot.characterClass.name}`.trim();
+  return what === '' ? 'SWN Character' : what;
+}
+
+/**
+ * A Stars Without Number character as an artifact.
+ *
+ * The codec is cheap on both sides — the snapshot is the character, and reading one back adds a
+ * default and nothing else — so unlike settlement or heraldry there is no expensive half to keep
+ * out of the chunk that merely lists a project. It is still loaded on demand, because the contract
+ * is the same for every kind and a codec that happens to be cheap today is not a reason to wire it
+ * differently from its neighbours.
+ */
+export const swnCharacterArtifactKind = defineArtifactKind<SWNCharacter, SwnCharacterSnapshot>({
+  kind: SWN_CHARACTER_ARTIFACT_KIND,
+  displayName: 'SWN Character',
+  icon: pistol,
+  payloadVersion: SWN_CHARACTER_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { swnCharacterFromSnapshotWithRng, toSwnCharacterSnapshot } =
+      await import('./swn_character_snapshot.js');
+    return {
+      toSnapshot: toSwnCharacterSnapshot,
+      fromSnapshot: swnCharacterFromSnapshotWithRng,
+    };
+  },
+  nameOf: swnCharacterName,
+  validate: validateSwnCharacterSnapshot,
+  migrate: migrateSwnCharacterSnapshot,
+});

--- a/src/lib/swn/swn_character_editing.test.ts
+++ b/src/lib/swn/swn_character_editing.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollSwnCharacterSnapshot } from './swn_character_roll.js';
+import {
+  addSwnCharacterAbility,
+  addSwnCharacterArmor,
+  addSwnCharacterEquipment,
+  addSwnCharacterSkill,
+  addSwnCharacterWeapon,
+  removeSwnCharacterAbility,
+  removeSwnCharacterArmor,
+  removeSwnCharacterEquipment,
+  removeSwnCharacterFocus,
+  removeSwnCharacterSkill,
+  removeSwnCharacterWeapon,
+  setSwnCharacterAbilityDescription,
+  setSwnCharacterArmorClass,
+  setSwnCharacterArmorName,
+  setSwnCharacterBackgroundName,
+  setSwnCharacterClassName,
+  setSwnCharacterEquipmentName,
+  setSwnCharacterFocusLevel,
+  setSwnCharacterFocusName,
+  setSwnCharacterNumber,
+  setSwnCharacterSkillLevel,
+  setSwnCharacterSkillName,
+  setSwnCharacterStat,
+  setSwnCharacterText,
+  setSwnCharacterWeaponField,
+  swnDerivedFromStats,
+} from './swn_character_editing.js';
+
+const character = rollSwnCharacterSnapshot('editing-fixture');
+
+describe('editing a SWN character', () => {
+  /** Requirement 4.4: one field at a time, and nothing else moves. */
+  it('changes one field and leaves the rest alone', () => {
+    const renamed = setSwnCharacterText(character, 'firstName', 'Vex');
+
+    expect(renamed.firstName).toBe('Vex');
+    expect({ ...renamed, firstName: character.firstName }).toEqual(character);
+  });
+
+  it('never writes into the snapshot it was given', () => {
+    const before = structuredClone(character);
+    setSwnCharacterNumber(character, 'hitPoints', 99);
+
+    expect(character).toEqual(before);
+  });
+
+  it('refuses a number a user has emptied rather than storing NaN', () => {
+    expect(setSwnCharacterNumber(character, 'hitPoints', Number.NaN)).toBe(character);
+    expect(setSwnCharacterStat(character, 0, 'score', Number.NaN)).toBe(character);
+    expect(setSwnCharacterSkillLevel(character, 0, Number.NaN)).toBe(character);
+    expect(setSwnCharacterArmorClass(character, 0, Number.NaN)).toBe(character);
+  });
+
+  it('rewrites the background and the class by name', () => {
+    expect(setSwnCharacterBackgroundName(character, 'Dilettante').background.name).toBe(
+      'Dilettante',
+    );
+    expect(setSwnCharacterClassName(character, 'Warrior').characterClass.name).toBe('Warrior');
+  });
+
+  /** 4.2, stated as a test: a score is not allowed to drag its modifier along. */
+  it('does not move a modifier when a score changes', () => {
+    const edited = setSwnCharacterStat(character, 0, 'score', 18);
+
+    expect(edited.stats[0].score).toBe(18);
+    expect(edited.stats[0].modifier).toBe(character.stats[0].modifier);
+  });
+
+  it('recalculates the modifiers and saves only when asked', () => {
+    const raised = setSwnCharacterStat(character, 0, 'score', 3);
+    const derived = swnDerivedFromStats(raised);
+
+    expect(derived.stats[0].modifier).toBe(-2);
+    for (const stat of derived.stats) {
+      expect(Number.isFinite(stat.modifier)).toBe(true);
+    }
+    const best = (abbreviation: string) =>
+      derived.stats.find((stat) => stat.abbreviation === abbreviation)?.modifier ?? 0;
+    expect(derived.savingThrowPhysical).toBe(15 - Math.max(best('STR'), best('CON')));
+    expect(derived.savingThrowEvasion).toBe(15 - Math.max(best('INT'), best('DEX')));
+    expect(derived.savingThrowMental).toBe(15 - Math.max(best('WIS'), best('CHA')));
+  });
+
+  it('leaves the numbers it cannot reconstruct alone when it recalculates', () => {
+    const derived = swnDerivedFromStats(setSwnCharacterNumber(character, 'hitPoints', 3));
+
+    expect(derived.hitPoints).toBe(3);
+    expect(derived.effort).toBe(character.effort);
+    expect(derived.armorClassEquipped).toBe(character.armorClassEquipped);
+    expect(derived.credits).toBe(character.credits);
+  });
+
+  it('edits, adds and removes a skill', () => {
+    const renamed = setSwnCharacterSkillName(character, 0, 'Program');
+    expect(renamed.skills[0].name).toBe('Program');
+
+    const levelled = setSwnCharacterSkillLevel(renamed, 0, 2);
+    expect(levelled.skills[0].level).toBe(2);
+
+    const added = addSwnCharacterSkill(levelled);
+    expect(added.skills).toHaveLength(levelled.skills.length + 1);
+
+    const removed = removeSwnCharacterSkill(added, added.skills.length - 1);
+    expect(removed.skills).toEqual(levelled.skills);
+  });
+
+  it('edits a focus by name and level, which is the pick itself', () => {
+    const renamed = setSwnCharacterFocusName(character, 0, 'Alert');
+    expect(renamed.focuses[0].name).toBe('Alert');
+    // The rulebook text under it is untouched: it is not the user's to rewrite.
+    expect(renamed.focuses[0].levelOneDescription).toBe(character.focuses[0].levelOneDescription);
+
+    const levelled = setSwnCharacterFocusLevel(renamed, 0, 2);
+    expect(levelled.focuses[0].currentLevel).toBe(2);
+
+    expect(removeSwnCharacterFocus(levelled, 0).focuses).toHaveLength(character.focuses.length - 1);
+  });
+
+  it('edits, adds and removes an ability', () => {
+    const edited = setSwnCharacterAbilityDescription(character, 0, 'Reads minds on Tuesdays');
+    expect(edited.abilities[0].description).toBe('Reads minds on Tuesdays');
+    expect(edited.abilities[0].kind).toBe(character.abilities[0].kind);
+
+    const added = addSwnCharacterAbility(edited);
+    expect(added.abilities).toHaveLength(edited.abilities.length + 1);
+    expect(removeSwnCharacterAbility(added, added.abilities.length - 1).abilities).toEqual(
+      edited.abilities,
+    );
+  });
+
+  it('edits, adds and removes equipment', () => {
+    const renamed = setSwnCharacterEquipmentName(character, 0, 'A very old backpack');
+    expect(renamed.equipment[0].name).toBe('A very old backpack');
+
+    const added = addSwnCharacterEquipment(renamed);
+    expect(added.equipment).toHaveLength(renamed.equipment.length + 1);
+    expect(removeSwnCharacterEquipment(added, added.equipment.length - 1).equipment).toEqual(
+      renamed.equipment,
+    );
+  });
+
+  it('keeps the two weapon lists apart', () => {
+    const withRanged = addSwnCharacterWeapon(character, 'rangedWeapons');
+    const named = setSwnCharacterWeaponField(
+      withRanged,
+      'rangedWeapons',
+      withRanged.rangedWeapons.length - 1,
+      'name',
+      'Laser pistol',
+    );
+
+    expect(named.rangedWeapons[named.rangedWeapons.length - 1].name).toBe('Laser pistol');
+    expect(named.meleeWeapons).toEqual(character.meleeWeapons);
+
+    expect(
+      removeSwnCharacterWeapon(named, 'rangedWeapons', named.rangedWeapons.length - 1)
+        .rangedWeapons,
+    ).toEqual(character.rangedWeapons);
+  });
+
+  it('edits, adds and removes armor', () => {
+    const added = addSwnCharacterArmor(character);
+    const index = added.armor.length - 1;
+    const named = setSwnCharacterArmorClass(
+      setSwnCharacterArmorName(added, index, 'Deflector field'),
+      index,
+      15,
+    );
+
+    expect(named.armor[index]).toMatchObject({ name: 'Deflector field', ac: 15 });
+    expect(removeSwnCharacterArmor(named, index).armor).toEqual(character.armor);
+  });
+
+  /** An index nothing is at is a no-op, not a throw: the editor is driven by a live list. */
+  it('ignores an index that is not there', () => {
+    expect(setSwnCharacterSkillName(character, 99, 'Fix')).toBe(character);
+    expect(setSwnCharacterFocusName(character, -1, 'Alert')).toBe(character);
+    expect(setSwnCharacterAbilityDescription(character, 99, 'nothing')).toBe(character);
+    expect(setSwnCharacterEquipmentName(character, 99, 'nothing')).toBe(character);
+    expect(setSwnCharacterWeaponField(character, 'meleeWeapons', 99, 'name', 'nothing')).toBe(
+      character,
+    );
+    expect(setSwnCharacterArmorName(character, 99, 'nothing')).toBe(character);
+    expect(removeSwnCharacterSkill(character, 99)).toBe(character);
+    expect(removeSwnCharacterFocus(character, 99)).toBe(character);
+    expect(removeSwnCharacterAbility(character, 99)).toBe(character);
+    expect(removeSwnCharacterEquipment(character, 99)).toBe(character);
+    expect(removeSwnCharacterArmor(character, 99)).toBe(character);
+    expect(removeSwnCharacterWeapon(character, 'rangedWeapons', 99)).toBe(character);
+    expect(setSwnCharacterStat(character, 99, 'score', 10)).toBe(character);
+  });
+});

--- a/src/lib/swn/swn_character_editing.ts
+++ b/src/lib/swn/swn_character_editing.ts
@@ -1,0 +1,384 @@
+/**
+ * Editing a stored Stars Without Number character, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction — renaming a character must not
+ * disturb their stats, and correcting one saving throw must not re-roll the rest — and it is what
+ * lets the editing framework compare what is on screen against what was read to decide whether
+ * anything needs saving.
+ *
+ * **Nothing here recomputes anything.** Editing Dexterity does not move the ranged attack bonus,
+ * and editing a stat's score does not move its modifier. That is requirement 4.2 taken seriously
+ * rather than a gap: a referee who has adjusted a number has made a decision, and a form that
+ * quietly corrected everything derived from it would overrule them repeatedly.
+ * `swnDerivedFromStats` exists for a caller that wants the arithmetic offered as an explicit
+ * command — see the editor, where it is a button.
+ */
+
+import {
+  createArmor,
+  createMiscItem,
+  createSkill,
+  createSpecialAbility,
+  createWeapon,
+  statModifierForScore,
+  type Stat,
+  type Weapon,
+} from './character.js';
+import type { SwnCharacterSnapshot } from './swn_character_snapshot.js';
+
+/** The identity fields a user may rewrite. */
+export type SwnCharacterTextField = 'firstName' | 'lastName';
+
+/**
+ * The whole numbers the sheet shows.
+ *
+ * All of them, including the three armour classes the screen shows only one of: an editor that
+ * offered the equipped AC alone would leave a character whose armour a user has rewritten carrying
+ * an unequipped number nothing on screen explains.
+ */
+export const SWN_NUMBER_FIELDS = [
+  'currentLevel',
+  'hitPoints',
+  'effort',
+  'attackBonus',
+  'meleeAttackBonus',
+  'rangedAttackBonus',
+  'armorClassBase',
+  'armorClassUnequipped',
+  'armorClassEquipped',
+  'credits',
+  'savingThrowMental',
+  'savingThrowEvasion',
+  'savingThrowPhysical',
+] as const;
+
+export type SwnCharacterNumberField = (typeof SWN_NUMBER_FIELDS)[number];
+
+/** The two weapon lists, which the sheet prints under separate headings and attack bonuses. */
+export type SwnWeaponList = 'rangedWeapons' | 'meleeWeapons';
+
+/** The parts of a weapon the sheet prints on its line. */
+export type SwnWeaponField = 'name' | 'damage' | 'range';
+
+export function setSwnCharacterText(
+  snapshot: SwnCharacterSnapshot,
+  field: SwnCharacterTextField,
+  value: string,
+): SwnCharacterSnapshot {
+  return { ...snapshot, [field]: value };
+}
+
+/**
+ * A whole number on the sheet.
+ *
+ * A field the user has emptied arrives as `NaN` and is refused rather than stored: a character with
+ * hit points of `NaN` is a payload that fails its own kind's validation, which the user would meet
+ * as a broken artifact rather than as a rejected keystroke.
+ */
+export function setSwnCharacterNumber(
+  snapshot: SwnCharacterSnapshot,
+  field: SwnCharacterNumberField,
+  value: number,
+): SwnCharacterSnapshot {
+  return Number.isFinite(value) ? { ...snapshot, [field]: value } : snapshot;
+}
+
+/** The background's name, which is what the sheet prints and what the character was built from. */
+export function setSwnCharacterBackgroundName(
+  snapshot: SwnCharacterSnapshot,
+  name: string,
+): SwnCharacterSnapshot {
+  return { ...snapshot, background: { ...snapshot.background, name } };
+}
+
+export function setSwnCharacterClassName(
+  snapshot: SwnCharacterSnapshot,
+  name: string,
+): SwnCharacterSnapshot {
+  return { ...snapshot, characterClass: { ...snapshot.characterClass, name } };
+}
+
+function hasIndex(length: number, index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < length;
+}
+
+function replaceAt<T>(list: T[], index: number, value: T): T[] {
+  return list.map((entry, position) => (position === index ? value : entry));
+}
+
+function removeAt<T>(list: T[], index: number): T[] {
+  return list.filter((_entry, position) => position !== index);
+}
+
+/**
+ * One half of one stat.
+ *
+ * The score and the modifier are edited separately and neither follows the other, for the reason in
+ * the module comment. A user who wants the standard arithmetic asks for it.
+ */
+export function setSwnCharacterStat(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+  part: 'score' | 'modifier',
+  value: number,
+): SwnCharacterSnapshot {
+  if (!Number.isFinite(value) || !hasIndex(snapshot.stats.length, index)) {
+    return snapshot;
+  }
+  const stat: Stat = { ...snapshot.stats[index], [part]: value };
+  return { ...snapshot, stats: replaceAt(snapshot.stats, index, stat) };
+}
+
+/**
+ * The six modifiers and the three saving throws as the rules would derive them from the scores.
+ *
+ * Offered as a command rather than run whenever a score changes — the destructive kind of helpful,
+ * kept explicit. It touches nothing else: hit points, Effort, the attack bonuses and the armour
+ * classes are left exactly as they are, because those took dice, a class and a pack of equipment
+ * that this cannot reconstruct.
+ */
+export function swnDerivedFromStats(snapshot: SwnCharacterSnapshot): SwnCharacterSnapshot {
+  const stats = snapshot.stats.map((stat) => ({
+    ...stat,
+    modifier: statModifierForScore(stat.score),
+  }));
+  const modifier = (abbreviation: string) =>
+    stats.find((stat) => stat.abbreviation === abbreviation)?.modifier ?? 0;
+
+  return {
+    ...snapshot,
+    stats,
+    savingThrowMental: 15 - Math.max(modifier('WIS'), modifier('CHA')),
+    savingThrowEvasion: 15 - Math.max(modifier('INT'), modifier('DEX')),
+    savingThrowPhysical: 15 - Math.max(modifier('STR'), modifier('CON')),
+  };
+}
+
+export function setSwnCharacterSkillName(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+  name: string,
+): SwnCharacterSnapshot {
+  return hasIndex(snapshot.skills.length, index)
+    ? {
+        ...snapshot,
+        skills: replaceAt(snapshot.skills, index, { ...snapshot.skills[index], name }),
+      }
+    : snapshot;
+}
+
+export function setSwnCharacterSkillLevel(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+  level: number,
+): SwnCharacterSnapshot {
+  return Number.isFinite(level) && hasIndex(snapshot.skills.length, index)
+    ? {
+        ...snapshot,
+        skills: replaceAt(snapshot.skills, index, { ...snapshot.skills[index], level }),
+      }
+    : snapshot;
+}
+
+/** A blank skill line. `non-combat` because it is the type most skills have, and it is editable. */
+export function addSwnCharacterSkill(snapshot: SwnCharacterSnapshot): SwnCharacterSnapshot {
+  return { ...snapshot, skills: [...snapshot.skills, createSkill('', 'non-combat')] };
+}
+
+export function removeSwnCharacterSkill(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+): SwnCharacterSnapshot {
+  return hasIndex(snapshot.skills.length, index)
+    ? { ...snapshot, skills: removeAt(snapshot.skills, index) }
+    : snapshot;
+}
+
+/**
+ * A focus's name.
+ *
+ * The row is the pick: `focuses` carries the name and the level the character holds it at, and
+ * editing either is how a user corrects what they took. The level-one and level-two descriptions
+ * travel with it untouched — they are the rulebook's text, not the user's.
+ */
+export function setSwnCharacterFocusName(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+  name: string,
+): SwnCharacterSnapshot {
+  return hasIndex(snapshot.focuses.length, index)
+    ? {
+        ...snapshot,
+        focuses: replaceAt(snapshot.focuses, index, { ...snapshot.focuses[index], name }),
+      }
+    : snapshot;
+}
+
+export function setSwnCharacterFocusLevel(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+  currentLevel: number,
+): SwnCharacterSnapshot {
+  return Number.isFinite(currentLevel) && hasIndex(snapshot.focuses.length, index)
+    ? {
+        ...snapshot,
+        focuses: replaceAt(snapshot.focuses, index, {
+          ...snapshot.focuses[index],
+          currentLevel,
+        }),
+      }
+    : snapshot;
+}
+
+export function removeSwnCharacterFocus(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+): SwnCharacterSnapshot {
+  return hasIndex(snapshot.focuses.length, index)
+    ? { ...snapshot, focuses: removeAt(snapshot.focuses, index) }
+    : snapshot;
+}
+
+/**
+ * An ability's text.
+ *
+ * Abilities are stored as a union of effects, and every variant carries the description the sheet
+ * prints. Only that description is offered: rewriting a `bonusSkillOfType`'s list of types would be
+ * editing an instruction that has already run, and the skill it granted is in `skills` where a user
+ * can see it.
+ */
+export function setSwnCharacterAbilityDescription(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+  description: string,
+): SwnCharacterSnapshot {
+  return hasIndex(snapshot.abilities.length, index)
+    ? {
+        ...snapshot,
+        abilities: replaceAt(snapshot.abilities, index, {
+          ...snapshot.abilities[index],
+          description,
+        }),
+      }
+    : snapshot;
+}
+
+/** A blank ability, which is a plain described one: the variant that grants nothing by itself. */
+export function addSwnCharacterAbility(snapshot: SwnCharacterSnapshot): SwnCharacterSnapshot {
+  return { ...snapshot, abilities: [...snapshot.abilities, createSpecialAbility('')] };
+}
+
+export function removeSwnCharacterAbility(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+): SwnCharacterSnapshot {
+  return hasIndex(snapshot.abilities.length, index)
+    ? { ...snapshot, abilities: removeAt(snapshot.abilities, index) }
+    : snapshot;
+}
+
+export function setSwnCharacterEquipmentName(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+  name: string,
+): SwnCharacterSnapshot {
+  return hasIndex(snapshot.equipment.length, index)
+    ? {
+        ...snapshot,
+        equipment: replaceAt(snapshot.equipment, index, {
+          ...snapshot.equipment[index],
+          name,
+        }),
+      }
+    : snapshot;
+}
+
+/** A blank pack item. A container would need a tech level nobody has said anything about. */
+export function addSwnCharacterEquipment(snapshot: SwnCharacterSnapshot): SwnCharacterSnapshot {
+  return { ...snapshot, equipment: [...snapshot.equipment, createMiscItem('')] };
+}
+
+export function removeSwnCharacterEquipment(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+): SwnCharacterSnapshot {
+  return hasIndex(snapshot.equipment.length, index)
+    ? { ...snapshot, equipment: removeAt(snapshot.equipment, index) }
+    : snapshot;
+}
+
+/**
+ * One field of one weapon, in whichever of the two lists it is in.
+ *
+ * The lists do not talk to each other. A pistol in the ranged list and a pistol-whip in the melee
+ * list are two lines on the sheet, and guessing that a rename of one was meant for the other would
+ * be guessing.
+ */
+export function setSwnCharacterWeaponField(
+  snapshot: SwnCharacterSnapshot,
+  list: SwnWeaponList,
+  index: number,
+  field: SwnWeaponField,
+  value: string,
+): SwnCharacterSnapshot {
+  return hasIndex(snapshot[list].length, index)
+    ? {
+        ...snapshot,
+        [list]: replaceAt(snapshot[list], index, {
+          ...snapshot[list][index],
+          [field]: value,
+        } as Weapon),
+      }
+    : snapshot;
+}
+
+export function addSwnCharacterWeapon(
+  snapshot: SwnCharacterSnapshot,
+  list: SwnWeaponList,
+): SwnCharacterSnapshot {
+  return { ...snapshot, [list]: [...snapshot[list], createWeapon('', '', '')] };
+}
+
+export function removeSwnCharacterWeapon(
+  snapshot: SwnCharacterSnapshot,
+  list: SwnWeaponList,
+  index: number,
+): SwnCharacterSnapshot {
+  return hasIndex(snapshot[list].length, index)
+    ? { ...snapshot, [list]: removeAt(snapshot[list], index) }
+    : snapshot;
+}
+
+export function setSwnCharacterArmorName(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+  name: string,
+): SwnCharacterSnapshot {
+  return hasIndex(snapshot.armor.length, index)
+    ? { ...snapshot, armor: replaceAt(snapshot.armor, index, { ...snapshot.armor[index], name }) }
+    : snapshot;
+}
+
+export function setSwnCharacterArmorClass(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+  ac: number,
+): SwnCharacterSnapshot {
+  return Number.isFinite(ac) && hasIndex(snapshot.armor.length, index)
+    ? { ...snapshot, armor: replaceAt(snapshot.armor, index, { ...snapshot.armor[index], ac }) }
+    : snapshot;
+}
+
+export function addSwnCharacterArmor(snapshot: SwnCharacterSnapshot): SwnCharacterSnapshot {
+  return { ...snapshot, armor: [...snapshot.armor, createArmor('', 10)] };
+}
+
+export function removeSwnCharacterArmor(
+  snapshot: SwnCharacterSnapshot,
+  index: number,
+): SwnCharacterSnapshot {
+  return hasIndex(snapshot.armor.length, index)
+    ? { ...snapshot, armor: removeAt(snapshot.armor, index) }
+    : snapshot;
+}

--- a/src/lib/swn/swn_character_roll.test.ts
+++ b/src/lib/swn/swn_character_roll.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  readSwnCharacterGeneratorConfig,
+  resolveSwnNameGeneratorSet,
+  rollSwnCharacter,
+  rollSwnCharacterSnapshot,
+  SWN_DEFAULT_NAME_SET,
+} from './swn_character_roll.js';
+
+describe('rollSwnCharacter', () => {
+  /** Requirement 2.2, and the defect this module was written to fix. */
+  it('gives the same character, names included, for the same seed', () => {
+    const first = rollSwnCharacter('a-fixed-seed');
+    const second = rollSwnCharacter('a-fixed-seed');
+
+    expect(second.character).toEqual(first.character);
+    expect(second.character.firstName).toBe(first.character.firstName);
+    expect(second.character.lastName).toBe(first.character.lastName);
+  });
+
+  it('gives a different character for a different seed', () => {
+    const first = rollSwnCharacter('one-seed');
+    const second = rollSwnCharacter('another-seed');
+
+    expect(second.character).not.toEqual(first.character);
+  });
+
+  /**
+   * The reason the name is drawn from its own stream: choosing a naming source must not shift which
+   * background, class or focus the same seed produces.
+   */
+  it('leaves the character unchanged when only the naming settings differ', () => {
+    const plain = rollSwnCharacter('shared-seed');
+    const elvish = rollSwnCharacter('shared-seed', { nameGeneratorSet: 'elf' });
+
+    expect(elvish.character.background).toEqual(plain.character.background);
+    expect(elvish.character.characterClass).toEqual(plain.character.characterClass);
+    expect(elvish.character.focuses).toEqual(plain.character.focuses);
+    expect(elvish.character.skills).toEqual(plain.character.skills);
+    expect(elvish.character.firstName).not.toBe(plain.character.firstName);
+  });
+
+  /** An anonymous sheet is an artifact nobody can pick out of a vault listing (3.5). */
+  it('always names the character, even with no naming source chosen', () => {
+    const { character, nameGeneratorSet } = rollSwnCharacter('unnamed-seed');
+
+    expect(character.firstName).not.toBe('');
+    expect(character.lastName).not.toBe('');
+    expect(nameGeneratorSet).toBe(SWN_DEFAULT_NAME_SET);
+  });
+
+  it('honours the naming gender that was asked for', () => {
+    const male = rollSwnCharacter('gendered-seed', { namingGender: 'male' });
+    const female = rollSwnCharacter('gendered-seed', { namingGender: 'female' });
+
+    expect(male.character.firstName).not.toBe(female.character.firstName);
+    // The body is the seed's, not the gender picker's.
+    expect(female.character.stats).toEqual(male.character.stats);
+  });
+
+  it('reports the set it actually used rather than the one it was asked for', () => {
+    const { nameGeneratorSet } = rollSwnCharacter('substituted-seed', {
+      nameGeneratorSet: 'a-set-this-build-does-not-have',
+    });
+
+    expect(nameGeneratorSet).toBe(SWN_DEFAULT_NAME_SET);
+  });
+
+  it('rolls a snapshot from the same seed and settings', () => {
+    const snapshot = rollSwnCharacterSnapshot('reroll-seed', { nameGeneratorSet: 'dwarf' });
+
+    expect(snapshot).toEqual(
+      rollSwnCharacter('reroll-seed', { nameGeneratorSet: 'dwarf' }).character,
+    );
+  });
+});
+
+describe('resolveSwnNameGeneratorSet', () => {
+  it('keeps a set this build has', () => {
+    expect(resolveSwnNameGeneratorSet('elf')).toBe('elf');
+  });
+
+  it('falls back rather than throwing on one it does not', () => {
+    expect(resolveSwnNameGeneratorSet('nothing-of-the-sort')).toBe(SWN_DEFAULT_NAME_SET);
+    expect(resolveSwnNameGeneratorSet(undefined)).toBe(SWN_DEFAULT_NAME_SET);
+    expect(resolveSwnNameGeneratorSet('')).toBe(SWN_DEFAULT_NAME_SET);
+  });
+});
+
+describe('readSwnCharacterGeneratorConfig', () => {
+  it('reads back what the generator recorded', () => {
+    expect(
+      readSwnCharacterGeneratorConfig({ nameGeneratorSet: 'dwarf', namingGender: 'female' }),
+    ).toEqual({ nameGeneratorSet: 'dwarf', namingGender: 'female' });
+  });
+
+  /** Provenance is `Record<string, unknown>`: this is the boundary where that becomes typed. */
+  it('drops what it does not recognise rather than coercing it', () => {
+    expect(
+      readSwnCharacterGeneratorConfig({
+        nameGeneratorSet: 42,
+        namingGender: 'neither',
+        somethingElse: true,
+      }),
+    ).toEqual({});
+    expect(readSwnCharacterGeneratorConfig({})).toEqual({});
+  });
+});

--- a/src/lib/swn/swn_character_roll.ts
+++ b/src/lib/swn/swn_character_roll.ts
@@ -1,0 +1,141 @@
+/**
+ * The single path from a seed to a Stars Without Number character, and the record of how it was
+ * rolled.
+ *
+ * Requirement 2.2 of docs/workshop.md wants the same seed and settings to give the same character.
+ * `SwnCharacterGenerator.svelte` satisfied that for the character's own numbers and for nothing
+ * else: it named from `` new RNG(`${Date.now()}-swn-name`) ``, so the seed on screen reproduced a
+ * body and never the person wearing it. Pressing Generate now draws a *new seed* from the page's
+ * own RNG and the roll itself is a pure function of seed and config.
+ *
+ * The name is drawn from `` `${seed}-swn-name` `` rather than off the character's own stream, so
+ * choosing a naming source cannot shift which background, class or focus the same seed produces.
+ *
+ * **A rolled character always has a name.** The page used to blank `firstName` and `lastName`
+ * whenever the user had not picked a naming source, which is most of the time, so the ordinary
+ * result of pressing Generate was an anonymous sheet — and an artifact nobody can pick out of a
+ * vault listing (requirement 3.5). Absent a chosen source the roll names from the `human` pattern
+ * set, which is what every other character tool here does for a character it has no better hint
+ * for; the naming section is still how a user asks for a different tongue.
+ */
+
+import {
+  generateCharacterName,
+  peopleNameGeneratorsFromNameSet,
+  type NamingGender,
+} from '$lib/characters';
+import { getFantasyNameGeneratorSet, getFantasyNameGeneratorSetNames } from '$lib/names';
+import { RNG } from '@ironarachne/rng';
+
+import { generate, type SWNCharacter } from './character.js';
+import { toSwnCharacterSnapshot, type SwnCharacterSnapshot } from './swn_character_snapshot.js';
+
+/** The pattern set a character is named from when nothing else has been asked for. */
+export const SWN_DEFAULT_NAME_SET = 'human' as const;
+
+/**
+ * What the generator records about how it rolled, and what a re-roll reads back.
+ *
+ * Stated as a type rather than read field by field at the call site so the two ends — what is
+ * written as provenance and what a re-roll expects to find — are in one place and drift loudly
+ * instead of quietly.
+ */
+export type SwnCharacterGeneratorConfigRecord = {
+  /**
+   * The name pattern set the character was named from.
+   *
+   * A character named from a culture records that culture's own pattern set here rather than the
+   * culture's id, so a re-roll produces names of the same tongue without reaching back into the
+   * store for an artifact it has no way to ask for. The link to the culture is an artifact
+   * reference and lives beside the payload, not in this record.
+   */
+  nameGeneratorSet?: string;
+  /** Which name to draw. `random` lets the seed choose, as the page's gender picker does. */
+  namingGender?: NamingGender;
+};
+
+/**
+ * A rolled character and the pattern set its name actually came from.
+ *
+ * The resolved set travels back out because provenance has to record what was *used* rather than
+ * what was asked for: a set this build has since dropped, recorded as it was requested, is
+ * provenance a re-roll cannot honour.
+ */
+export type SwnCharacterRoll = {
+  character: SWNCharacter;
+  nameGeneratorSet: string;
+};
+
+const NAMING_GENDERS: NamingGender[] = ['male', 'female', 'random'];
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Provenance is `Record<string, unknown>` because the store cannot know what any tool puts in it,
+ * so this is the boundary where that becomes typed. Anything unrecognisable is dropped rather than
+ * coerced: a config written by a build that spelled these differently should fall back to the
+ * defaults, not roll a character from a field it misread.
+ */
+export function readSwnCharacterGeneratorConfig(
+  config: Record<string, unknown>,
+): SwnCharacterGeneratorConfigRecord {
+  return {
+    ...(typeof config.nameGeneratorSet === 'string' && config.nameGeneratorSet !== ''
+      ? { nameGeneratorSet: config.nameGeneratorSet }
+      : {}),
+    ...(NAMING_GENDERS.includes(config.namingGender as NamingGender)
+      ? { namingGender: config.namingGender as NamingGender }
+      : {}),
+  };
+}
+
+/**
+ * The pattern set a roll should name from.
+ *
+ * A set this build no longer has falls back to the default rather than throwing:
+ * `getFantasyNameGeneratorSet` refuses a name it does not know, and a character that cannot be
+ * rolled at all is a worse answer than one named in the common tongue.
+ */
+export function resolveSwnNameGeneratorSet(requested: string | undefined): string {
+  if (requested === undefined || requested === '') {
+    return SWN_DEFAULT_NAME_SET;
+  }
+  return getFantasyNameGeneratorSetNames().includes(requested) ? requested : SWN_DEFAULT_NAME_SET;
+}
+
+/**
+ * Roll a character from a seed and a set of options — the one path the generator page and a re-roll
+ * both take.
+ */
+export function rollSwnCharacter(
+  seed: string,
+  config: SwnCharacterGeneratorConfigRecord = {},
+): SwnCharacterRoll {
+  const character = generate(new RNG(seed));
+
+  const nameGeneratorSet = resolveSwnNameGeneratorSet(config.nameGeneratorSet);
+  const nameRng = new RNG(`${seed}-swn-name`);
+  const nameSet = getFantasyNameGeneratorSet(nameGeneratorSet, nameRng);
+  const name = generateCharacterName(
+    nameRng,
+    peopleNameGeneratorsFromNameSet(nameSet),
+    config.namingGender ?? 'random',
+  );
+
+  character.firstName = name.firstName;
+  character.lastName = name.lastName;
+
+  return { character, nameGeneratorSet };
+}
+
+/**
+ * Roll a fresh character snapshot from a seed and the settings it was first made with — the
+ * destructive half of editing (requirement 4.3), and what `ARTIFACT_EDITORS` registers as this
+ * kind's roller.
+ */
+export function rollSwnCharacterSnapshot(
+  seed: string,
+  config: SwnCharacterGeneratorConfigRecord = {},
+): SwnCharacterSnapshot {
+  return toSwnCharacterSnapshot(rollSwnCharacter(seed, config).character);
+}

--- a/src/lib/swn/swn_character_snapshot.test.ts
+++ b/src/lib/swn/swn_character_snapshot.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SWNCharacter } from './character.js';
+import { rollSwnCharacter } from './swn_character_roll.js';
+import {
+  swnCharacterFromSnapshot,
+  toSwnCharacterSnapshot,
+  type SwnCharacterSnapshot,
+} from './swn_character_snapshot.js';
+
+/**
+ * A generated character of a given shape, found by sweeping seeds.
+ *
+ * Sweeping rather than hand-building, because the point of a round-trip test is that a character the
+ * generator actually produces survives, and a hand-built one only proves the fields the test author
+ * remembered to set.
+ */
+function rollMatching(predicate: (character: SWNCharacter) => boolean): SWNCharacter {
+  for (let seed = 0; seed < 300; seed += 1) {
+    const { character } = rollSwnCharacter(`roundtrip-${seed}`);
+    if (predicate(character)) {
+      return character;
+    }
+  }
+  throw new Error('no seed in the sweep produced a character of that shape');
+}
+
+const character = rollMatching(() => true);
+
+describe('the SWN character snapshot', () => {
+  /** Requirement 7.2: lossless for everything the sheet shows. */
+  it('round-trips a generated character', () => {
+    expect(swnCharacterFromSnapshot(toSwnCharacterSnapshot(character))).toEqual(character);
+  });
+
+  it('keeps every derived number rather than recomputing it', () => {
+    const restored = swnCharacterFromSnapshot(toSwnCharacterSnapshot(character));
+
+    expect(restored.hitPoints).toBe(character.hitPoints);
+    expect(restored.armorClassEquipped).toBe(character.armorClassEquipped);
+    expect(restored.armorClassUnequipped).toBe(character.armorClassUnequipped);
+    expect(restored.meleeAttackBonus).toBe(character.meleeAttackBonus);
+    expect(restored.rangedAttackBonus).toBe(character.rangedAttackBonus);
+    expect(restored.savingThrowEvasion).toBe(character.savingThrowEvasion);
+    expect(restored.savingThrowMental).toBe(character.savingThrowMental);
+    expect(restored.savingThrowPhysical).toBe(character.savingThrowPhysical);
+    expect(restored.effort).toBe(character.effort);
+  });
+
+  /**
+   * A referee's edit survives the round trip untouched, which is the claim 4.2 actually makes: a
+   * save nobody could have rolled comes back exactly as it was left.
+   */
+  it('does not correct a number a user has changed', () => {
+    const edited = { ...toSwnCharacterSnapshot(character), savingThrowPhysical: 3 };
+
+    expect(swnCharacterFromSnapshot(edited).savingThrowPhysical).toBe(3);
+  });
+
+  it('is free of the functions IndexedDB refuses', () => {
+    expect(() => structuredClone(toSwnCharacterSnapshot(character))).not.toThrow();
+  });
+
+  it('does not hand out the character it was given', () => {
+    const snapshot = toSwnCharacterSnapshot(character);
+    snapshot.credits = 9_999;
+
+    expect(character.credits).not.toBe(9_999);
+  });
+
+  /** A psychic character's picks are stored, because the prose in `abilities` is not a decision. */
+  it('keeps the psychic picks a character was rolled with', () => {
+    const psychic = rollMatching((rolled) => rolled.psychicPicks.length > 0);
+    const restored = swnCharacterFromSnapshot(toSwnCharacterSnapshot(psychic));
+
+    expect(restored.psychicPicks).toEqual(psychic.psychicPicks);
+    for (const pick of restored.psychicPicks) {
+      expect(pick.disciplineName).not.toBe('');
+    }
+  });
+
+  /** A payload written before the field existed reads as a character with no recorded picks. */
+  it('reads a payload with no picks at all', () => {
+    const { psychicPicks: _dropped, ...older } = toSwnCharacterSnapshot(character);
+
+    expect(swnCharacterFromSnapshot(older as SwnCharacterSnapshot).psychicPicks).toEqual([]);
+  });
+});

--- a/src/lib/swn/swn_character_snapshot.ts
+++ b/src/lib/swn/swn_character_snapshot.ts
@@ -1,0 +1,79 @@
+/**
+ * Writing a Stars Without Number character snapshot, and reading one back.
+ *
+ * **The conversion is the identity function, and that is worth stating rather than leaving a
+ * reader to wonder what was missed.** A `SWNCharacter` is plain data all the way down: stats,
+ * skills, foci, equipment and armour are records of strings and numbers, and `abilities` is a
+ * discriminated union of records — `{ kind: 'effortAbility', description }` and its siblings —
+ * rather than the handlers the DCC character holds. A search of this library for a function-typed
+ * field on a character returns nothing. So there is no closure to strip and nothing to resolve by
+ * name on the way back, and a codec that pretended otherwise would be ceremony.
+ *
+ * What the module is still for is the contract: the kind's `toSnapshot`/`fromSnapshot` pair has to
+ * live somewhere, the copy has to be shallow-but-fresh so an editor cannot write through into a
+ * character the page is still showing, and `psychicPicks` needs its default on read — see below.
+ *
+ * **Every derived number stays in the payload.** The saving throws, the attack bonuses, the three
+ * armour classes, hit points and Effort are all stored, even though every one of them could be
+ * recomputed from the stats and the class. A referee who has adjusted a save has made a decision no
+ * recomputation may overrule, and a character saved under one printing of the tables must still be
+ * that character after the tables change. `swn_character_editing.ts` offers the arithmetic as an
+ * explicit command instead.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+
+import type { PsychicPick, SWNCharacter } from './character.js';
+
+/**
+ * A SWN character as it is stored.
+ *
+ * An alias rather than a mapped type, because there is nothing to map: the stored shape and the
+ * live shape are the same shape. Named all the same, so the kind, the validator and the editor
+ * speak in snapshots like every other kind, and so the day the two shapes diverge there is a name
+ * to diverge.
+ */
+export type SwnCharacterSnapshot = SWNCharacter;
+
+/**
+ * A fresh top-level object over the same arrays.
+ *
+ * Shallow: the arrays and the records inside them are not copied, because nothing downstream
+ * mutates them — the editor replaces entries rather than writing into them, and IndexedDB stores
+ * through `structuredClone`, which copies. What the fresh top level buys is that a snapshot handed
+ * to a save control is not the object a page is still rendering.
+ */
+export function toSwnCharacterSnapshot(character: SWNCharacter): SwnCharacterSnapshot {
+  return { ...character };
+}
+
+/**
+ * A stored character back into the live one the library works with.
+ *
+ * Nothing is recomputed and nothing is re-rolled. The one thing done on read is defaulting
+ * `psychicPicks`: it is checked by the kind's validator only when present, so a payload written
+ * before this field existed — or hand-edited out of a vault file — comes back as a character with
+ * no recorded picks rather than one whose `psychicPicks.length` throws on the first render.
+ */
+export function swnCharacterFromSnapshot(snapshot: SwnCharacterSnapshot): SWNCharacter {
+  return { ...snapshot, psychicPicks: swnPsychicPicks(snapshot) };
+}
+
+/** The picks a stored character carries, or none. */
+function swnPsychicPicks(snapshot: SwnCharacterSnapshot): PsychicPick[] {
+  return Array.isArray(snapshot.psychicPicks) ? snapshot.psychicPicks : [];
+}
+
+/**
+ * The codec's reading half, with the signature the registry hands it.
+ *
+ * The RNG is unused, and that is the correct amount of use for it. It exists for kinds that rebuild
+ * name generators; a character is finished when it is stored, and drawing anything from a seed on
+ * the way back would be regenerating over the user's edits.
+ */
+export function swnCharacterFromSnapshotWithRng(
+  snapshot: SwnCharacterSnapshot,
+  _rng: RNG,
+): SWNCharacter {
+  return swnCharacterFromSnapshot(snapshot);
+}

--- a/src/lib/swn/swn_presentation.test.ts
+++ b/src/lib/swn/swn_presentation.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SWNCharacter } from './character.js';
+import { rollSwnCharacter } from './swn_character_roll.js';
+import {
+  formatSwnModifier,
+  swnCharacterDisplayName,
+  swnCharacterFileStem,
+  swnCharacterToDocument,
+  swnCharacterToMarkdown,
+} from './swn_presentation.js';
+
+function rollMatching(predicate: (character: SWNCharacter) => boolean): SWNCharacter {
+  for (let seed = 0; seed < 300; seed += 1) {
+    const { character } = rollSwnCharacter(`presentation-${seed}`);
+    if (predicate(character)) {
+      return character;
+    }
+  }
+  throw new Error('no seed in the sweep produced a character of that shape');
+}
+
+const character = rollMatching(() => true);
+
+describe('formatSwnModifier', () => {
+  it('signs a modifier the way a sheet prints it', () => {
+    expect(formatSwnModifier(2)).toBe('+2');
+    expect(formatSwnModifier(0)).toBe('+0');
+    expect(formatSwnModifier(-1)).toBe('-1');
+  });
+});
+
+describe('the SWN character document', () => {
+  it('heads the document with the character', () => {
+    expect(swnCharacterToDocument(character).title).toBe(
+      `${character.firstName} ${character.lastName}`,
+    );
+  });
+
+  /** Requirement 6.4: no heading over nothing. */
+  it('drops a section with nothing under it', () => {
+    const stripped: SWNCharacter = {
+      ...character,
+      armor: [],
+      equipment: [],
+      rangedWeapons: [],
+      meleeWeapons: [],
+    };
+    const headings = swnCharacterToDocument(stripped).sections.map((entry) => entry.heading);
+
+    expect(headings).not.toContain('Armor');
+    expect(headings).not.toContain('Equipment');
+    expect(headings).not.toContain('Weapons');
+    expect(headings).toContain('Stats');
+  });
+
+  it('says nothing about psychic training for a character with none', () => {
+    const mundane: SWNCharacter = { ...character, psychicPicks: [] };
+    const headings = swnCharacterToDocument(mundane).sections.map((entry) => entry.heading);
+
+    expect(headings).not.toContain('Psychic Training');
+  });
+
+  it('prints the disciplines a psychic actually has', () => {
+    const psychic = rollMatching((rolled) => rolled.psychicPicks.length > 0);
+    const section = swnCharacterToDocument(psychic).sections.find(
+      (entry) => entry.heading === 'Psychic Training',
+    );
+
+    expect(section).toBeDefined();
+    expect(section?.items.join('\n')).toContain(psychic.psychicPicks[0].disciplineName);
+  });
+});
+
+describe('swnCharacterToMarkdown', () => {
+  const markdown = swnCharacterToMarkdown(character);
+
+  it('leads with the character and heads every section', () => {
+    expect(markdown.startsWith(`# ${swnCharacterDisplayName(character)}`)).toBe(true);
+    expect(markdown).toContain('## Stats');
+    expect(markdown).toContain('## Skills');
+  });
+
+  it('prints the character’s own numbers', () => {
+    expect(markdown).toContain(`Hit points: ${character.hitPoints}`);
+    expect(markdown).toContain(`Class: ${character.characterClass.name}`);
+  });
+
+  it('ends with a newline, as a text file should', () => {
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('swnCharacterDisplayName', () => {
+  it('falls back to what the character is, then to the kind', () => {
+    const unnamed: SWNCharacter = { ...character, firstName: '', lastName: ' ' };
+    expect(swnCharacterDisplayName(unnamed)).toBe(
+      `${character.background.name} ${character.characterClass.name}`,
+    );
+
+    const anonymous: SWNCharacter = {
+      ...unnamed,
+      background: { ...character.background, name: '' },
+      characterClass: { ...character.characterClass, name: '' },
+    };
+    expect(swnCharacterDisplayName(anonymous)).toBe('SWN Character');
+  });
+});
+
+describe('swnCharacterFileStem', () => {
+  it('reduces a name to something a filesystem takes', () => {
+    expect(swnCharacterFileStem({ ...character, firstName: 'Vex', lastName: "O'Hara" })).toBe(
+      'swn-vex-o-hara',
+    );
+  });
+
+  it('falls back for a character whose name reduces to nothing', () => {
+    const punctuation: SWNCharacter = {
+      ...character,
+      firstName: '!!!',
+      lastName: '',
+      background: { ...character.background, name: '' },
+      characterClass: { ...character.characterClass, name: '' },
+    };
+
+    expect(swnCharacterFileStem(punctuation)).toBe('swn-character');
+  });
+});

--- a/src/lib/swn/swn_presentation.ts
+++ b/src/lib/swn/swn_presentation.ts
@@ -1,0 +1,188 @@
+/**
+ * A Stars Without Number character arranged for reading, and the Markdown export written from it.
+ *
+ * The library already renders a **character sheet** as a PDF (`render_swn_character_pdf.ts`) — a
+ * drawn form with boxes and rules, which is what a player wants at the table. That is 6.3 satisfied
+ * for the sheet, and this module does not replace it: a document model underneath a drawn form
+ * would be a worse form.
+ *
+ * What was missing is the other half of 6.3 — the character as *text*, for a referee's notes — and
+ * 6.4 with it. `formatAsText` prints every heading it knows about whether or not anything sits
+ * under it, so an unarmoured character with an empty pack gets an Armor heading and an Equipment
+ * heading with nothing beneath either. The document model is where a section with neither prose nor
+ * items is dropped, once, rather than in each renderer.
+ *
+ * `formatAsText` is left as it is. It is the library's own long-standing text form, tested as such,
+ * and what a reader of a saved `.txt` from an older build expects to see.
+ */
+
+import type { Focus, SWNCharacter, Skill, Stat, Weapon } from './character.js';
+
+/** One heading and what sits under it. A section with neither prose nor items is not printed. */
+export type SwnCharacterSection = {
+  heading: string;
+  paragraphs: string[];
+  items: string[];
+};
+
+/** A SWN character arranged for reading, independent of the format it is finally written in. */
+export type SwnCharacterDocument = {
+  title: string;
+  sections: SwnCharacterSection[];
+};
+
+function section(heading: string, paragraphs: string[], items: string[] = []): SwnCharacterSection {
+  return { heading, paragraphs: paragraphs.filter(isPrintable), items: items.filter(isPrintable) };
+}
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+function hasContent(entry: SwnCharacterSection): boolean {
+  return entry.paragraphs.length > 0 || entry.items.length > 0;
+}
+
+/** A signed number, as a sheet prints a modifier. */
+export function formatSwnModifier(value: number): string {
+  return value < 0 ? `${value}` : `+${value}`;
+}
+
+export function formatSwnStat(stat: Stat): string {
+  return `${stat.abbreviation} ${stat.score} (${formatSwnModifier(stat.modifier)})`;
+}
+
+export function formatSwnSkill(skill: Skill): string {
+  return `${skill.name}-${skill.level}`;
+}
+
+export function formatSwnFocus(focus: Focus): string {
+  return `${focus.name}, level ${focus.currentLevel}`;
+}
+
+export function formatSwnWeaponLine(weapon: Weapon, attackBonus: number): string {
+  return `${weapon.name}: ${weapon.damage} damage, ${formatSwnModifier(attackBonus)} to hit, ${weapon.range} range`;
+}
+
+/** What the character is, in the terms the top of a SWN sheet uses. */
+function identityLines(character: SWNCharacter): string[] {
+  return [
+    `Background: ${character.background.name}`,
+    `Class: ${character.characterClass.name}`,
+    `Level: ${character.currentLevel}`,
+    `Hit points: ${character.hitPoints}`,
+    `Armor class: ${character.armorClassEquipped}`,
+    `Credits: ${character.credits}`,
+  ];
+}
+
+function combatLines(character: SWNCharacter): string[] {
+  return [
+    `Attack bonus: ${formatSwnModifier(character.attackBonus)}`,
+    `Melee: ${formatSwnModifier(character.meleeAttackBonus)}`,
+    `Ranged: ${formatSwnModifier(character.rangedAttackBonus)}`,
+    `Evasion: ${character.savingThrowEvasion}`,
+    `Mental: ${character.savingThrowMental}`,
+    `Physical: ${character.savingThrowPhysical}`,
+  ];
+}
+
+/**
+ * Psychic training, which most characters have none of.
+ *
+ * Dropped entirely for a character with no discipline, rather than printed as a heading over
+ * nothing: that is the stray content 6.4 is about. Effort belongs here rather than in the block at
+ * the top for the same reason — a character with no Effort has nothing to say about it.
+ */
+function psychicLines(character: SWNCharacter): string[] {
+  if (character.psychicPicks.length === 0) {
+    return [];
+  }
+  return [
+    `Effort: ${character.effort}`,
+    ...character.psychicPicks.map((pick) =>
+      isPrintable(pick.abilityName)
+        ? `${pick.disciplineName}-${pick.level}: ${pick.abilityName}`
+        : `${pick.disciplineName}-${pick.level}`,
+    ),
+  ];
+}
+
+/** Arrange a character for reading. Every empty section is dropped here, once. */
+export function swnCharacterToDocument(character: SWNCharacter): SwnCharacterDocument {
+  const sections = [
+    section('At a Glance', [], identityLines(character)),
+    section('Stats', [], character.stats.map(formatSwnStat)),
+    section('Combat', [], combatLines(character)),
+    section('Skills', [], character.skills.map(formatSwnSkill)),
+    section('Foci', [], character.focuses.map(formatSwnFocus)),
+    section('Psychic Training', [], psychicLines(character)),
+    section(
+      'Abilities',
+      [],
+      character.abilities.map((ability) => ability.description),
+    ),
+    section(
+      'Weapons',
+      [],
+      [
+        ...character.rangedWeapons.map((weapon) =>
+          formatSwnWeaponLine(weapon, character.rangedAttackBonus),
+        ),
+        ...character.meleeWeapons.map((weapon) =>
+          formatSwnWeaponLine(weapon, character.meleeAttackBonus),
+        ),
+      ],
+    ),
+    section(
+      'Armor',
+      [],
+      character.armor.map((item) => `${item.name}: AC ${item.ac}`),
+    ),
+    section(
+      'Equipment',
+      [],
+      character.equipment.map((item) => item.name),
+    ),
+  ];
+
+  return {
+    title: swnCharacterDisplayName(character),
+    sections: sections.filter(hasContent),
+  };
+}
+
+/** What to head the document with: the character's name, or what they are when they have none. */
+export function swnCharacterDisplayName(character: SWNCharacter): string {
+  const given = `${character.firstName} ${character.lastName}`.trim();
+  if (isPrintable(given)) {
+    return given;
+  }
+  const what = `${character.background.name} ${character.characterClass.name}`.trim();
+  return isPrintable(what) ? what : 'SWN Character';
+}
+
+/** A SWN character as Markdown, for a referee who wants them in their own notes. */
+export function swnCharacterToMarkdown(character: SWNCharacter): string {
+  const document = swnCharacterToDocument(character);
+  const blocks = [`# ${document.title}`];
+
+  for (const entry of document.sections) {
+    blocks.push(`## ${entry.heading}`);
+    blocks.push(...entry.paragraphs);
+    if (entry.items.length > 0) {
+      blocks.push(entry.items.map((item) => `- ${item}`).join('\n'));
+    }
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** A filename stem for an exported character: their name, reduced to something a filesystem takes. */
+export function swnCharacterFileStem(character: SWNCharacter): string {
+  const stem = swnCharacterDisplayName(character)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' ? 'swn-character' : `swn-${stem}`;
+}

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -117,6 +117,7 @@ describe('TOOL_CATALOG', () => {
       '/fantasy/religion',
       '/fantasy/settlement',
       '/heraldry',
+      '/swn/character',
       '/fantasy/adnd/character',
       '/fantasy/adnd/character/build',
     ];
@@ -219,6 +220,7 @@ describe('toolsWithMaturity', () => {
       '/fantasy/dcc/character',
       '/fantasy/religion',
       '/fantasy/settlement',
+      '/swn/character',
     ]);
   });
 

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -78,7 +78,11 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     label: 'Stars Without Number Character',
     kind: 'generator',
     domain: 'characters',
-    maturity: 'experimental',
+    // Release-ready, assessed section by section against docs/workshop.md and recorded in
+    // docs/readiness-characters.md (#49). It saves as `character.swn`, has an editor in
+    // `ARTIFACT_EDITORS`, composes a naming culture by reference, and exports a PDF sheet and
+    // Markdown. Its roll is deterministic from the seed via `swn_character_roll.ts`.
+    maturity: 'release-ready',
     genres: ['scifi'],
     systems: ['swn'],
     tags: ['character'],

--- a/src/lib/workshop/README.md
+++ b/src/lib/workshop/README.md
@@ -223,8 +223,8 @@ artifact does not restamp contents nobody changed.
 ## Artifact editors
 
 `ARTIFACT_EDITORS` maps a kind to the component that edits it, alongside an optional roller.
-**Culture, religion, settlement, and the AD&D 2E, fantasy and DCC characters are the entries**, and
-most kinds having none is the shipped state: #39
+**Culture, religion, settlement, and the AD&D 2E, fantasy, DCC and SWN characters are the
+entries**, and most kinds having none is the shipped state: #39
 built the frame, and an editing view for a particular kind is part of taking that tool to
 Release-ready (docs/workshop.md, section 4). A kind with no entry opens read-only — the stored
 snapshot, rendered honestly — which is a state the surface draws rather than an error it reports.

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -95,6 +95,18 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         );
     },
   },
+  'character.swn': {
+    loadEditor: () => import('$components/characters/SwnCharacterArtifactEditor.svelte'),
+    loadRoller: async () => {
+      const { readSwnCharacterGeneratorConfig, rollSwnCharacterSnapshot } =
+        await import('$lib/swn/swn_character_roll.js');
+      return (provenance) =>
+        rollSwnCharacterSnapshot(
+          provenance.seed,
+          readSwnCharacterGeneratorConfig(provenance.config),
+        );
+    },
+  },
   /**
    * The first kind whose editor is a tool rather than a component written for the purpose.
    *

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -18,6 +18,7 @@ describe('artifact kind catalog', () => {
       'character.adnd-2e',
       'character',
       'character.dcc',
+      'character.swn',
     ]);
   });
 
@@ -38,7 +39,7 @@ describe('artifact kind catalog', () => {
     expect(artifactKindEntry('culture')?.displayName).toBe('Culture');
     // A kind this build does not have is the normal case for a file from a newer one, and the miss
     // is what routes it to quarantine rather than an exception.
-    expect(artifactKindEntry('character.swn')).toBeUndefined();
+    expect(artifactKindEntry('character.traveller')).toBeUndefined();
   });
 
   // Given its own timeout, because the default five seconds is not a budget this test can be held
@@ -66,7 +67,7 @@ describe('artifact kind catalog', () => {
   }, 30_000);
 
   it('quarantines a payload whose kind came from a newer build', () => {
-    const result = readRegisteredArtifactPayload('character.swn', { name: 'Vex' }, 1);
+    const result = readRegisteredArtifactPayload('character.traveller', { name: 'Vex' }, 1);
     expect(result.ok === false && result.reason).toBe('unknown-kind');
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -22,6 +22,7 @@ import { dccCharacterArtifactKind } from '$lib/dcc/dcc_character_artifact_kind';
 import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
 import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
 import { settlementArtifactKind } from '$lib/settlements/settlement_artifact_kind';
+import { swnCharacterArtifactKind } from '$lib/swn/swn_character_artifact_kind';
 
 /**
  * Assembled statically, in a single list, exactly like `TOOL_PANELS` beside it and the tool
@@ -41,6 +42,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, adndCharacterArtifactKind);
   registerArtifactKind(registry, characterArtifactKind);
   registerArtifactKind(registry, dccCharacterArtifactKind);
+  registerArtifactKind(registry, swnCharacterArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Implements the #49 section of `docs/readiness-characters.md`, part of the readiness pass. Closes #49.

`/swn/character` is assessed section by section against the readiness spec rather than declared. What it needed was everything from section 3 onwards: nothing it produced survived the tab closing. The kind is `character.swn`, with an editor in `ARTIFACT_EDITORS`, a naming culture composed by reference, and a PDF sheet and Markdown export.

**The snapshot really is the identity function, and the module says so.** A `SWNCharacter` carries no closures — `abilities` is a discriminated union of plain records, and stats, skills, foci, equipment and weapons are plain data — so there is nothing to strip and nothing to resolve by name on the way back.

**Only the psychic half of the design's `picks` exists, and that is deliberate.** The psychic half was a real finding: `applyPsychicDiscipline` resolves a discipline into `abilities` as prose, so the decision existed only as its consequence. The focus half would have been a second copy of data already in the payload — a `Focus` carries its own `name` and `currentLevel`, so the row *is* the pick. The design document records the departure beside the #49 section.

**Requirement 2.2 was failing for the person, not the body.** The page named from `` new RNG(`${Date.now()}-swn-name`) ``, so the same seed reproduced a character and never their name. `swn_character_roll.ts` is the single path from a seed now, with the name on a derived stream.

Two things beyond the design: a rolled character is **always named** now (the page used to blank both names with no naming source chosen, which is most of the time — an artifact nobody can pick out of a vault listing, 3.5), and a **Markdown export** beside the PDF, where 6.4 lives.

One test fix beyond this tool: `e2e/dcc_character.spec.ts` typed `Chaos` into a character whose alignment was already one of three values, so it left nothing to save on roughly one run in three.

`npm run verify` green (0 svelte-check errors, coverage gate passed with no new baseline entries) and the full `npm run test:e2e` green — 480 passed, including five new SWN tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJM16yc7mt4tY41t9GpoMD