### PR TITLE
Take the arms manufacturer generator to Release-ready

### DIFF
--- a/docs/readiness-factions.md
+++ b/docs/readiness-factions.md
@@ -10,7 +10,8 @@ Five tools: the arms manufacturer
 Part of [the readiness pass](tool-readiness.md). Measured against
 [Tool release readiness](workshop.md#tool-release-readiness).
 
-**Status:** accepted; not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in this document is clear to start.
+**Status:** accepted; the arms manufacturer ([#53](#53--arms-manufacturer)) is **implemented**;
+#54 to #57 are not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in this document is clear to start.
 
 This domain holds the pass's easiest tool and its second-hardest. The arms manufacturer is three
 files and a flat payload; the organization generator is the richest generator on the site, with a
@@ -35,6 +36,29 @@ cross-library dependency except `$lib/weapons`, which nothing else on the site i
 
 The issue calls this a good tool to take through the whole spec early precisely because nothing
 about it is hard, and [wave 1](tool-readiness.md#the-order-of-the-work) agrees.
+
+**As built.** Everything above landed as written except the editor, which is bespoke — and this is
+the second time the document has been wrong about that in the same way. "A list of models" is a
+list of _records_: a `Weapon` is a name, a damage type and a description (and two string lists
+behind them), and the only repeating control `SnapshotFieldEditor`'s descriptor language declares
+is `string-list`. The guard at the end of
+[decision 5](tool-readiness.md#5-flat-payloads-get-a-declared-field-editor-not-twenty-five-bespoke-components)
+applies exactly as it did to Velgarth Gifts, so `ArmsManufacturerArtifactEditor.svelte` is the
+company's two fields and one row per model with its own add and remove, and **the declared
+component is still unbuilt**. Two of the twelve tools listed as flat have now turned out not to be,
+and both for the same reason — a catalogue, a set, a roster is a list of records — which is worth
+knowing before the next one is assumed to be.
+
+The kind question the issue asked was settled the way the kind table says: `arms-manufacturer` is
+its own kind, not a discriminator on `organization`. An `Organization` is a leader, members, a
+hierarchy and a visual identity; a manufacturer shares a `name` with it and nothing else, so one
+kind would be one validator and one migration path over two shapes.
+
+The PDF is `$lib/pdf`'s `downloadTextPdf` over the same document model the Markdown is written
+from, so the two cannot drift. `Weapon.maker`, which the generator leaves empty, is left empty:
+filling it would be a generator change nothing asked for, and a model added by hand in the editor
+is the one place it is set, to the company's name, because that is the one field a blank row can
+truthfully start with.
 
 **One thing to settle while here.** `$lib/weapons` is imported by `$lib/arms_manufacturer` and by
 nothing else in the application — its science-fiction weapon path belongs to this tool. #69 assumes

--- a/docs/tool-readiness.md
+++ b/docs/tool-readiness.md
@@ -268,8 +268,11 @@ twenty-five, and every one of them a flat record of strings and numbers with at 
 Velgarth gifts was the thirteenth until #52 built it and found it was not one: a set of Gifts is a
 list of _records_ — a name, a description and a strength each — and no descriptor in the language
 above says "repeat these three fields per row". It took a bespoke editor, per the guard at the end
-of this decision, and **`SnapshotFieldEditor` is still unbuilt**: the first of the twelve above to
-be taken to Release-ready should write it, on a payload that is actually flat.
+of this decision. The arms manufacturer (#53) then went the same way for the same reason: its
+"list of models" is a list of `Weapon` records, not a `string-list`. **`SnapshotFieldEditor` is
+still unbuilt**: the first of the remaining eleven above to be taken to Release-ready should write
+it, on a payload that is actually flat — and should check that it is, since two "flat" payloads
+have now turned out to carry a list of records.
 
 **Which tools it does not:** the three system characters, heraldry, organization, family, encounter,
 dungeon, region and language. Each of those is a structure — a hierarchy, a graph, a device, a
@@ -486,8 +489,9 @@ thirteen tools depend on it. `environment` is here because two other tools refer
 
 `velgarth-gifts` came out of this wave first, with the characters domain rather than with its
 neighbours, and it did **not** prove the decision: its payload turned out to be a list of records
-rather than a flat one, so it took a bespoke editor (see decision 5). The component is still owed by
-whichever of the others lands first.
+rather than a flat one, so it took a bespoke editor (see decision 5). `arms-manufacturer` came out
+second and did not prove it either — a catalogue of `Weapon`s is a list of records too. The
+component is still owed by whichever of the others lands first.
 
 **Wave 2 — the structured.** `character.dcc`, `character.swn`, `character.uncharted-worlds`,
 `starship.swn`, `heraldry`'s editor, `encounter`, `family`, `organization`, `merchant`,

--- a/e2e/arms_manufacturer.spec.ts
+++ b/e2e/arms_manufacturer.spec.ts
@@ -1,0 +1,171 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `arms-manufacturer` kind: generate, save, reopen, edit.
+ *
+ * This is the half no unit test can settle. The library tests prove a manufacturer round-trips
+ * through the codec and that each editing function changes one field; what they cannot prove is
+ * that a user can press Generate, keep the result, come back to it in a different page, change
+ * something, and still have the company they saved. Every step of that crosses a boundary the unit
+ * tests stub out — the artifact store, IndexedDB, the editor registry, and a page reload.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+
+const ARMS_TITLE = 'Arms Manufacturer Generator | Iron Arachne';
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool on this page has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+test.describe('an arms manufacturer', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'Outer Rim');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/arms-manufacturer', { title: ARMS_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a company to keep straight away.
+    await expect(page.locator('.model').first()).toBeVisible();
+    await saveAs(page, 'Vex Heavy Industries');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'Vex Heavy Industries');
+
+    // Typed rather than filled: `fill` sets the value in one go, and the point of this assertion is
+    // that the editor's own bindings carry a user's keystrokes through to the snapshot it
+    // announces. The value is one no roll produces, so there is always something to save.
+    const description = panel.getByRole('textbox', { name: 'Model description' }).first();
+    await description.fill('');
+    await description.pressSequentially('It fires backwards.');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'Vex Heavy Industries');
+    await expect(reopened.getByRole('textbox', { name: 'Model description' }).first()).toHaveValue(
+      'It fires backwards.',
+    );
+  });
+
+  test('renames the company without rewriting its description', async ({ page }) => {
+    // Requirement 4.2: the name and the prose are separate decisions, and a form that silently
+    // rewrote the sentence that opens with the old name would overrule the user.
+    await visitRoute(page, '/arms-manufacturer', { title: ARMS_TITLE });
+    await saveAs(page, 'Kessler Arms');
+
+    const panel = await openInWorkshop(page, 'Kessler Arms');
+    const description = panel.getByRole('textbox', { name: 'Company description' });
+    const before = await description.inputValue();
+
+    await panel.getByRole('textbox', { name: 'Company name' }).fill('Kessler Applied Sciences');
+    await expect(description).toHaveValue(before);
+
+    // A model can be added and taken away again, which is what makes the catalogue a list and not
+    // a form.
+    await panel.getByRole('button', { name: 'Add a model' }).click();
+    const removers = panel.getByRole('button', { name: /^Remove model \d+$/ });
+    const count = await removers.count();
+    await removers.last().click();
+    await expect(removers).toHaveCount(count - 1);
+  });
+
+  test('downloads the catalogue a referee can take to the table', async ({ page }) => {
+    // Requirement 6.3, and the first exports this tool has ever had.
+    await visitRoute(page, '/arms-manufacturer', { title: ARMS_TITLE });
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    expect((await markdown).suggestedFilename()).toMatch(/\.md$/);
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/\.pdf$/);
+  });
+
+  test('reproduces the same manufacturer from the same seed', async ({ page }) => {
+    // Requirement 2.2 and 2.3: the page had no seed control at all and called `Date.now()` three
+    // times, so nothing it produced could be reproduced by anyone.
+    await visitRoute(page, '/arms-manufacturer', { title: ARMS_TITLE });
+
+    const manufacturer = page.locator('.manufacturer');
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const first = await manufacturer.innerText();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await manufacturer.innerText()).toEqual(first);
+
+    // And a different seed is a different company, so the reproduction above is not the page
+    // simply failing to re-roll.
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await manufacturer.innerText()).not.toEqual(first);
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -40,6 +40,7 @@ const SILENT_TOOL_PAGES = [
   },
   { path: '/heraldry', title: 'Heraldry Generator | Iron Arachne' },
   { path: '/velgarth-gifts', title: 'Velgarth Gifts Generator | Iron Arachne' },
+  { path: '/arms-manufacturer', title: 'Arms Manufacturer Generator | Iron Arachne' },
   { path: '/fantasy/settlement', title: 'Settlement Generator | Iron Arachne' },
   { path: '/fantasy/religion', title: 'Religion Generator | Iron Arachne' },
   { path: '/fantasy/adnd/character', title: 'AD&D 2e Character Generator | Iron Arachne' },
@@ -128,6 +129,9 @@ test('maturity: the tool browser marks every tool that has something to warn abo
   ).not.toContainText('Release-ready');
   await expect(browser.getByRole('button', { name: /^Heraldry/ })).not.toContainText('Beta');
   await expect(browser.getByRole('button', { name: /^Velgarth Gifts/ })).not.toContainText(
+    'Experimental',
+  );
+  await expect(browser.getByRole('button', { name: /^Arms Manufacturer/ })).not.toContainText(
     'Experimental',
   );
   await expect(browser.getByRole('button', { name: /^Planet/ })).toContainText('Experimental');

--- a/src/components/factions/ArmsManufacturerArtifactEditor.svelte
+++ b/src/components/factions/ArmsManufacturerArtifactEditor.svelte
@@ -1,0 +1,218 @@
+<script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import {
+    addArmsManufacturerModel,
+    removeArmsManufacturerModel,
+    setArmsManufacturerModelText,
+    setArmsManufacturerText,
+    validateArmsManufacturerSnapshot,
+    type ArmsManufacturerSnapshot,
+  } from '$lib/arms_manufacturer';
+
+  /**
+   * The editing view for a saved arms manufacturer.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it, so
+   * what is here is the company's two fields, one row per model, and the calls that change them.
+   *
+   * **This is not the `SnapshotFieldEditor` case docs/readiness-factions.md called it**, for the
+   * reason Velgarth Gifts was not either. That component (decision 5 of docs/tool-readiness.md) is
+   * a list of labelled inputs bound to the fields of a *flat* object, with `string-list` as the
+   * only repeating control; a manufacturer's catalogue is a list of *records* — a name, a damage
+   * type and a description each — with its own add and remove. The decision's own guard applies: a
+   * payload the descriptor language does not describe gets a bespoke editor rather than a fifth
+   * control, and the declared component is still waiting for a genuinely flat payload.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps this editor from rendering fields over
+   * something that is not a manufacturer.
+   */
+  const accepted = $derived(validateArmsManufacturerSnapshot(snapshot));
+  const manufacturer = $derived<ArmsManufacturerSnapshot | undefined>(
+    accepted.ok ? accepted.value : undefined,
+  );
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: ArmsManufacturerSnapshot) => ArmsManufacturerSnapshot): void {
+    if (manufacturer === undefined) {
+      return;
+    }
+    onChange(change(manufacturer));
+  }
+</script>
+
+{#if manufacturer === undefined}
+  <Notice tone="danger">
+    These contents are stored as an arms manufacturer but do not read as one, so there is nothing
+    safe to edit here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="manufacturer-editor">
+    <fieldset>
+      <legend>Company</legend>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-name">Company name</label>
+        <input
+          id="{uid}-name"
+          type="text"
+          value={manufacturer.name}
+          oninput={(event) =>
+            edit((current) => setArmsManufacturerText(current, 'name', event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+
+      <!-- Qualified as "Company name" rather than "Name", like every other editor: the panel above
+           already has a field labelled "Name" that renames the artifact, and two fields with the
+           same accessible name in one region is the 6.2 failure. -->
+      <!-- The description opens with the company's name as it was rolled, and renaming the
+           company above deliberately does not rewrite it: the prose was assembled from three lists
+           at generation time, so there is nothing to derive it from and it is the user's to keep or
+           change. -->
+      <div class="input-group input-group--inline">
+        <label for="{uid}-description">Company description</label>
+        <textarea
+          id="{uid}-description"
+          rows="4"
+          value={manufacturer.description}
+          oninput={(event) =>
+            edit((current) =>
+              setArmsManufacturerText(current, 'description', event.currentTarget.value),
+            )}
+        ></textarea>
+      </div>
+    </fieldset>
+
+    {#if manufacturer.models.length === 0}
+      <!-- A catalogue with nothing in it is an ordinary state, not a fault: a user may have removed
+           every model on the way to writing their own. -->
+      <p class="manufacturer-editor__note">No models in this catalogue yet.</p>
+    {/if}
+
+    <!-- Keyed by position rather than by name: two rows may read the same while one is being
+         typed, and a key that changed as the user typed would lose focus on every keystroke. -->
+    {#each manufacturer.models as model, index (index)}
+      <fieldset>
+        <legend>Model {index + 1}</legend>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-model-{index}-name">Model name</label>
+          <input
+            id="{uid}-model-{index}-name"
+            type="text"
+            value={model.name}
+            oninput={(event) =>
+              edit((current) =>
+                setArmsManufacturerModelText(current, index, 'name', event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+        </div>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-model-{index}-damage">Damage type</label>
+          <input
+            id="{uid}-model-{index}-damage"
+            type="text"
+            value={model.damage}
+            oninput={(event) =>
+              edit((current) =>
+                setArmsManufacturerModelText(current, index, 'damage', event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+        </div>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-model-{index}-description">Model description</label>
+          <textarea
+            id="{uid}-model-{index}-description"
+            rows="3"
+            value={model.description}
+            oninput={(event) =>
+              edit((current) =>
+                setArmsManufacturerModelText(
+                  current,
+                  index,
+                  'description',
+                  event.currentTarget.value,
+                ),
+              )}
+          ></textarea>
+        </div>
+
+        <BaseButton
+          aria-label="Remove model {index + 1}"
+          onclick={() => edit((current) => removeArmsManufacturerModel(current, index))}
+        >
+          Remove model {index + 1}
+        </BaseButton>
+      </fieldset>
+    {/each}
+
+    <BaseButton onclick={() => edit(addArmsManufacturerModel)}>Add a model</BaseButton>
+  </div>
+{/if}
+
+<style>
+  .manufacturer-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+  }
+
+  .manufacturer-editor fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s3);
+    align-items: flex-start;
+    margin: 0;
+    /* No border and no radius, matching the character editors: a fieldset inside an editor panel
+       was a box inside a box, and the legend and the spacing already group these. */
+    padding: var(--s4) 0;
+    min-width: 0;
+  }
+
+  .manufacturer-editor legend {
+    padding: 0 var(--s3);
+    color: var(--gold);
+    font-size: var(--t-micro-size);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .manufacturer-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .manufacturer-editor input[type='text'],
+  .manufacturer-editor textarea {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+
+  .manufacturer-editor__note {
+    font-size: var(--t-small-size);
+    font-style: italic;
+    margin: 0;
+  }
+</style>

--- a/src/components/factions/ArmsManufacturerGenerator.svelte
+++ b/src/components/factions/ArmsManufacturerGenerator.svelte
@@ -1,21 +1,73 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { RNG } from '@ironarachne/rng';
-  import { generate as generateArmsManufacturer } from '$lib/arms_manufacturer';
+  import * as Arms from '$lib/arms_manufacturer';
   import type { ArmsManufacturer } from '$lib/arms_manufacturer';
+  import { downloadTextFile } from '$lib/download';
+  import { downloadTextPdf } from '$lib/pdf';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
+  import SeedControls from '$components/common/SeedControls.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
 
-  const rng = new RNG(Date.now());
+  const TOOL_PATH = '/arms-manufacturer';
 
-  let seed = new RNG(Date.now().toString()).randomString(13);
-  rng.setSeed(seed);
-  let manufacturer: ArmsManufacturer | null = $state(null);
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. This page used to call `Date.now()`
+   * three times and showed no seed at all, so nothing it produced could be reproduced — the
+   * requirement 2.3 failure docs/readiness-factions.md calls most of the work here.
+   */
+  const rng = new RNG(Date.now().toString());
+  let seed = $state(rng.randomString(13));
+  let lockSeed = $state(false);
+
+  /**
+   * The rolled manufacturer.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every object in the value
+   * in a Proxy, and `structuredClone` — what IndexedDB stores with — refuses a Proxy outright, so
+   * saving fails with `could not be cloned`. The same trap is written up in `$lib/workshop`'s
+   * README beside `saveToolArtifact`.
+   */
+  let manufacturer = $state.raw<ArmsManufacturer | null>(null);
+
+  const manufacturerSnapshot = $derived(
+    manufacturer === null ? null : Arms.toArmsManufacturerSnapshot(manufacturer),
+  );
+
+  const defaultArtifactName = $derived(
+    manufacturer === null ? '' : Arms.armsManufacturerDisplayName(manufacturer),
+  );
 
   function generate() {
-    seed = new RNG(Date.now().toString()).randomString(13);
-    rng.setSeed(seed);
-    manufacturer = generateArmsManufacturer(rng);
+    if (!lockSeed) {
+      seed = rng.randomString(13);
+    }
+    manufacturer = Arms.rollArmsManufacturer(seed);
+  }
+
+  function exportMarkdown() {
+    if (manufacturer === null) {
+      return;
+    }
+    downloadTextFile(
+      Arms.armsManufacturerToMarkdown(manufacturer),
+      `${Arms.armsManufacturerFileStem(manufacturer)}.md`,
+      'text/markdown',
+    );
+  }
+
+  async function exportPdf() {
+    if (manufacturer === null) {
+      return;
+    }
+    await downloadTextPdf(
+      Arms.armsManufacturerDisplayName(manufacturer),
+      Arms.armsManufacturerToText(manufacturer),
+      `${Arms.armsManufacturerFileStem(manufacturer)}.pdf`,
+    );
   }
 
   onMount(() => {
@@ -23,23 +75,48 @@
   });
 </script>
 
-<GeneratorPage toolPath="/arms-manufacturer" title="Arms Manufacturer Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Arms Manufacturer Generator">
   {#snippet description()}
     <p>This generator produces sci-fi arms manufacturing companies.</p>
   {/snippet}
 
+  <SeedControls bind:seed bind:lockSeed />
+
   <BaseButton onclick={generate}>Generate</BaseButton>
 
-  {#if manufacturer}
-    <p>{manufacturer.description}</p>
+  <SaveArtifactButton
+    kind={Arms.ARMS_MANUFACTURER_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={manufacturerSnapshot}
+    {seed}
+    defaultName={defaultArtifactName}
+  />
 
-    <h2>Models</h2>
-    <p>The following are the manufacturer's most popular models.</p>
-    {#each manufacturer.models as model}
-      <div>
-        <h3>{model.name}</h3>
-        <p>{model.description}</p>
-      </div>
-    {/each}
+  {#if manufacturer}
+    <div class="manufacturer-exports">
+      <BaseButton onclick={exportMarkdown}>Download Markdown</BaseButton>
+      <BaseButton onclick={exportPdf}>Download PDF</BaseButton>
+    </div>
+
+    <div class="manufacturer">
+      <p>{manufacturer.description}</p>
+
+      <h2>Models</h2>
+      <p>The following are the manufacturer's most popular models.</p>
+      {#each manufacturer.models as model}
+        <div class="model">
+          <h3>{model.name}</h3>
+          <p>{model.description}</p>
+        </div>
+      {/each}
+    </div>
   {/if}
 </GeneratorPage>
+
+<style>
+  .manufacturer-exports {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+</style>

--- a/src/lib/arms_manufacturer/README.md
+++ b/src/lib/arms_manufacturer/README.md
@@ -26,3 +26,27 @@ manufacturer.models; // the weapons in its catalog
 
 The generator takes an existing `RNG` rather than a seed because it is normally called as part of a
 larger generation run that already owns one.
+
+## Saving a manufacturer
+
+The generator is Release-ready (issue #53), which means a rolled company can be kept:
+
+- `arms_manufacturer_snapshot.ts` — the stored form, which is the `ArmsManufacturer` type as it
+  stands. **This is the one snapshot in the readiness pass that is genuinely the identity
+  function**: a `Weapon` is six plain fields, so the conversion is a deep copy and nothing more.
+- `arms_manufacturer_artifact_kind.ts` — the `arms-manufacturer` kind. Its own kind rather than a
+  discriminator on `organization`, because the two payloads share nothing but a name; a saved
+  manufacturer is named after the company.
+- `arms_manufacturer_roll.ts` — the single path from a seed to a manufacturer. The page had no seed
+  control at all before, and called `Date.now()` three times.
+- `arms_manufacturer_editing.ts` — one function per field, each returning a new snapshot. Renaming
+  the company deliberately does not rewrite the description that opens with its old name.
+- `arms_manufacturer_presentation.ts` — the manufacturer as a document, and the Markdown and PDF
+  exports written from it. This tool had no export of any kind before.
+
+A model's `cosmetics` and `effects` are the parts its description was assembled from. They are
+stored, because the snapshot is the value, but the page does not show them and the editor has no
+control for them.
+
+This tool implements no game system, so there is no edition to name and nothing deliberately
+omitted from one: the weapon types, damage types and corporate suffixes are this library's own.

--- a/src/lib/arms_manufacturer/arms_manufacturer_artifact_kind.test.ts
+++ b/src/lib/arms_manufacturer/arms_manufacturer_artifact_kind.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import { readArtifactPayload, type AnyArtifactKindEntry } from '$lib/artifact_kinds';
+
+import {
+  armsManufacturerArtifactKind,
+  ARMS_MANUFACTURER_ARTIFACT_KIND,
+  ARMS_MANUFACTURER_PAYLOAD_VERSION,
+  migrateArmsManufacturerSnapshot,
+  validateArmsManufacturerSnapshot,
+} from './arms_manufacturer_artifact_kind.js';
+import { rollArmsManufacturerSnapshot } from './arms_manufacturer_roll.js';
+import type { ArmsManufacturerSnapshot } from './arms_manufacturer_snapshot.js';
+
+/** A stored payload, as anything reading one actually receives it. */
+const snapshot = JSON.parse(JSON.stringify(rollArmsManufacturerSnapshot('kind-fixture'))) as Record<
+  string,
+  unknown
+>;
+
+const model = {
+  name: 'XR-7 Laser Rifle',
+  maker: '',
+  damage: 'energy',
+  cosmetics: ['a matte finish'],
+  effects: ['fires in bursts'],
+  description: 'A rifle that fires in bursts and has a matte finish.',
+};
+
+describe('the arms manufacturer artifact kind', () => {
+  /** Its own kind, unqualified: neither a game system nor a setting, and not an `organization`. */
+  it('is registered under its own name', () => {
+    expect(ARMS_MANUFACTURER_ARTIFACT_KIND).toBe('arms-manufacturer');
+    expect(armsManufacturerArtifactKind.kind).toBe('arms-manufacturer');
+    expect(armsManufacturerArtifactKind.displayName).toBe('Arms Manufacturer');
+    expect(armsManufacturerArtifactKind.payloadVersion).toBe(ARMS_MANUFACTURER_PAYLOAD_VERSION);
+    expect(armsManufacturerArtifactKind.icon).not.toBe('');
+  });
+
+  it('names a saved manufacturer after the company', () => {
+    expect(
+      armsManufacturerArtifactKind.nameOf({
+        name: 'Vex Heavy Industries',
+        description: '',
+        models: [],
+      }),
+    ).toBe('Vex Heavy Industries');
+  });
+
+  it('names a manufacturer with no name by its kind', () => {
+    expect(armsManufacturerArtifactKind.nameOf({ name: '  ', description: '', models: [] })).toBe(
+      'Arms Manufacturer',
+    );
+  });
+
+  it('accepts a payload the generator produced', () => {
+    expect(validateArmsManufacturerSnapshot(snapshot).ok).toBe(true);
+  });
+
+  /** 3.3: an emptied manufacturer is a well-defined result, not a refusal. */
+  it('accepts a manufacturer with no models and no name left', () => {
+    expect(validateArmsManufacturerSnapshot({ name: '', description: '', models: [] }).ok).toBe(
+      true,
+    );
+  });
+
+  it('rejects something that is not an object at all', () => {
+    for (const payload of [null, 'Vex', 42, [{ name: 'Vex' }]]) {
+      const result = validateArmsManufacturerSnapshot(payload);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toBe('invalid-payload');
+    }
+  });
+
+  it('rejects a payload missing either text field', () => {
+    expect(validateArmsManufacturerSnapshot({ description: '', models: [] }).ok).toBe(false);
+    expect(validateArmsManufacturerSnapshot({ name: 'Vex', models: [] }).ok).toBe(false);
+    expect(validateArmsManufacturerSnapshot({ name: 3, description: '', models: [] }).ok).toBe(
+      false,
+    );
+  });
+
+  it('rejects a payload with no model list', () => {
+    expect(validateArmsManufacturerSnapshot({ name: 'Vex', description: '' }).ok).toBe(false);
+    expect(
+      validateArmsManufacturerSnapshot({ name: 'Vex', description: '', models: 'XR-7' }).ok,
+    ).toBe(false);
+  });
+
+  it('rejects a model missing any of its six fields', () => {
+    const fields = Object.keys(model) as (keyof typeof model)[];
+    for (const field of fields) {
+      const broken: Record<string, unknown> = { ...model };
+      delete broken[field];
+      expect(
+        validateArmsManufacturerSnapshot({ name: 'Vex', description: '', models: [broken] }).ok,
+      ).toBe(false);
+    }
+  });
+
+  it('rejects a model whose lists are not lists of strings', () => {
+    expect(
+      validateArmsManufacturerSnapshot({
+        name: 'Vex',
+        description: '',
+        models: [{ ...model, cosmetics: [1] }],
+      }).ok,
+    ).toBe(false);
+    expect(
+      validateArmsManufacturerSnapshot({
+        name: 'Vex',
+        description: '',
+        models: [{ ...model, effects: 'bursts' }],
+      }).ok,
+    ).toBe(false);
+  });
+
+  it('accepts a model with every field in place', () => {
+    expect(
+      validateArmsManufacturerSnapshot({ name: 'Vex', description: '', models: [model] }).ok,
+    ).toBe(true);
+  });
+
+  it('has no migration to offer, and says so rather than guessing', () => {
+    const result = migrateArmsManufacturerSnapshot(snapshot, 0);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toBe('unsupported-version');
+  });
+
+  /** The whole read path, as the store runs it. */
+  it('reads a stored payload of its own version', () => {
+    expect(
+      readArtifactPayload(
+        armsManufacturerArtifactKind as AnyArtifactKindEntry,
+        snapshot,
+        ARMS_MANUFACTURER_PAYLOAD_VERSION,
+      ).ok,
+    ).toBe(true);
+  });
+
+  it('quarantines a payload from a version it has no step for', () => {
+    expect(
+      readArtifactPayload(
+        armsManufacturerArtifactKind as AnyArtifactKindEntry,
+        snapshot,
+        ARMS_MANUFACTURER_PAYLOAD_VERSION + 1,
+      ).ok,
+    ).toBe(false);
+  });
+
+  it('loads a codec that round-trips the payload', async () => {
+    const codec = await armsManufacturerArtifactKind.loadCodec();
+    const accepted = validateArmsManufacturerSnapshot(snapshot);
+
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) {
+      return;
+    }
+    const { RNG } = await import('@ironarachne/rng');
+    const live = codec.fromSnapshot(accepted.value as ArmsManufacturerSnapshot, new RNG('unused'));
+
+    expect(codec.toSnapshot(live)).toEqual(accepted.value);
+  });
+});

--- a/src/lib/arms_manufacturer/arms_manufacturer_artifact_kind.ts
+++ b/src/lib/arms_manufacturer/arms_manufacturer_artifact_kind.ts
@@ -1,0 +1,123 @@
+import rifle from '$lib/assets/icons/set3/gun-rifle.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  isStringArray,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import type { ArmsManufacturer } from './arms_manufacturer';
+import type { ArmsManufacturerSnapshot } from './arms_manufacturer_snapshot';
+
+/**
+ * Stable artifact kind id.
+ *
+ * **Its own kind, not a discriminator on `organization`**, which is the question issue #53 asks
+ * before anything else. An arms manufacturer is an organization in the everyday sense, but not in
+ * the payload sense: `$lib/organizations` is a leader, members, a hierarchy held as `Map`s and a
+ * generated visual identity, and a manufacturer is a name, a sentence and a product catalogue.
+ * Sharing a kind would mean one editor, one validator and one migration path covering two shapes
+ * with no field in common except the name — docs/tool-readiness.md settled it as `arms-manufacturer`
+ * in its kind table, unqualified because it is neither a game system nor a setting.
+ */
+export const ARMS_MANUFACTURER_ARTIFACT_KIND = 'arms-manufacturer' as const;
+
+/** Version 1. The first shape an arms manufacturer has been stored in. */
+export const ARMS_MANUFACTURER_PAYLOAD_VERSION = 1 as const;
+
+/** The six fields a `Weapon` from `$lib/weapons` has, as a stored record must show them. */
+function isStoredWeapon(entry: unknown): boolean {
+  const weapon = asRecord(entry);
+  return (
+    weapon !== null &&
+    hasStringFields(weapon, ['name', 'maker', 'damage', 'description']) &&
+    isStringArray(weapon.cosmetics) &&
+    isStringArray(weapon.effects)
+  );
+}
+
+/**
+ * Checks what reading depends on: the two text fields, and a list of models each shaped as a
+ * weapon.
+ *
+ * An empty model list is accepted, and so is an empty name. A user who has removed every model
+ * from a saved manufacturer, or cleared its name on the way to writing their own, has made an
+ * editing decision, and a payload that fails its own validator is a broken artifact rather than an
+ * empty one — 3.3 asks for a well-defined empty result, not a refusal.
+ */
+export function validateArmsManufacturerSnapshot(
+  payload: unknown,
+): PayloadResult<ArmsManufacturerSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'Arms manufacturer payload is not an object');
+  }
+  if (!hasStringFields(record, ['name', 'description'])) {
+    return rejectedPayload(
+      'invalid-payload',
+      'Arms manufacturer payload needs a name and a description',
+    );
+  }
+  if (!Array.isArray(record.models) || !record.models.every(isStoredWeapon)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'Arms manufacturer payload needs a list of models, each with a name, a maker, a damage type, a description, and lists of cosmetics and effects',
+    );
+  }
+
+  return acceptedPayload(record as unknown as ArmsManufacturerSnapshot);
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day the
+ * shape changes. A kind without one looks complete right up until it silently drops someone's work
+ * — and local-only means there is no server-side migration to fall back on.
+ */
+export function migrateArmsManufacturerSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<ArmsManufacturerSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Arms manufacturers have no migration from payload version ${from}; version ${ARMS_MANUFACTURER_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/** What to call a saved manufacturer: its name, or the kind when the name has been emptied. */
+function armsManufacturerName(snapshot: ArmsManufacturerSnapshot): string {
+  const name = snapshot.name.trim();
+  return name === '' ? 'Arms Manufacturer' : name;
+}
+
+/**
+ * An arms manufacturer as an artifact.
+ *
+ * The codec is a copy — the payload is the value — so the split `loadCodec` asks for buys nothing
+ * here. It is still written this way, because the contract is the same for every kind and a codec
+ * that happens to be trivial today is not a reason to wire it differently from its neighbours.
+ */
+export const armsManufacturerArtifactKind = defineArtifactKind<
+  ArmsManufacturer,
+  ArmsManufacturerSnapshot
+>({
+  kind: ARMS_MANUFACTURER_ARTIFACT_KIND,
+  displayName: 'Arms Manufacturer',
+  icon: rifle,
+  payloadVersion: ARMS_MANUFACTURER_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { toArmsManufacturerSnapshot, armsManufacturerFromSnapshotWithRng } =
+      await import('./arms_manufacturer_snapshot.js');
+    return {
+      toSnapshot: toArmsManufacturerSnapshot,
+      fromSnapshot: armsManufacturerFromSnapshotWithRng,
+    };
+  },
+  nameOf: armsManufacturerName,
+  validate: validateArmsManufacturerSnapshot,
+  migrate: migrateArmsManufacturerSnapshot,
+});

--- a/src/lib/arms_manufacturer/arms_manufacturer_editing.test.ts
+++ b/src/lib/arms_manufacturer/arms_manufacturer_editing.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addArmsManufacturerModel,
+  removeArmsManufacturerModel,
+  setArmsManufacturerModelText,
+  setArmsManufacturerText,
+} from './arms_manufacturer_editing.js';
+import { rollArmsManufacturerSnapshot } from './arms_manufacturer_roll.js';
+
+/** Every roll has at least three models, so "one at a time" is always worth asserting. */
+const manufacturer = rollArmsManufacturerSnapshot('editing-fixture');
+
+describe('editing an arms manufacturer', () => {
+  /** Requirement 4.4: one field at a time, and nothing else moves. */
+  it('renames the company and leaves the catalogue alone', () => {
+    const edited = setArmsManufacturerText(manufacturer, 'name', 'Vex Heavy Industries');
+
+    expect(edited.name).toBe('Vex Heavy Industries');
+    expect(edited.description).toBe(manufacturer.description);
+    expect(edited.models).toEqual(manufacturer.models);
+  });
+
+  /** 4.2: the name and the prose are separate decisions, and neither drags the other. */
+  it('does not rewrite a description that opens with the old name', () => {
+    const edited = setArmsManufacturerText(manufacturer, 'name', 'Renamed');
+
+    expect(edited.description.startsWith(manufacturer.name)).toBe(true);
+  });
+
+  it('edits the description, which is the user’s and not a table’s', () => {
+    const edited = setArmsManufacturerText(manufacturer, 'description', 'They make big guns.');
+
+    expect(edited.description).toBe('They make big guns.');
+    expect(edited.name).toBe(manufacturer.name);
+  });
+
+  it('changes one model and leaves the others alone', () => {
+    const edited = setArmsManufacturerModelText(manufacturer, 0, 'name', 'XR-7 Laser Rifle');
+
+    expect(edited.models[0].name).toBe('XR-7 Laser Rifle');
+    expect(edited.models[0].description).toBe(manufacturer.models[0].description);
+    expect(edited.models.slice(1)).toEqual(manufacturer.models.slice(1));
+  });
+
+  it('edits a model’s damage type and description', () => {
+    const damage = setArmsManufacturerModelText(manufacturer, 1, 'damage', 'plasma');
+    const described = setArmsManufacturerModelText(damage, 1, 'description', 'It melts.');
+
+    expect(described.models[1].damage).toBe('plasma');
+    expect(described.models[1].description).toBe('It melts.');
+    expect(described.models[1].name).toBe(manufacturer.models[1].name);
+  });
+
+  it('never writes into the snapshot it was given', () => {
+    const before = structuredClone(manufacturer);
+    setArmsManufacturerText(manufacturer, 'name', 'Other');
+    setArmsManufacturerModelText(manufacturer, 0, 'name', 'Other');
+    addArmsManufacturerModel(manufacturer);
+    removeArmsManufacturerModel(manufacturer, 0);
+
+    expect(manufacturer).toEqual(before);
+  });
+
+  it('adds a blank model made by the company', () => {
+    const added = addArmsManufacturerModel(manufacturer);
+    const last = added.models[added.models.length - 1];
+
+    expect(added.models).toHaveLength(manufacturer.models.length + 1);
+    expect(last).toEqual({
+      name: '',
+      maker: manufacturer.name,
+      damage: '',
+      cosmetics: [],
+      effects: [],
+      description: '',
+    });
+  });
+
+  it('removes a model and leaves the rest in order', () => {
+    const removed = removeArmsManufacturerModel(manufacturer, 0);
+
+    expect(removed.models).toEqual(manufacturer.models.slice(1));
+  });
+
+  it('can empty the catalogue, which is an ordinary state', () => {
+    let current = manufacturer;
+    while (current.models.length > 0) {
+      current = removeArmsManufacturerModel(current, 0);
+    }
+
+    expect(current.models).toEqual([]);
+    expect(current.name).toBe(manufacturer.name);
+  });
+
+  /** An index nothing is at is a no-op, not a throw: the editor is driven by a live list. */
+  it('ignores an index that is not there', () => {
+    expect(setArmsManufacturerModelText(manufacturer, 99, 'name', 'XR-7')).toBe(manufacturer);
+    expect(setArmsManufacturerModelText(manufacturer, -1, 'name', 'XR-7')).toBe(manufacturer);
+    expect(setArmsManufacturerModelText(manufacturer, 0.5, 'name', 'XR-7')).toBe(manufacturer);
+    expect(removeArmsManufacturerModel(manufacturer, 99)).toBe(manufacturer);
+  });
+});

--- a/src/lib/arms_manufacturer/arms_manufacturer_editing.ts
+++ b/src/lib/arms_manufacturer/arms_manufacturer_editing.ts
@@ -1,0 +1,96 @@
+/**
+ * Editing a saved arms manufacturer, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction — renaming one model must not
+ * disturb another, and renaming the company must not touch its catalogue — and it is what lets the
+ * editing framework compare what is on screen against what was read to decide whether anything
+ * needs saving.
+ *
+ * **Every text field is the user's.** The description was assembled at generation time from a
+ * specialty, an outlook and a reputation drawn from three lists, and a model's description from a
+ * base, its effects and its cosmetics; none of that is a table row the prose could be re-derived
+ * from, so nothing here recomputes anything. Renaming the company deliberately does not rewrite
+ * the description that opens with its old name: the two are separate decisions, and a form that
+ * silently rewrote a user's prose would overrule them. The destructive command is a re-roll from
+ * provenance, which is `arms_manufacturer_roll.ts` and a button of its own (4.3).
+ *
+ * A model's `cosmetics` and `effects` are the parts its description was assembled from. They are
+ * stored, because the snapshot is the value, but they are not shown on the page and so have no
+ * control here (4.1 covers what the user sees). Removing a model removes them with it.
+ */
+
+import type { Weapon } from '$lib/weapons';
+
+import type { ArmsManufacturerSnapshot } from './arms_manufacturer_snapshot.js';
+
+/** The parts of the manufacturer itself the page prints as text. */
+export type ArmsManufacturerTextField = 'name' | 'description';
+
+/** The parts of a model the page prints, plus the damage type the model carries. */
+export type ArmsManufacturerModelTextField = 'name' | 'damage' | 'description';
+
+function hasIndex(length: number, index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < length;
+}
+
+function replaceAt<T>(list: T[], index: number, value: T): T[] {
+  return list.map((entry, position) => (position === index ? value : entry));
+}
+
+function removeAt<T>(list: T[], index: number): T[] {
+  return list.filter((_entry, position) => position !== index);
+}
+
+export function setArmsManufacturerText(
+  snapshot: ArmsManufacturerSnapshot,
+  field: ArmsManufacturerTextField,
+  value: string,
+): ArmsManufacturerSnapshot {
+  return { ...snapshot, [field]: value };
+}
+
+export function setArmsManufacturerModelText(
+  snapshot: ArmsManufacturerSnapshot,
+  index: number,
+  field: ArmsManufacturerModelTextField,
+  value: string,
+): ArmsManufacturerSnapshot {
+  return hasIndex(snapshot.models.length, index)
+    ? {
+        ...snapshot,
+        models: replaceAt(snapshot.models, index, { ...snapshot.models[index], [field]: value }),
+      }
+    : snapshot;
+}
+
+/**
+ * A blank model, made by this manufacturer.
+ *
+ * Blank rather than drawn from the weapon tables: the tool rolls a catalogue, so adding a model by
+ * hand is a user saying "and this one too" about something they have in mind. The maker is the
+ * company, because that is the one field a new row can be filled in truthfully; the generator
+ * itself leaves `maker` empty, and nothing here rewrites the rolled ones.
+ */
+export function addArmsManufacturerModel(
+  snapshot: ArmsManufacturerSnapshot,
+): ArmsManufacturerSnapshot {
+  const model: Weapon = {
+    name: '',
+    maker: snapshot.name,
+    damage: '',
+    cosmetics: [],
+    effects: [],
+    description: '',
+  };
+  return { ...snapshot, models: [...snapshot.models, model] };
+}
+
+export function removeArmsManufacturerModel(
+  snapshot: ArmsManufacturerSnapshot,
+  index: number,
+): ArmsManufacturerSnapshot {
+  return hasIndex(snapshot.models.length, index)
+    ? { ...snapshot, models: removeAt(snapshot.models, index) }
+    : snapshot;
+}

--- a/src/lib/arms_manufacturer/arms_manufacturer_presentation.test.ts
+++ b/src/lib/arms_manufacturer/arms_manufacturer_presentation.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ArmsManufacturer } from './arms_manufacturer.js';
+import {
+  armsManufacturerDisplayName,
+  armsManufacturerFileStem,
+  armsManufacturerModelHeading,
+  armsManufacturerToDocument,
+  armsManufacturerToMarkdown,
+  armsManufacturerToText,
+} from './arms_manufacturer_presentation.js';
+import { rollArmsManufacturer } from './arms_manufacturer_roll.js';
+
+const manufacturer = rollArmsManufacturer('presentation-fixture');
+
+const model = {
+  name: 'XR-7 Laser Rifle',
+  maker: '',
+  damage: 'energy',
+  cosmetics: [],
+  effects: [],
+  description: 'A rifle.',
+};
+
+describe('armsManufacturerModelHeading', () => {
+  it('names the model and its damage type', () => {
+    expect(armsManufacturerModelHeading(model)).toBe('XR-7 Laser Rifle (energy)');
+  });
+
+  it('leaves the damage type off when there is none', () => {
+    expect(armsManufacturerModelHeading({ ...model, damage: ' ' })).toBe('XR-7 Laser Rifle');
+  });
+
+  it('says so for a model with no name, because the row is still a fact', () => {
+    expect(armsManufacturerModelHeading({ ...model, name: '' })).toBe('An unnamed model (energy)');
+  });
+});
+
+describe('the arms manufacturer document', () => {
+  it('heads the document with the company', () => {
+    expect(armsManufacturerToDocument(manufacturer).title).toBe(
+      armsManufacturerDisplayName(manufacturer),
+    );
+  });
+
+  it('gives every model a section of its own', () => {
+    expect(armsManufacturerToDocument(manufacturer).models).toHaveLength(
+      manufacturer.models.length,
+    );
+  });
+
+  /** Requirement 6.4: a heading, yes; a blank line where the prose was, no. */
+  it('drops an empty description without dropping the manufacturer or the model', () => {
+    const stripped: ArmsManufacturer = {
+      name: 'Vex',
+      description: '   ',
+      models: [{ ...model, description: '' }],
+    };
+    const document = armsManufacturerToDocument(stripped);
+
+    expect(document.paragraphs).toEqual([]);
+    expect(document.models[0].heading).toBe('XR-7 Laser Rifle (energy)');
+    expect(document.models[0].paragraphs).toEqual([]);
+  });
+});
+
+describe('armsManufacturerToMarkdown', () => {
+  const markdown = armsManufacturerToMarkdown(manufacturer);
+
+  it('leads with the company and heads every model', () => {
+    expect(markdown.startsWith(`# ${manufacturer.name}`)).toBe(true);
+    expect(markdown).toContain(manufacturer.description);
+    expect(markdown).toContain('## Models');
+    for (const entry of manufacturer.models) {
+      expect(markdown).toContain(`### ${armsManufacturerModelHeading(entry)}`);
+      expect(markdown).toContain(entry.description);
+    }
+  });
+
+  it('ends with a newline, as a text file should', () => {
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  /** 6.4 again: no "Models" heading over nothing. */
+  it('prints no catalogue heading for a manufacturer with no models', () => {
+    expect(armsManufacturerToMarkdown({ name: 'Vex', description: 'Guns.', models: [] })).toBe(
+      '# Vex\n\nGuns.\n',
+    );
+  });
+});
+
+describe('armsManufacturerToText', () => {
+  it('carries the same content as the Markdown, without the title', () => {
+    const text = armsManufacturerToText(manufacturer);
+
+    expect(text.startsWith(manufacturer.description)).toBe(true);
+    expect(text).toContain('MODELS');
+    for (const entry of manufacturer.models) {
+      expect(text).toContain(`${armsManufacturerModelHeading(entry)}\n${entry.description}`);
+    }
+    expect(text).not.toContain('#');
+  });
+
+  it('prints nothing but the prose for a manufacturer with no models', () => {
+    expect(armsManufacturerToText({ name: 'Vex', description: 'Guns.', models: [] })).toBe('Guns.');
+  });
+});
+
+describe('armsManufacturerDisplayName', () => {
+  it('is the company’s name', () => {
+    expect(armsManufacturerDisplayName(manufacturer)).toBe(manufacturer.name);
+  });
+
+  it('falls back to the kind for a manufacturer with no name', () => {
+    expect(armsManufacturerDisplayName({ name: ' ', description: '', models: [] })).toBe(
+      'Arms Manufacturer',
+    );
+  });
+});
+
+describe('armsManufacturerFileStem', () => {
+  it('reduces the name to something a filesystem takes', () => {
+    expect(
+      armsManufacturerFileStem({ name: 'Vex Arms, Limited', description: '', models: [] }),
+    ).toBe('vex-arms-limited');
+  });
+
+  it('falls back for a name that reduces to nothing', () => {
+    expect(armsManufacturerFileStem({ name: '!!!', description: '', models: [] })).toBe(
+      'arms-manufacturer',
+    );
+  });
+});

--- a/src/lib/arms_manufacturer/arms_manufacturer_presentation.ts
+++ b/src/lib/arms_manufacturer/arms_manufacturer_presentation.ts
@@ -1,0 +1,116 @@
+/**
+ * An arms manufacturer arranged for reading, and the Markdown and PDF exports written from it.
+ *
+ * This tool had **no export at all** before requirement 6.3 asked for one, so there is no drawn
+ * sheet to sit beneath this. What a referee wants at the table is the company as a paragraph and
+ * its catalogue as a list — the page, on paper — which is what this produces, and the same
+ * document is written once as Markdown and once as plain text for the PDF so the two cannot drift.
+ *
+ * 6.4 is the reason the document model exists rather than a single template string: a manufacturer
+ * whose description a user has emptied prints its name without a blank paragraph, a catalogue with
+ * nothing in it prints no "Models" heading, and a model whose description has been cleared prints
+ * its name and nothing under it.
+ */
+
+import type { Weapon } from '$lib/weapons';
+
+import type { ArmsManufacturer } from './arms_manufacturer.js';
+
+/** One model arranged for reading: its heading, and the lines under it. */
+export type ArmsManufacturerModelSection = {
+  heading: string;
+  paragraphs: string[];
+};
+
+/** A manufacturer arranged for reading, independent of the format it is finally written in. */
+export type ArmsManufacturerDocument = {
+  title: string;
+  paragraphs: string[];
+  models: ArmsManufacturerModelSection[];
+};
+
+/** The heading the catalogue gets when there is one. */
+export const ARMS_MANUFACTURER_MODELS_HEADING = 'Models';
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+/**
+ * What to head the document with: the company's name, or the kind when it has none.
+ *
+ * It matches what the artifact kind calls a saved manufacturer, so the export and the vault agree.
+ */
+export function armsManufacturerDisplayName(manufacturer: ArmsManufacturer): string {
+  const name = manufacturer.name.trim();
+  return name === '' ? 'Arms Manufacturer' : name;
+}
+
+/** The heading a model gets: its name, and its damage type when it has one. */
+export function armsManufacturerModelHeading(model: Weapon): string {
+  const name = isPrintable(model.name) ? model.name.trim() : 'An unnamed model';
+  return isPrintable(model.damage) ? `${name} (${model.damage.trim()})` : name;
+}
+
+/**
+ * Arrange a manufacturer for reading.
+ *
+ * A model with no name and no description still gets a heading, because a row in the catalogue is
+ * a fact about the company and dropping it would lose it. What is dropped is empty prose, which is
+ * the blank content 6.4 is about.
+ */
+export function armsManufacturerToDocument(
+  manufacturer: ArmsManufacturer,
+): ArmsManufacturerDocument {
+  return {
+    title: armsManufacturerDisplayName(manufacturer),
+    paragraphs: [manufacturer.description].filter(isPrintable),
+    models: manufacturer.models.map((model) => ({
+      heading: armsManufacturerModelHeading(model),
+      paragraphs: [model.description].filter(isPrintable),
+    })),
+  };
+}
+
+/** A manufacturer as Markdown, for a referee who wants it in their own notes. */
+export function armsManufacturerToMarkdown(manufacturer: ArmsManufacturer): string {
+  const document = armsManufacturerToDocument(manufacturer);
+  const blocks = [`# ${document.title}`, ...document.paragraphs];
+
+  if (document.models.length > 0) {
+    blocks.push(`## ${ARMS_MANUFACTURER_MODELS_HEADING}`);
+    for (const entry of document.models) {
+      blocks.push(`### ${entry.heading}`);
+      blocks.push(...entry.paragraphs);
+    }
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/**
+ * The body of the PDF: the same document as plain text, without the title, which the PDF draws
+ * as its own heading.
+ */
+export function armsManufacturerToText(manufacturer: ArmsManufacturer): string {
+  const document = armsManufacturerToDocument(manufacturer);
+  const blocks = [...document.paragraphs];
+
+  if (document.models.length > 0) {
+    blocks.push(ARMS_MANUFACTURER_MODELS_HEADING.toUpperCase());
+    for (const entry of document.models) {
+      blocks.push([entry.heading, ...entry.paragraphs].join('\n'));
+    }
+  }
+
+  return blocks.join('\n\n');
+}
+
+/** A filename stem for an exported manufacturer, reduced to something a filesystem takes. */
+export function armsManufacturerFileStem(manufacturer: ArmsManufacturer): string {
+  const stem = armsManufacturerDisplayName(manufacturer)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' ? 'arms-manufacturer' : stem;
+}

--- a/src/lib/arms_manufacturer/arms_manufacturer_roll.test.ts
+++ b/src/lib/arms_manufacturer/arms_manufacturer_roll.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollArmsManufacturer, rollArmsManufacturerSnapshot } from './arms_manufacturer_roll.js';
+
+describe('rollArmsManufacturer', () => {
+  /** Requirement 2.2. */
+  it('gives the same manufacturer for the same seed', () => {
+    expect(rollArmsManufacturer('a-fixed-seed')).toEqual(rollArmsManufacturer('a-fixed-seed'));
+  });
+
+  it('gives a different manufacturer for a different seed', () => {
+    const seeds = ['one', 'two', 'three', 'four', 'five'].map((seed) =>
+      JSON.stringify(rollArmsManufacturer(seed)),
+    );
+
+    expect(new Set(seeds).size).toBeGreaterThan(1);
+  });
+
+  it('gives the manufacturer a name, a description and a catalogue', () => {
+    const manufacturer = rollArmsManufacturer('fields-seed');
+
+    expect(manufacturer.name).not.toBe('');
+    expect(manufacturer.description).not.toBe('');
+    expect(manufacturer.models.length).toBeGreaterThan(0);
+    for (const model of manufacturer.models) {
+      expect(model.name).not.toBe('');
+      expect(model.description).not.toBe('');
+    }
+  });
+
+  it('rolls a snapshot from the same seed', () => {
+    expect(rollArmsManufacturerSnapshot('reroll-seed')).toEqual(
+      rollArmsManufacturer('reroll-seed'),
+    );
+  });
+});

--- a/src/lib/arms_manufacturer/arms_manufacturer_roll.ts
+++ b/src/lib/arms_manufacturer/arms_manufacturer_roll.ts
@@ -1,0 +1,37 @@
+/**
+ * The single path from a seed to an arms manufacturer.
+ *
+ * Requirement 2.2 of docs/workshop.md wants the same seed to give the same result, and 2.3 wants a
+ * seed the user can see and pin. `ArmsManufacturerGenerator.svelte` had neither: it rendered no
+ * `SeedControls` and called `Date.now()` three times, so what it produced could not be reproduced
+ * by anyone, including the page that produced it. The page now takes a seed from the seed box, and
+ * the roll itself is a pure function of that seed.
+ *
+ * **There is no config record here, and that is deliberate.** The page has one control, the seed
+ * box. How many models a manufacturer lists and which weapon types it favours are the generator's
+ * own decisions, drawn from the seed, and recording them as provenance would describe controls the
+ * page does not have — the mistake `dcc_character_roll.ts` names about naming gender. A re-roll
+ * takes the seed and nothing else.
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import type { ArmsManufacturer } from './arms_manufacturer.js';
+import { generate } from './generator.js';
+import {
+  toArmsManufacturerSnapshot,
+  type ArmsManufacturerSnapshot,
+} from './arms_manufacturer_snapshot.js';
+
+/** Roll a manufacturer from a seed — the one path the generator page and a re-roll both take. */
+export function rollArmsManufacturer(seed: string): ArmsManufacturer {
+  return generate(new RNG(seed));
+}
+
+/**
+ * Roll a fresh manufacturer as a snapshot — the destructive half of editing (requirement 4.3),
+ * and what `ARTIFACT_EDITORS` registers as this kind's roller.
+ */
+export function rollArmsManufacturerSnapshot(seed: string): ArmsManufacturerSnapshot {
+  return toArmsManufacturerSnapshot(rollArmsManufacturer(seed));
+}

--- a/src/lib/arms_manufacturer/arms_manufacturer_snapshot.test.ts
+++ b/src/lib/arms_manufacturer/arms_manufacturer_snapshot.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollArmsManufacturer } from './arms_manufacturer_roll.js';
+import {
+  armsManufacturerFromSnapshot,
+  toArmsManufacturerSnapshot,
+} from './arms_manufacturer_snapshot.js';
+
+const manufacturer = rollArmsManufacturer('snapshot-fixture');
+
+describe('the arms manufacturer snapshot', () => {
+  /** Requirement 7.2: lossless for everything the page shows. The identity function, tested. */
+  it('round-trips a rolled manufacturer', () => {
+    expect(armsManufacturerFromSnapshot(toArmsManufacturerSnapshot(manufacturer))).toEqual(
+      manufacturer,
+    );
+  });
+
+  it('round-trips a manufacturer with no models, which is an ordinary state', () => {
+    const empty = { name: 'Vex Consolidated', description: '', models: [] };
+
+    expect(armsManufacturerFromSnapshot(toArmsManufacturerSnapshot(empty))).toEqual(empty);
+  });
+
+  it('keeps a description a user has changed rather than recomputing it', () => {
+    const edited = toArmsManufacturerSnapshot(manufacturer);
+    edited.description = 'They make very large guns.';
+
+    expect(armsManufacturerFromSnapshot(edited).description).toBe('They make very large guns.');
+  });
+
+  it('is free of the functions IndexedDB refuses', () => {
+    expect(() => structuredClone(toArmsManufacturerSnapshot(manufacturer))).not.toThrow();
+  });
+
+  it('does not hand out the lists it was given', () => {
+    const snapshot = toArmsManufacturerSnapshot(manufacturer);
+    snapshot.models[0].name = 'Something else entirely';
+    snapshot.models[0].cosmetics.push('a bow on top');
+    snapshot.models.pop();
+
+    expect(manufacturer.models[0].name).not.toBe('Something else entirely');
+    expect(manufacturer.models[0].cosmetics).not.toContain('a bow on top');
+    expect(manufacturer.models.length).toBe(snapshot.models.length + 1);
+  });
+
+  it('does not hand a restored value the snapshot’s own lists', () => {
+    const snapshot = toArmsManufacturerSnapshot(manufacturer);
+    const restored = armsManufacturerFromSnapshot(snapshot);
+    restored.models[0].effects.push('fires backwards');
+
+    expect(snapshot.models[0].effects).not.toContain('fires backwards');
+  });
+});

--- a/src/lib/arms_manufacturer/arms_manufacturer_snapshot.ts
+++ b/src/lib/arms_manufacturer/arms_manufacturer_snapshot.ts
@@ -1,0 +1,65 @@
+/**
+ * Writing an arms manufacturer, and reading one back.
+ *
+ * **This is the one snapshot in the readiness pass that is genuinely the identity function**, and
+ * docs/readiness-factions.md says so rather than inventing a conversion to look thorough. An
+ * `ArmsManufacturer` is a name, a description and a list of `Weapon`s, and a `Weapon` from
+ * `$lib/weapons` is six plain fields — two of them string lists. There is no closure to strip, no
+ * table row to resolve by name, and no imagery. The conversion is a copy, and this module exists
+ * for the contract rather than for the work.
+ *
+ * The copy is a deep one all the same: the snapshot must not share its `models` list, or the
+ * `cosmetics` and `effects` lists inside each model, with the value it was made from, or an edit
+ * to one would silently show up in the other.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+import type { Weapon } from '$lib/weapons';
+
+import type { ArmsManufacturer } from './arms_manufacturer.js';
+
+/** An arms manufacturer as it is stored: the type as it stands. */
+export type ArmsManufacturerSnapshot = ArmsManufacturer;
+
+function copyWeapon(weapon: Weapon): Weapon {
+  return { ...weapon, cosmetics: [...weapon.cosmetics], effects: [...weapon.effects] };
+}
+
+function copyManufacturer(manufacturer: ArmsManufacturer): ArmsManufacturer {
+  return {
+    name: manufacturer.name,
+    description: manufacturer.description,
+    models: manufacturer.models.map(copyWeapon),
+  };
+}
+
+export function toArmsManufacturerSnapshot(
+  manufacturer: ArmsManufacturer,
+): ArmsManufacturerSnapshot {
+  return copyManufacturer(manufacturer);
+}
+
+/**
+ * A stored manufacturer back into the value the library works with.
+ *
+ * Nothing is recomputed and nothing is re-rolled: the description and every model come back
+ * exactly as they were stored, which is requirement 4.2 — a user who has rewritten what their
+ * favourite gunsmith is known for has made a decision no read may overrule.
+ */
+export function armsManufacturerFromSnapshot(snapshot: ArmsManufacturerSnapshot): ArmsManufacturer {
+  return copyManufacturer(snapshot);
+}
+
+/**
+ * The codec's reading half, with the signature the registry hands it.
+ *
+ * The RNG is unused, and that is the correct amount of use for it. It exists for kinds that rebuild
+ * name generators; a manufacturer is finished when it is stored, and drawing anything from a seed
+ * on the way back would be regenerating over the user's edits.
+ */
+export function armsManufacturerFromSnapshotWithRng(
+  snapshot: ArmsManufacturerSnapshot,
+  _rng: RNG,
+): ArmsManufacturer {
+  return armsManufacturerFromSnapshot(snapshot);
+}

--- a/src/lib/arms_manufacturer/generator.test.ts
+++ b/src/lib/arms_manufacturer/generator.test.ts
@@ -66,6 +66,12 @@ describe('generate', () => {
     expect(manufacturer.description.startsWith(manufacturer.name)).toBe(true);
   });
 
+  it('never doubles a space, because the exports do not collapse them', () => {
+    for (let index = 0; index < 20; index += 1) {
+      expect(generate(`spacing-${index}`).description).not.toMatch(/ {2}/);
+    }
+  });
+
   it('states a specialty, an outlook and a reputation', () => {
     const description = generate('described').description;
 

--- a/src/lib/arms_manufacturer/generator.ts
+++ b/src/lib/arms_manufacturer/generator.ts
@@ -7,7 +7,9 @@ import type { ArmsManufacturer } from './arms_manufacturer.js';
 export function generate(rng: RNG): ArmsManufacturer {
   const name = randomName(rng);
 
-  let description = `${name} `;
+  // Every sentence appended below carries its own leading space, so the name is bare here: a
+  // second space after it collapses in HTML but not in the Markdown and PDF exports.
+  let description = name;
 
   const specialty = rng.item(SciFiWeaponTypes.all);
   const secondaryOptions = SciFiWeaponTypes.all.filter((wType) => wType.name !== specialty.name);
@@ -15,8 +17,8 @@ export function generate(rng: RNG): ArmsManufacturer {
   const secondary = rng.item(secondaryOptions);
 
   description += rng.item([
-    ` specializes in ${specialty.name}s. `,
-    ` is known for their ${specialty.name}s. `,
+    ` specializes in ${specialty.name}s.`,
+    ` is known for their ${specialty.name}s.`,
   ]);
 
   description += randomOutlook(rng);

--- a/src/lib/arms_manufacturer/index.ts
+++ b/src/lib/arms_manufacturer/index.ts
@@ -1,2 +1,7 @@
 export type * from './arms_manufacturer';
 export * from './generator';
+export * from './arms_manufacturer_artifact_kind';
+export * from './arms_manufacturer_editing';
+export * from './arms_manufacturer_presentation';
+export * from './arms_manufacturer_roll';
+export * from './arms_manufacturer_snapshot';

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -75,6 +75,10 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // The tenth. `$lib/velgarth_gifts`'s entry point re-exports the gift table, which is four hundred
   // lines of setting prose. The kind module holds metadata and validation only.
   '$lib/velgarth_gifts/velgarth_gifts_artifact_kind',
+  // The eleventh. `$lib/arms_manufacturer`'s entry point reaches the generator, and from there
+  // `$lib/weapons` and the made-up-names package. The kind module holds metadata and validation
+  // only.
+  '$lib/arms_manufacturer/arms_manufacturer_artifact_kind',
 ]);
 
 /**

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -111,6 +111,7 @@ describe('TOOL_CATALOG', () => {
     // change that earns it. That is the point — a level should not be able to rise as a side
     // effect of editing a catalog entry for some other reason.
     const assessedHigher = [
+      '/arms-manufacturer',
       '/character',
       '/culture',
       '/fantasy/dcc/character',
@@ -215,6 +216,7 @@ describe('toolsWithMaturity', () => {
     const releaseReady = toolsWithMaturity('release-ready');
 
     expect(releaseReady.map((tool) => tool.path).sort()).toEqual([
+      '/arms-manufacturer',
       '/character',
       '/culture',
       '/fantasy/adnd/character',

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -139,7 +139,14 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     label: 'Arms Manufacturer',
     kind: 'generator',
     domain: 'factions',
-    maturity: 'experimental',
+    // Release-ready, assessed section by section against docs/workshop.md and recorded in
+    // docs/readiness-factions.md (#53). It saves as `arms-manufacturer` — its own kind rather than
+    // a discriminator on `organization`, because the two payloads share nothing but a name — has
+    // an editor in `ARTIFACT_EDITORS`, and exports Markdown and PDF, the first exports it has ever
+    // had. Its roll is deterministic from the seed via `arms_manufacturer_roll.ts`; the page had
+    // no seed control at all before. Nothing it takes as input has an artifact kind, so
+    // requirement 5.1 does not bind; 5.3 is met, as it always was.
+    maturity: 'release-ready',
     genres: ['scifi'],
     tags: ['organization'],
   }),

--- a/src/lib/workshop/README.md
+++ b/src/lib/workshop/README.md
@@ -223,8 +223,8 @@ artifact does not restamp contents nobody changed.
 ## Artifact editors
 
 `ARTIFACT_EDITORS` maps a kind to the component that edits it, alongside an optional roller.
-**Every registered kind now has one**: heraldry, culture, religion, settlement, Velgarth gifts, and
-the AD&D 2E, fantasy, DCC, SWN and Uncharted Worlds characters. That is where the readiness pass has got to
+**Every registered kind now has one**: heraldry, culture, religion, settlement, Velgarth gifts, the
+arms manufacturer, and the AD&D 2E, fantasy, DCC, SWN and Uncharted Worlds characters. That is where the readiness pass has got to
 rather than a rule — a kind with no entry opens read-only, which is still a state the surface
 renders rather than an error it reports, and `loadViewer` is still in the vocabulary for a kind
 that can be shown and not sensibly edited. #39

--- a/src/lib/workshop/artifact_editors.test.ts
+++ b/src/lib/workshop/artifact_editors.test.ts
@@ -137,6 +137,18 @@ describe('the artifact editor registry', () => {
     expect(hasArtifactEditor('heraldry')).toBe(true);
   });
 
+  it('rolls an arms manufacturer from provenance through the registered roller', async () => {
+    const roll = await artifactEditorEntry('arms-manufacturer')!.loadRoller!();
+    const rolled = roll({
+      toolPath: '/arms-manufacturer',
+      seed: 'registry-seed',
+      config: {},
+    }) as { name: string; models: unknown[] };
+
+    expect(rolled.name).not.toBe('');
+    expect(rolled.models.length).toBeGreaterThan(0);
+  });
+
   /**
    * The seed and nothing else, which is what this kind's provenance holds: the tool has one
    * control, and how many Gifts a character has is the setting's business rather than the user's.

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -126,6 +126,19 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         rollUwCharacterSnapshot(provenance.seed, readUwCharacterGeneratorConfig(provenance.config));
     },
   },
+  'arms-manufacturer': {
+    loadEditor: () => import('$components/factions/ArmsManufacturerArtifactEditor.svelte'),
+    /**
+     * The seed and nothing else: this tool has one control, and how many models a company lists
+     * and which weapon types it favours are the generator's decisions, so there is no config to
+     * read back.
+     */
+    loadRoller: async () => {
+      const { rollArmsManufacturerSnapshot } =
+        await import('$lib/arms_manufacturer/arms_manufacturer_roll.js');
+      return (provenance) => rollArmsManufacturerSnapshot(provenance.seed);
+    },
+  },
   'velgarth-gifts': {
     loadEditor: () => import('$components/characters/VelgarthGiftsArtifactEditor.svelte'),
     /**

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -21,6 +21,7 @@ describe('artifact kind catalog', () => {
       'character.swn',
       'character.uncharted-worlds',
       'velgarth-gifts',
+      'arms-manufacturer',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -17,6 +17,7 @@ import {
 // point reaches `$lib/organizations`, and from there the heraldry generator and the charge library.
 import { adndCharacterArtifactKind } from '$lib/adnd/adnd_character_artifact_kind';
 import { characterArtifactKind } from '$lib/characters/character_artifact_kind';
+import { armsManufacturerArtifactKind } from '$lib/arms_manufacturer/arms_manufacturer_artifact_kind';
 import { cultureArtifactKind } from '$lib/culture/culture_artifact_kind';
 import { dccCharacterArtifactKind } from '$lib/dcc/dcc_character_artifact_kind';
 import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
@@ -47,6 +48,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, swnCharacterArtifactKind);
   registerArtifactKind(registry, uwCharacterArtifactKind);
   registerArtifactKind(registry, velgarthGiftsArtifactKind);
+  registerArtifactKind(registry, armsManufacturerArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Closes #53. Implements the #53 section of `docs/readiness-factions.md`, part of the readiness pass; the first factions-domain tool.

## What changed

- **Kind `arms-manufacturer`**, its own kind rather than a discriminator on `organization`: the two payloads share nothing but a name. Registered in the kind catalog, `ARTIFACT_EDITORS` (with a seed-only roller), and `SaveArtifactButton` wired into the generator.
- **Snapshot is the identity function** (deep copy), validated on read, empty catalogue and empty name accepted (3.3). Migration rejects with `unsupported-version` since v1 is the only shape.
- **Bespoke editor** (`ArmsManufacturerArtifactEditor.svelte`): company name and description, one row per model with add/remove. Renaming the company deliberately does not rewrite the description. Not a `SnapshotFieldEditor` case after all — the model list is a list of records, same finding as #52 — and both design docs now say so.
- **2.3 fixed**: `SeedControls` added, three `Date.now()` calls replaced by `arms_manufacturer_roll.ts`.
- **Markdown and PDF export** (6.3), from one document model, with 6.4 handled. Fixed a pre-existing double space in the generated description that the exports would have shipped to paper.
- Catalog entry now `release-ready` with the assessment recorded; README, `docs/readiness-factions.md` and `docs/tool-readiness.md` updated.

## Testing

- `npm run verify`: green, 4855 unit tests, 0 svelte-check errors, coverage gate passed with no new baseline entries.
- `npm run test:e2e`: 500 passed, including `e2e/arms_manufacturer.spec.ts` (generate → save → reopen → edit, rename without rewrite, both downloads, seed reproduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DDb1aVQzSNQPUw1zdjysm
