### PR TITLE
Take the Velgarth Gifts generator to Release-ready

### DIFF
--- a/docs/readiness-characters.md
+++ b/docs/readiness-characters.md
@@ -12,9 +12,10 @@ Part of [the readiness pass](tool-readiness.md); read that first for what all tw
 share — the determinism fix, the stored vocabulary, the kind ids, and the field-editor decision.
 Measured against [Tool release readiness](workshop.md#tool-release-readiness).
 
-**Status:** accepted; the three system characters — [#48](#48--dungeon-crawl-classics),
-[#49](#49--stars-without-number) and [#50](#50--uncharted-worlds) — and
-[#51](#51--heraldry-from-beta-to-release-ready) are **implemented**; #52 is not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in
+**Status:** accepted, and **implemented in full** — all five tools: the three system characters
+([#48](#48--dungeon-crawl-classics), [#49](#49--stars-without-number),
+[#50](#50--uncharted-worlds)), heraldry ([#51](#51--heraldry-from-beta-to-release-ready)) and
+Velgarth Gifts ([#52](#52--velgarth-gifts)). Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in
 this document is clear to start.
 
 ## The three system characters
@@ -242,9 +243,29 @@ and the library has no dependency on any other.
   `gifts` would claim a concept this does not own.
 - **The editor is a `SnapshotFieldEditor` case** over a string list plus a number per gift — the
   simplest instance of decision 5 in the pass.
+
+  **As built it is not, and this is the one place this document was wrong.** `SnapshotFieldEditor`
+  is a list of labelled inputs bound to the fields of a _flat_ object; a set of Gifts is a list of
+  records — a name, a description and a strength each — with its own add and remove. There is no
+  descriptor in the declared language that says "repeat these three fields per row", and inventing
+  one is exactly what
+  [decision 5's own guard](tool-readiness.md#5-flat-payloads-get-a-declared-field-editor-not-twenty-five-bespoke-components)
+  refuses: a kind that needs a fifth control gets a bespoke editor instead. So Velgarth Gifts has a
+  bespoke editor of about a hundred lines, and **the component the pass declared is still unbuilt**
+  — it should be written by the first tool in the pass with a genuinely flat payload (the arms
+  manufacturer, the drug, the planet), which will shape it better than this one would have.
+
 - **8.4 applies to a setting as much as to a system.** The README says which of Velgarth's gifts
   are represented, that strength levels follow the published descriptions rather than any
   mechanical system, and that this is unofficial fan content.
+
+**Two things the issue asked to be settled out loud.** A set of Gifts is **an artifact of its own**,
+not a field on a character: the character kind is the _fantasy_ character, which knows nothing about
+Velgarth, and a setting's psychic talents on a generic payload would be a field only one setting
+could ever fill. The cost is that a character wearing these Gifts references them rather than
+containing them, and nothing does that yet. And **5.1 does not bind**: no input of this generator
+has an artifact kind, which is recorded here rather than answered by inventing one. 5.3 is met, as
+it always was.
 
 ## What every tool in this domain owes
 

--- a/docs/tool-readiness.md
+++ b/docs/tool-readiness.md
@@ -261,9 +261,15 @@ type SnapshotFieldDescriptor = {
 It takes `ArtifactEditorProps` like any other editor and calls `onChange` with a new snapshot. The
 kind supplies the descriptors; nothing in the framework learns what a drug or a star nation is.
 
-**Which tools it serves:** the arms manufacturer, chop shop, spooky ship, drug, Velgarth gifts,
-environment, planet, star nation, star system, potion, item, treasure hoard and merchant — thirteen
-of twenty-five, and every one of them a flat record of strings and numbers with at most a list.
+**Which tools it serves:** the arms manufacturer, chop shop, spooky ship, drug, environment,
+planet, star nation, star system, potion, item, treasure hoard and merchant — twelve of
+twenty-five, and every one of them a flat record of strings and numbers with at most a list.
+
+Velgarth gifts was the thirteenth until #52 built it and found it was not one: a set of Gifts is a
+list of _records_ — a name, a description and a strength each — and no descriptor in the language
+above says "repeat these three fields per row". It took a bespoke editor, per the guard at the end
+of this decision, and **`SnapshotFieldEditor` is still unbuilt**: the first of the twelve above to
+be taken to Release-ready should write it, on a payload that is actually flat.
 
 **Which tools it does not:** the three system characters, heraldry, organization, family, encounter,
 dungeon, region and language. Each of those is a structure — a hierarchy, a graph, a device, a
@@ -477,6 +483,11 @@ the pass composes what this wave declares, so it is the only strictly serial ste
 `velgarth-gifts`, `environment`, `potion`, `item`, and the three reference tools. Small flat
 payloads, no composition, and between them they prove the `SnapshotFieldEditor` decision before
 thirteen tools depend on it. `environment` is here because two other tools reference it.
+
+`velgarth-gifts` came out of this wave first, with the characters domain rather than with its
+neighbours, and it did **not** prove the decision: its payload turned out to be a list of records
+rather than a flat one, so it took a bespoke editor (see decision 5). The component is still owed by
+whichever of the others lands first.
 
 **Wave 2 — the structured.** `character.dcc`, `character.swn`, `character.uncharted-worlds`,
 `starship.swn`, `heraldry`'s editor, `encounter`, `family`, `organization`, `merchant`,

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -39,6 +39,7 @@ const SILENT_TOOL_PAGES = [
     title: 'Uncharted Worlds Character Generator | Iron Arachne',
   },
   { path: '/heraldry', title: 'Heraldry Generator | Iron Arachne' },
+  { path: '/velgarth-gifts', title: 'Velgarth Gifts Generator | Iron Arachne' },
   { path: '/fantasy/settlement', title: 'Settlement Generator | Iron Arachne' },
   { path: '/fantasy/religion', title: 'Religion Generator | Iron Arachne' },
   { path: '/fantasy/adnd/character', title: 'AD&D 2e Character Generator | Iron Arachne' },
@@ -126,5 +127,8 @@ test('maturity: the tool browser marks every tool that has something to warn abo
     browser.getByRole('button', { name: /^Uncharted Worlds Character/ }),
   ).not.toContainText('Release-ready');
   await expect(browser.getByRole('button', { name: /^Heraldry/ })).not.toContainText('Beta');
+  await expect(browser.getByRole('button', { name: /^Velgarth Gifts/ })).not.toContainText(
+    'Experimental',
+  );
   await expect(browser.getByRole('button', { name: /^Planet/ })).toContainText('Experimental');
 });

--- a/e2e/velgarth_gifts.spec.ts
+++ b/e2e/velgarth_gifts.spec.ts
@@ -1,0 +1,166 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `velgarth-gifts` kind: generate, save, reopen, edit.
+ *
+ * This is the half no unit test can settle. The library tests prove a character round-trips through
+ * the codec and that each editing function changes one field; what they cannot prove is that a user
+ * can press Generate, keep the result, come back to it in a different page, change something, and
+ * still have the character they saved. Every step of that crosses a boundary the unit tests stub
+ * out — the artifact store, IndexedDB, the editor registry, and a page reload.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+
+const GIFTS_TITLE = 'Velgarth Gifts Generator | Iron Arachne';
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool on this page has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+test.describe('a set of Velgarth Gifts', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'Valdemar');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/velgarth-gifts', { title: GIFTS_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a set to keep straight away.
+    await expect(page.locator('.gift').first()).toBeVisible();
+    await saveAs(page, 'Talia’s Gifts');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'Talia’s Gifts');
+
+    // Typed rather than filled: `fill` sets the value in one go, and the point of this assertion is
+    // that the editor's own bindings carry a user's keystrokes through to the snapshot it
+    // announces. The value is one no roll produces, so there is always something to save.
+    const description = panel.getByRole('textbox', { name: 'What it does' }).first();
+    await description.fill('');
+    await description.pressSequentially('She hears the horses.');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'Talia’s Gifts');
+    await expect(reopened.getByRole('textbox', { name: 'What it does' }).first()).toHaveValue(
+      'She hears the horses.',
+    );
+  });
+
+  test('changes a strength without rewriting what the Gift does', async ({ page }) => {
+    // Requirement 4.2: the strength and the prose are separate decisions, and a form that silently
+    // replaced a user's sentence with the table's would overrule them.
+    await visitRoute(page, '/velgarth-gifts', { title: GIFTS_TITLE });
+    await saveAs(page, 'Herald Gifts');
+
+    const panel = await openInWorkshop(page, 'Herald Gifts');
+    const description = panel.getByRole('textbox', { name: 'What it does' }).first();
+    const before = await description.inputValue();
+
+    await panel.getByLabel('Strength', { exact: true }).first().selectOption('5');
+    await expect(description).toHaveValue(before);
+
+    // A Gift can be added and taken away again, which is what makes this a list and not a form.
+    await panel.getByRole('button', { name: 'Add a Gift' }).click();
+    const added = panel.getByRole('button', { name: /^Remove Gift \d+$/ });
+    const count = await added.count();
+    await added.last().click();
+    await expect(added).toHaveCount(count - 1);
+  });
+
+  test('downloads the Gifts a player can take to the table', async ({ page }) => {
+    // Requirement 6.3, and the first export this tool has ever had.
+    await visitRoute(page, '/velgarth-gifts', { title: GIFTS_TITLE });
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    expect((await markdown).suggestedFilename()).toMatch(/\.md$/);
+  });
+
+  test('reproduces the same Gifts from the same seed', async ({ page }) => {
+    // Requirement 2.2: the page built a fresh clock-seeded RNG on every press to take one string
+    // from it, which is the same defect the rest of the pass found wearing a smaller coat.
+    await visitRoute(page, '/velgarth-gifts', { title: GIFTS_TITLE });
+
+    const gifts = page.locator('.gift');
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const first = await gifts.allInnerTexts();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await gifts.allInnerTexts()).toEqual(first);
+
+    // And a different seed is a different set, so the reproduction above is not the page simply
+    // failing to re-roll.
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await gifts.allInnerTexts()).not.toEqual(first);
+  });
+});

--- a/src/components/characters/VelgarthGiftsArtifactEditor.svelte
+++ b/src/components/characters/VelgarthGiftsArtifactEditor.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import {
+    addVelgarthGift,
+    removeVelgarthGift,
+    setVelgarthGiftStrength,
+    setVelgarthGiftText,
+    validateVelgarthGiftsSnapshot,
+    VELGARTH_STRENGTHS,
+    type VelgarthGiftsSnapshot,
+  } from '$lib/velgarth_gifts';
+
+  /**
+   * The editing view for a saved set of Velgarth Gifts.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it, so
+   * what is here is one row per Gift and the calls that change it.
+   *
+   * **This is not the `SnapshotFieldEditor` case docs/readiness-characters.md called it.** That
+   * component (decision 5 of docs/tool-readiness.md) is a list of labelled inputs bound to the
+   * fields of a *flat* object; a set of Gifts is a list of records, three fields each, with its own
+   * add and remove. The decision's own guard is what applies — a payload the descriptor language
+   * does not describe gets a bespoke editor rather than a fifth control — so the declared component
+   * is still waiting for the first genuinely flat payload in the pass to build it.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps this editor from rendering fields over
+   * something that is not a set of Gifts.
+   */
+  const accepted = $derived(validateVelgarthGiftsSnapshot(snapshot));
+  const gifts = $derived<VelgarthGiftsSnapshot | undefined>(
+    accepted.ok ? accepted.value : undefined,
+  );
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: VelgarthGiftsSnapshot) => VelgarthGiftsSnapshot): void {
+    if (gifts === undefined) {
+      return;
+    }
+    onChange(change(gifts));
+  }
+</script>
+
+{#if gifts === undefined}
+  <Notice tone="danger">
+    These contents are stored as a set of Velgarth Gifts but do not read as one, so there is nothing
+    safe to edit here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="gifts-editor">
+    {#if gifts.gifts.length === 0}
+      <!-- A set with nothing in it is an ordinary state, not a fault: a user may have removed every
+           Gift on the way to writing their own. -->
+      <p class="gifts-editor__note">No Gifts in this set yet.</p>
+    {/if}
+
+    <!-- Keyed by position rather than by name: two rows may read the same while one is being
+         typed, and a key that changed as the user typed would lose focus on every keystroke. -->
+    {#each gifts.gifts as gift, index (index)}
+      <fieldset>
+        <legend>Gift {index + 1}</legend>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-gift-{index}-name">Name</label>
+          <input
+            id="{uid}-gift-{index}-name"
+            type="text"
+            value={gift.name}
+            oninput={(event) =>
+              edit((current) =>
+                setVelgarthGiftText(current, index, 'name', event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+        </div>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-gift-{index}-strength">Strength</label>
+          <select
+            id="{uid}-gift-{index}-strength"
+            value={String(gift.strength)}
+            onchange={(event) =>
+              edit((current) =>
+                setVelgarthGiftStrength(current, index, Number(event.currentTarget.value)),
+              )}
+          >
+            {#each VELGARTH_STRENGTHS as strength (strength)}
+              <option value={String(strength)}>{strength}</option>
+            {/each}
+          </select>
+        </div>
+
+        <!-- The description is the user's, not a table's: it was assembled from two rows at
+             generation time, so there is nothing to derive it from and nothing a rewrite loses.
+             Raising the strength above deliberately does not rewrite it. -->
+        <div class="input-group input-group--inline">
+          <label for="{uid}-gift-{index}-description">What it does</label>
+          <textarea
+            id="{uid}-gift-{index}-description"
+            rows="3"
+            value={gift.description}
+            oninput={(event) =>
+              edit((current) =>
+                setVelgarthGiftText(current, index, 'description', event.currentTarget.value),
+              )}
+          ></textarea>
+        </div>
+
+        <BaseButton
+          aria-label="Remove Gift {index + 1}"
+          onclick={() => edit((current) => removeVelgarthGift(current, index))}
+        >
+          Remove Gift {index + 1}
+        </BaseButton>
+      </fieldset>
+    {/each}
+
+    <BaseButton onclick={() => edit(addVelgarthGift)}>Add a Gift</BaseButton>
+  </div>
+{/if}
+
+<style>
+  .gifts-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+  }
+
+  .gifts-editor fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s3);
+    align-items: flex-start;
+    margin: 0;
+    /* No border and no radius, matching the character editors: a fieldset inside an editor panel
+       was a box inside a box, and the legend and the spacing already group these. */
+    padding: var(--s4) 0;
+    min-width: 0;
+  }
+
+  .gifts-editor legend {
+    padding: 0 var(--s3);
+    color: var(--gold);
+    font-size: var(--t-micro-size);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .gifts-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .gifts-editor input[type='text'],
+  .gifts-editor select,
+  .gifts-editor textarea {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+
+  .gifts-editor__note {
+    font-size: var(--t-small-size);
+    font-style: italic;
+    margin: 0;
+  }
+</style>

--- a/src/components/characters/VelgarthGiftsGenerator.svelte
+++ b/src/components/characters/VelgarthGiftsGenerator.svelte
@@ -1,27 +1,58 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { RNG } from '@ironarachne/rng';
-  import { VelgarthGifts, VelgarthGiftPossibilities } from '$lib/velgarth_gifts';
-  import type { Gift, GiftGeneratorConfig } from '$lib/velgarth_gifts';
+  import * as Velgarth from '$lib/velgarth_gifts';
+  import type { Gift } from '$lib/velgarth_gifts';
+  import Download from '$lib/download';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
   import SeedControls from '$components/common/SeedControls.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
 
-  let seed = $state(new RNG(Date.now().toString()).randomString(13));
+  const TOOL_PATH = '/velgarth-gifts';
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. The page used to build a whole new
+   * `RNG` from `Date.now()` on every press to take one string from it, which is the same defect
+   * requirement 2.2 names elsewhere in the pass wearing a smaller coat.
+   */
+  const rng = new RNG(Date.now().toString());
+  let seed = $state(rng.randomString(13));
   let lockSeed = $state(false);
-  let gifts: Gift[] = $state([]);
+
+  /**
+   * The rolled Gifts.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every object in the list in
+   * a Proxy, and `structuredClone` — what IndexedDB stores with — refuses a Proxy outright, so
+   * saving fails with `could not be cloned`. The same trap is written up in `$lib/workshop`'s
+   * README beside `saveToolArtifact`.
+   */
+  let gifts = $state.raw<Gift[]>([]);
+
+  const giftsSnapshot = $derived(
+    gifts.length === 0 ? null : Velgarth.toVelgarthGiftsSnapshot(gifts),
+  );
+
+  const defaultArtifactName = $derived(Velgarth.velgarthGiftsDisplayName(gifts));
 
   function generate() {
     if (!lockSeed) {
-      seed = new RNG(Date.now().toString()).randomString(13);
+      seed = rng.randomString(13);
     }
-    const rng = new RNG(seed);
-    const config: GiftGeneratorConfig = {
-      possibilities: VelgarthGiftPossibilities.all(),
-      max_gifts: 3,
-      min_gifts: 1,
-    };
-    gifts = VelgarthGifts.generate(config, rng);
+    gifts = Velgarth.rollVelgarthGifts(seed);
+  }
+
+  function exportMarkdown() {
+    if (gifts.length === 0) {
+      return;
+    }
+    const markdown = Velgarth.velgarthGiftsToMarkdown(gifts);
+    const url = URL.createObjectURL(new Blob([markdown], { type: 'text/markdown' }));
+    Download(url, `${Velgarth.velgarthGiftsFileStem(gifts)}.md`);
+    URL.revokeObjectURL(url);
   }
 
   onMount(() => {
@@ -29,7 +60,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/velgarth-gifts" title="Velgarth Gifts Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Velgarth Gifts Generator">
   {#snippet description()}
     <p>This gives you a set of Gifts for a character from Mercedes Lackey's Velgarth setting.</p>
   {/snippet}
@@ -38,10 +69,32 @@
 
   <BaseButton onclick={generate}>Generate</BaseButton>
 
+  <SaveArtifactButton
+    kind={Velgarth.VELGARTH_GIFTS_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={giftsSnapshot}
+    {seed}
+    defaultName={defaultArtifactName}
+  />
+
+  {#if gifts.length > 0}
+    <div class="gift-exports">
+      <BaseButton onclick={exportMarkdown}>Download Markdown</BaseButton>
+    </div>
+  {/if}
+
   {#each gifts as gift}
     <div class="gift">
-      <h2>{gift.name}</h2>
+      <h2>{Velgarth.velgarthGiftHeading(gift)}</h2>
       <p>{gift.description}</p>
     </div>
   {/each}
 </GeneratorPage>
+
+<style>
+  .gift-exports {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+</style>

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -72,6 +72,9 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // along with the career, origin and asset tables. The kind module holds metadata and validation
   // only.
   '$lib/unchartedworlds/uw_character_artifact_kind',
+  // The tenth. `$lib/velgarth_gifts`'s entry point re-exports the gift table, which is four hundred
+  // lines of setting prose. The kind module holds metadata and validation only.
+  '$lib/velgarth_gifts/velgarth_gifts_artifact_kind',
 ]);
 
 /**

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -119,6 +119,7 @@ describe('TOOL_CATALOG', () => {
       '/heraldry',
       '/swn/character',
       '/unchartedworlds/character',
+      '/velgarth-gifts',
       '/fantasy/adnd/character',
       '/fantasy/adnd/character/build',
     ];
@@ -224,6 +225,7 @@ describe('toolsWithMaturity', () => {
       '/heraldry',
       '/swn/character',
       '/unchartedworlds/character',
+      '/velgarth-gifts',
     ]);
   });
 
@@ -274,6 +276,7 @@ describe('filterTools', () => {
       '/fantasy/adnd/character',
       '/fantasy/dcc/character',
       '/heraldry',
+      '/velgarth-gifts',
       '/culture',
       '/fantasy/religion',
       '/fantasy/settlement',

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -122,7 +122,13 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     label: 'Velgarth Gifts',
     kind: 'generator',
     domain: 'characters',
-    maturity: 'experimental',
+    // Release-ready, assessed section by section against docs/workshop.md and recorded in
+    // docs/readiness-characters.md (#52). It saves as `velgarth-gifts` — named for the setting,
+    // because it is neither generic nor a game system — has an editor in `ARTIFACT_EDITORS`, and
+    // exports Markdown, which is the first export it has ever had. Its roll is deterministic from
+    // the seed via `velgarth_gifts_roll.ts`. Nothing it takes as input has an artifact kind, so
+    // requirement 5.1 does not bind; 5.3 is met, as it always was.
+    maturity: 'release-ready',
     genres: ['fantasy'],
     tags: ['character', 'velgarth'],
   }),

--- a/src/lib/velgarth_gifts/README.md
+++ b/src/lib/velgarth_gifts/README.md
@@ -7,6 +7,25 @@ a game set there.
 A generated character gets several Gifts, and no Gift twice: each pick is removed from the pool
 before the next, so a set of three is three different talents rather than the same one thrice.
 
+## The setting, and what is not here
+
+This is **unofficial fan content** for Mercedes Lackey's Velgarth — the world of the Heralds of
+Valdemar — and is not affiliated with or endorsed by the author or her publishers.
+
+What is represented: the ten Gifts the books name most often — Bardic, Earth-sense, Empathy,
+Farsight, Fetching, Firestarting, Foresight, Healing, Mage-Gift and Mindspeech — each with five
+strength bands.
+
+**The strength levels follow the published descriptions rather than any mechanical system.** The
+novels describe a Gift as weak or powerful and say what that means in practice; they do not give it
+a number. The 1-to-5 scale here is this library's own, so that a rolled Gift can be sorted and
+compared, and the sentence beside it is what actually says what the character can do. No game
+system's statistics are implied, and none is intended.
+
+Deliberately absent: Companions, the Heraldic Circle, lifebonds, blood-magic and the rest of the
+setting's furniture. This tool answers one question — what Gifts is this character born with — and
+leaves the rest of Velgarth to the person running the game.
+
 ## Features
 
 - **`Gift`** — `name`, `description`, and numeric `strength`.
@@ -27,3 +46,24 @@ const gifts: Gift[] = generate({ possibilities: all(), min_gifts: 1, max_gifts: 
 
 Both the Gift and its strength are chosen by commonality weight, so a rare Gift at a rare strength
 is doubly unlikely — which is the intent.
+
+## Saving a set
+
+The generator is Release-ready (issue #52), which means a rolled set can be kept:
+
+- `velgarth_gifts_snapshot.ts` — the stored form, `{ gifts: Gift[] }`. **The description is stored
+  rather than derived**, which is the opposite of what Uncharted Worlds does with a skill: a Gift's
+  prose is assembled at generation time from the Gift's own sentence and the sentence for the
+  strength that was rolled, so there is no table row to look it up in.
+- `velgarth_gifts_artifact_kind.ts` — the `velgarth-gifts` kind. Named for the setting, because it
+  is neither generic nor a game system; a saved set is named after the Gifts in it.
+- `velgarth_gifts_roll.ts` — the single path from a seed to a set. `VELGARTH_MIN_GIFTS` and
+  `VELGARTH_MAX_GIFTS` live here, with the reason for each beside it.
+- `velgarth_gifts_editing.ts` — one function per field, each returning a new snapshot. Raising a
+  strength deliberately does not rewrite the prose beside it.
+- `velgarth_gifts_presentation.ts` — the set as a document, and the Markdown export written from
+  it. This tool had no export of any kind before.
+
+A set of Gifts is an artifact of its own rather than a field on a character: the character kind is
+the _fantasy_ character, which knows nothing about Velgarth, and a setting's psychic talents on a
+generic character payload would be a field only one setting could ever fill.

--- a/src/lib/velgarth_gifts/index.ts
+++ b/src/lib/velgarth_gifts/index.ts
@@ -4,6 +4,11 @@ export type { default as GiftStrengthLevel } from './gift_strength_level';
 export type { default as GiftGeneratorConfig } from './generator_config';
 export * from './gifts';
 export * from './gift_possibilities';
+export * from './velgarth_gifts_artifact_kind';
+export * from './velgarth_gifts_editing';
+export * from './velgarth_gifts_presentation';
+export * from './velgarth_gifts_roll';
+export * from './velgarth_gifts_snapshot';
 
 export * as VelgarthGiftPossibilities from './gift_possibilities';
 export * as VelgarthGifts from './gifts';

--- a/src/lib/velgarth_gifts/velgarth_gifts_artifact_kind.test.ts
+++ b/src/lib/velgarth_gifts/velgarth_gifts_artifact_kind.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import { readArtifactPayload, type AnyArtifactKindEntry } from '$lib/artifact_kinds';
+
+import {
+  migrateVelgarthGiftsSnapshot,
+  validateVelgarthGiftsSnapshot,
+  velgarthGiftsArtifactKind,
+  VELGARTH_GIFTS_ARTIFACT_KIND,
+  VELGARTH_GIFTS_PAYLOAD_VERSION,
+} from './velgarth_gifts_artifact_kind.js';
+import { rollVelgarthGiftsSnapshot } from './velgarth_gifts_roll.js';
+import type { VelgarthGiftsSnapshot } from './velgarth_gifts_snapshot.js';
+
+/** A stored payload, as anything reading one actually receives it. */
+const snapshot = JSON.parse(JSON.stringify(rollVelgarthGiftsSnapshot('kind-fixture'))) as Record<
+  string,
+  unknown
+>;
+
+describe('the Velgarth gifts artifact kind', () => {
+  /** Named for the setting: neither generic nor system-qualified, because it is neither. */
+  it('is registered under the setting’s name', () => {
+    expect(VELGARTH_GIFTS_ARTIFACT_KIND).toBe('velgarth-gifts');
+    expect(velgarthGiftsArtifactKind.kind).toBe('velgarth-gifts');
+    expect(velgarthGiftsArtifactKind.displayName).toBe('Velgarth Gifts');
+    expect(velgarthGiftsArtifactKind.payloadVersion).toBe(VELGARTH_GIFTS_PAYLOAD_VERSION);
+    expect(velgarthGiftsArtifactKind.icon).not.toBe('');
+  });
+
+  it('names a saved set after the Gifts in it', () => {
+    expect(
+      velgarthGiftsArtifactKind.nameOf({
+        gifts: [
+          { name: 'Mindspeech', description: '', strength: 3 },
+          { name: 'Farsight', description: '', strength: 2 },
+        ],
+      }),
+    ).toBe('Mindspeech and Farsight');
+  });
+
+  it('names a single Gift plainly, and an empty set by its kind', () => {
+    expect(
+      velgarthGiftsArtifactKind.nameOf({
+        gifts: [{ name: 'Healing', description: '', strength: 1 }],
+      }),
+    ).toBe('Healing');
+    expect(velgarthGiftsArtifactKind.nameOf({ gifts: [] })).toBe('Velgarth Gifts');
+    expect(
+      velgarthGiftsArtifactKind.nameOf({ gifts: [{ name: '  ', description: '', strength: 1 }] }),
+    ).toBe('Velgarth Gifts');
+  });
+
+  it('accepts a payload the generator produced', () => {
+    expect(validateVelgarthGiftsSnapshot(snapshot).ok).toBe(true);
+  });
+
+  /** 3.3: an empty set is a well-defined result, not a refusal. */
+  it('accepts a set with no Gifts left in it', () => {
+    expect(validateVelgarthGiftsSnapshot({ gifts: [] }).ok).toBe(true);
+  });
+
+  it('rejects something that is not an object at all', () => {
+    for (const payload of [null, 'gifts', 42, [{ name: 'Mindspeech' }]]) {
+      const result = validateVelgarthGiftsSnapshot(payload);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toBe('invalid-payload');
+    }
+  });
+
+  it('rejects a payload with no gifts list', () => {
+    expect(validateVelgarthGiftsSnapshot({}).ok).toBe(false);
+    expect(validateVelgarthGiftsSnapshot({ gifts: 'Mindspeech' }).ok).toBe(false);
+  });
+
+  it('rejects a Gift missing any of its three fields', () => {
+    expect(validateVelgarthGiftsSnapshot({ gifts: [{ name: 'Mindspeech' }] }).ok).toBe(false);
+    expect(
+      validateVelgarthGiftsSnapshot({ gifts: [{ name: 'Mindspeech', description: 'x' }] }).ok,
+    ).toBe(false);
+    expect(validateVelgarthGiftsSnapshot({ gifts: [{ description: 'x', strength: 2 }] }).ok).toBe(
+      false,
+    );
+  });
+
+  it('has no migration to offer, and says so rather than guessing', () => {
+    const result = migrateVelgarthGiftsSnapshot(snapshot, 0);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toBe('unsupported-version');
+  });
+
+  /** The whole read path, as the store runs it. */
+  it('reads a stored payload of its own version', () => {
+    expect(
+      readArtifactPayload(
+        velgarthGiftsArtifactKind as AnyArtifactKindEntry,
+        snapshot,
+        VELGARTH_GIFTS_PAYLOAD_VERSION,
+      ).ok,
+    ).toBe(true);
+  });
+
+  it('quarantines a payload from a version it has no step for', () => {
+    expect(
+      readArtifactPayload(
+        velgarthGiftsArtifactKind as AnyArtifactKindEntry,
+        snapshot,
+        VELGARTH_GIFTS_PAYLOAD_VERSION + 1,
+      ).ok,
+    ).toBe(false);
+  });
+
+  it('loads a codec that round-trips the payload', async () => {
+    const codec = await velgarthGiftsArtifactKind.loadCodec();
+    const accepted = validateVelgarthGiftsSnapshot(snapshot);
+
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) {
+      return;
+    }
+    const { RNG } = await import('@ironarachne/rng');
+    const live = codec.fromSnapshot(accepted.value as VelgarthGiftsSnapshot, new RNG('unused'));
+
+    expect(codec.toSnapshot(live)).toEqual(accepted.value);
+  });
+});

--- a/src/lib/velgarth_gifts/velgarth_gifts_artifact_kind.ts
+++ b/src/lib/velgarth_gifts/velgarth_gifts_artifact_kind.ts
@@ -1,0 +1,128 @@
+import gem from '$lib/assets/icons/set3/gem-1.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import type Gift from './gift';
+import type { VelgarthGiftsSnapshot } from './velgarth_gifts_snapshot';
+
+/**
+ * Stable artifact kind id, named for the setting.
+ *
+ * Neither generic nor system-qualified, because it is neither — decision 5 of
+ * docs/readiness-characters.md. A Velgarth Gift is fan content for one setting; there is no
+ * `setting:` namespace to qualify with, and the generic kind `gifts` would claim a concept this
+ * does not own.
+ *
+ * **A set of Gifts is an artifact of its own**, which is the question issue #52 asks before
+ * anything else. They are an attribute of a person, so the alternative was a field on the character
+ * kind — but that kind is the *fantasy* character, which knows nothing about Velgarth, and adding a
+ * setting's psychic talents to a generic character payload would make every character carry a field
+ * only one setting can fill. What the setting-specific kind costs is that a character wearing these
+ * Gifts references them rather than containing them, and nothing does that yet: no input of this
+ * generator has an artifact kind, so requirement 5.1 does not bind on it (5.3 does, and is met —
+ * the tool works with nothing supplied, which is all it has ever done).
+ */
+export const VELGARTH_GIFTS_ARTIFACT_KIND = 'velgarth-gifts' as const;
+
+/** Version 1. The first shape a set of Gifts has been stored in. */
+export const VELGARTH_GIFTS_PAYLOAD_VERSION = 1 as const;
+
+/**
+ * Checks what reading depends on: a list of Gifts, each with the three fields one has.
+ *
+ * An empty list is accepted. A user who has removed every Gift from a saved set has made an
+ * editing decision, and a payload that fails its own validator is a broken artifact rather than an
+ * empty one — 3.3 asks for a well-defined empty result, not a refusal.
+ */
+export function validateVelgarthGiftsSnapshot(
+  payload: unknown,
+): PayloadResult<VelgarthGiftsSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'Velgarth gifts payload is not an object');
+  }
+  if (
+    !Array.isArray(record.gifts) ||
+    !record.gifts.every((entry) => {
+      const gift = asRecord(entry);
+      return (
+        gift !== null &&
+        hasStringFields(gift, ['name', 'description']) &&
+        Number.isFinite(gift.strength)
+      );
+    })
+  ) {
+    return rejectedPayload(
+      'invalid-payload',
+      'Velgarth gifts payload needs a list of gifts with a name, a description and a strength',
+    );
+  }
+
+  return acceptedPayload(record as unknown as VelgarthGiftsSnapshot);
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day the
+ * shape changes. A kind without one looks complete right up until it silently drops someone's work
+ * — and local-only means there is no server-side migration to fall back on.
+ */
+export function migrateVelgarthGiftsSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<VelgarthGiftsSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Velgarth gifts have no migration from payload version ${from}; version ${VELGARTH_GIFTS_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/**
+ * What to call a saved set: the Gifts in it.
+ *
+ * A set has no name of its own — it is what a person can do, not a thing with a title — so the
+ * listing reads "Mindspeech and Farsight", which is how a player would refer to it anyway.
+ */
+function velgarthGiftsName(snapshot: VelgarthGiftsSnapshot): string {
+  const names = snapshot.gifts.map((gift) => gift.name.trim()).filter((name) => name !== '');
+  if (names.length === 0) {
+    return 'Velgarth Gifts';
+  }
+  if (names.length === 1) {
+    return names[0];
+  }
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+}
+
+/**
+ * A set of Velgarth Gifts as an artifact.
+ *
+ * The codec is the cheapest in the build — the payload is the value, copied — so the split
+ * `loadCodec` asks for buys nothing here. It is still written this way, because the contract is the
+ * same for every kind and a codec that happens to be trivial today is not a reason to wire it
+ * differently from its neighbours.
+ */
+export const velgarthGiftsArtifactKind = defineArtifactKind<Gift[], VelgarthGiftsSnapshot>({
+  kind: VELGARTH_GIFTS_ARTIFACT_KIND,
+  displayName: 'Velgarth Gifts',
+  icon: gem,
+  payloadVersion: VELGARTH_GIFTS_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { toVelgarthGiftsSnapshot, velgarthGiftsFromSnapshotWithRng } =
+      await import('./velgarth_gifts_snapshot.js');
+    return {
+      toSnapshot: toVelgarthGiftsSnapshot,
+      fromSnapshot: velgarthGiftsFromSnapshotWithRng,
+    };
+  },
+  nameOf: velgarthGiftsName,
+  validate: validateVelgarthGiftsSnapshot,
+  migrate: migrateVelgarthGiftsSnapshot,
+});

--- a/src/lib/velgarth_gifts/velgarth_gifts_editing.test.ts
+++ b/src/lib/velgarth_gifts/velgarth_gifts_editing.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addVelgarthGift,
+  removeVelgarthGift,
+  setVelgarthGiftStrength,
+  setVelgarthGiftText,
+  VELGARTH_STRENGTHS,
+} from './velgarth_gifts_editing.js';
+import { rollVelgarthGiftsSnapshot } from './velgarth_gifts_roll.js';
+
+/** A set with more than one Gift in it, so "one at a time" is worth asserting. */
+function multiGiftSet() {
+  for (let seed = 0; seed < 100; seed += 1) {
+    const snapshot = rollVelgarthGiftsSnapshot(`editing-${seed}`);
+    if (snapshot.gifts.length > 1) {
+      return snapshot;
+    }
+  }
+  throw new Error('no seed in the sweep produced a set with more than one Gift');
+}
+
+const gifts = multiGiftSet();
+
+describe('editing a set of Velgarth Gifts', () => {
+  /** Requirement 4.4: one field at a time, and nothing else moves. */
+  it('changes one Gift and leaves the others alone', () => {
+    const edited = setVelgarthGiftText(gifts, 0, 'name', 'Mindspeech');
+
+    expect(edited.gifts[0].name).toBe('Mindspeech');
+    expect(edited.gifts.slice(1)).toEqual(gifts.gifts.slice(1));
+  });
+
+  it('never writes into the snapshot it was given', () => {
+    const before = structuredClone(gifts);
+    setVelgarthGiftText(gifts, 0, 'description', 'something else');
+    setVelgarthGiftStrength(gifts, 0, 5);
+
+    expect(gifts).toEqual(before);
+  });
+
+  /** 4.2: the strength and the prose are separate decisions, and neither drags the other. */
+  it('does not rewrite the description when the strength changes', () => {
+    const edited = setVelgarthGiftStrength(gifts, 0, 5);
+
+    expect(edited.gifts[0].strength).toBe(5);
+    expect(edited.gifts[0].description).toBe(gifts.gifts[0].description);
+  });
+
+  it('edits the description, which is the user’s and not a table’s', () => {
+    const edited = setVelgarthGiftText(gifts, 0, 'description', 'She hears the horses.');
+
+    expect(edited.gifts[0].description).toBe('She hears the horses.');
+    expect(edited.gifts[0].name).toBe(gifts.gifts[0].name);
+    expect(edited.gifts[0].strength).toBe(gifts.gifts[0].strength);
+  });
+
+  it('refuses a strength a user has emptied rather than storing NaN', () => {
+    expect(setVelgarthGiftStrength(gifts, 0, Number.NaN)).toBe(gifts);
+  });
+
+  it('adds a Gift at a strength the user can see and change', () => {
+    const added = addVelgarthGift(gifts);
+    const last = added.gifts[added.gifts.length - 1];
+
+    expect(added.gifts).toHaveLength(gifts.gifts.length + 1);
+    expect(last).toEqual({ name: '', description: '', strength: 3 });
+    expect(VELGARTH_STRENGTHS).toContain(last.strength);
+  });
+
+  it('removes a Gift and leaves the rest in order', () => {
+    const removed = removeVelgarthGift(gifts, 0);
+
+    expect(removed.gifts).toEqual(gifts.gifts.slice(1));
+  });
+
+  it('can empty a set, which is an ordinary state', () => {
+    let current = gifts;
+    while (current.gifts.length > 0) {
+      current = removeVelgarthGift(current, 0);
+    }
+
+    expect(current.gifts).toEqual([]);
+  });
+
+  /** An index nothing is at is a no-op, not a throw: the editor is driven by a live list. */
+  it('ignores an index that is not there', () => {
+    expect(setVelgarthGiftText(gifts, 99, 'name', 'Mindspeech')).toBe(gifts);
+    expect(setVelgarthGiftText(gifts, -1, 'name', 'Mindspeech')).toBe(gifts);
+    expect(setVelgarthGiftStrength(gifts, 99, 2)).toBe(gifts);
+    expect(removeVelgarthGift(gifts, 99)).toBe(gifts);
+  });
+});

--- a/src/lib/velgarth_gifts/velgarth_gifts_editing.ts
+++ b/src/lib/velgarth_gifts/velgarth_gifts_editing.ts
@@ -1,0 +1,96 @@
+/**
+ * Editing a saved set of Velgarth Gifts, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction — renaming one Gift must not
+ * disturb another, and changing a strength must not rewrite the prose beside it — and it is what
+ * lets the editing framework compare what is on screen against what was read to decide whether
+ * anything needs saving.
+ *
+ * **Both text fields are the user's.** A Gift's description is assembled at generation time from
+ * the Gift's own sentence and the sentence for the strength that was rolled, so unlike an Uncharted
+ * Worlds skill there is no table row that owns it — nothing would be corrected by deriving it, and
+ * a referee who has written what their character's Foresight actually does is the authority on it.
+ *
+ * **Nothing here recomputes anything.** Raising a strength does not rewrite the description to the
+ * table's sentence for that band: the two are separate decisions, and a form that silently replaced
+ * a user's prose would overrule them. The destructive command is a re-roll from provenance, which
+ * is `velgarth_gifts_roll.ts` and a button of its own (4.3).
+ */
+
+import type Gift from './gift.js';
+import type { VelgarthGiftsSnapshot } from './velgarth_gifts_snapshot.js';
+
+/** The strength bands the tables use, which is what the editor's control offers. */
+export const VELGARTH_STRENGTHS = [1, 2, 3, 4, 5] as const;
+
+/** The parts of a Gift the sheet prints as text. */
+export type VelgarthGiftTextField = 'name' | 'description';
+
+function hasIndex(length: number, index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < length;
+}
+
+function replaceAt<T>(list: T[], index: number, value: T): T[] {
+  return list.map((entry, position) => (position === index ? value : entry));
+}
+
+function removeAt<T>(list: T[], index: number): T[] {
+  return list.filter((_entry, position) => position !== index);
+}
+
+export function setVelgarthGiftText(
+  snapshot: VelgarthGiftsSnapshot,
+  index: number,
+  field: VelgarthGiftTextField,
+  value: string,
+): VelgarthGiftsSnapshot {
+  return hasIndex(snapshot.gifts.length, index)
+    ? {
+        ...snapshot,
+        gifts: replaceAt(snapshot.gifts, index, { ...snapshot.gifts[index], [field]: value }),
+      }
+    : snapshot;
+}
+
+/**
+ * One Gift's strength.
+ *
+ * A field the user has emptied arrives as `NaN` and is refused rather than stored: a Gift with a
+ * strength of `NaN` is a payload that fails its own kind's validation, which the user would meet as
+ * a broken artifact rather than as a rejected keystroke.
+ */
+export function setVelgarthGiftStrength(
+  snapshot: VelgarthGiftsSnapshot,
+  index: number,
+  strength: number,
+): VelgarthGiftsSnapshot {
+  return Number.isFinite(strength) && hasIndex(snapshot.gifts.length, index)
+    ? {
+        ...snapshot,
+        gifts: replaceAt(snapshot.gifts, index, { ...snapshot.gifts[index], strength }),
+      }
+    : snapshot;
+}
+
+/**
+ * A blank Gift at the middling strength.
+ *
+ * Blank rather than drawn from the table: a set is normally one to three Gifts and the tool rolls
+ * them, so adding one by hand is a user saying "and this one too" about something they have in
+ * mind. Strength 3 because the scale runs 1 to 5 and a new row has to start somewhere the user can
+ * see and change.
+ */
+export function addVelgarthGift(snapshot: VelgarthGiftsSnapshot): VelgarthGiftsSnapshot {
+  const gift: Gift = { name: '', description: '', strength: 3 };
+  return { ...snapshot, gifts: [...snapshot.gifts, gift] };
+}
+
+export function removeVelgarthGift(
+  snapshot: VelgarthGiftsSnapshot,
+  index: number,
+): VelgarthGiftsSnapshot {
+  return hasIndex(snapshot.gifts.length, index)
+    ? { ...snapshot, gifts: removeAt(snapshot.gifts, index) }
+    : snapshot;
+}

--- a/src/lib/velgarth_gifts/velgarth_gifts_presentation.test.ts
+++ b/src/lib/velgarth_gifts/velgarth_gifts_presentation.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import type Gift from './gift.js';
+import { rollVelgarthGifts } from './velgarth_gifts_roll.js';
+import {
+  velgarthGiftHeading,
+  velgarthGiftsDisplayName,
+  velgarthGiftsFileStem,
+  velgarthGiftsToDocument,
+  velgarthGiftsToMarkdown,
+} from './velgarth_gifts_presentation.js';
+
+const gifts = rollVelgarthGifts('presentation-fixture');
+
+describe('velgarthGiftHeading', () => {
+  it('names the Gift and the strength it was rolled at', () => {
+    expect(velgarthGiftHeading({ name: 'Mindspeech', description: '', strength: 4 })).toBe(
+      'Mindspeech (strength 4)',
+    );
+  });
+
+  it('says so for a Gift with no name, because the strength is still a fact', () => {
+    expect(velgarthGiftHeading({ name: '  ', description: '', strength: 2 })).toBe(
+      'An unnamed Gift (strength 2)',
+    );
+  });
+});
+
+describe('the Velgarth gifts document', () => {
+  it('heads the document with the Gifts', () => {
+    expect(velgarthGiftsToDocument(gifts).title).toBe(velgarthGiftsDisplayName(gifts));
+  });
+
+  it('gives every Gift a section of its own', () => {
+    expect(velgarthGiftsToDocument(gifts).sections).toHaveLength(gifts.length);
+  });
+
+  /** Requirement 6.4: a heading, yes; a blank line where the prose was, no. */
+  it('drops an empty description without dropping the Gift', () => {
+    const stripped: Gift[] = [{ name: 'Fetching', description: '   ', strength: 2 }];
+    const section = velgarthGiftsToDocument(stripped).sections[0];
+
+    expect(section.heading).toBe('Fetching (strength 2)');
+    expect(section.paragraphs).toEqual([]);
+  });
+
+  it('prints nothing at all for a set with no Gifts', () => {
+    expect(velgarthGiftsToDocument([]).sections).toEqual([]);
+  });
+});
+
+describe('velgarthGiftsToMarkdown', () => {
+  const markdown = velgarthGiftsToMarkdown(gifts);
+
+  it('leads with the set and heads every Gift', () => {
+    expect(markdown.startsWith(`# ${velgarthGiftsDisplayName(gifts)}`)).toBe(true);
+    expect(markdown).toContain(`## ${velgarthGiftHeading(gifts[0])}`);
+    expect(markdown).toContain(gifts[0].description);
+  });
+
+  it('ends with a newline, as a text file should', () => {
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('prints a heading and nothing else for a set with no Gifts', () => {
+    expect(velgarthGiftsToMarkdown([])).toBe('# Velgarth Gifts\n');
+  });
+});
+
+describe('velgarthGiftsDisplayName', () => {
+  it('reads the way a player would say it out loud', () => {
+    expect(
+      velgarthGiftsDisplayName([
+        { name: 'Mindspeech', description: '', strength: 1 },
+        { name: 'Farsight', description: '', strength: 1 },
+        { name: 'Healing', description: '', strength: 1 },
+      ]),
+    ).toBe('Mindspeech, Farsight and Healing');
+  });
+
+  it('falls back to the kind for a set with nothing named in it', () => {
+    expect(velgarthGiftsDisplayName([])).toBe('Velgarth Gifts');
+  });
+});
+
+describe('velgarthGiftsFileStem', () => {
+  it('reduces the names to something a filesystem takes', () => {
+    expect(velgarthGiftsFileStem([{ name: 'Mage-Gift', description: '', strength: 3 }])).toBe(
+      'velgarth-mage-gift',
+    );
+  });
+
+  it('falls back for a set whose names reduce to nothing', () => {
+    expect(velgarthGiftsFileStem([{ name: '!!!', description: '', strength: 1 }])).toBe(
+      'velgarth-gifts',
+    );
+  });
+});

--- a/src/lib/velgarth_gifts/velgarth_gifts_presentation.ts
+++ b/src/lib/velgarth_gifts/velgarth_gifts_presentation.ts
@@ -1,0 +1,92 @@
+/**
+ * A set of Velgarth Gifts arranged for reading, and the Markdown export written from it.
+ *
+ * This tool had **no export at all** before requirement 6.3 asked for one — no PDF, no text, no
+ * file of any kind — so unlike its neighbours in the pass there is no drawn sheet to sit beneath.
+ * What a player wants is the Gifts as prose they can paste into a character's notes, which is what
+ * this produces.
+ *
+ * 6.4 is the reason the document model exists rather than a single template string: a set with no
+ * Gifts in it prints no headings at all, and a Gift whose description a user has emptied prints its
+ * name and its strength without a blank line where the prose was.
+ */
+
+import type Gift from './gift.js';
+
+/** One Gift arranged for reading: its heading, and the lines under it. */
+export type VelgarthGiftSection = {
+  heading: string;
+  paragraphs: string[];
+};
+
+/** A set of Gifts arranged for reading, independent of the format it is finally written in. */
+export type VelgarthGiftsDocument = {
+  title: string;
+  sections: VelgarthGiftSection[];
+};
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+/** The heading a Gift gets: its name and the strength it was rolled at. */
+export function velgarthGiftHeading(gift: Gift): string {
+  const name = isPrintable(gift.name) ? gift.name.trim() : 'An unnamed Gift';
+  return `${name} (strength ${gift.strength})`;
+}
+
+/**
+ * Arrange a set for reading.
+ *
+ * A Gift with no name and no description still gets a heading, because its strength is a fact about
+ * the character and dropping the row would lose it. What is dropped is an empty description, which
+ * is the blank content 6.4 is about.
+ */
+export function velgarthGiftsToDocument(gifts: Gift[]): VelgarthGiftsDocument {
+  return {
+    title: velgarthGiftsDisplayName(gifts),
+    sections: gifts.map((gift) => ({
+      heading: velgarthGiftHeading(gift),
+      paragraphs: [gift.description].filter(isPrintable),
+    })),
+  };
+}
+
+/**
+ * What to head the document with: the Gifts, listed.
+ *
+ * A set has no name of its own — it is what a person can do — so this reads the way a player would
+ * say it out loud, and it matches what the artifact kind calls a saved set.
+ */
+export function velgarthGiftsDisplayName(gifts: Gift[]): string {
+  const names = gifts.map((gift) => gift.name.trim()).filter(isPrintable);
+  if (names.length === 0) {
+    return 'Velgarth Gifts';
+  }
+  if (names.length === 1) {
+    return names[0];
+  }
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+}
+
+/** A set of Gifts as Markdown, for a player who wants them in their own notes. */
+export function velgarthGiftsToMarkdown(gifts: Gift[]): string {
+  const document = velgarthGiftsToDocument(gifts);
+  const blocks = [`# ${document.title}`];
+
+  for (const entry of document.sections) {
+    blocks.push(`## ${entry.heading}`);
+    blocks.push(...entry.paragraphs);
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** A filename stem for an exported set, reduced to something a filesystem takes. */
+export function velgarthGiftsFileStem(gifts: Gift[]): string {
+  const stem = velgarthGiftsDisplayName(gifts)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' ? 'velgarth-gifts' : `velgarth-${stem}`;
+}

--- a/src/lib/velgarth_gifts/velgarth_gifts_roll.test.ts
+++ b/src/lib/velgarth_gifts/velgarth_gifts_roll.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  rollVelgarthGifts,
+  rollVelgarthGiftsSnapshot,
+  velgarthGiftsGeneratorConfig,
+  VELGARTH_MAX_GIFTS,
+  VELGARTH_MIN_GIFTS,
+} from './velgarth_gifts_roll.js';
+
+describe('rollVelgarthGifts', () => {
+  /** Requirement 2.2. */
+  it('gives the same set for the same seed', () => {
+    expect(rollVelgarthGifts('a-fixed-seed')).toEqual(rollVelgarthGifts('a-fixed-seed'));
+  });
+
+  it('gives a different set for a different seed', () => {
+    const seeds = ['one', 'two', 'three', 'four', 'five'].map((seed) =>
+      JSON.stringify(rollVelgarthGifts(seed)),
+    );
+
+    expect(new Set(seeds).size).toBeGreaterThan(1);
+  });
+
+  it('rolls between one and three Gifts', () => {
+    for (let i = 0; i < 50; i += 1) {
+      const gifts = rollVelgarthGifts(`bounds-${i}`);
+      expect(gifts.length).toBeGreaterThanOrEqual(VELGARTH_MIN_GIFTS);
+      expect(gifts.length).toBeLessThanOrEqual(VELGARTH_MAX_GIFTS);
+    }
+  });
+
+  /** A set of three is three different talents rather than the same one thrice. */
+  it('never rolls the same Gift twice in one set', () => {
+    for (let i = 0; i < 50; i += 1) {
+      const names = rollVelgarthGifts(`unique-${i}`).map((gift) => gift.name);
+      expect(new Set(names).size).toBe(names.length);
+    }
+  });
+
+  it('gives every Gift a name, a description and a strength', () => {
+    for (const gift of rollVelgarthGifts('fields-seed')) {
+      expect(gift.name).not.toBe('');
+      expect(gift.description).not.toBe('');
+      expect(Number.isFinite(gift.strength)).toBe(true);
+    }
+  });
+
+  it('rolls a snapshot from the same seed', () => {
+    expect(rollVelgarthGiftsSnapshot('reroll-seed')).toEqual({
+      gifts: rollVelgarthGifts('reroll-seed'),
+    });
+  });
+});
+
+describe('velgarthGiftsGeneratorConfig', () => {
+  it('draws from the whole table, within the setting’s bounds', () => {
+    const config = velgarthGiftsGeneratorConfig();
+
+    expect(config.possibilities.length).toBeGreaterThan(0);
+    expect(config.min_gifts).toBe(VELGARTH_MIN_GIFTS);
+    expect(config.max_gifts).toBe(VELGARTH_MAX_GIFTS);
+  });
+});

--- a/src/lib/velgarth_gifts/velgarth_gifts_roll.ts
+++ b/src/lib/velgarth_gifts/velgarth_gifts_roll.ts
@@ -1,0 +1,57 @@
+/**
+ * The single path from a seed to a set of Velgarth Gifts.
+ *
+ * Requirement 2.2 of docs/workshop.md wants the same seed to give the same result.
+ * `VelgarthGiftsGenerator.svelte` did that for the Gifts themselves — it built an `RNG` from the
+ * seed box — but it drew each *new* seed from `new RNG(Date.now().toString())`, building a whole
+ * generator to take one string from it. Pressing Generate now draws a new seed from the page's own
+ * RNG, seeded once, and the roll itself is a pure function of the seed.
+ *
+ * **There is no config record here, and that is deliberate.** The page has one control, the seed
+ * box, and the bounds on how many Gifts a character has are the setting's rather than the user's.
+ * Recording `minGifts` and `maxGifts` as provenance would describe a page with controls that do not
+ * exist — the mistake `dcc_character_roll.ts` names about naming gender — so a re-roll takes the
+ * seed and nothing else, and the bounds live here as the constants they are.
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import type Gift from './gift.js';
+import type GiftGeneratorConfig from './generator_config.js';
+import { all } from './gift_possibilities.js';
+import { generate } from './gifts.js';
+import { toVelgarthGiftsSnapshot, type VelgarthGiftsSnapshot } from './velgarth_gifts_snapshot.js';
+
+/**
+ * How many Gifts a rolled character has.
+ *
+ * One is the floor because a character with none is not what this tool is for, and three is the
+ * ceiling because a fourth is vanishingly rare in the setting — a character with four strong Gifts
+ * is a protagonist rather than a person. These were the generator page's own numbers; they are
+ * named here because a constant with a reason beside it is not the same thing as a literal in a
+ * component.
+ */
+export const VELGARTH_MIN_GIFTS = 1 as const;
+export const VELGARTH_MAX_GIFTS = 3 as const;
+
+/** The config a roll uses: the whole table, and the bounds above. */
+export function velgarthGiftsGeneratorConfig(): GiftGeneratorConfig {
+  return {
+    possibilities: all(),
+    min_gifts: VELGARTH_MIN_GIFTS,
+    max_gifts: VELGARTH_MAX_GIFTS,
+  };
+}
+
+/** Roll a set of Gifts from a seed — the one path the generator page and a re-roll both take. */
+export function rollVelgarthGifts(seed: string): Gift[] {
+  return generate(velgarthGiftsGeneratorConfig(), new RNG(seed));
+}
+
+/**
+ * Roll a fresh set as a snapshot — the destructive half of editing (requirement 4.3), and what
+ * `ARTIFACT_EDITORS` registers as this kind's roller.
+ */
+export function rollVelgarthGiftsSnapshot(seed: string): VelgarthGiftsSnapshot {
+  return toVelgarthGiftsSnapshot(rollVelgarthGifts(seed));
+}

--- a/src/lib/velgarth_gifts/velgarth_gifts_snapshot.test.ts
+++ b/src/lib/velgarth_gifts/velgarth_gifts_snapshot.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollVelgarthGifts } from './velgarth_gifts_roll.js';
+import { toVelgarthGiftsSnapshot, velgarthGiftsFromSnapshot } from './velgarth_gifts_snapshot.js';
+
+const gifts = rollVelgarthGifts('snapshot-fixture');
+
+describe('the Velgarth gifts snapshot', () => {
+  /** Requirement 7.2: lossless for everything the page shows. */
+  it('round-trips a rolled set', () => {
+    expect(velgarthGiftsFromSnapshot(toVelgarthGiftsSnapshot(gifts))).toEqual(gifts);
+  });
+
+  it('round-trips an empty set, which is an ordinary state', () => {
+    expect(velgarthGiftsFromSnapshot(toVelgarthGiftsSnapshot([]))).toEqual([]);
+  });
+
+  /**
+   * The description is stored rather than derived, unlike an Uncharted Worlds skill: it is
+   * assembled at generation time from the Gift's sentence and the strength's, so there is no row to
+   * look it up in.
+   */
+  it('keeps the description the roll assembled', () => {
+    const restored = velgarthGiftsFromSnapshot(toVelgarthGiftsSnapshot(gifts));
+
+    expect(restored[0].description).toBe(gifts[0].description);
+    expect(restored[0].description).not.toBe('');
+  });
+
+  it('keeps a strength a user has changed rather than recomputing it', () => {
+    const edited = toVelgarthGiftsSnapshot(gifts);
+    edited.gifts[0].strength = 5;
+
+    expect(velgarthGiftsFromSnapshot(edited)[0].strength).toBe(5);
+  });
+
+  it('is free of the functions IndexedDB refuses', () => {
+    expect(() => structuredClone(toVelgarthGiftsSnapshot(gifts))).not.toThrow();
+  });
+
+  it('does not hand out the list it was given', () => {
+    const snapshot = toVelgarthGiftsSnapshot(gifts);
+    snapshot.gifts[0].name = 'Something else entirely';
+
+    expect(gifts[0].name).not.toBe('Something else entirely');
+  });
+});

--- a/src/lib/velgarth_gifts/velgarth_gifts_snapshot.ts
+++ b/src/lib/velgarth_gifts/velgarth_gifts_snapshot.ts
@@ -1,0 +1,52 @@
+/**
+ * Writing a set of Velgarth Gifts, and reading one back.
+ *
+ * **A `Gift` is three plain fields** — a name, the description its strength level produced, and the
+ * numeric strength — so there is no closure to strip and nothing to resolve by name. The conversion
+ * is a copy, and this module exists for the contract rather than for the work.
+ *
+ * **The description is stored, not derived**, which is the opposite of what Uncharted Worlds does
+ * with a skill (decision 3 of docs/readiness-characters.md), and the difference is worth stating.
+ * A UW skill's prose is a table row a character points at. A Gift's is *assembled at generation
+ * time* from two rows — the Gift's own sentence and the sentence for the strength that was rolled —
+ * so there is no row to look it up in, and rebuilding it would mean re-deriving a roll. It is the
+ * same reason an Uncharted Worlds asset is stored in full.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+
+import type Gift from './gift.js';
+
+/** A set of Gifts as it is stored. */
+export type VelgarthGiftsSnapshot = {
+  gifts: Gift[];
+};
+
+export function toVelgarthGiftsSnapshot(gifts: Gift[]): VelgarthGiftsSnapshot {
+  return { gifts: gifts.map((gift) => ({ ...gift })) };
+}
+
+/**
+ * A stored set back into the list the library works with.
+ *
+ * Nothing is recomputed and nothing is re-rolled: the strengths and the prose come back exactly as
+ * they were stored, which is requirement 4.2 — a user who has rewritten what their Foresight does
+ * has made a decision no read may overrule.
+ */
+export function velgarthGiftsFromSnapshot(snapshot: VelgarthGiftsSnapshot): Gift[] {
+  return snapshot.gifts.map((gift) => ({ ...gift }));
+}
+
+/**
+ * The codec's reading half, with the signature the registry hands it.
+ *
+ * The RNG is unused, and that is the correct amount of use for it. It exists for kinds that rebuild
+ * name generators; a set of Gifts is finished when it is stored, and drawing anything from a seed
+ * on the way back would be regenerating over the user's edits.
+ */
+export function velgarthGiftsFromSnapshotWithRng(
+  snapshot: VelgarthGiftsSnapshot,
+  _rng: RNG,
+): Gift[] {
+  return velgarthGiftsFromSnapshot(snapshot);
+}

--- a/src/lib/workshop/README.md
+++ b/src/lib/workshop/README.md
@@ -223,8 +223,8 @@ artifact does not restamp contents nobody changed.
 ## Artifact editors
 
 `ARTIFACT_EDITORS` maps a kind to the component that edits it, alongside an optional roller.
-**Every registered kind now has one**: heraldry, culture, religion, settlement, and the AD&D 2E,
-fantasy, DCC, SWN and Uncharted Worlds characters. That is where the readiness pass has got to
+**Every registered kind now has one**: heraldry, culture, religion, settlement, Velgarth gifts, and
+the AD&D 2E, fantasy, DCC, SWN and Uncharted Worlds characters. That is where the readiness pass has got to
 rather than a rule — a kind with no entry opens read-only, which is still a state the surface
 renders rather than an error it reports, and `loadViewer` is still in the vocabulary for a kind
 that can be shown and not sensibly edited. #39

--- a/src/lib/workshop/artifact_editors.test.ts
+++ b/src/lib/workshop/artifact_editors.test.ts
@@ -137,6 +137,22 @@ describe('the artifact editor registry', () => {
     expect(hasArtifactEditor('heraldry')).toBe(true);
   });
 
+  /**
+   * The seed and nothing else, which is what this kind's provenance holds: the tool has one
+   * control, and how many Gifts a character has is the setting's business rather than the user's.
+   */
+  it('rolls a set of Velgarth gifts from provenance through the registered roller', async () => {
+    const roll = await artifactEditorEntry('velgarth-gifts')!.loadRoller!();
+    const rolled = roll({
+      toolPath: '/velgarth-gifts',
+      seed: 'registry-seed',
+      config: {},
+    }) as { gifts: { name: string }[] };
+
+    expect(rolled.gifts.length).toBeGreaterThan(0);
+    expect(rolled.gifts[0].name).not.toBe('');
+  });
+
   it('rolls a coat of arms from provenance through the registered roller', async () => {
     const roll = await artifactEditorEntry('heraldry')!.loadRoller!();
     const rolled = roll({

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -126,6 +126,18 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         rollUwCharacterSnapshot(provenance.seed, readUwCharacterGeneratorConfig(provenance.config));
     },
   },
+  'velgarth-gifts': {
+    loadEditor: () => import('$components/characters/VelgarthGiftsArtifactEditor.svelte'),
+    /**
+     * The seed and nothing else: this tool has one control, and the bounds on how many Gifts a
+     * character has are the setting's rather than the user's, so there is no config to read back.
+     */
+    loadRoller: async () => {
+      const { rollVelgarthGiftsSnapshot } =
+        await import('$lib/velgarth_gifts/velgarth_gifts_roll.js');
+      return (provenance) => rollVelgarthGiftsSnapshot(provenance.seed);
+    },
+  },
   /**
    * The first kind whose editor is a tool rather than a component written for the purpose.
    *

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -20,6 +20,7 @@ describe('artifact kind catalog', () => {
       'character.dcc',
       'character.swn',
       'character.uncharted-worlds',
+      'velgarth-gifts',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -24,6 +24,7 @@ import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
 import { settlementArtifactKind } from '$lib/settlements/settlement_artifact_kind';
 import { swnCharacterArtifactKind } from '$lib/swn/swn_character_artifact_kind';
 import { uwCharacterArtifactKind } from '$lib/unchartedworlds/uw_character_artifact_kind';
+import { velgarthGiftsArtifactKind } from '$lib/velgarth_gifts/velgarth_gifts_artifact_kind';
 
 /**
  * Assembled statically, in a single list, exactly like `TOOL_PANELS` beside it and the tool
@@ -45,6 +46,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, dccCharacterArtifactKind);
   registerArtifactKind(registry, swnCharacterArtifactKind);
   registerArtifactKind(registry, uwCharacterArtifactKind);
+  registerArtifactKind(registry, velgarthGiftsArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Implements the #52 section of `docs/readiness-characters.md`. Closes #52, and **completes the characters domain** — all five tools (#48, #49, #50, #51, #52).

`/velgarth-gifts` needed everything from section 3 onwards: nothing it produced survived the tab closing, and it had no export of any kind.

**The question the issue asked first, answered: a set of Gifts is an artifact of its own.** The alternative was a field on the character kind — but that kind is the *fantasy* character, which knows nothing about Velgarth, and a setting's psychic talents on a generic payload would be a field only one setting could ever fill. The kind is `velgarth-gifts`, named for the setting.

**Two things worth a reviewer's eye:**

- **The editor is bespoke, and this is where the design document was wrong.** It called this "the simplest `SnapshotFieldEditor` case in the pass". That component (decision 5 of `docs/tool-readiness.md`) binds inputs to the fields of a *flat* object; a set of Gifts is a list of records — name, description, strength — with its own add and remove, and no descriptor says "repeat these three fields per row". Inventing one is what that decision's own guard refuses, so this took a bespoke editor and **`SnapshotFieldEditor` is still unbuilt** — owed by the first wave-1 tool with a genuinely flat payload. Both documents now say so.
- **The description is stored, not derived** — the opposite of #50's treatment of an Uncharted Worlds skill, and deliberately: a Gift's prose is assembled at generation time from the Gift's sentence *and* the sentence for the strength rolled, so there is no row to look it up in. Raising a strength in the editor does not rewrite it.

Also: 2.2 was failing in a small way (the page built a fresh clock-seeded `RNG` on every press to take one string from it); Markdown export is the first export this tool has ever had; and 8.4 for a setting is recorded in the README — which ten Gifts, that the 1-to-5 scale is this library's own rather than any published system's, what is left out, and that it is unofficial fan content.

`npm run verify` green (0 svelte-check errors, coverage gate passed with no new baseline entries) and the full `npm run test:e2e` green — 495 passed, including four new Velgarth tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJM16yc7mt4tY41t9GpoMD