### PR TITLE
Take the Uncharted Worlds character generator to Release-ready

### DIFF
--- a/docs/readiness-characters.md
+++ b/docs/readiness-characters.md
@@ -12,8 +12,9 @@ Part of [the readiness pass](tool-readiness.md); read that first for what all tw
 share — the determinism fix, the stored vocabulary, the kind ids, and the field-editor decision.
 Measured against [Tool release readiness](workshop.md#tool-release-readiness).
 
-**Status:** accepted; [#48](#48--dungeon-crawl-classics) and
-[#49](#49--stars-without-number) are **implemented**, the other three are not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in
+**Status:** accepted; the three system characters — [#48](#48--dungeon-crawl-classics),
+[#49](#49--stars-without-number) and [#50](#50--uncharted-worlds) — are **implemented**; #51 and
+#52 are not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in
 this document is clear to start.
 
 ## The three system characters
@@ -148,6 +149,18 @@ because the derivation takes no RNG and no user input: it is a lookup, not a rol
 The edit that follows: a user who rewrites a skill description is editing prose the library owns,
 so the editor does not offer that field. Careers, origin, workspace, assets and the stat block are
 what it offers.
+
+**As built, the rule applies to every rulebook row rather than only to a skill.** A career, an
+origin and a workspace each carry text this library owns too — and a career carries a list of skills
+with their descriptions, so storing the row whole would have frozen the very prose decision 3 says
+to derive. All four travel by name and are rebuilt from the tables; a name this build no longer has
+becomes a placeholder wearing it, and the character stays readable. What is stored in full is the
+**assets**, because an asset is not a row: it is a class, a type and a hand of upgrades assembled at
+generation time, with no table to look it up in.
+
+That also answers the question #48 and #49 left. Nothing here writes to a row after it is drawn —
+`rng.shuffle` reorders a copied origin's list of skills, and the order of a list of options is not
+data — so unlike the DCC occupation and the SWN lucky sign, a name really is enough.
 
 ## #51 — Heraldry, from Beta to Release-ready
 
@@ -292,10 +305,14 @@ classDiagram
     }
     class UwCharacterSnapshot {
         +StatBlock stats
-        +Career[] careers
-        +Origin origin
-        +Skill[] skills
+        +StoredUwRow[] careers
+        +StoredUwRow origin
+        +StoredUwRow workspace
+        +StoredUwRow[] skills
         +Asset[] assets
+    }
+    class StoredUwRow {
+        +string name
     }
 
     DCCCharacter "1" o-- "1" DCCOccupation
@@ -303,7 +320,8 @@ classDiagram
     DCCCharacter --> DccCharacterSnapshot : rule objects by name
     SWNCharacter --> SwnCharacterSnapshot : picks recorded beside effects
     SwnCharacterSnapshot "1" o-- "*" PsychicPick
-    UWCharacter --> UwCharacterSnapshot : identity, descriptions derived on read
+    UWCharacter --> UwCharacterSnapshot : rows by name, prose derived on read
+    UwCharacterSnapshot "1" o-- "*" StoredUwRow
 ```
 
 ### Heraldry, edited
@@ -364,6 +382,11 @@ migration. This is the AD&D thief-skills finding in a different system.
 The one thing in this domain deliberately not stored. It is a lookup with no RNG and no user input,
 so deriving it is safe, and a wording fix then reaches characters saved before it. The editor does
 not offer the field, because it is not the user's text.
+
+As implemented this covers every rulebook row — career, origin, workspace and skill — for the reason
+in the #50 section: a career carries its own skills and their descriptions, so a row stored whole
+would freeze exactly the prose this decision exists to keep live. Assets stay in the payload, being
+assembled rather than looked up.
 
 ### 4. Heraldry's editor is bespoke, and the blazon is derived
 

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -35,6 +35,10 @@ const SILENT_TOOL_PAGES = [
     path: '/swn/character',
     title: 'Stars Without Number Character Generator | Iron Arachne',
   },
+  {
+    path: '/unchartedworlds/character',
+    title: 'Uncharted Worlds Character Generator | Iron Arachne',
+  },
   { path: '/fantasy/settlement', title: 'Settlement Generator | Iron Arachne' },
   { path: '/fantasy/religion', title: 'Religion Generator | Iron Arachne' },
   { path: '/fantasy/adnd/character', title: 'AD&D 2e Character Generator | Iron Arachne' },
@@ -117,6 +121,9 @@ test('maturity: the tool browser marks every tool that has something to warn abo
   ).not.toContainText('Release-ready');
   await expect(
     browser.getByRole('button', { name: /^Stars Without Number Character/ }),
+  ).not.toContainText('Release-ready');
+  await expect(
+    browser.getByRole('button', { name: /^Uncharted Worlds Character/ }),
   ).not.toContainText('Release-ready');
   await expect(browser.getByRole('button', { name: /^Heraldry/ })).toContainText('Beta');
   await expect(browser.getByRole('button', { name: /^Planet/ })).toContainText('Experimental');

--- a/e2e/uw_character.spec.ts
+++ b/e2e/uw_character.spec.ts
@@ -1,0 +1,198 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `character.uncharted-worlds` kind: generate, save, reopen, edit.
+ *
+ * This is the half no unit test can settle. The library tests prove a character round-trips through
+ * the codec and that each editing function changes one field; what they cannot prove is that a user
+ * can press Generate, keep the result, come back to it in a different page, change something, and
+ * still have the character they saved. Every step of that crosses a boundary the unit tests stub
+ * out — the artifact store, IndexedDB, the editor registry, and a page reload.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+
+const UW_TITLE = 'Uncharted Worlds Character Generator | Iron Arachne';
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool on this page has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+test.describe('an Uncharted Worlds character', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'The Frontier');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/unchartedworlds/character', { title: UW_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a character to keep straight away.
+    await expect(page.getByRole('heading', { name: 'Statistics' })).toBeVisible();
+    await saveAs(page, 'Vex Calloway');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'Vex Calloway');
+
+    // Typed rather than filled: `fill` sets the value in one go, and the point of this assertion is
+    // that the editor's own bindings carry a user's keystrokes through to the snapshot it announces.
+    // The value is one no roll produces, so there is always something to save.
+    const descriptors = panel.getByRole('textbox', { name: 'Descriptors', exact: true });
+    await descriptors.fill('');
+    await descriptors.pressSequentially('Weathered and unhurried');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'Vex Calloway');
+    await expect(reopened.getByRole('textbox', { name: 'Descriptors', exact: true })).toHaveValue(
+      'Weathered and unhurried',
+    );
+  });
+
+  test('offers which skill a character has, never what the skill does', async ({ page }) => {
+    // Decision 3 of docs/readiness-characters.md, tested where it shows: the prose belongs to the
+    // library and is derived on read, so a wording fix reaches a character saved last month. The
+    // editor offers the pick; it does not offer the paragraph.
+    await visitRoute(page, '/unchartedworlds/character', { title: UW_TITLE });
+
+    const firstSkill = page.locator('ul.skills > li.skill').first();
+    const skillName = (await firstSkill.locator('p.skill-name').innerText()).trim();
+    const skillLine = (await firstSkill.locator('p.skill-line').first().innerText()).trim();
+
+    await saveAs(page, 'Juno Marek');
+    const panel = await openInWorkshop(page, 'Juno Marek');
+
+    await expect(panel.getByRole('textbox', { name: 'Skill 1', exact: true })).toHaveValue(
+      skillName,
+    );
+    // The description is nowhere in the editor: not as a field, and not as text.
+    await expect(panel.getByText(skillLine, { exact: false })).toHaveCount(0);
+
+    // Changing the pick is what a user does, and the character stays readable afterwards.
+    await panel.getByRole('textbox', { name: 'Skill 1', exact: true }).fill('Leadership');
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+  });
+
+  test('reproduces the same character, name included, from the same seed', async ({ page }) => {
+    // Requirement 2.2, and the defect `uw_character_roll.ts` was written to fix: the page named
+    // from the clock, so a locked seed reproduced a career and an origin belonging to somebody
+    // with a different name every time.
+    await visitRoute(page, '/unchartedworlds/character', { title: UW_TITLE });
+
+    const heading = page.getByRole('heading', { level: 2 }).first();
+    const careers = page.locator('h2', { hasText: 'Careers' }).locator('+ div');
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const first = await heading.textContent();
+    const firstCareer = await careers.textContent();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    await expect(heading).toHaveText(first ?? '');
+    await expect(careers).toHaveText(firstCareer ?? '');
+
+    // And a different seed is a different character, so the reproduction above is not the page
+    // simply failing to re-roll.
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    await expect(heading).not.toHaveText(first ?? '');
+  });
+
+  test('offers a project culture to name from, and only once there is one', async ({ page }) => {
+    await visitRoute(page, '/unchartedworlds/character', { title: UW_TITLE });
+
+    // No cultures in the project, so no offer. An offer with nothing behind it is noise, and
+    // requirement 5.3 is what makes its absence correct rather than a gap: the tool generates its
+    // own names and saves perfectly well without one.
+    await expect(page.getByLabel('Name from a saved culture in this project')).toHaveCount(0);
+
+    await visitRoute(page, '/culture', { title: 'Culture Generator | Iron Arachne' });
+    await saveAs(page, 'The Vaskaari');
+
+    await visitRoute(page, '/unchartedworlds/character', { title: UW_TITLE });
+
+    // Composition is opt-in (rule 1): the offer is there and starts unticked.
+    const offer = page.getByLabel('Name from a saved culture in this project');
+    await expect(offer).toBeVisible();
+    await expect(offer).not.toBeChecked();
+  });
+
+  test('downloads a character sheet a player can take to the table', async ({ page }) => {
+    // Requirement 6.3. Two exports, and they are different things: the PDF is the drawn sheet a
+    // player writes on, the Markdown is the character as text for a referee's notes.
+    await visitRoute(page, '/unchartedworlds/character', { title: UW_TITLE });
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    expect((await markdown).suggestedFilename()).toMatch(/\.md$/);
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: /Download PDF/ }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/\.pdf$/);
+  });
+});

--- a/src/components/characters/UnchartedWorldsCharacterGenerator.svelte
+++ b/src/components/characters/UnchartedWorldsCharacterGenerator.svelte
@@ -1,135 +1,177 @@
 <script lang="ts">
   import Stat from '$components/common/Stat.svelte';
   import StatBlock from '$components/common/StatBlock.svelte';
-  import { CharGen, parseSkillDescription, downloadUwCharacterPdf } from '$lib/unchartedworlds';
+  import * as UW from '$lib/unchartedworlds';
   import type { UWCharacter } from '$lib/unchartedworlds';
-  import * as RNG from '@ironarachne/rng';
+  import { RNG } from '@ironarachne/rng';
   import {
     buildCharacterNameSource,
-    isCustomCharacterNameSource,
-    restoreLockedCharacterName,
+    nameGeneratorSetForSource,
     rollCharacterNameForSource,
     loadCulturesForNaming,
   } from '$lib/characters';
+  import type { ArtifactReference } from '$lib/artifacts';
   import type { Culture } from '$lib/culture';
+  import Download from '$lib/download';
   import { onMount } from 'svelte';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
   import SeedControls from '$components/common/SeedControls.svelte';
   import CharacterNameSection from '$components/characters/CharacterNameSection.svelte';
   import DownloadPdfButton from '$components/common/DownloadPdfButton.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
 
-  const rng = new RNG.RNG(Date.now().toString());
+  const TOOL_PATH = '/unchartedworlds/character';
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. That is the whole of requirement 2.2's
+   * fix here: the clock decides where the sequence of seeds *starts*, and everything after it is a
+   * pure function of the seed on screen. The names in particular used to come from
+   * `` `${Date.now()}-uw-name` ``, so a locked seed reproduced a career and an origin belonging to
+   * somebody with a different name every time.
+   */
+  const rng = new RNG(Date.now().toString());
   let seed = $state(rng.randomString(13));
   let lockSeed = $state(false);
-  $effect(() => {
-    rng.setSeed(seed);
-  });
-  let character: UWCharacter | null = $state(null);
-  let downloadingPdf = $state(false);
 
   let savedCultures = $state<Culture[]>([]);
-  let nameSourceKind = $state<'default' | 'preset' | 'saved_culture'>('default');
+  let nameSourceKind = $state<'default' | 'preset' | 'saved_culture' | 'referenced_culture'>(
+    'default',
+  );
   let presetSetName = $state('human');
   let savedCultureName = $state('');
   let firstName = $state('');
   let lastName = $state('');
   let lockName = $state(false);
   let namingGender = $state<'male' | 'female' | 'random'>('random');
+  /** The culture the picker loaded, and the link to record for it. */
+  let referencedCulture = $state<Culture | undefined>();
+  let cultureReference = $state<ArtifactReference | undefined>();
+  /**
+   * The link, recorded only when the character on screen was actually named from that culture.
+   *
+   * Gated on the roll rather than on the picker, as the other character generators gate their own:
+   * a reference is a record of what the tool was handed, and one written for a character whose
+   * names came from somewhere else would claim an input that was never used.
+   */
+  let rolledCultureReference = $state.raw<ArtifactReference | undefined>();
 
-  function applyNamesToCharacter(target: CharGen.UWCharacter) {
-    target.firstName = firstName;
-    target.lastName = lastName;
-  }
+  /**
+   * The rolled character.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every array and object in
+   * the character in a Proxy, and `structuredClone` — what IndexedDB stores with — refuses a Proxy
+   * outright, so saving fails with `could not be cloned`. The same trap is written up in
+   * `$lib/workshop`'s README beside `saveToolArtifact`.
+   */
+  let character = $state.raw<UWCharacter | null>(null);
+  /** The settings the character on screen was actually rolled with. Raw, for the same reason. */
+  let rolledConfig = $state.raw<Record<string, unknown>>({});
+  let downloadingPdf = $state(false);
 
-  function rollNamesForCurrentSource() {
-    const source = buildCharacterNameSource(
+  /** The character with the names the page is showing, which is what the sheet and exports want. */
+  const namedCharacter = $derived<UWCharacter | null>(
+    character === null ? null : { ...character, firstName, lastName },
+  );
+
+  const characterSnapshot = $derived(
+    namedCharacter === null ? null : UW.toUwCharacterSnapshot(namedCharacter),
+  );
+
+  const defaultArtifactName = $derived(`${firstName} ${lastName}`.trim());
+
+  function currentNameSource() {
+    return buildCharacterNameSource(
       nameSourceKind,
       presetSetName,
       savedCultureName,
       savedCultures,
+      referencedCulture,
     );
-    const nameRng = new RNG.RNG(`${Date.now()}-uw-name`);
-    return rollCharacterNameForSource(nameRng, source, 'human', namingGender);
   }
 
-  function applyGeneratedNamesFromSource(target: CharGen.UWCharacter) {
-    const source = buildCharacterNameSource(
-      nameSourceKind,
-      presetSetName,
-      savedCultureName,
-      savedCultures,
-    );
-    if (!isCustomCharacterNameSource(source)) {
-      target.firstName = '';
-      target.lastName = '';
-      firstName = '';
-      lastName = '';
-      return;
-    }
-
-    const generated = rollNamesForCurrentSource();
-    target.firstName = generated.firstName;
-    target.lastName = generated.lastName;
-    firstName = generated.firstName;
-    lastName = generated.lastName;
+  /** The settings a roll takes, and the ones provenance records. */
+  function currentConfig(): UW.UwCharacterGeneratorConfigRecord {
+    const nameGeneratorSet = nameGeneratorSetForSource(currentNameSource());
+    return {
+      namingGender,
+      ...(nameGeneratorSet === '' ? {} : { nameGeneratorSet }),
+    };
   }
 
   function generate() {
     if (!lockSeed) {
       seed = rng.randomString(13);
     }
-    rng.setSeed(seed);
 
     const lockedFirstName = firstName;
     const lockedLastName = lastName;
 
-    character = CharGen.generate(rng);
+    const config = currentConfig();
+    const rolled = UW.rollUwCharacter(seed, config);
+    character = rolled.character;
+    // The resolved set, not the requested one: a set this build has since dropped would otherwise
+    // be recorded as provenance a re-roll could not honour.
+    rolledConfig = { ...config, nameGeneratorSet: rolled.nameGeneratorSet };
+    rolledCultureReference =
+      nameSourceKind === 'referenced_culture' && referencedCulture !== undefined
+        ? cultureReference
+        : undefined;
+
     if (lockName) {
-      restoreLockedCharacterName(character, lockedFirstName, lockedLastName);
+      firstName = lockedFirstName;
+      lastName = lockedLastName;
     } else {
-      applyGeneratedNamesFromSource(character);
+      firstName = rolled.character.firstName;
+      lastName = rolled.character.lastName;
     }
   }
 
+  /**
+   * Another name for the character already on screen.
+   *
+   * An **edit**, not a generation, and so a fresh draw that does not touch the recorded seed:
+   * requirement 4.2 says the payload is what the user kept, and a name they asked for is not
+   * something a seed reproduces. This is also the one path that names from a chosen culture's own
+   * generators rather than from the pattern set recorded beside it.
+   */
   function generateNameOnly() {
-    if (lockName) {
+    if (lockName || character === null) {
       return;
     }
-    const generated = rollNamesForCurrentSource();
+    const generated = rollCharacterNameForSource(
+      new RNG(`${Date.now()}-uw-name`),
+      currentNameSource(),
+      'human',
+      namingGender,
+    );
     firstName = generated.firstName;
     lastName = generated.lastName;
-    if (character) {
-      character.firstName = generated.firstName;
-      character.lastName = generated.lastName;
-    }
-  }
-
-  function save() {
-    if (!character) return;
-    applyNamesToCharacter(character);
-    const description = CharGen.formatAsText(character);
-
-    const blob = new Blob([description], { type: 'text/plain' });
-    const link = document.createElement('a');
-    link.href = window.URL.createObjectURL(blob);
-    link.download = 'uw-character.txt';
-    link.click();
-    URL.revokeObjectURL(link.href);
   }
 
   async function downloadPdf() {
-    if (downloadingPdf || !character) {
+    if (downloadingPdf || namedCharacter === null) {
       return;
     }
 
-    applyNamesToCharacter(character);
     downloadingPdf = true;
     try {
-      await downloadUwCharacterPdf(character);
+      await UW.downloadUwCharacterPdf(namedCharacter);
     } finally {
       downloadingPdf = false;
     }
+  }
+
+  function exportMarkdown() {
+    if (namedCharacter === null) {
+      return;
+    }
+    const markdown = UW.uwCharacterToMarkdown(namedCharacter);
+    const url = URL.createObjectURL(new Blob([markdown], { type: 'text/markdown' }));
+    Download(url, `${UW.uwCharacterFileStem(namedCharacter)}.md`);
+    URL.revokeObjectURL(url);
   }
 
   onMount(() => {
@@ -145,7 +187,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/unchartedworlds/character" title="Uncharted Worlds Character Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Uncharted Worlds Character Generator">
   {#snippet description()}
     <p>Generate starting characters for Uncharted Worlds.</p>
   {/snippet}
@@ -153,6 +195,9 @@
   <SeedControls bind:seed bind:lockSeed />
 
   <CharacterNameSection
+    offerReferencedCulture
+    bind:referencedCulture
+    bind:cultureReference
     bind:nameSourceKind
     bind:presetSetName
     bind:savedCultureName
@@ -166,43 +211,56 @@
   />
 
   <BaseButton onclick={generate}>Generate</BaseButton>
-  <BaseButton onclick={save}>Save</BaseButton>
-  <DownloadPdfButton onclick={downloadPdf} downloading={downloadingPdf} />
 
-  <h2>{firstName || lastName ? `${firstName} ${lastName}`.trim() : 'Character summary'}</h2>
+  <SaveArtifactButton
+    kind={UW.UW_CHARACTER_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={characterSnapshot}
+    {seed}
+    config={rolledConfig}
+    defaultName={defaultArtifactName}
+    references={rolledCultureReference === undefined ? [] : [rolledCultureReference]}
+  />
 
-  {#if character}
+  {#if namedCharacter}
+    <h2>{UW.uwCharacterDisplayName(namedCharacter)}</h2>
+
+    <div class="uw-exports">
+      <BaseButton onclick={exportMarkdown}>Download Markdown</BaseButton>
+      <DownloadPdfButton onclick={downloadPdf} downloading={downloadingPdf} />
+    </div>
+
     <h3>Statistics</h3>
 
     <StatBlock>
-      <Stat label="Physique">{character.stats.physique}</Stat>
-      <Stat label="Mettle">{character.stats.mettle}</Stat>
-      <Stat label="Expertise">{character.stats.expertise}</Stat>
-      <Stat label="Influence">{character.stats.influence}</Stat>
-      <Stat label="Interface">{character.stats.interface}</Stat>
+      <Stat label="Physique">{UW.formatUwStat(namedCharacter.stats.physique)}</Stat>
+      <Stat label="Mettle">{UW.formatUwStat(namedCharacter.stats.mettle)}</Stat>
+      <Stat label="Expertise">{UW.formatUwStat(namedCharacter.stats.expertise)}</Stat>
+      <Stat label="Influence">{UW.formatUwStat(namedCharacter.stats.influence)}</Stat>
+      <Stat label="Interface">{UW.formatUwStat(namedCharacter.stats.interface)}</Stat>
     </StatBlock>
 
     <h2>Careers</h2>
 
-    {#each character.careers as career}
+    {#each namedCharacter.careers as career}
       <div>{career.name}</div>
     {/each}
 
     <h2>Origin</h2>
 
-    <p>{character.origin.name}</p>
+    <p>{namedCharacter.origin.name}</p>
 
     <h2>Descriptors</h2>
 
-    <p>{character.descriptors}</p>
+    <p>{namedCharacter.descriptors}</p>
 
     <h2>Skills</h2>
 
     <ul class="skills">
-      {#each character.skills as skill}
+      {#each namedCharacter.skills as skill}
         <li class="skill">
           <p class="skill-name"><strong>{skill.name}</strong></p>
-          {#each parseSkillDescription(skill.description) as block}
+          {#each UW.parseSkillDescription(skill.description) as block}
             {#if block.kind === 'options'}
               <ul class="skill-options">
                 {#each block.items as item}
@@ -219,16 +277,16 @@
 
     <h2>Advancement</h2>
 
-    <p>{character.advancement}</p>
+    <p>{namedCharacter.advancement}</p>
 
     <h2>Assets</h2>
 
     <div class="asset">
-      <h4>Workspace: {character.workspace.name}</h4>
-      <p>{character.workspace.description}</p>
+      <h4>Workspace: {namedCharacter.workspace.name}</h4>
+      <p>{namedCharacter.workspace.description}</p>
     </div>
 
-    {#each character.assets as asset}
+    {#each namedCharacter.assets as asset}
       <div>
         <h4>{asset.name}</h4>
         <p>{asset.description}</p>
@@ -248,6 +306,12 @@
 </GeneratorPage>
 
 <style>
+  .uw-exports {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
   ul.skills > li.skill {
     list-style-type: none;
     margin-left: 0;

--- a/src/components/characters/UwCharacterArtifactEditor.svelte
+++ b/src/components/characters/UwCharacterArtifactEditor.svelte
@@ -1,0 +1,437 @@
+<script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import {
+    addUwCharacterAsset,
+    addUwCharacterRow,
+    addUwCharacterUpgrade,
+    isUnknownUwCareerName,
+    isUnknownUwOriginName,
+    isUnknownUwSkillName,
+    removeUwCharacterAsset,
+    removeUwCharacterRow,
+    removeUwCharacterUpgrade,
+    setUwCharacterAssetClass,
+    setUwCharacterAssetText,
+    setUwCharacterAssetTypeName,
+    setUwCharacterRowListName,
+    setUwCharacterRowName,
+    setUwCharacterStat,
+    setUwCharacterText,
+    setUwCharacterUpgradeText,
+    validateUwCharacterSnapshot,
+    UW_STAT_FIELDS,
+    UW_TEXT_FIELDS,
+    type UwCharacterSnapshot,
+    type UwCharacterTextField,
+    type UwStatField,
+  } from '$lib/unchartedworlds';
+
+  /**
+   * The editing view for a saved Uncharted Worlds character.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it, so
+   * what is here is the character's own shape and the calls that change it.
+   *
+   * **No skill description is offered, and no career or origin prose either.** That text belongs to
+   * the library: it is derived from this build's tables when a character is read, so a wording fix
+   * reaches a character saved last month. What a user changes here is *which* row they took, and
+   * the prose follows — decision 3 of docs/readiness-characters.md. An asset is the opposite case
+   * and every part of one is editable, because it was assembled at generation time rather than
+   * looked up.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps this editor from rendering fields over
+   * something that is not an Uncharted Worlds character.
+   */
+  const accepted = $derived(validateUwCharacterSnapshot(snapshot));
+  const character = $derived<UwCharacterSnapshot | undefined>(
+    accepted.ok ? accepted.value : undefined,
+  );
+
+  const TEXT_LABELS: Record<UwCharacterTextField, string> = {
+    firstName: 'First name',
+    lastName: 'Last name',
+    descriptors: 'Descriptors',
+    advancement: 'Advancement',
+  };
+
+  const STAT_LABELS: Record<UwStatField, string> = {
+    physique: 'Physique',
+    mettle: 'Mettle',
+    expertise: 'Expertise',
+    influence: 'Influence',
+    interface: 'Interface',
+  };
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: UwCharacterSnapshot) => UwCharacterSnapshot): void {
+    if (character === undefined) {
+      return;
+    }
+    onChange(change(character));
+  }
+</script>
+
+{#if character === undefined}
+  <Notice tone="danger">
+    These contents are stored as an Uncharted Worlds character but do not read as one, so there is
+    nothing safe to edit here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="uw-editor">
+    <fieldset>
+      <legend>Who they are</legend>
+
+      {#each UW_TEXT_FIELDS as field (field)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-{field}">{TEXT_LABELS[field]}</label>
+          <input
+            id="{uid}-{field}"
+            type="text"
+            value={character[field]}
+            oninput={(event) =>
+              edit((current) => setUwCharacterText(current, field, event.currentTarget.value))}
+            autocomplete="off"
+          />
+        </div>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Statistics</legend>
+
+      {#each UW_STAT_FIELDS as field (field)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-stat-{field}">{STAT_LABELS[field]}</label>
+          <input
+            id="{uid}-stat-{field}"
+            type="number"
+            value={character.stats[field]}
+            oninput={(event) =>
+              edit((current) =>
+                setUwCharacterStat(current, field, event.currentTarget.valueAsNumber),
+              )}
+          />
+        </div>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Careers</legend>
+
+      <!-- Keyed by position rather than by value: two entries may read the same, and a key that
+           changed as the user typed would lose focus on every keystroke. -->
+      {#each character.careers as career, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-career-{index}">Career {index + 1}</label>
+          <input
+            id="{uid}-career-{index}"
+            type="text"
+            value={career.name}
+            oninput={(event) =>
+              edit((current) =>
+                setUwCharacterRowListName(current, 'careers', index, event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+          <BaseButton
+            aria-label="Remove career {index + 1}"
+            onclick={() => edit((current) => removeUwCharacterRow(current, 'careers', index))}
+          >
+            Remove
+          </BaseButton>
+        </div>
+      {/each}
+
+      <!-- Said rather than hidden. A career this build no longer has is still the career the
+           user's notes say they took, and everything it granted is already on the character. -->
+      {#if character.careers.some((career) => isUnknownUwCareerName(career.name))}
+        <p class="uw-editor__note">
+          One of those careers is not in this build's table, so nothing further will be drawn from
+          it. What it already gave this character is on the sheet regardless.
+        </p>
+      {/if}
+
+      <BaseButton onclick={() => edit((current) => addUwCharacterRow(current, 'careers'))}>
+        Add a career
+      </BaseButton>
+    </fieldset>
+
+    <fieldset>
+      <legend>Origin and workspace</legend>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-origin">Origin</label>
+        <input
+          id="{uid}-origin"
+          type="text"
+          value={character.origin.name}
+          oninput={(event) =>
+            edit((current) => setUwCharacterRowName(current, 'origin', event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+
+      {#if isUnknownUwOriginName(character.origin.name)}
+        <p class="uw-editor__note">
+          That origin is not in this build's table. The character keeps it; nothing further will be
+          drawn from it.
+        </p>
+      {/if}
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-workspace">Workspace</label>
+        <input
+          id="{uid}-workspace"
+          type="text"
+          value={character.workspace.name}
+          oninput={(event) =>
+            edit((current) =>
+              setUwCharacterRowName(current, 'workspace', event.currentTarget.value),
+            )}
+          autocomplete="off"
+        />
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Skills</legend>
+
+      <!-- The name only. What each skill does is this build's text, derived when the character is
+           read, so a corrected description reaches a character saved long before the fix. -->
+      {#each character.skills as skill, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-skill-{index}">Skill {index + 1}</label>
+          <input
+            id="{uid}-skill-{index}"
+            type="text"
+            value={skill.name}
+            oninput={(event) =>
+              edit((current) =>
+                setUwCharacterRowListName(current, 'skills', index, event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+          <BaseButton
+            aria-label="Remove skill {index + 1}"
+            onclick={() => edit((current) => removeUwCharacterRow(current, 'skills', index))}
+          >
+            Remove
+          </BaseButton>
+        </div>
+      {/each}
+
+      {#if character.skills.some((skill) => isUnknownUwSkillName(skill.name))}
+        <p class="uw-editor__note">
+          One of those skills has no description in this build, so the sheet will print its name
+          alone.
+        </p>
+      {/if}
+
+      <BaseButton onclick={() => edit((current) => addUwCharacterRow(current, 'skills'))}>
+        Add a skill
+      </BaseButton>
+    </fieldset>
+
+    <fieldset>
+      <legend>Assets</legend>
+
+      {#each character.assets as asset, assetIndex (assetIndex)}
+        <div class="uw-editor__row">
+          <div class="input-group input-group--inline">
+            <label for="{uid}-asset-{assetIndex}-name">Asset {assetIndex + 1} name</label>
+            <input
+              id="{uid}-asset-{assetIndex}-name"
+              type="text"
+              value={asset.name}
+              oninput={(event) =>
+                edit((current) =>
+                  setUwCharacterAssetText(current, assetIndex, 'name', event.currentTarget.value),
+                )}
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="input-group input-group--inline">
+            <label for="{uid}-asset-{assetIndex}-type">Asset {assetIndex + 1} type</label>
+            <input
+              id="{uid}-asset-{assetIndex}-type"
+              type="text"
+              value={asset.type.name}
+              oninput={(event) =>
+                edit((current) =>
+                  setUwCharacterAssetTypeName(current, assetIndex, event.currentTarget.value),
+                )}
+              autocomplete="off"
+            />
+            <label for="{uid}-asset-{assetIndex}-class">Asset {assetIndex + 1} class</label>
+            <input
+              id="{uid}-asset-{assetIndex}-class"
+              type="number"
+              value={asset.assetClass}
+              oninput={(event) =>
+                edit((current) =>
+                  setUwCharacterAssetClass(current, assetIndex, event.currentTarget.valueAsNumber),
+                )}
+            />
+          </div>
+
+          <div class="input-group input-group--inline">
+            <label for="{uid}-asset-{assetIndex}-description">
+              Asset {assetIndex + 1} description
+            </label>
+            <textarea
+              id="{uid}-asset-{assetIndex}-description"
+              rows="2"
+              value={asset.description}
+              oninput={(event) =>
+                edit((current) =>
+                  setUwCharacterAssetText(
+                    current,
+                    assetIndex,
+                    'description',
+                    event.currentTarget.value,
+                  ),
+                )}
+            ></textarea>
+          </div>
+
+          {#each asset.upgrades as upgrade, upgradeIndex (upgradeIndex)}
+            <div class="input-group input-group--inline">
+              <label for="{uid}-asset-{assetIndex}-upgrade-{upgradeIndex}-name">
+                Asset {assetIndex + 1} upgrade {upgradeIndex + 1} name
+              </label>
+              <input
+                id="{uid}-asset-{assetIndex}-upgrade-{upgradeIndex}-name"
+                type="text"
+                value={upgrade.name}
+                oninput={(event) =>
+                  edit((current) =>
+                    setUwCharacterUpgradeText(
+                      current,
+                      assetIndex,
+                      upgradeIndex,
+                      'name',
+                      event.currentTarget.value,
+                    ),
+                  )}
+                autocomplete="off"
+              />
+              <label for="{uid}-asset-{assetIndex}-upgrade-{upgradeIndex}-description">
+                Asset {assetIndex + 1} upgrade {upgradeIndex + 1} description
+              </label>
+              <input
+                id="{uid}-asset-{assetIndex}-upgrade-{upgradeIndex}-description"
+                type="text"
+                value={upgrade.description}
+                oninput={(event) =>
+                  edit((current) =>
+                    setUwCharacterUpgradeText(
+                      current,
+                      assetIndex,
+                      upgradeIndex,
+                      'description',
+                      event.currentTarget.value,
+                    ),
+                  )}
+                autocomplete="off"
+              />
+              <BaseButton
+                aria-label="Remove asset {assetIndex + 1} upgrade {upgradeIndex + 1}"
+                onclick={() =>
+                  edit((current) => removeUwCharacterUpgrade(current, assetIndex, upgradeIndex))}
+              >
+                Remove
+              </BaseButton>
+            </div>
+          {/each}
+
+          <BaseButton onclick={() => edit((current) => addUwCharacterUpgrade(current, assetIndex))}>
+            Add an upgrade to asset {assetIndex + 1}
+          </BaseButton>
+
+          <BaseButton
+            aria-label="Remove asset {assetIndex + 1}"
+            onclick={() => edit((current) => removeUwCharacterAsset(current, assetIndex))}
+          >
+            Remove asset {assetIndex + 1}
+          </BaseButton>
+        </div>
+      {/each}
+
+      <BaseButton onclick={() => edit(addUwCharacterAsset)}>Add an asset</BaseButton>
+    </fieldset>
+  </div>
+{/if}
+
+<style>
+  .uw-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+  }
+
+  .uw-editor fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s3);
+    align-items: flex-start;
+    margin: 0;
+    /* No border and no radius, matching the culture, character, DCC and SWN editors: a fieldset
+       inside an editor panel was a box inside a box, and the legend and the spacing already group
+       these. */
+    padding: var(--s4) 0;
+    min-width: 0;
+  }
+
+  .uw-editor legend {
+    padding: 0 var(--s3);
+    color: var(--gold);
+    font-size: var(--t-micro-size);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .uw-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .uw-editor input[type='text'],
+  .uw-editor input[type='number'],
+  .uw-editor textarea {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+
+  .uw-editor__row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s2);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .uw-editor__note {
+    font-size: var(--t-small-size);
+    font-style: italic;
+    margin: 0;
+  }
+</style>

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -68,6 +68,10 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // The eighth. `$lib/swn`'s entry point re-exports the PDF renderer, and jsPDF with it, along with
   // the focus, psychic, and starship tables. The kind module holds metadata and validation only.
   '$lib/swn/swn_character_artifact_kind',
+  // The ninth. `$lib/unchartedworlds`'s entry point re-exports the PDF renderer, and jsPDF with it,
+  // along with the career, origin and asset tables. The kind module holds metadata and validation
+  // only.
+  '$lib/unchartedworlds/uw_character_artifact_kind',
 ]);
 
 /**

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -118,6 +118,7 @@ describe('TOOL_CATALOG', () => {
       '/fantasy/settlement',
       '/heraldry',
       '/swn/character',
+      '/unchartedworlds/character',
       '/fantasy/adnd/character',
       '/fantasy/adnd/character/build',
     ];
@@ -221,6 +222,7 @@ describe('toolsWithMaturity', () => {
       '/fantasy/religion',
       '/fantasy/settlement',
       '/swn/character',
+      '/unchartedworlds/character',
     ]);
   });
 

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -92,7 +92,12 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     label: 'Uncharted Worlds Character',
     kind: 'generator',
     domain: 'characters',
-    maturity: 'experimental',
+    // Release-ready, assessed section by section against docs/workshop.md and recorded in
+    // docs/readiness-characters.md (#50). It saves as `character.uncharted-worlds` — rulebook rows
+    // by name, so a corrected description reaches a character saved last month — has an editor in
+    // `ARTIFACT_EDITORS`, composes a naming culture by reference, and exports a PDF sheet and
+    // Markdown. Its roll is deterministic from the seed via `uw_character_roll.ts`.
+    maturity: 'release-ready',
     genres: ['scifi'],
     systems: ['uncharted-worlds'],
     tags: ['character'],

--- a/src/lib/unchartedworlds/README.md
+++ b/src/lib/unchartedworlds/README.md
@@ -7,6 +7,22 @@ Uncharted Worlds characters are defined by what they have done rather than by a 
 are the spine of generation — each contributes skills and assets, and a character is the
 accumulation of several.
 
+## What is implemented, and what is not
+
+This covers **Uncharted Worlds character creation**, and only that: the ten careers with their
+skills, workspaces, descriptors and advancements, the ten origins, the standard stat array
+(+2/+1/+1/0/-1), and the assets a starting character has accumulated.
+
+Deliberately absent: everything about play rather than creation — the moves, Data Points, factions,
+crew and ship sheets beyond the assets a character personally owns, and advancement past the first
+one a character picks. A character generated here is a starting character; a player who advances one
+edits the saved artifact rather than asking the tool for a veteran.
+
+**Which printing the tables were transcribed from is not recorded anywhere in this repository**, and
+this file is not the place to guess it. What requirement 8.4 asks for that can be stated honestly is
+above: what is here, and what is not. Anyone who knows the answer should replace this paragraph with
+it. Iron Arachne is unofficial and unaffiliated with the game's publisher.
+
 ## Features
 
 - **Types** — `UWCharacter`, `Origin`, `Career`, `Skill`, `Workspace`, `Asset`, `AssetType`,
@@ -36,6 +52,31 @@ row it actually uses — a chosen template, the two careers kept, the picked ori
 it apart. That copy is load bearing, because building a character shuffles those lists in place
 and pops from them; working on a table row directly would reorder it and gradually empty it for
 every character generated afterwards.
+
+## Saving a character
+
+The character generator is Release-ready (issue #50), which means everything it produces can be
+kept:
+
+- `uw_character_snapshot.ts` — the stored form. **Rulebook rows travel by name and their prose is
+  derived on read**: a career, an origin, a workspace and a skill are all rows a character points
+  at, so a corrected description reaches a character saved last month, and an artifact does not
+  carry several kilobytes of this repository's own text. Assets are the exception and are stored in
+  full, because an asset is assembled at generation time rather than looked up.
+- `uw_character_artifact_kind.ts` — the `character.uncharted-worlds` kind: validation, the payload
+  version, and what to call an artifact whose character was never named (their careers, because in
+  this game that is what a character is).
+- `uw_character_roll.ts` — the single path from a seed to a character, names included. Both the
+  generator page and a re-roll from the vault go through it.
+- `uw_character_editing.ts` — one function per field, each returning a new snapshot. There is no
+  function for a skill's description, and that is the point: what a user changes is _which_ skill
+  they have.
+- `uw_presentation.ts` — the character as a document, and the Markdown export written from it.
+  Empty sections are dropped here rather than in each renderer.
+
+A row this build no longer has rebuilds as a placeholder wearing the stored name, rather than
+throwing: a character whose career was renamed is still that character, and their stats, skills and
+assets are all still on the sheet.
 
 ## Usage
 

--- a/src/lib/unchartedworlds/index.ts
+++ b/src/lib/unchartedworlds/index.ts
@@ -1,6 +1,11 @@
 export * from './character';
 export * from './render_uw_character_pdf';
 export * from './skill_description';
+export * from './uw_character_artifact_kind';
+export * from './uw_character_editing';
+export * from './uw_character_roll';
+export * from './uw_character_snapshot';
+export * from './uw_presentation';
 export type * from './skill_description_types';
 
 export * as CharGen from './character';

--- a/src/lib/unchartedworlds/uw_character_artifact_kind.test.ts
+++ b/src/lib/unchartedworlds/uw_character_artifact_kind.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import { readArtifactPayload, type AnyArtifactKindEntry } from '$lib/artifact_kinds';
+
+import {
+  migrateUwCharacterSnapshot,
+  uwCharacterArtifactKind,
+  UW_CHARACTER_ARTIFACT_KIND,
+  UW_CHARACTER_PAYLOAD_VERSION,
+  validateUwCharacterSnapshot,
+} from './uw_character_artifact_kind.js';
+import { rollUwCharacterSnapshot } from './uw_character_roll.js';
+import type { UwCharacterSnapshot } from './uw_character_snapshot.js';
+
+/** A stored payload, as anything reading one actually receives it. */
+function storedSnapshot(seed = 'kind-fixture'): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(rollUwCharacterSnapshot(seed))) as Record<string, unknown>;
+}
+
+const snapshot = storedSnapshot();
+
+describe('the Uncharted Worlds character artifact kind', () => {
+  it('is registered system-qualified, concept first', () => {
+    expect(UW_CHARACTER_ARTIFACT_KIND).toBe('character.uncharted-worlds');
+    expect(uwCharacterArtifactKind.kind).toBe('character.uncharted-worlds');
+    expect(uwCharacterArtifactKind.displayName).toBe('Uncharted Worlds Character');
+    expect(uwCharacterArtifactKind.payloadVersion).toBe(UW_CHARACTER_PAYLOAD_VERSION);
+    expect(uwCharacterArtifactKind.icon).not.toBe('');
+  });
+
+  it('names an artifact after the character', () => {
+    const named = snapshot as unknown as UwCharacterSnapshot;
+
+    expect(uwCharacterArtifactKind.nameOf(named)).toBe(
+      `${named.firstName} ${named.lastName}`.trim(),
+    );
+  });
+
+  /** No classes in this game: a character is what they have done, so that is what names them. */
+  it('falls back to the careers for a character with no name', () => {
+    const unnamed = { ...snapshot, firstName: '', lastName: ' ' } as unknown as UwCharacterSnapshot;
+
+    expect(uwCharacterArtifactKind.nameOf(unnamed)).toBe(
+      unnamed.careers.map((career) => career.name).join(' and '),
+    );
+  });
+
+  it('falls back again for a character with neither', () => {
+    const anonymous = {
+      ...snapshot,
+      firstName: '',
+      lastName: '',
+      careers: [],
+    } as unknown as UwCharacterSnapshot;
+
+    expect(uwCharacterArtifactKind.nameOf(anonymous)).toBe('Uncharted Worlds Character');
+  });
+
+  it('accepts a payload the generator produced', () => {
+    expect(validateUwCharacterSnapshot(snapshot).ok).toBe(true);
+  });
+
+  it('rejects something that is not an object at all', () => {
+    for (const payload of [null, 'a character', 42, ['stats']]) {
+      const result = validateUwCharacterSnapshot(payload);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toBe('invalid-payload');
+    }
+  });
+
+  it('rejects a payload missing the prose the sheet is read from', () => {
+    const { descriptors: _dropped, ...rest } = snapshot;
+
+    expect(validateUwCharacterSnapshot(rest).ok).toBe(false);
+  });
+
+  /** A -1 is an ordinary stat here, so the check is for a number rather than for a size. */
+  it('accepts the standard array and rejects a missing stat', () => {
+    expect(
+      validateUwCharacterSnapshot({
+        ...snapshot,
+        stats: { physique: 2, mettle: 1, expertise: 1, influence: 0, interface: -1 },
+      }).ok,
+    ).toBe(true);
+    expect(validateUwCharacterSnapshot({ ...snapshot, stats: { physique: 2, mettle: 1 } }).ok).toBe(
+      false,
+    );
+  });
+
+  it('rejects a career, origin, workspace or skill with no name', () => {
+    expect(validateUwCharacterSnapshot({ ...snapshot, careers: [{}] }).ok).toBe(false);
+    expect(validateUwCharacterSnapshot({ ...snapshot, origin: {} }).ok).toBe(false);
+    expect(validateUwCharacterSnapshot({ ...snapshot, workspace: 'A Shed' }).ok).toBe(false);
+    expect(validateUwCharacterSnapshot({ ...snapshot, skills: [{ level: 1 }] }).ok).toBe(false);
+  });
+
+  it('rejects an asset that is not a classed item with upgrades', () => {
+    expect(validateUwCharacterSnapshot({ ...snapshot, assets: [{ name: 'A ship' }] }).ok).toBe(
+      false,
+    );
+    expect(
+      validateUwCharacterSnapshot({
+        ...snapshot,
+        assets: [
+          {
+            name: 'A ship',
+            description: '',
+            assetClass: 2,
+            type: { name: 'Freighter' },
+            upgrades: [{ name: 'Cargo hold' }],
+          },
+        ],
+      }).ok,
+    ).toBe(false);
+  });
+
+  it('accepts an asset with no upgrades, which is what Attire is', () => {
+    expect(
+      validateUwCharacterSnapshot({
+        ...snapshot,
+        assets: [
+          {
+            name: 'Attire',
+            description: 'A coat',
+            assetClass: 0,
+            type: { name: 'Attire' },
+            upgrades: [],
+          },
+        ],
+      }).ok,
+    ).toBe(true);
+  });
+
+  it('has no migration to offer, and says so rather than guessing', () => {
+    const result = migrateUwCharacterSnapshot(snapshot, 0);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toBe('unsupported-version');
+  });
+
+  /** The whole read path, as the store runs it. */
+  it('reads a stored payload of its own version', () => {
+    const result = readArtifactPayload(
+      uwCharacterArtifactKind as AnyArtifactKindEntry,
+      snapshot,
+      UW_CHARACTER_PAYLOAD_VERSION,
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('quarantines a payload from a version it has no step for', () => {
+    const result = readArtifactPayload(
+      uwCharacterArtifactKind as AnyArtifactKindEntry,
+      snapshot,
+      UW_CHARACTER_PAYLOAD_VERSION + 1,
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('loads a codec that round-trips the payload', async () => {
+    const codec = await uwCharacterArtifactKind.loadCodec();
+    const accepted = validateUwCharacterSnapshot(snapshot);
+
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) {
+      return;
+    }
+    const { RNG } = await import('@ironarachne/rng');
+    const live = codec.fromSnapshot(accepted.value, new RNG('unused'));
+
+    expect(codec.toSnapshot(live)).toEqual(accepted.value);
+  });
+});

--- a/src/lib/unchartedworlds/uw_character_artifact_kind.ts
+++ b/src/lib/unchartedworlds/uw_character_artifact_kind.ts
@@ -1,0 +1,201 @@
+import compass from '$lib/assets/icons/set2/compass.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import type { UWCharacter } from './character';
+import type { UwCharacterSnapshot } from './uw_character_snapshot';
+
+/**
+ * Stable artifact kind id.
+ *
+ * Concept first, system as the qualifier, so every character kind sorts together in a vault
+ * listing — `character.adnd-2e`, `character.dcc`, `character.swn`, and this. That is decision 4 of
+ * docs/workshop.md and the form docs/readiness-characters.md names for all three system characters.
+ * Issue #50's scope section writes it the other way round, as `uncharted-worlds.character`; the
+ * design's form wins, because the ordering is the decision and a kind id is a migration to rename.
+ */
+export const UW_CHARACTER_ARTIFACT_KIND = 'character.uncharted-worlds' as const;
+
+/** Version 1. The first shape an Uncharted Worlds character has been stored in. */
+export const UW_CHARACTER_PAYLOAD_VERSION = 1 as const;
+
+/** The five stats every Uncharted Worlds character has, in the order the sheet prints them. */
+const STAT_FIELDS = ['physique', 'mettle', 'expertise', 'influence', 'interface'] as const;
+
+/** A stored rulebook row: a name, and nothing else. The prose is derived when it is read back. */
+function isStoredRow(value: unknown): boolean {
+  const record = asRecord(value);
+  return record !== null && typeof record.name === 'string';
+}
+
+function validateStoredRow(value: unknown, field: string): PayloadResult<unknown> {
+  if (!isStoredRow(value)) {
+    return rejectedPayload('invalid-payload', `Uncharted Worlds character ${field} has no name`);
+  }
+  return acceptedPayload(value);
+}
+
+function validateStoredRowList(value: unknown, field: string): PayloadResult<unknown> {
+  if (!Array.isArray(value) || !value.every(isStoredRow)) {
+    return rejectedPayload(
+      'invalid-payload',
+      `Uncharted Worlds character ${field} is not a list of named entries`,
+    );
+  }
+  return acceptedPayload(value);
+}
+
+/**
+ * The stat block: five numbers, all of them required.
+ *
+ * A character with a missing stat is not a character a sheet can be read from, and the standard
+ * array — +2, +1, +1, 0, -1 — means zero and negative values are ordinary rather than suspicious,
+ * so the check is for a finite number rather than for anything about its size.
+ */
+function validateStats(value: unknown): PayloadResult<unknown> {
+  const stats = asRecord(value);
+  if (stats === null || !STAT_FIELDS.every((field) => Number.isFinite(stats[field]))) {
+    return rejectedPayload(
+      'invalid-payload',
+      `Uncharted Worlds character stats need numeric ${STAT_FIELDS.join(', ')}`,
+    );
+  }
+  return acceptedPayload(stats);
+}
+
+/**
+ * The assets, which are stored in full because they are not table rows.
+ *
+ * Each is checked for what the sheet prints: a name, a description, a class, and a list of upgrades
+ * that each have a name and a description. The type is checked for a name alone — an asset built
+ * from a template with no types carries one made up of the template's own name.
+ */
+function validateAssets(value: unknown): PayloadResult<unknown> {
+  if (
+    !Array.isArray(value) ||
+    !value.every((entry) => {
+      const asset = asRecord(entry);
+      if (
+        asset === null ||
+        !hasStringFields(asset, ['name', 'description']) ||
+        !Number.isFinite(asset.assetClass) ||
+        !isStoredRow(asset.type)
+      ) {
+        return false;
+      }
+      return (
+        Array.isArray(asset.upgrades) &&
+        asset.upgrades.every((upgrade) => {
+          const record = asRecord(upgrade);
+          return record !== null && hasStringFields(record, ['name', 'description']);
+        })
+      );
+    })
+  ) {
+    return rejectedPayload(
+      'invalid-payload',
+      'Uncharted Worlds character assets are not classed items with upgrades',
+    );
+  }
+  return acceptedPayload(value);
+}
+
+/** Checks what `uwCharacterFromSnapshot` depends on, and what a sheet is printed from. */
+export function validateUwCharacterSnapshot(payload: unknown): PayloadResult<UwCharacterSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload(
+      'invalid-payload',
+      'Uncharted Worlds character payload is not an object',
+    );
+  }
+  if (!hasStringFields(record, ['firstName', 'lastName', 'descriptors', 'advancement'])) {
+    return rejectedPayload(
+      'invalid-payload',
+      'Uncharted Worlds character payload needs string firstName, lastName, descriptors, advancement',
+    );
+  }
+
+  const checks: PayloadResult<unknown>[] = [
+    validateStats(record.stats),
+    validateStoredRowList(record.careers, 'careers'),
+    validateStoredRow(record.origin, 'origin'),
+    validateStoredRow(record.workspace, 'workspace'),
+    validateStoredRowList(record.skills, 'skills'),
+    validateAssets(record.assets),
+  ];
+  const failed = checks.find((check) => !check.ok);
+  if (failed !== undefined) {
+    return failed as PayloadResult<UwCharacterSnapshot>;
+  }
+
+  return acceptedPayload(record as unknown as UwCharacterSnapshot);
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day the
+ * shape changes. A kind without one looks complete right up until it silently drops someone's work
+ * — and local-only means there is no server-side migration to fall back on.
+ */
+export function migrateUwCharacterSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<UwCharacterSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Uncharted Worlds character has no migration from payload version ${from}; version ${UW_CHARACTER_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/**
+ * What to call a character saved unnamed.
+ *
+ * Their careers, because in Uncharted Worlds that is what a character *is*: the game has no classes,
+ * and a person is the accumulation of what they have done. A two-career listing reads as an
+ * identity in a vault — "Explorer and Technician" — in a way "Character" never does.
+ */
+function uwCharacterName(snapshot: UwCharacterSnapshot): string {
+  const given = `${snapshot.firstName} ${snapshot.lastName}`.trim();
+  if (given !== '') {
+    return given;
+  }
+  const careers = snapshot.careers
+    .map((career) => career.name.trim())
+    .filter((name) => name !== '');
+  return careers.length === 0 ? 'Uncharted Worlds Character' : careers.join(' and ');
+}
+
+/**
+ * An Uncharted Worlds character as an artifact.
+ *
+ * The codec is cheap on both sides — the tables it reads back from are the same three data modules
+ * the generator uses — so unlike settlement or heraldry there is no expensive half to keep out of
+ * the chunk that merely lists a project. It is still loaded on demand, because the contract is the
+ * same for every kind and a codec that happens to be cheap today is not a reason to wire it
+ * differently from its neighbours.
+ */
+export const uwCharacterArtifactKind = defineArtifactKind<UWCharacter, UwCharacterSnapshot>({
+  kind: UW_CHARACTER_ARTIFACT_KIND,
+  displayName: 'Uncharted Worlds Character',
+  icon: compass,
+  payloadVersion: UW_CHARACTER_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { toUwCharacterSnapshot, uwCharacterFromSnapshotWithRng } =
+      await import('./uw_character_snapshot.js');
+    return {
+      toSnapshot: toUwCharacterSnapshot,
+      fromSnapshot: uwCharacterFromSnapshotWithRng,
+    };
+  },
+  nameOf: uwCharacterName,
+  validate: validateUwCharacterSnapshot,
+  migrate: migrateUwCharacterSnapshot,
+});

--- a/src/lib/unchartedworlds/uw_character_editing.test.ts
+++ b/src/lib/unchartedworlds/uw_character_editing.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollUwCharacterSnapshot } from './uw_character_roll.js';
+import {
+  addUwCharacterAsset,
+  addUwCharacterRow,
+  addUwCharacterUpgrade,
+  removeUwCharacterAsset,
+  removeUwCharacterRow,
+  removeUwCharacterUpgrade,
+  setUwCharacterAssetClass,
+  setUwCharacterAssetText,
+  setUwCharacterAssetTypeName,
+  setUwCharacterRowListName,
+  setUwCharacterRowName,
+  setUwCharacterStat,
+  setUwCharacterText,
+  setUwCharacterUpgradeText,
+} from './uw_character_editing.js';
+import { uwCharacterFromSnapshot } from './uw_character_snapshot.js';
+
+const character = rollUwCharacterSnapshot('editing-fixture');
+
+describe('editing an Uncharted Worlds character', () => {
+  /** Requirement 4.4: one field at a time, and nothing else moves. */
+  it('changes one field and leaves the rest alone', () => {
+    const renamed = setUwCharacterText(character, 'firstName', 'Sabra');
+
+    expect(renamed.firstName).toBe('Sabra');
+    expect({ ...renamed, firstName: character.firstName }).toEqual(character);
+  });
+
+  it('never writes into the snapshot it was given', () => {
+    const before = structuredClone(character);
+    setUwCharacterStat(character, 'physique', 9);
+    setUwCharacterAssetText(character, 0, 'name', 'Something else');
+
+    expect(character).toEqual(before);
+  });
+
+  it('refuses a number a user has emptied rather than storing NaN', () => {
+    expect(setUwCharacterStat(character, 'mettle', Number.NaN)).toBe(character);
+    expect(setUwCharacterAssetClass(character, 0, Number.NaN)).toBe(character);
+  });
+
+  it('edits a stat without disturbing the others', () => {
+    const edited = setUwCharacterStat(character, 'interface', 3);
+
+    expect(edited.stats.interface).toBe(3);
+    expect({ ...edited.stats, interface: character.stats.interface }).toEqual(character.stats);
+  });
+
+  /**
+   * Decision 3, as a test: a career is stored by name, so changing the name changes which career
+   * the character has and the prose follows on read.
+   */
+  it('changes which career a character took, and the prose follows', () => {
+    const edited = setUwCharacterRowListName(character, 'careers', 0, 'Explorer');
+
+    expect(edited.careers[0]).toEqual({ name: 'Explorer' });
+    expect(uwCharacterFromSnapshot(edited).careers[0].skills.length).toBeGreaterThan(0);
+  });
+
+  it('changes which skill a character has, and the description follows', () => {
+    const edited = setUwCharacterRowListName(character, 'skills', 0, 'Leadership');
+    const live = uwCharacterFromSnapshot(edited);
+
+    expect(live.skills[0].name).toBe('Leadership');
+    expect(live.skills[0].description).not.toBe('');
+  });
+
+  it('adds and removes a career or a skill', () => {
+    for (const list of ['careers', 'skills'] as const) {
+      const added = addUwCharacterRow(character, list);
+      expect(added[list]).toHaveLength(character[list].length + 1);
+      expect(added[list][added[list].length - 1]).toEqual({ name: '' });
+
+      expect(removeUwCharacterRow(added, list, added[list].length - 1)[list]).toEqual(
+        character[list],
+      );
+    }
+  });
+
+  it('sets the origin and the workspace by name', () => {
+    expect(setUwCharacterRowName(character, 'origin', 'Frontier').origin).toEqual({
+      name: 'Frontier',
+    });
+    expect(setUwCharacterRowName(character, 'workspace', 'A Shed').workspace).toEqual({
+      name: 'A Shed',
+    });
+  });
+
+  it('edits every part of an asset, because nothing else owns its text', () => {
+    const renamed = setUwCharacterAssetText(character, 0, 'name', 'The Kestrel');
+    const described = setUwCharacterAssetText(renamed, 0, 'description', 'Scarred but reliable');
+    const typed = setUwCharacterAssetTypeName(described, 0, 'Freighter');
+    const classed = setUwCharacterAssetClass(typed, 0, 3);
+
+    expect(classed.assets[0]).toMatchObject({
+      name: 'The Kestrel',
+      description: 'Scarred but reliable',
+      assetClass: 3,
+      type: { name: 'Freighter' },
+    });
+    expect(classed.assets.slice(1)).toEqual(character.assets.slice(1));
+  });
+
+  it('adds and removes an asset', () => {
+    const added = addUwCharacterAsset(character);
+
+    expect(added.assets).toHaveLength(character.assets.length + 1);
+    expect(added.assets[added.assets.length - 1]).toMatchObject({ name: '', assetClass: 0 });
+    expect(removeUwCharacterAsset(added, added.assets.length - 1).assets).toEqual(character.assets);
+  });
+
+  it('edits, adds and removes an upgrade on one asset only', () => {
+    const withUpgrade = addUwCharacterUpgrade(character, 0);
+    const index = withUpgrade.assets[0].upgrades.length - 1;
+    const named = setUwCharacterUpgradeText(withUpgrade, 0, index, 'name', 'Reinforced hull');
+    const described = setUwCharacterUpgradeText(named, 0, index, 'description', 'It holds');
+
+    expect(described.assets[0].upgrades[index]).toMatchObject({
+      name: 'Reinforced hull',
+      description: 'It holds',
+    });
+    expect(described.assets[1]).toEqual(character.assets[1]);
+    expect(removeUwCharacterUpgrade(described, 0, index).assets[0].upgrades).toEqual(
+      character.assets[0].upgrades,
+    );
+  });
+
+  /** An index nothing is at is a no-op, not a throw: the editor is driven by a live list. */
+  it('ignores an index that is not there', () => {
+    expect(setUwCharacterRowListName(character, 'skills', 99, 'Whistling')).toBe(character);
+    expect(setUwCharacterRowListName(character, 'careers', -1, 'Explorer')).toBe(character);
+    expect(removeUwCharacterRow(character, 'skills', 99)).toBe(character);
+    expect(setUwCharacterAssetText(character, 99, 'name', 'nothing')).toBe(character);
+    expect(setUwCharacterAssetTypeName(character, 99, 'nothing')).toBe(character);
+    expect(removeUwCharacterAsset(character, 99)).toBe(character);
+    expect(addUwCharacterUpgrade(character, 99)).toBe(character);
+    expect(setUwCharacterUpgradeText(character, 99, 0, 'name', 'nothing')).toBe(character);
+    expect(setUwCharacterUpgradeText(character, 0, 99, 'name', 'nothing')).toBe(character);
+    expect(removeUwCharacterUpgrade(character, 99, 0)).toBe(character);
+    expect(removeUwCharacterUpgrade(character, 0, 99)).toBe(character);
+  });
+});

--- a/src/lib/unchartedworlds/uw_character_editing.ts
+++ b/src/lib/unchartedworlds/uw_character_editing.ts
@@ -1,0 +1,250 @@
+/**
+ * Editing a stored Uncharted Worlds character, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction — renaming a character must not
+ * disturb their stats, and correcting one career must not re-roll the rest — and it is what lets the
+ * editing framework compare what is on screen against what was read to decide whether anything
+ * needs saving.
+ *
+ * **There is no function for a skill's description, and that is the point.** The prose belongs to
+ * the library, not to the user: it is derived on read from this build's tables so a wording fix
+ * reaches a character saved last month (decision 3 of docs/readiness-characters.md). What a user
+ * changes is *which* skill they have, and the description follows. The same holds for a career, an
+ * origin and a workspace.
+ *
+ * An asset is the opposite case, and every part of one is editable: it was assembled at generation
+ * time rather than looked up, so there is no table that owns its text.
+ */
+
+import { createAsset, createAssetType, createUpgrade, type StatBlock } from './character.js';
+import type { StoredUwRow, UwCharacterSnapshot } from './uw_character_snapshot.js';
+
+/** The identity and prose fields a user may rewrite. */
+export const UW_TEXT_FIELDS = ['firstName', 'lastName', 'descriptors', 'advancement'] as const;
+
+export type UwCharacterTextField = (typeof UW_TEXT_FIELDS)[number];
+
+/** The five stats, in the order the sheet prints them. */
+export const UW_STAT_FIELDS = [
+  'physique',
+  'mettle',
+  'expertise',
+  'influence',
+  'interface',
+] as const;
+
+export type UwStatField = (typeof UW_STAT_FIELDS)[number];
+
+/** The two lists of rulebook rows a character may hold more than one of. */
+export type UwRowListField = 'careers' | 'skills';
+
+/** The single rows a character holds exactly one of. */
+export type UwRowField = 'origin' | 'workspace';
+
+export function setUwCharacterText(
+  snapshot: UwCharacterSnapshot,
+  field: UwCharacterTextField,
+  value: string,
+): UwCharacterSnapshot {
+  return { ...snapshot, [field]: value };
+}
+
+/**
+ * One stat.
+ *
+ * A field the user has emptied arrives as `NaN` and is refused rather than stored: a character with
+ * a Physique of `NaN` is a payload that fails its own kind's validation, which the user would meet
+ * as a broken artifact rather than as a rejected keystroke.
+ */
+export function setUwCharacterStat(
+  snapshot: UwCharacterSnapshot,
+  field: UwStatField,
+  value: number,
+): UwCharacterSnapshot {
+  if (!Number.isFinite(value)) {
+    return snapshot;
+  }
+  const stats: StatBlock = { ...snapshot.stats, [field]: value };
+  return { ...snapshot, stats };
+}
+
+function hasIndex(length: number, index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < length;
+}
+
+function replaceAt<T>(list: T[], index: number, value: T): T[] {
+  return list.map((entry, position) => (position === index ? value : entry));
+}
+
+function removeAt<T>(list: T[], index: number): T[] {
+  return list.filter((_entry, position) => position !== index);
+}
+
+/** The origin or the workspace, by name. Its description is this build's to supply. */
+export function setUwCharacterRowName(
+  snapshot: UwCharacterSnapshot,
+  field: UwRowField,
+  name: string,
+): UwCharacterSnapshot {
+  return { ...snapshot, [field]: { name } };
+}
+
+export function setUwCharacterRowListName(
+  snapshot: UwCharacterSnapshot,
+  list: UwRowListField,
+  index: number,
+  name: string,
+): UwCharacterSnapshot {
+  return hasIndex(snapshot[list].length, index)
+    ? { ...snapshot, [list]: replaceAt(snapshot[list], index, { name }) }
+    : snapshot;
+}
+
+export function addUwCharacterRow(
+  snapshot: UwCharacterSnapshot,
+  list: UwRowListField,
+): UwCharacterSnapshot {
+  const row: StoredUwRow = { name: '' };
+  return { ...snapshot, [list]: [...snapshot[list], row] };
+}
+
+export function removeUwCharacterRow(
+  snapshot: UwCharacterSnapshot,
+  list: UwRowListField,
+  index: number,
+): UwCharacterSnapshot {
+  return hasIndex(snapshot[list].length, index)
+    ? { ...snapshot, [list]: removeAt(snapshot[list], index) }
+    : snapshot;
+}
+
+/** The parts of an asset the sheet prints as text. */
+export type UwAssetTextField = 'name' | 'description';
+
+export function setUwCharacterAssetText(
+  snapshot: UwCharacterSnapshot,
+  index: number,
+  field: UwAssetTextField,
+  value: string,
+): UwCharacterSnapshot {
+  return hasIndex(snapshot.assets.length, index)
+    ? {
+        ...snapshot,
+        assets: replaceAt(snapshot.assets, index, { ...snapshot.assets[index], [field]: value }),
+      }
+    : snapshot;
+}
+
+/** An asset's class, which is what says how much it can do and how many upgrades it carries. */
+export function setUwCharacterAssetClass(
+  snapshot: UwCharacterSnapshot,
+  index: number,
+  assetClass: number,
+): UwCharacterSnapshot {
+  return Number.isFinite(assetClass) && hasIndex(snapshot.assets.length, index)
+    ? {
+        ...snapshot,
+        assets: replaceAt(snapshot.assets, index, { ...snapshot.assets[index], assetClass }),
+      }
+    : snapshot;
+}
+
+/** The asset's type — a Freighter, a Sidearm — which the name usually repeats in parentheses. */
+export function setUwCharacterAssetTypeName(
+  snapshot: UwCharacterSnapshot,
+  index: number,
+  name: string,
+): UwCharacterSnapshot {
+  return hasIndex(snapshot.assets.length, index)
+    ? {
+        ...snapshot,
+        assets: replaceAt(snapshot.assets, index, {
+          ...snapshot.assets[index],
+          type: { ...snapshot.assets[index].type, name },
+        }),
+      }
+    : snapshot;
+}
+
+export function addUwCharacterAsset(snapshot: UwCharacterSnapshot): UwCharacterSnapshot {
+  // A blank asset of class 0 rather than a guessed one. Every part of an asset describes what the
+  // draw gave it, and inventing a type and a class would put things on the sheet nothing stands
+  // behind.
+  return {
+    ...snapshot,
+    assets: [...snapshot.assets, createAsset('', '', 0, createAssetType('', ''), [])],
+  };
+}
+
+export function removeUwCharacterAsset(
+  snapshot: UwCharacterSnapshot,
+  index: number,
+): UwCharacterSnapshot {
+  return hasIndex(snapshot.assets.length, index)
+    ? { ...snapshot, assets: removeAt(snapshot.assets, index) }
+    : snapshot;
+}
+
+export type UwUpgradeField = 'name' | 'description';
+
+export function setUwCharacterUpgradeText(
+  snapshot: UwCharacterSnapshot,
+  assetIndex: number,
+  upgradeIndex: number,
+  field: UwUpgradeField,
+  value: string,
+): UwCharacterSnapshot {
+  if (!hasIndex(snapshot.assets.length, assetIndex)) {
+    return snapshot;
+  }
+  const asset = snapshot.assets[assetIndex];
+  if (!hasIndex(asset.upgrades.length, upgradeIndex)) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    assets: replaceAt(snapshot.assets, assetIndex, {
+      ...asset,
+      upgrades: replaceAt(asset.upgrades, upgradeIndex, {
+        ...asset.upgrades[upgradeIndex],
+        [field]: value,
+      }),
+    }),
+  };
+}
+
+export function addUwCharacterUpgrade(
+  snapshot: UwCharacterSnapshot,
+  assetIndex: number,
+): UwCharacterSnapshot {
+  return hasIndex(snapshot.assets.length, assetIndex)
+    ? {
+        ...snapshot,
+        assets: replaceAt(snapshot.assets, assetIndex, {
+          ...snapshot.assets[assetIndex],
+          upgrades: [...snapshot.assets[assetIndex].upgrades, createUpgrade('', '')],
+        }),
+      }
+    : snapshot;
+}
+
+export function removeUwCharacterUpgrade(
+  snapshot: UwCharacterSnapshot,
+  assetIndex: number,
+  upgradeIndex: number,
+): UwCharacterSnapshot {
+  if (!hasIndex(snapshot.assets.length, assetIndex)) {
+    return snapshot;
+  }
+  const asset = snapshot.assets[assetIndex];
+  return hasIndex(asset.upgrades.length, upgradeIndex)
+    ? {
+        ...snapshot,
+        assets: replaceAt(snapshot.assets, assetIndex, {
+          ...asset,
+          upgrades: removeAt(asset.upgrades, upgradeIndex),
+        }),
+      }
+    : snapshot;
+}

--- a/src/lib/unchartedworlds/uw_character_roll.test.ts
+++ b/src/lib/unchartedworlds/uw_character_roll.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  readUwCharacterGeneratorConfig,
+  resolveUwNameGeneratorSet,
+  rollUwCharacter,
+  rollUwCharacterSnapshot,
+  UW_DEFAULT_NAME_SET,
+} from './uw_character_roll.js';
+import { toUwCharacterSnapshot } from './uw_character_snapshot.js';
+
+describe('rollUwCharacter', () => {
+  /** Requirement 2.2, and the defect this module was written to fix. */
+  it('gives the same character, names included, for the same seed', () => {
+    const first = rollUwCharacter('a-fixed-seed');
+    const second = rollUwCharacter('a-fixed-seed');
+
+    expect(second.character).toEqual(first.character);
+    expect(second.character.firstName).toBe(first.character.firstName);
+  });
+
+  it('gives a different character for a different seed', () => {
+    expect(rollUwCharacter('one-seed').character).not.toEqual(
+      rollUwCharacter('another-seed').character,
+    );
+  });
+
+  /**
+   * The reason the name is drawn from its own stream: choosing a naming source must not shift which
+   * careers, origin or assets the same seed produces.
+   */
+  it('leaves the character unchanged when only the naming settings differ', () => {
+    const plain = rollUwCharacter('shared-seed');
+    const elvish = rollUwCharacter('shared-seed', { nameGeneratorSet: 'elf' });
+
+    expect(elvish.character.careers).toEqual(plain.character.careers);
+    expect(elvish.character.origin).toEqual(plain.character.origin);
+    expect(elvish.character.assets).toEqual(plain.character.assets);
+    expect(elvish.character.firstName).not.toBe(plain.character.firstName);
+  });
+
+  /** An anonymous sheet is an artifact nobody can pick out of a vault listing (3.5). */
+  it('always names the character, even with no naming source chosen', () => {
+    const { character, nameGeneratorSet } = rollUwCharacter('unnamed-seed');
+
+    expect(character.firstName).not.toBe('');
+    expect(character.lastName).not.toBe('');
+    expect(nameGeneratorSet).toBe(UW_DEFAULT_NAME_SET);
+  });
+
+  it('honours the naming gender that was asked for', () => {
+    const male = rollUwCharacter('gendered-seed', { namingGender: 'male' });
+    const female = rollUwCharacter('gendered-seed', { namingGender: 'female' });
+
+    expect(male.character.firstName).not.toBe(female.character.firstName);
+    // The character is the seed's, not the gender picker's.
+    expect(female.character.stats).toEqual(male.character.stats);
+  });
+
+  it('reports the set it actually used rather than the one it was asked for', () => {
+    expect(
+      rollUwCharacter('substituted-seed', { nameGeneratorSet: 'a-set-this-build-lacks' })
+        .nameGeneratorSet,
+    ).toBe(UW_DEFAULT_NAME_SET);
+  });
+
+  it('rolls a snapshot from the same seed and settings', () => {
+    const snapshot = rollUwCharacterSnapshot('reroll-seed', { nameGeneratorSet: 'dwarf' });
+
+    expect(snapshot).toEqual(
+      toUwCharacterSnapshot(
+        rollUwCharacter('reroll-seed', { nameGeneratorSet: 'dwarf' }).character,
+      ),
+    );
+  });
+});
+
+describe('resolveUwNameGeneratorSet', () => {
+  it('keeps a set this build has', () => {
+    expect(resolveUwNameGeneratorSet('elf')).toBe('elf');
+  });
+
+  it('falls back rather than throwing on one it does not', () => {
+    expect(resolveUwNameGeneratorSet('nothing-of-the-sort')).toBe(UW_DEFAULT_NAME_SET);
+    expect(resolveUwNameGeneratorSet(undefined)).toBe(UW_DEFAULT_NAME_SET);
+    expect(resolveUwNameGeneratorSet('')).toBe(UW_DEFAULT_NAME_SET);
+  });
+});
+
+describe('readUwCharacterGeneratorConfig', () => {
+  it('reads back what the generator recorded', () => {
+    expect(
+      readUwCharacterGeneratorConfig({ nameGeneratorSet: 'dwarf', namingGender: 'female' }),
+    ).toEqual({ nameGeneratorSet: 'dwarf', namingGender: 'female' });
+  });
+
+  /** Provenance is `Record<string, unknown>`: this is the boundary where that becomes typed. */
+  it('drops what it does not recognise rather than coercing it', () => {
+    expect(
+      readUwCharacterGeneratorConfig({
+        nameGeneratorSet: 42,
+        namingGender: 'neither',
+        somethingElse: true,
+      }),
+    ).toEqual({});
+    expect(readUwCharacterGeneratorConfig({})).toEqual({});
+  });
+});

--- a/src/lib/unchartedworlds/uw_character_roll.ts
+++ b/src/lib/unchartedworlds/uw_character_roll.ts
@@ -1,0 +1,141 @@
+/**
+ * The single path from a seed to an Uncharted Worlds character, and the record of how it was
+ * rolled.
+ *
+ * Requirement 2.2 of docs/workshop.md wants the same seed and settings to give the same character.
+ * `UnchartedWorldsCharacterGenerator.svelte` satisfied that for the character and not for the
+ * person: it named from `` new RNG(`${Date.now()}-uw-name`) ``, so a locked seed reproduced a
+ * career, an origin and a hand of assets belonging to somebody with a different name every time.
+ * Pressing Generate now draws a *new seed* from the page's own RNG, and the roll itself is a pure
+ * function of seed and config.
+ *
+ * The name is drawn from `` `${seed}-uw-name` `` rather than off the character's own stream, so
+ * choosing a naming source cannot shift which careers or assets the same seed produces.
+ *
+ * **A rolled character always has a name**, for the reason `swn_character_roll.ts` gives: the page
+ * used to blank both names whenever no naming source was chosen, which is most of the time, and an
+ * unnamed character is an artifact nobody can pick out of a vault listing (requirement 3.5).
+ */
+
+import {
+  generateCharacterName,
+  peopleNameGeneratorsFromNameSet,
+  type NamingGender,
+} from '$lib/characters';
+import { getFantasyNameGeneratorSet, getFantasyNameGeneratorSetNames } from '$lib/names';
+import { RNG } from '@ironarachne/rng';
+
+import { generate, type UWCharacter } from './character.js';
+import { toUwCharacterSnapshot, type UwCharacterSnapshot } from './uw_character_snapshot.js';
+
+/** The pattern set a character is named from when nothing else has been asked for. */
+export const UW_DEFAULT_NAME_SET = 'human' as const;
+
+/**
+ * What the generator records about how it rolled, and what a re-roll reads back.
+ *
+ * Stated as a type rather than read field by field at the call site so the two ends — what is
+ * written as provenance and what a re-roll expects to find — are in one place and drift loudly
+ * instead of quietly. There is nothing else in it because the page has no other setting: an
+ * Uncharted Worlds character is two careers and an origin drawn from the whole table, and the tool
+ * offers no way to narrow that.
+ */
+export type UwCharacterGeneratorConfigRecord = {
+  /**
+   * The name pattern set the character was named from.
+   *
+   * A character named from a culture records that culture's own pattern set here rather than the
+   * culture's id, so a re-roll produces names of the same tongue without reaching back into the
+   * store for an artifact it has no way to ask for. The link to the culture is an artifact
+   * reference and lives beside the payload, not in this record.
+   */
+  nameGeneratorSet?: string;
+  /** Which name to draw. `random` lets the seed choose, as the page's gender picker does. */
+  namingGender?: NamingGender;
+};
+
+/**
+ * A rolled character and the pattern set its name actually came from.
+ *
+ * The resolved set travels back out because provenance has to record what was *used* rather than
+ * what was asked for: a set this build has since dropped, recorded as it was requested, is
+ * provenance a re-roll cannot honour.
+ */
+export type UwCharacterRoll = {
+  character: UWCharacter;
+  nameGeneratorSet: string;
+};
+
+const NAMING_GENDERS: NamingGender[] = ['male', 'female', 'random'];
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Provenance is `Record<string, unknown>` because the store cannot know what any tool puts in it,
+ * so this is the boundary where that becomes typed. Anything unrecognisable is dropped rather than
+ * coerced: a config written by a build that spelled these differently should fall back to the
+ * defaults, not roll a character from a field it misread.
+ */
+export function readUwCharacterGeneratorConfig(
+  config: Record<string, unknown>,
+): UwCharacterGeneratorConfigRecord {
+  return {
+    ...(typeof config.nameGeneratorSet === 'string' && config.nameGeneratorSet !== ''
+      ? { nameGeneratorSet: config.nameGeneratorSet }
+      : {}),
+    ...(NAMING_GENDERS.includes(config.namingGender as NamingGender)
+      ? { namingGender: config.namingGender as NamingGender }
+      : {}),
+  };
+}
+
+/**
+ * The pattern set a roll should name from.
+ *
+ * A set this build no longer has falls back to the default rather than throwing:
+ * `getFantasyNameGeneratorSet` refuses a name it does not know, and a character that cannot be
+ * rolled at all is a worse answer than one named in the common tongue.
+ */
+export function resolveUwNameGeneratorSet(requested: string | undefined): string {
+  if (requested === undefined || requested === '') {
+    return UW_DEFAULT_NAME_SET;
+  }
+  return getFantasyNameGeneratorSetNames().includes(requested) ? requested : UW_DEFAULT_NAME_SET;
+}
+
+/**
+ * Roll a character from a seed and a set of options — the one path the generator page and a re-roll
+ * both take.
+ */
+export function rollUwCharacter(
+  seed: string,
+  config: UwCharacterGeneratorConfigRecord = {},
+): UwCharacterRoll {
+  const character = generate(new RNG(seed));
+
+  const nameGeneratorSet = resolveUwNameGeneratorSet(config.nameGeneratorSet);
+  const nameRng = new RNG(`${seed}-uw-name`);
+  const nameSet = getFantasyNameGeneratorSet(nameGeneratorSet, nameRng);
+  const name = generateCharacterName(
+    nameRng,
+    peopleNameGeneratorsFromNameSet(nameSet),
+    config.namingGender ?? 'random',
+  );
+
+  character.firstName = name.firstName;
+  character.lastName = name.lastName;
+
+  return { character, nameGeneratorSet };
+}
+
+/**
+ * Roll a fresh character snapshot from a seed and the settings it was first made with — the
+ * destructive half of editing (requirement 4.3), and what `ARTIFACT_EDITORS` registers as this
+ * kind's roller.
+ */
+export function rollUwCharacterSnapshot(
+  seed: string,
+  config: UwCharacterGeneratorConfigRecord = {},
+): UwCharacterSnapshot {
+  return toUwCharacterSnapshot(rollUwCharacter(seed, config).character);
+}

--- a/src/lib/unchartedworlds/uw_character_snapshot.test.ts
+++ b/src/lib/unchartedworlds/uw_character_snapshot.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import type { UWCharacter } from './character.js';
+import { rollUwCharacter } from './uw_character_roll.js';
+import {
+  isUnknownUwCareerName,
+  isUnknownUwOriginName,
+  isUnknownUwSkillName,
+  toUwCharacterSnapshot,
+  uwCharacterFromSnapshot,
+} from './uw_character_snapshot.js';
+
+/**
+ * A generated character of a given shape, found by sweeping seeds.
+ *
+ * Sweeping rather than hand-building, because the point of a round-trip test is that a character the
+ * generator actually produces survives, and a hand-built one only proves the fields the test author
+ * remembered to set.
+ */
+function rollMatching(predicate: (character: UWCharacter) => boolean): UWCharacter {
+  for (let seed = 0; seed < 300; seed += 1) {
+    const { character } = rollUwCharacter(`roundtrip-${seed}`);
+    if (predicate(character)) {
+      return character;
+    }
+  }
+  throw new Error('no seed in the sweep produced a character of that shape');
+}
+
+const character = rollMatching(() => true);
+
+describe('the Uncharted Worlds character snapshot', () => {
+  /**
+   * Requirement 7.2, in the form this codec can actually claim: everything the character decided
+   * survives, and the rulebook's prose comes back from the tables rather than from the payload.
+   */
+  it('round-trips a generated character', () => {
+    const restored = uwCharacterFromSnapshot(toUwCharacterSnapshot(character));
+
+    expect(restored.firstName).toBe(character.firstName);
+    expect(restored.lastName).toBe(character.lastName);
+    expect(restored.descriptors).toBe(character.descriptors);
+    expect(restored.advancement).toBe(character.advancement);
+    expect(restored.stats).toEqual(character.stats);
+    expect(restored.assets).toEqual(character.assets);
+    expect(restored.careers.map((career) => career.name)).toEqual(
+      character.careers.map((career) => career.name),
+    );
+    expect(restored.origin.name).toBe(character.origin.name);
+    expect(restored.workspace).toEqual(character.workspace);
+    expect(restored.skills).toEqual(character.skills);
+  });
+
+  /** The snapshot is the fixed point: writing what was read back changes nothing. */
+  it('is stable across a second trip through the codec', () => {
+    const snapshot = toUwCharacterSnapshot(character);
+
+    expect(toUwCharacterSnapshot(uwCharacterFromSnapshot(snapshot))).toEqual(snapshot);
+  });
+
+  /** Decision 3: the prose is the library's, and it is not in the payload at all. */
+  it('stores a skill by name and derives what it does', () => {
+    const snapshot = toUwCharacterSnapshot(character);
+
+    expect(snapshot.skills.every((skill) => Object.keys(skill).length === 1)).toBe(true);
+    expect(JSON.stringify(snapshot)).not.toContain(character.skills[0].description);
+    expect(uwCharacterFromSnapshot(snapshot).skills[0].description).toBe(
+      character.skills[0].description,
+    );
+  });
+
+  it('stores the careers, the origin and the workspace by name too', () => {
+    const snapshot = toUwCharacterSnapshot(character);
+
+    expect(snapshot.careers.every((career) => Object.keys(career).length === 1)).toBe(true);
+    expect(Object.keys(snapshot.origin)).toEqual(['name']);
+    expect(Object.keys(snapshot.workspace)).toEqual(['name']);
+    // And they come back whole, because the tables are still here.
+    const restored = uwCharacterFromSnapshot(snapshot);
+    expect(restored.careers[0].skills.length).toBeGreaterThan(0);
+    expect(restored.origin.skills.length).toBeGreaterThan(0);
+    expect(restored.workspace.description).not.toBe('');
+  });
+
+  it('keeps the assets in full, because they are not table rows', () => {
+    const snapshot = toUwCharacterSnapshot(character);
+
+    expect(snapshot.assets).toEqual(character.assets);
+    // Attire, the class 0 asset every character starts with, carries no upgrades — so the check is
+    // that upgrades survive at all, not that the first asset has any.
+    expect(snapshot.assets.some((asset) => asset.upgrades.length > 0)).toBe(true);
+  });
+
+  /**
+   * A row this build has dropped rebuilds as a placeholder wearing the stored name. The character
+   * is still readable, which is the whole point of not quarantining them.
+   */
+  it('rebuilds a placeholder for a row this build no longer has', () => {
+    const snapshot = toUwCharacterSnapshot(character);
+    const restored = uwCharacterFromSnapshot({
+      ...snapshot,
+      careers: [{ name: 'Chronomancer' }],
+      origin: { name: 'Somewhere Else' },
+      workspace: { name: 'A Shed' },
+      skills: [{ name: 'Whistling' }],
+    });
+
+    expect(restored.careers[0].name).toBe('Chronomancer');
+    expect(restored.careers[0].skills).toEqual([]);
+    expect(restored.origin.name).toBe('Somewhere Else');
+    expect(restored.workspace.description).toBe('');
+    expect(restored.skills[0]).toEqual({ name: 'Whistling', description: '' });
+  });
+
+  it('says which names this build no longer has', () => {
+    expect(isUnknownUwCareerName(character.careers[0].name)).toBe(false);
+    expect(isUnknownUwCareerName('Chronomancer')).toBe(true);
+    expect(isUnknownUwOriginName(character.origin.name)).toBe(false);
+    expect(isUnknownUwOriginName('Somewhere Else')).toBe(true);
+    expect(isUnknownUwSkillName(character.skills[0].name)).toBe(false);
+    expect(isUnknownUwSkillName('Whistling')).toBe(true);
+  });
+
+  it('is free of the functions IndexedDB refuses', () => {
+    expect(() => structuredClone(toUwCharacterSnapshot(character))).not.toThrow();
+  });
+
+  it('does not hand out the character it was given', () => {
+    const snapshot = toUwCharacterSnapshot(character);
+    snapshot.stats.physique = 99;
+    snapshot.assets[0].name = 'Something else entirely';
+
+    expect(character.stats.physique).not.toBe(99);
+    expect(character.assets[0].name).not.toBe('Something else entirely');
+  });
+
+  /** A user's edit is authoritative: nothing on the read path recomputes it. */
+  it('does not correct a stat a user has changed', () => {
+    const edited = toUwCharacterSnapshot(character);
+    edited.stats.mettle = 7;
+
+    expect(uwCharacterFromSnapshot(edited).stats.mettle).toBe(7);
+  });
+});

--- a/src/lib/unchartedworlds/uw_character_snapshot.ts
+++ b/src/lib/unchartedworlds/uw_character_snapshot.ts
@@ -1,0 +1,201 @@
+/**
+ * Writing an Uncharted Worlds character snapshot, and reading one back.
+ *
+ * **Nothing in this library is function-typed** — the search for a closure on a `UWCharacter`
+ * returns nothing — so unlike the DCC character there is no handler to strip and put back. What
+ * this codec does instead is decide which prose belongs to the character and which belongs to the
+ * rulebook, and store only the first.
+ *
+ * **The rulebook rows travel by name, and their prose is derived on read.** That is decision 3 of
+ * docs/readiness-characters.md, applied to every table row rather than only to a skill: a career, an
+ * origin, a workspace and a skill are all rows a character *points at*, and each carries text this
+ * library owns. Storing the text would freeze it — a wording fix would reach a character generated
+ * tomorrow and never one saved last month — and it would put several kilobytes of rulebook into
+ * every artifact. Deriving it is safe here in a way it would not be elsewhere, because the
+ * derivation is a lookup: no RNG, no user input, no dice.
+ *
+ * **The question #48 and #49 left is answered cleanly here: nothing writes to a row after it is
+ * drawn.** The DCC farmer's own handler rewrites its occupation's name, and a SWN lucky sign
+ * carries the character's own modifier, so neither could be rebuilt from a name. Uncharted Worlds
+ * generation copies each row it uses and then only ever *reads* it — `rng.shuffle` reorders the
+ * copied origin's skill list, and the order of a list of options is not data. So a name is enough.
+ *
+ * **The assets are the exception, and they are stored in full.** An asset is not a table row: it is
+ * a class, a type and a hand of upgrades drawn and assembled at generation time, with a name
+ * composed from the parts. There is nothing to look it up by, and it is the most characterful thing
+ * a character owns.
+ *
+ * A row this build no longer has rebuilds as a placeholder carrying the stored name and nothing
+ * else, rather than throwing or quarantining the character. A character whose career was renamed is
+ * still that character, and their stats, assets and skills are all still on the sheet.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+
+import { CAREERS } from './career_data.js';
+import { ORIGINS } from './origin_data.js';
+import type {
+  Asset,
+  Career,
+  Origin,
+  Skill,
+  StatBlock,
+  UWCharacter,
+  Workspace,
+} from './character.js';
+
+/** A rulebook row as it is stored: the name it was drawn under, and nothing else. */
+export type StoredUwRow = {
+  name: string;
+};
+
+/** An Uncharted Worlds character as it is stored. */
+export type UwCharacterSnapshot = {
+  firstName: string;
+  lastName: string;
+  descriptors: string;
+  stats: StatBlock;
+  careers: StoredUwRow[];
+  origin: StoredUwRow;
+  workspace: StoredUwRow;
+  skills: StoredUwRow[];
+  advancement: string;
+  assets: Asset[];
+};
+
+function storedRow(row: { name: string }): StoredUwRow {
+  return { name: row.name };
+}
+
+export function toUwCharacterSnapshot(character: UWCharacter): UwCharacterSnapshot {
+  return {
+    firstName: character.firstName,
+    lastName: character.lastName,
+    descriptors: character.descriptors,
+    stats: { ...character.stats },
+    careers: character.careers.map(storedRow),
+    origin: storedRow(character.origin),
+    workspace: storedRow(character.workspace),
+    skills: character.skills.map(storedRow),
+    advancement: character.advancement,
+    assets: structuredClone(character.assets),
+  };
+}
+
+/**
+ * Every skill this build has, from both tables, by name.
+ *
+ * Four names appear in a career and in an origin with descriptions that differ — by trailing
+ * whitespace, and by nothing else — so which one wins is not a decision worth making carefully. The
+ * career table is read first because it is the larger of the two.
+ */
+function skillDescriptions(): Map<string, string> {
+  const descriptions = new Map<string, string>();
+  for (const career of CAREERS) {
+    for (const skill of career.skills) {
+      descriptions.set(skill.name, skill.description);
+    }
+  }
+  for (const origin of ORIGINS) {
+    for (const skill of origin.skills) {
+      if (!descriptions.has(skill.name)) {
+        descriptions.set(skill.name, skill.description);
+      }
+    }
+  }
+  return descriptions;
+}
+
+/** Every workspace this build has. A workspace belongs to the careers that offer it. */
+function workspaceDescriptions(): Map<string, string> {
+  const descriptions = new Map<string, string>();
+  for (const career of CAREERS) {
+    for (const workspace of career.workspaces) {
+      descriptions.set(workspace.name, workspace.description);
+    }
+  }
+  return descriptions;
+}
+
+/** Whether this build's tables still have a career of that name. */
+export function isUnknownUwCareerName(name: string): boolean {
+  return !CAREERS.some((career) => career.name === name);
+}
+
+/** Whether this build's tables still have an origin of that name. */
+export function isUnknownUwOriginName(name: string): boolean {
+  return !ORIGINS.some((origin) => origin.name === name);
+}
+
+/** Whether this build knows what a skill of that name does. */
+export function isUnknownUwSkillName(name: string): boolean {
+  return !skillDescriptions().has(name);
+}
+
+/**
+ * The career of that name, or a placeholder wearing it.
+ *
+ * A placeholder rather than a throw, and a placeholder rather than a substitute: a career this
+ * build has dropped is still the career the user's notes say they took, and the skills it granted
+ * are on the character already. What is empty is only what a *further* draw would need — the
+ * descriptors, workspaces and advancements nobody is drawing from a saved character.
+ */
+function careerFor(name: string): Career {
+  const found = CAREERS.find((career) => career.name === name);
+  return found === undefined
+    ? { name, descriptors: [], workspaces: [], advancements: [], skills: [] }
+    : structuredClone(found);
+}
+
+function originFor(name: string): Origin {
+  const found = ORIGINS.find((origin) => origin.name === name);
+  return found === undefined ? { name, descriptors: [], skills: [] } : structuredClone(found);
+}
+
+function workspaceFor(name: string, descriptions: Map<string, string>): Workspace {
+  return { name, description: descriptions.get(name) ?? '' };
+}
+
+function skillFor(name: string, descriptions: Map<string, string>): Skill {
+  return { name, description: descriptions.get(name) ?? '' };
+}
+
+/**
+ * A stored character back into the live one the library works with.
+ *
+ * The character's own decisions — the stats, the descriptors, the advancement, the assets, and
+ * which rows they took — come back exactly as they were stored. The rulebook's prose comes back
+ * from this build's tables, which is the whole point: a description corrected today is corrected on
+ * every character who ever took that skill.
+ */
+export function uwCharacterFromSnapshot(snapshot: UwCharacterSnapshot): UWCharacter {
+  const skills = skillDescriptions();
+  const workspaces = workspaceDescriptions();
+
+  return {
+    firstName: snapshot.firstName,
+    lastName: snapshot.lastName,
+    descriptors: snapshot.descriptors,
+    stats: { ...snapshot.stats },
+    careers: snapshot.careers.map((career) => careerFor(career.name)),
+    origin: originFor(snapshot.origin.name),
+    workspace: workspaceFor(snapshot.workspace.name, workspaces),
+    skills: snapshot.skills.map((skill) => skillFor(skill.name, skills)),
+    advancement: snapshot.advancement,
+    assets: structuredClone(snapshot.assets),
+  };
+}
+
+/**
+ * The codec's reading half, with the signature the registry hands it.
+ *
+ * The RNG is unused, and that is the correct amount of use for it. It exists for kinds that rebuild
+ * name generators; a character is finished when it is stored, and drawing anything from a seed on
+ * the way back would be regenerating over the user's edits.
+ */
+export function uwCharacterFromSnapshotWithRng(
+  snapshot: UwCharacterSnapshot,
+  _rng: RNG,
+): UWCharacter {
+  return uwCharacterFromSnapshot(snapshot);
+}

--- a/src/lib/unchartedworlds/uw_presentation.test.ts
+++ b/src/lib/unchartedworlds/uw_presentation.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import type { UWCharacter } from './character.js';
+import { rollUwCharacter } from './uw_character_roll.js';
+import {
+  formatUwStat,
+  uwCharacterDisplayName,
+  uwCharacterFileStem,
+  uwCharacterToDocument,
+  uwCharacterToMarkdown,
+} from './uw_presentation.js';
+
+const { character } = rollUwCharacter('presentation-fixture');
+
+describe('formatUwStat', () => {
+  it('signs a stat the way a sheet prints it', () => {
+    expect(formatUwStat(2)).toBe('+2');
+    expect(formatUwStat(0)).toBe('+0');
+    expect(formatUwStat(-1)).toBe('-1');
+  });
+});
+
+describe('the Uncharted Worlds character document', () => {
+  it('heads the document with the character', () => {
+    expect(uwCharacterToDocument(character).title).toBe(
+      `${character.firstName} ${character.lastName}`,
+    );
+  });
+
+  it('gives each skill and each asset a heading of its own', () => {
+    const sections = uwCharacterToDocument(character).sections;
+
+    for (const skill of character.skills) {
+      expect(sections.some((entry) => entry.heading === skill.name && entry.level === 3)).toBe(
+        true,
+      );
+    }
+    for (const asset of character.assets) {
+      expect(sections.some((entry) => entry.heading === asset.name && entry.level === 3)).toBe(
+        true,
+      );
+    }
+  });
+
+  /** Requirement 6.4: no heading over nothing. */
+  it('drops a group heading with nothing under it', () => {
+    const stripped: UWCharacter = { ...character, skills: [], assets: [] };
+    const headings = uwCharacterToDocument(stripped).sections.map((entry) => entry.heading);
+
+    expect(headings).not.toContain('Skills');
+    expect(headings).not.toContain('Assets');
+    expect(headings).toContain('Statistics');
+  });
+
+  it('drops the workspace section for a character with no workspace description', () => {
+    const noWorkspace: UWCharacter = {
+      ...character,
+      workspace: { name: 'A Shed', description: '' },
+    };
+    const headings = uwCharacterToDocument(noWorkspace).sections.map((entry) => entry.heading);
+
+    expect(headings).not.toContain('Workspace');
+    // Its name is still in the glance block, which is where a reader looks for it.
+    const glance = uwCharacterToDocument(noWorkspace).sections.find(
+      (entry) => entry.heading === 'At a Glance',
+    );
+    expect(glance?.items.join('\n')).toContain('A Shed');
+  });
+
+  /** A skill with no description still prints its name: the name is the fact. */
+  it('keeps a skill this build has no description for', () => {
+    const unknown: UWCharacter = {
+      ...character,
+      skills: [{ name: 'Whistling', description: '' }],
+    };
+
+    expect(uwCharacterToDocument(unknown).sections.some((e) => e.heading === 'Whistling')).toBe(
+      true,
+    );
+  });
+});
+
+describe('uwCharacterToMarkdown', () => {
+  const markdown = uwCharacterToMarkdown(character);
+
+  it('leads with the character and nests the skills under their heading', () => {
+    expect(markdown.startsWith(`# ${uwCharacterDisplayName(character)}`)).toBe(true);
+    expect(markdown).toContain('## Skills');
+    expect(markdown).toContain(`### ${character.skills[0].name}`);
+  });
+
+  it('prints what the character has done', () => {
+    expect(markdown).toContain(`Origin: ${character.origin.name}`);
+    expect(markdown).toContain(`Advancement: ${character.advancement}`);
+  });
+
+  it('ends with a newline, as a text file should', () => {
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('uwCharacterDisplayName', () => {
+  it('falls back to the careers, then to the kind', () => {
+    const unnamed: UWCharacter = { ...character, firstName: '', lastName: ' ' };
+    expect(uwCharacterDisplayName(unnamed)).toBe(
+      character.careers.map((career) => career.name).join(' and '),
+    );
+
+    expect(uwCharacterDisplayName({ ...unnamed, careers: [] })).toBe('Uncharted Worlds Character');
+  });
+});
+
+describe('uwCharacterFileStem', () => {
+  it('reduces a name to something a filesystem takes', () => {
+    expect(uwCharacterFileStem({ ...character, firstName: 'Sabra', lastName: "O'Neil" })).toBe(
+      'uw-sabra-o-neil',
+    );
+  });
+
+  it('falls back for a character whose name reduces to nothing', () => {
+    expect(uwCharacterFileStem({ ...character, firstName: '!!!', lastName: '', careers: [] })).toBe(
+      'uw-character',
+    );
+  });
+});

--- a/src/lib/unchartedworlds/uw_presentation.ts
+++ b/src/lib/unchartedworlds/uw_presentation.ts
@@ -1,0 +1,174 @@
+/**
+ * An Uncharted Worlds character arranged for reading, and the Markdown export written from it.
+ *
+ * The library already renders a **character sheet** as a PDF (`render_uw_character_pdf.ts`) — a
+ * drawn form, which is what a player wants at the table. That is 6.3 satisfied for the sheet, and
+ * this module does not replace it: a document model underneath a drawn form would be a worse form.
+ *
+ * What was missing is the other half of 6.3 — the character as *text* — and 6.4 with it.
+ * `formatAsText` prints an Assets heading over nothing for a character whose assets were all
+ * removed, and a Skills heading over nothing for one with no skills. The document model is where a
+ * section with neither prose nor items is dropped, once, rather than in each renderer.
+ *
+ * `formatAsText` is left as it is. It is the library's own long-standing text form, tested as such,
+ * and what a reader of a saved `.txt` from an older build expects to see.
+ *
+ * **A skill and an asset each get a heading of their own**, which is why a section carries a level:
+ * a skill's description is several lines and often a list of choices, and running four of those
+ * together under one heading is how the plain-text export became hard to read at the table.
+ */
+
+import type { Asset, Skill, UWCharacter } from './character.js';
+
+/** One heading and what sits under it. A section with neither prose nor items is not printed. */
+export type UwCharacterSection = {
+  heading: string;
+  /** 2 for a part of the sheet, 3 for one skill or one asset within it. */
+  level: 2 | 3;
+  paragraphs: string[];
+  items: string[];
+};
+
+/** A character arranged for reading, independent of the format it is finally written in. */
+export type UwCharacterDocument = {
+  title: string;
+  sections: UwCharacterSection[];
+};
+
+function section(
+  heading: string,
+  level: 2 | 3,
+  paragraphs: string[],
+  items: string[] = [],
+): UwCharacterSection {
+  return {
+    heading,
+    level,
+    paragraphs: paragraphs.filter(isPrintable),
+    items: items.filter(isPrintable),
+  };
+}
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+function hasContent(entry: UwCharacterSection): boolean {
+  return entry.paragraphs.length > 0 || entry.items.length > 0;
+}
+
+/** A stat as the sheet prints it: signed, because a -1 and a +1 are read at a glance. */
+export function formatUwStat(value: number): string {
+  return value < 0 ? `${value}` : `+${value}`;
+}
+
+/** What the character is, in the terms Uncharted Worlds uses: what they have done. */
+function identityLines(character: UWCharacter): string[] {
+  return [
+    `Careers: ${character.careers.map((career) => career.name).join(', ')}`,
+    `Origin: ${character.origin.name}`,
+    `Descriptors: ${character.descriptors}`,
+    `Workspace: ${character.workspace.name}`,
+    `Advancement: ${character.advancement}`,
+  ];
+}
+
+function statLines(character: UWCharacter): string[] {
+  return [
+    `Physique: ${formatUwStat(character.stats.physique)}`,
+    `Mettle: ${formatUwStat(character.stats.mettle)}`,
+    `Expertise: ${formatUwStat(character.stats.expertise)}`,
+    `Influence: ${formatUwStat(character.stats.influence)}`,
+    `Interface: ${formatUwStat(character.stats.interface)}`,
+  ];
+}
+
+/** A skill's own prose, as the lines it was written in. */
+function skillSection(skill: Skill): UwCharacterSection {
+  return section(
+    skill.name,
+    3,
+    skill.description.split('\n').map((line) => line.trim()),
+  );
+}
+
+/**
+ * One asset: what it is, and the upgrades bolted to it.
+ *
+ * The workspace is printed with the assets on the character's own sheet, and it is printed in the
+ * glance block here instead — it has a name and a line of description, not upgrades, and a heading
+ * with one line under it in a list of things that have several reads as a mistake.
+ */
+function assetSection(asset: Asset): UwCharacterSection {
+  return section(
+    asset.name,
+    3,
+    [asset.description],
+    asset.upgrades.map((upgrade) => `${upgrade.name}: ${upgrade.description}`),
+  );
+}
+
+/**
+ * Arrange a character for reading.
+ *
+ * The three summary sections are dropped when they are empty, which is 6.4. The two group headings
+ * — Skills and Assets — are printed only when something is under them, which is the same rule
+ * stated for a heading that has children rather than lines. A skill with no description still
+ * prints its name: the name is the fact, and the prose is the gloss.
+ */
+export function uwCharacterToDocument(character: UWCharacter): UwCharacterDocument {
+  const summary = [
+    section('At a Glance', 2, [], identityLines(character)),
+    section('Statistics', 2, [], statLines(character)),
+    section('Workspace', 2, [character.workspace.description]),
+  ].filter(hasContent);
+
+  const skills = character.skills.map(skillSection);
+  const assets = character.assets.map(assetSection);
+
+  return {
+    title: uwCharacterDisplayName(character),
+    sections: [
+      ...summary,
+      ...(skills.length > 0 ? [section('Skills', 2, [], []), ...skills] : []),
+      ...(assets.length > 0 ? [section('Assets', 2, [], []), ...assets] : []),
+    ],
+  };
+}
+
+/** What to head the document with: the character's name, or what they have done. */
+export function uwCharacterDisplayName(character: UWCharacter): string {
+  const given = `${character.firstName} ${character.lastName}`.trim();
+  if (isPrintable(given)) {
+    return given;
+  }
+  const careers = character.careers
+    .map((career) => career.name.trim())
+    .filter((name) => isPrintable(name));
+  return careers.length === 0 ? 'Uncharted Worlds Character' : careers.join(' and ');
+}
+
+/** A character as Markdown, for a player who wants them in their own notes. */
+export function uwCharacterToMarkdown(character: UWCharacter): string {
+  const document = uwCharacterToDocument(character);
+  const blocks = [`# ${document.title}`];
+
+  for (const entry of document.sections) {
+    blocks.push(`${'#'.repeat(entry.level)} ${entry.heading}`);
+    blocks.push(...entry.paragraphs);
+    if (entry.items.length > 0) {
+      blocks.push(entry.items.map((item) => `- ${item}`).join('\n'));
+    }
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** A filename stem for an exported character: their name, reduced to something a filesystem takes. */
+export function uwCharacterFileStem(character: UWCharacter): string {
+  const stem = uwCharacterDisplayName(character)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' ? 'uw-character' : `uw-${stem}`;
+}

--- a/src/lib/workshop/README.md
+++ b/src/lib/workshop/README.md
@@ -223,8 +223,8 @@ artifact does not restamp contents nobody changed.
 ## Artifact editors
 
 `ARTIFACT_EDITORS` maps a kind to the component that edits it, alongside an optional roller.
-**Culture, religion, settlement, and the AD&D 2E, fantasy, DCC and SWN characters are the
-entries**, and most kinds having none is the shipped state: #39
+**Culture, religion, settlement, and the AD&D 2E, fantasy, DCC, SWN and Uncharted Worlds
+characters are the entries**, and most kinds having none is the shipped state: #39
 built the frame, and an editing view for a particular kind is part of taking that tool to
 Release-ready (docs/workshop.md, section 4). A kind with no entry opens read-only — the stored
 snapshot, rendered honestly — which is a state the surface draws rather than an error it reports.

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -107,6 +107,15 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         );
     },
   },
+  'character.uncharted-worlds': {
+    loadEditor: () => import('$components/characters/UwCharacterArtifactEditor.svelte'),
+    loadRoller: async () => {
+      const { readUwCharacterGeneratorConfig, rollUwCharacterSnapshot } =
+        await import('$lib/unchartedworlds/uw_character_roll.js');
+      return (provenance) =>
+        rollUwCharacterSnapshot(provenance.seed, readUwCharacterGeneratorConfig(provenance.config));
+    },
+  },
   /**
    * The first kind whose editor is a tool rather than a component written for the purpose.
    *

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -19,6 +19,7 @@ describe('artifact kind catalog', () => {
       'character',
       'character.dcc',
       'character.swn',
+      'character.uncharted-worlds',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -23,6 +23,7 @@ import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
 import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
 import { settlementArtifactKind } from '$lib/settlements/settlement_artifact_kind';
 import { swnCharacterArtifactKind } from '$lib/swn/swn_character_artifact_kind';
+import { uwCharacterArtifactKind } from '$lib/unchartedworlds/uw_character_artifact_kind';
 
 /**
  * Assembled statically, in a single list, exactly like `TOOL_PANELS` beside it and the tool
@@ -43,6 +44,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, characterArtifactKind);
   registerArtifactKind(registry, dccCharacterArtifactKind);
   registerArtifactKind(registry, swnCharacterArtifactKind);
+  registerArtifactKind(registry, uwCharacterArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Implements the #50 section of `docs/readiness-characters.md`, part of the readiness pass. Closes #50. This completes the three system characters (#48, #49, #50).

`/unchartedworlds/character` is assessed section by section against the readiness spec rather than declared. The kind is `character.uncharted-worlds`, with an editor in `ARTIFACT_EDITORS`, a naming culture composed by reference, and a PDF sheet and Markdown export.

**Every rulebook row travels by name, and its prose is derived on read.** Decision 3 says a skill's description is derived rather than stored. As built that covers the career, origin and workspace too, and it has to: a career carries its own list of skills *with their descriptions*, so a row stored whole would freeze exactly the prose the decision exists to keep live. A name this build no longer has rebuilds as a placeholder wearing it. The **assets** are stored in full, because an asset is assembled at generation time rather than looked up.

**The question #48 and #49 left is answered cleanly here: nothing writes to a row after it is drawn.** `rng.shuffle` reorders a copied origin's skill list, and the order of a list of options is not data — so unlike the DCC occupation and the SWN lucky sign, a name really is enough.

**Requirement 2.2 was failing for the person, not the character.** The page named from `` new RNG(`${Date.now()}-uw-name`) ``. `uw_character_roll.ts` is the single path from a seed now, and as in #49 a rolled character is always named.

Two things worth a reviewer's eye:

- **The kind id.** The issue's scope section writes it `uncharted-worlds.character`; I used `character.uncharted-worlds`, which is what the design document and decision 4 of `docs/workshop.md` specify. Renaming a kind is a migration, so this is worth disagreeing with now if you disagree.
- **8.4 asks which edition a tool implements.** Which printing these tables were transcribed from is recorded nowhere in this repository, so the README states what is and is not implemented and says plainly that the edition is unknown rather than guessing one.

`npm run verify` green (0 svelte-check errors, coverage gate passed with no new baseline entries) and the full `npm run test:e2e` green — 486 passed, including five new Uncharted Worlds tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJM16yc7mt4tY41t9GpoMD