### PR TITLE
Take the fantasy organization generator to Release-ready

### DIFF
--- a/docs/readiness-factions.md
+++ b/docs/readiness-factions.md
@@ -11,8 +11,8 @@ Part of [the readiness pass](tool-readiness.md). Measured against
 [Tool release readiness](workshop.md#tool-release-readiness).
 
 **Status:** accepted; the arms manufacturer ([#53](#53--arms-manufacturer)), the fantasy encounter
-([#54](#54--fantasy-encounter)) and the fantasy family ([#55](#55--fantasy-family)) are
-**implemented**; #56 and #57 are not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in this document is clear to start.
+([#54](#54--fantasy-encounter)), the fantasy family ([#55](#55--fantasy-family)) and the fantasy
+organization ([#56](#56--fantasy-organization)) are **implemented**; #57 is not yet built. Reviewed and approved with [the pass](tool-readiness.md#domain-model), so the work in this document is clear to start.
 
 This domain holds the pass's easiest tool and its second-hardest. The arms manufacturer is three
 files and a flat payload; the organization generator is the richest generator on the site, with a
@@ -204,6 +204,45 @@ identity's parameters — with a redraw, not a re-roll, after each change.
 
 **Composition:** `heraldry` for the arms, `character` for the leader and notable members, `culture`
 for naming.
+
+**As built.** The wave 0 move happened here, since nothing before it needed it: `StoredOrganization`
+and `StoredOrganizationHierarchy` are declared in `$lib/organizations`, `StoredVisualIdentity` and
+`StoredVisualEmblem` in `$lib/visual_identity`, each split into a writing half and a reading half
+the way the character's are, and `$lib/settlements` composes them and re-exports the names. No
+settlement payload changed shape, so no version step.
+
+**`arms: null` on a heraldic emblem means a referenced coat of arms**, the convention
+`StoredCharacter.heraldry` set. The page takes a saved coat of arms through `SavedArtifactPicker`,
+shows the organization bearing it, stores `null` plus the reference, and reads it back as no emblem
+of its own for the holder of the reference to draw. A re-roll never wears referenced arms.
+
+**Two of the three compositions are built**: a saved culture for naming (the pattern set's name as
+provenance, the culture as a reference, gated on the roll) and a saved coat of arms. **A saved
+character as leader is not offered.** The leader is shaped by the kind's role mutators — a title,
+an age band, a species tweak per role — and a character rolled elsewhere would not fit the role it
+was put in. That is a design question for the character kind (a "fits role" mutation on read),
+not a picker, and it is recorded here rather than half-built.
+
+**2.2 was failing in the same way the family's was.** The page's RNG was the generator's, reseeded
+from the seed box on each press, but the kind list and the name set were drawn from it _before_
+the reseed, so "any" depended on how many times Generate had been pressed. `organization_roll.ts`
+draws the kind registry, the name set and the organization from streams named for the seed.
+
+**The editor is bespoke**, as designed: name and description, motto and palette, the profile's
+traits, goal, weakness, standing and hook, and each person's names and line, with the emblem drawn
+from its stored parameters — a redraw, not a re-roll — and the hierarchy's roles listed by standing.
+Each role's _holder_ is not a field the payload has: notables are generated for planned role ids
+but the id is not recorded on the character. Recording it is a generator change and a version 2,
+and is noted rather than done.
+
+6.4 bound on the motto, the environment line, the relationships list and the notable-members
+heading, each of which may be absent and none of which prints when it is.
+
+The editor's three palette fields are live surface over a field no kind fills today:
+`VisualColorPalette` is in the type and the rehydrate path, but `buildVisualExtras` sets a motto
+on one kind and colours on none. They are kept because the payload carries the field and a user
+may fill it, and clearing them on an organization that never had a palette leaves it without one
+rather than inventing one with an empty primary.
 
 ## #57 — Star nation
 

--- a/docs/tool-readiness.md
+++ b/docs/tool-readiness.md
@@ -128,10 +128,11 @@ shared concept **once, in the library that owns the concept**, and every payload
 | `StoredNameGeneratorPatternSet`                     | `$lib/names`           | `NameGenerator` — closures                                             | culture, family, civilization, region, merchant                        |
 | `StoredVisualIdentity`, `StoredVisualEmblem`        | `$lib/visual_identity` | An emblem that may be heraldry                                         | organization, settlement, merchant                                     |
 
-Three of these already exist in the wrong place: `StoredCharacter`, `StoredArchetype`,
+Three of these already existed in the wrong place: `StoredCharacter`, `StoredArchetype`,
 `StoredOrganization`, `StoredOrganizationHierarchy`, `StoredVisualIdentity` and
-`StoredVisualEmblem` are all declared in `src/lib/settlements/settlement_snapshot.ts`, because a
-settlement was the first payload that needed them. Moving each to the library that owns the
+`StoredVisualEmblem` were all declared in `src/lib/settlements/settlement_snapshot.ts`, because a
+settlement was the first payload that needed them. #46 moved the character pair and #56 moved the
+other four; the settlement kind re-exports every one of them. Moving each to the library that owns the
 concept is the first work item of the pass, and
 [docs/fantasy-character.md](fantasy-character.md#storedcharacter-moves-to-libcharacters-and-the-settlement-payload-advances-to-version-2)
 already designs the character half of that move, including the settlement payload's advance to

--- a/e2e/organization.spec.ts
+++ b/e2e/organization.spec.ts
@@ -3,13 +3,13 @@ import { expect, test, type Page } from '@playwright/test';
 import { visitRoute } from './helpers';
 
 /**
- * Requirement 7.4 for the `family` kind: generate, save, reopen, edit.
+ * Requirement 7.4 for the `organization` kind: generate, save, reopen, edit.
  *
- * This is the half no unit test can settle. The library tests prove a multi-generation family
- * round-trips through the codec — members by name, edges as ids, generators as patterns — and that
- * each editing function changes one field; what they cannot prove is that a user can press
- * Generate, keep the result, come back to it in a different page, change something, and still
- * have the family they saved. Every step of that crosses a boundary the unit tests stub out — the
+ * This is the half no unit test can settle. The library tests prove an organization round-trips
+ * through the codec — maps as entries, people by name, imagery as parameters — and that each
+ * editing function changes one field; what they cannot prove is that a user can press Generate,
+ * keep the result, come back to it in a different page, change something, and still have the
+ * organization they saved. Every step of that crosses a boundary the unit tests stub out — the
  * artifact store, IndexedDB, the editor registry, and a page reload.
  *
  * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
@@ -22,7 +22,7 @@ const vault = (page: Page) => page.locator('section.vault');
 const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
 const saveArtifact = (page: Page) => page.locator('.save-artifact');
 
-const FAMILY_TITLE = 'Fantasy Family Generator | Iron Arachne';
+const ORGANIZATION_TITLE = 'Organization Generator | Iron Arachne';
 
 async function openEmpty(page: Page): Promise<void> {
   await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
@@ -78,67 +78,71 @@ async function openInWorkshop(page: Page, name: string) {
   return panel;
 }
 
-test.describe('a family', () => {
+test.describe('an organization', () => {
   test.beforeEach(async ({ page }) => {
     await openEmpty(page);
     await createProject(page, 'The Marches');
   });
 
   test('is generated, saved, reopened, and edited', async ({ page }) => {
-    await visitRoute(page, '/fantasy/family', { title: FAMILY_TITLE });
+    await visitRoute(page, '/fantasy/organization', { title: ORGANIZATION_TITLE });
 
-    // The generator rolls on mount (2.4), so there is a family to keep straight away.
+    // The generator rolls on mount (2.4), so there is an organization to keep straight away.
     await expect(page.locator('.member').first()).toBeVisible();
-    await saveAs(page, 'House Ashford');
+    await saveAs(page, 'The Ashford Compact');
 
     // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
     // rather than a state test.
-    const panel = await openInWorkshop(page, 'House Ashford');
+    const panel = await openInWorkshop(page, 'The Ashford Compact');
 
     // Typed rather than filled: `fill` sets the value in one go, and the point of this assertion is
     // that the editor's own bindings carry a user's keystrokes through to the snapshot it
     // announces. The value is one no roll produces, so there is always something to save.
-    const name = panel.getByRole('textbox', { name: 'Member 1 first name' });
-    await name.fill('');
-    await name.pressSequentially('Tam');
+    const goal = panel.getByRole('textbox', { name: 'Goal' });
+    await goal.fill('');
+    await goal.pressSequentially('to own every mill');
     await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
     await panel.getByRole('button', { name: 'Save changes' }).click();
     await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
 
     // And it survived the round trip through IndexedDB, which is the whole claim.
     await page.reload({ waitUntil: 'load' });
-    const reopened = await openInWorkshop(page, 'House Ashford');
-    await expect(reopened.getByRole('textbox', { name: 'Member 1 first name' })).toHaveValue('Tam');
+    const reopened = await openInWorkshop(page, 'The Ashford Compact');
+    await expect(reopened.getByRole('textbox', { name: 'Goal' })).toHaveValue('to own every mill');
   });
 
-  test('removes a member and the edges that named them', async ({ page }) => {
-    // Requirement 4.4: one part changes without re-rolling the whole, and 5.4: what is left still
-    // reads. The seed is pinned because a random one is not always more than one person — a
-    // founder who never married is a family of one — and `family_roll.test.ts` already relies on
-    // this seed rolling several generations of humans.
-    await visitRoute(page, '/fantasy/family', { title: FAMILY_TITLE });
-    await page.getByLabel('Species', { exact: true }).selectOption('human');
-    await page.getByLabel('Seed', { exact: true }).fill('generations');
-    await page.getByLabel('Lock Seed').check();
+  test('draws the emblem from its parameters and edits people without a re-roll', async ({
+    page,
+  }) => {
+    // Requirement 4.4 and the issue's own warning: imagery is parameters, so the editor draws it
+    // rather than showing a stored picture, and it is still there after a name changes.
+    await visitRoute(page, '/fantasy/organization', { title: ORGANIZATION_TITLE });
+    await page.getByLabel('Organization kind').selectOption('trading_company');
     await page.getByRole('button', { name: 'Generate', exact: true }).click();
-    await saveAs(page, 'House Kessler');
+    await saveAs(page, 'Kessler & Sons');
 
-    const panel = await openInWorkshop(page, 'House Kessler');
+    const panel = await openInWorkshop(page, 'Kessler & Sons');
+    await expect(panel.locator('.organization-editor__emblem > svg')).toBeVisible();
+
+    const leader = panel.getByRole('textbox', { name: 'Leader first name' });
+    const description = panel.getByRole('textbox', { name: 'Organization description' });
+    const before = await description.inputValue();
+    await leader.fill('Tam');
+    await expect(description).toHaveValue(before);
+    await expect(panel.locator('.organization-editor__emblem > svg')).toBeVisible();
+
     // The editor mounts through a dynamic import after the panel is visible, so the first thing
     // asserted must be one that retries; `count()` does not.
     const removers = panel.getByRole('button', { name: /^Remove member \d+$/ });
     await expect(removers.first()).toBeVisible();
     const count = await removers.count();
-    expect(count).toBeGreaterThan(1);
-
     await removers.first().click();
     await expect(removers).toHaveCount(count - 1);
-    await expect(panel.getByRole('textbox', { name: 'Member 1 first name' })).toBeVisible();
   });
 
-  test('downloads the roster and the tree a GM can put on the table', async ({ page }) => {
-    // Requirement 6.3: the tree was drawn all along and never offered; the roster is new.
-    await visitRoute(page, '/fantasy/family', { title: FAMILY_TITLE });
+  test('downloads the sheet and the emblem a GM can put on the table', async ({ page }) => {
+    // Requirement 6.3: the first exports this tool has ever had.
+    await visitRoute(page, '/fantasy/organization', { title: ORGANIZATION_TITLE });
 
     const markdown = page.waitForEvent('download');
     await page.getByRole('button', { name: 'Download Markdown' }).click();
@@ -149,29 +153,29 @@ test.describe('a family', () => {
     expect((await pdf).suggestedFilename()).toMatch(/\.pdf$/);
 
     const svg = page.waitForEvent('download');
-    await page.getByRole('button', { name: 'Download Tree (SVG)' }).click();
-    expect((await svg).suggestedFilename()).toMatch(/-tree\.svg$/);
+    await page.getByRole('button', { name: 'Download Emblem (SVG)' }).click();
+    expect((await svg).suggestedFilename()).toMatch(/-emblem\.svg$/);
   });
 
-  test('reproduces the same family, names included, from the same seed', async ({ page }) => {
-    // Requirement 2.2: the page used to build the name generators from its own RNG, so a locked
-    // seed reproduced the people and not what they were called.
-    await visitRoute(page, '/fantasy/family', { title: FAMILY_TITLE });
+  test('reproduces the same organization from the same seed and settings', async ({ page }) => {
+    // Requirement 2.2: the kind list and the name set used to be drawn from the page's RNG before
+    // it was reseeded, so "any" depended on how many times Generate had been pressed.
+    await visitRoute(page, '/fantasy/organization', { title: ORGANIZATION_TITLE });
 
-    const family = page.locator('.family');
+    const organization = page.locator('.organization');
 
     await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
     await page.getByLabel('Lock Seed').check();
     await page.getByRole('button', { name: 'Generate', exact: true }).click();
-    const first = await family.innerText();
+    const first = await organization.innerText();
 
     await page.getByRole('button', { name: 'Generate', exact: true }).click();
-    expect(await family.innerText()).toEqual(first);
+    expect(await organization.innerText()).toEqual(first);
 
-    // And a different seed is a different family, so the reproduction above is not the page
+    // And a different seed is a different organization, so the reproduction above is not the page
     // simply failing to re-roll.
     await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
     await page.getByRole('button', { name: 'Generate', exact: true }).click();
-    expect(await family.innerText()).not.toEqual(first);
+    expect(await organization.innerText()).not.toEqual(first);
   });
 });

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -43,6 +43,7 @@ const SILENT_TOOL_PAGES = [
   { path: '/arms-manufacturer', title: 'Arms Manufacturer Generator | Iron Arachne' },
   { path: '/fantasy/encounter', title: 'Encounter | Iron Arachne' },
   { path: '/fantasy/family', title: 'Fantasy Family Generator | Iron Arachne' },
+  { path: '/fantasy/organization', title: 'Organization Generator | Iron Arachne' },
   { path: '/fantasy/settlement', title: 'Settlement Generator | Iron Arachne' },
   { path: '/fantasy/religion', title: 'Religion Generator | Iron Arachne' },
   { path: '/fantasy/adnd/character', title: 'AD&D 2e Character Generator | Iron Arachne' },
@@ -140,6 +141,9 @@ test('maturity: the tool browser marks every tool that has something to warn abo
     'Experimental',
   );
   await expect(browser.getByRole('button', { name: /^Fantasy Family/ })).not.toContainText(
+    'Experimental',
+  );
+  await expect(browser.getByRole('button', { name: /^Fantasy Organization/ })).not.toContainText(
     'Experimental',
   );
   await expect(browser.getByRole('button', { name: /^Planet/ })).toContainText('Experimental');

--- a/src/components/factions/OrganizationArtifactEditor.svelte
+++ b/src/components/factions/OrganizationArtifactEditor.svelte
@@ -1,0 +1,384 @@
+<script lang="ts">
+  import { RNG } from '@ironarachne/rng';
+  import Notice from '$components/common/Notice.svelte';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import {
+    addOrganizationTrait,
+    describeOrganizationEmblem,
+    organizationPersonHeading,
+    removeOrganizationNotable,
+    removeOrganizationTrait,
+    renderOrganizationEmblemSvg,
+    setOrganizationColor,
+    setOrganizationFacetLabel,
+    setOrganizationHook,
+    setOrganizationMotto,
+    setOrganizationPersonField,
+    setOrganizationText,
+    setOrganizationTraitLabel,
+    validateOrganizationSnapshot,
+    type OrganizationColorSlot,
+    type OrganizationFacetField,
+    type OrganizationPerson,
+    type OrganizationSnapshot,
+  } from '$lib/organizations';
+
+  /**
+   * The editing view for a saved organization.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it.
+   *
+   * Bespoke, as docs/readiness-factions.md says: a hierarchy is a tree of roles with people in
+   * them, and a flat form would be a worse view of it than the generic snapshot view. What it
+   * reaches is the name and description, the motto and palette, the profile's traits, goal,
+   * weakness, standing and hook, and each person's names and line. The emblem is **drawn from its
+   * stored parameters** — a redraw, not a re-roll, after every change — and described in words
+   * beside it; the emblem itself is what a re-roll is for. The hierarchy's roles are listed by
+   * standing so a reader can see the structure the people sit in.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  const accepted = $derived(validateOrganizationSnapshot(snapshot));
+  const organization = $derived<OrganizationSnapshot | undefined>(
+    accepted.ok ? accepted.value : undefined,
+  );
+
+  /** The emblem, drawn from parameters. A fixed RNG, so the same arms draw the same way twice. */
+  const emblemSvg = $derived(
+    organization === undefined
+      ? null
+      : renderOrganizationEmblemSvg(organization.visualIdentity.emblem, new RNG(organization.id)),
+  );
+
+  /** The roles by standing, highest first. */
+  const roles = $derived(
+    organization === undefined
+      ? []
+      : [...organization.hierarchy.roleById]
+          .map(([id, info]) => ({
+            id,
+            name: info.roleName,
+            order: organization.hierarchy.idToOrder.find(([roleId]) => roleId === id)?.[1] ?? 0,
+          }))
+          .sort((a, b) => b.order - a.order),
+  );
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: OrganizationSnapshot) => OrganizationSnapshot): void {
+    if (organization === undefined) {
+      return;
+    }
+    onChange(change(organization));
+  }
+
+  const facets: { field: OrganizationFacetField; label: string }[] = [
+    { field: 'goal', label: 'Goal' },
+    { field: 'weakness', label: 'Weakness' },
+    { field: 'publicStanding', label: 'Public standing' },
+  ];
+  const colorSlots: OrganizationColorSlot[] = ['primary', 'secondary', 'accent'];
+
+  function personLabel(person: OrganizationPerson): string {
+    return person === 'leader' ? 'Leader' : `Member ${person + 1}`;
+  }
+</script>
+
+{#if organization === undefined}
+  <Notice tone="danger">
+    These contents are stored as an organization but do not read as one, so there is nothing safe to
+    edit here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="organization-editor">
+    <!-- Qualified as "Organization name" rather than "Name": the panel above already has a field
+         labelled "Name" that renames the artifact, and two fields with the same accessible name in
+         one region is the 6.2 failure. -->
+    <div class="input-group input-group--inline">
+      <label for="{uid}-name">Organization name</label>
+      <input
+        id="{uid}-name"
+        type="text"
+        value={organization.name}
+        oninput={(event) =>
+          edit((current) => setOrganizationText(current, 'name', event.currentTarget.value))}
+        autocomplete="off"
+      />
+    </div>
+
+    <div class="input-group input-group--inline">
+      <label for="{uid}-description">Organization description</label>
+      <textarea
+        id="{uid}-description"
+        rows="5"
+        value={organization.description}
+        oninput={(event) =>
+          edit((current) => setOrganizationText(current, 'description', event.currentTarget.value))}
+      ></textarea>
+    </div>
+
+    <fieldset>
+      <legend>Identity</legend>
+
+      <div class="organization-editor__emblem">
+        {#if emblemSvg !== null}
+          <!-- Drawn from the stored parameters, never from a stored picture. -->
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+          {@html emblemSvg}
+        {/if}
+        <p class="organization-editor__note">
+          {describeOrganizationEmblem(organization.visualIdentity.emblem) ||
+            'No emblem. A re-roll draws one.'}
+        </p>
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-motto">Motto</label>
+        <input
+          id="{uid}-motto"
+          type="text"
+          value={organization.visualIdentity.motto ?? ''}
+          oninput={(event) =>
+            edit((current) => setOrganizationMotto(current, event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+
+      {#each colorSlots as slot (slot)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-color-{slot}"
+            >{slot.charAt(0).toUpperCase() + slot.slice(1)} colour</label
+          >
+          <input
+            id="{uid}-color-{slot}"
+            type="text"
+            value={organization.visualIdentity.colors?.[slot] ?? ''}
+            oninput={(event) =>
+              edit((current) => setOrganizationColor(current, slot, event.currentTarget.value))}
+            autocomplete="off"
+          />
+        </div>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Profile</legend>
+
+      {#each organization.profile.personalityTraits as trait, index (index)}
+        <div class="organization-editor__row">
+          <div class="input-group input-group--inline">
+            <label for="{uid}-trait-{index}">Trait {index + 1}</label>
+            <input
+              id="{uid}-trait-{index}"
+              type="text"
+              value={trait.label}
+              oninput={(event) =>
+                edit((current) =>
+                  setOrganizationTraitLabel(current, index, event.currentTarget.value),
+                )}
+              autocomplete="off"
+            />
+          </div>
+          <BaseButton
+            aria-label="Remove trait {index + 1}"
+            onclick={() => edit((current) => removeOrganizationTrait(current, index))}
+          >
+            Remove
+          </BaseButton>
+        </div>
+      {/each}
+      <BaseButton onclick={() => edit(addOrganizationTrait)}>Add a trait</BaseButton>
+
+      {#each facets as facet (facet.field)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-facet-{facet.field}">{facet.label}</label>
+          <input
+            id="{uid}-facet-{facet.field}"
+            type="text"
+            value={organization.profile[facet.field].label}
+            oninput={(event) =>
+              edit((current) =>
+                setOrganizationFacetLabel(current, facet.field, event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+        </div>
+      {/each}
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-hook">Hook</label>
+        <textarea
+          id="{uid}-hook"
+          rows="3"
+          value={organization.profile.hook}
+          oninput={(event) =>
+            edit((current) => setOrganizationHook(current, event.currentTarget.value))}
+        ></textarea>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Structure</legend>
+      <ol class="organization-editor__roles">
+        {#each roles as role (role.id)}
+          <li>{role.name}</li>
+        {/each}
+      </ol>
+    </fieldset>
+
+    {#each [{ person: 'leader' as const, character: organization.leader }, ...organization.notableMembers.map( (character, index) => ({ person: index, character }), )] as entry (entry.person)}
+      <fieldset>
+        <legend>{personLabel(entry.person)}</legend>
+        <p class="organization-editor__note">{organizationPersonHeading(entry.character)}</p>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-person-{entry.person}-first"
+            >{personLabel(entry.person)} first name</label
+          >
+          <input
+            id="{uid}-person-{entry.person}-first"
+            type="text"
+            value={entry.character.firstName}
+            oninput={(event) =>
+              edit((current) =>
+                setOrganizationPersonField(
+                  current,
+                  entry.person,
+                  'firstName',
+                  event.currentTarget.value,
+                ),
+              )}
+            autocomplete="off"
+          />
+        </div>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-person-{entry.person}-last">{personLabel(entry.person)} last name</label
+          >
+          <input
+            id="{uid}-person-{entry.person}-last"
+            type="text"
+            value={entry.character.lastName}
+            oninput={(event) =>
+              edit((current) =>
+                setOrganizationPersonField(
+                  current,
+                  entry.person,
+                  'lastName',
+                  event.currentTarget.value,
+                ),
+              )}
+            autocomplete="off"
+          />
+        </div>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-person-{entry.person}-description">
+            {personLabel(entry.person)} description
+          </label>
+          <textarea
+            id="{uid}-person-{entry.person}-description"
+            rows="3"
+            value={entry.character.description}
+            oninput={(event) =>
+              edit((current) =>
+                setOrganizationPersonField(
+                  current,
+                  entry.person,
+                  'description',
+                  event.currentTarget.value,
+                ),
+              )}
+          ></textarea>
+        </div>
+
+        {#if entry.person !== 'leader'}
+          {@const index = entry.person}
+          <BaseButton
+            aria-label="Remove member {index + 1}"
+            onclick={() => edit((current) => removeOrganizationNotable(current, index))}
+          >
+            Remove member {index + 1}
+          </BaseButton>
+        {/if}
+      </fieldset>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .organization-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+  }
+
+  .organization-editor fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s3);
+    align-items: flex-start;
+    margin: 0;
+    /* No border and no radius, matching the character editors: a fieldset inside an editor panel
+       was a box inside a box, and the legend and the spacing already group these. */
+    padding: var(--s4) 0;
+    min-width: 0;
+  }
+
+  .organization-editor legend {
+    padding: 0 var(--s3);
+    color: var(--gold);
+    font-size: var(--t-micro-size);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .organization-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .organization-editor input[type='text'],
+  .organization-editor textarea {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+
+  .organization-editor__row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--s3);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .organization-editor__emblem {
+    max-width: 200px;
+  }
+
+  .organization-editor__emblem :global(svg) {
+    max-width: 100%;
+    height: auto;
+  }
+
+  .organization-editor__roles {
+    margin: 0;
+    padding-left: var(--s5);
+  }
+
+  .organization-editor__note {
+    font-size: var(--t-small-size);
+    margin: 0;
+  }
+</style>

--- a/src/components/factions/OrganizationGenerator.svelte
+++ b/src/components/factions/OrganizationGenerator.svelte
@@ -1,51 +1,54 @@
 <script lang="ts">
-  import {
-    getOrganizationKindsForRegistry,
-    generateOrganization,
-    type OrganizationSizeInput,
-    FantasyOrganizations,
-  } from '$lib/organizations';
+  import { onMount } from 'svelte';
+  import { RNG } from '@ironarachne/rng';
+  import * as Organizations from '$lib/organizations';
   import type {
     Organization,
-    OrganizationProfile,
+    OrganizationGeneratorConfigRecord,
+    OrganizationGenreFilter,
+    OrganizationSizePreset,
     OrganizationWorldContextPreset,
   } from '$lib/organizations';
-  import { RNG } from '@ironarachne/rng';
   import * as Characters from '$lib/characters';
-  import * as Names from '$lib/names';
-  import { onMount } from 'svelte';
-  import { renderSVGAsPNG } from '$lib/images';
-  import {
-    isDiscEmblem,
-    isHeraldryEmblem,
-    isMerchantMarkEmblem,
-    isPatternLatticeEmblem,
-  } from '$lib/visual_identity';
-  import { renderDiscEmblemSvg } from '$lib/disc_emblem';
-  import type { Arms } from '$lib/heraldry';
-  import { renderMerchantMarkSvg } from '$lib/merchant_marks';
-  import { renderPatternLatticeSvg } from '$lib/pattern_lattice';
+  import type { ArtifactReference } from '$lib/artifacts';
+  import { CULTURE_ARTIFACT_KIND, type Culture } from '$lib/culture';
+  import { downloadTextFile } from '$lib/download';
+  import { HERALDRY_ARTIFACT_KIND, type Arms, type RestoredHeraldry } from '$lib/heraldry';
+  import { getFantasyNameGeneratorSetNames } from '$lib/names';
+  import { downloadTextPdf } from '$lib/pdf';
   import { showHeraldryModal } from '$lib/ui';
+  import { isHeraldryEmblem } from '$lib/visual_identity';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
   import SeedControls from '$components/common/SeedControls.svelte';
   import SelectField from '$components/common/SelectField.svelte';
+  import SavedArtifactPicker from '$components/common/SavedArtifactPicker.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
   import HeraldryEmblemButton from '$components/heraldry/HeraldryEmblemButton.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
 
-  const rng = new RNG(Date.now().toString());
-  let seed: string = $state(rng.randomString(13));
-  let lockSeed = $state(false);
-  $effect(() => {
-    rng.setSeed(seed);
-  });
+  const TOOL_PATH = '/fantasy/organization';
+  const ANY = Organizations.ORGANIZATION_ANY;
+  /** The value of the name-set select that means the culture the picker loaded. */
+  const NAMES_FROM_CULTURE = 'culture';
 
-  let genreFilter = $state<'any' | 'fantasy' | 'science_fiction'>('fantasy');
-  let organizationKindId = $state('any');
-  let nameSetName = $state('any');
-  const nameSets = Names.getAllFantasyNameGeneratorSets(rng);
-  let nameSet: Names.NameGeneratorSet = rng.item(nameSets);
-  let sizePreset = $state<'any' | 'small' | 'medium' | 'large'>('any');
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. It used to also be the generator's RNG,
+   * reseeded from the seed box on every press, and the kind list and the name set were drawn from
+   * it before the reseed — so what "any" gave you depended on how many times you had pressed
+   * Generate. `organization_roll.ts` draws all of that from the seed now.
+   */
+  const rng = new RNG(Date.now().toString());
+  let seed = $state(rng.randomString(13));
+  let lockSeed = $state(false);
+
+  let genreFilter = $state<OrganizationGenreFilter>('fantasy');
+  let organizationKindId = $state<string>(ANY);
+  let nameSetName = $state<string>(ANY);
+  let sizePreset = $state<OrganizationSizePreset | typeof ANY>(ANY);
   let worldContextPreset = $state<'none' | OrganizationWorldContextPreset>('none');
+  const nameSetNames = getFantasyNameGeneratorSetNames();
   const worldPresetChoices: { value: 'none' | OrganizationWorldContextPreset; label: string }[] = [
     { value: 'none', label: 'No preset (no extra environment paragraph)' },
     { value: 'desert_route', label: 'Desert / arid trade routes' },
@@ -59,117 +62,192 @@
     { value: 'dome_sprawl', label: 'SF: dome / sealed habitats' },
   ];
 
-  function matchKinds() {
-    const all = getOrganizationKindsForRegistry(rng);
-    if (genreFilter === 'any') {
-      return all;
+  /**
+   * The kinds the genre filter offers.
+   *
+   * Built from a fixed RNG: the registry takes one because each kind draws a heraldry template
+   * from it, but the *list* of kinds does not vary and the dropdown must not either.
+   */
+  const kindChoices = $derived(
+    Organizations.organizationKindsForGenre(genreFilter, new RNG('organization-kind-list')).map(
+      (kind) => ({ value: kind.id, label: kind.typeLabel }),
+    ),
+  );
+
+  /** Filled in by the culture picker: a saved culture to name the people from (5.1). */
+  let useReferencedCulture = $state(false);
+  let referencedCulture = $state<Culture | undefined>();
+  let cultureReference = $state<ArtifactReference | undefined>();
+  const cultureLoaded = $derived(useReferencedCulture && referencedCulture !== undefined);
+
+  /** Filled in by the arms picker: a saved coat of arms to bear instead of rolling an emblem. */
+  let useReferencedArms = $state(false);
+  let referencedArms = $state<RestoredHeraldry | undefined>();
+  let armsReference = $state<ArtifactReference | undefined>();
+  const wearingReferencedArms = $derived(useReferencedArms && referencedArms !== undefined);
+
+  /**
+   * Follow the culture into and out of the name-set select, keyed on the culture arriving or
+   * leaving rather than on the select, so the user's own choice stands in between.
+   */
+  $effect(() => {
+    if (cultureLoaded) {
+      nameSetName = NAMES_FROM_CULTURE;
+    } else if (nameSetName === NAMES_FROM_CULTURE) {
+      nameSetName = ANY;
     }
-    return all.filter((k) => k.genre === genreFilter);
-  }
+  });
 
-  function buildCharacterConfig() {
-    const c = FantasyOrganizations.getDefaultOrganizationCharacterConfig(seed);
-    c.familyNameGenerator = nameSet.family;
-    c.femaleFirstNameGenerator = nameSet.female;
-    c.maleFirstNameGenerator = nameSet.male;
-    return c;
-  }
+  /**
+   * The rolled organization.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every object in the value
+   * in a Proxy, and `structuredClone` — what IndexedDB stores with — refuses a Proxy outright, so
+   * saving fails with `could not be cloned`. The same trap is written up in `$lib/workshop`'s
+   * README beside `saveToolArtifact`.
+   */
+  let organization = $state.raw<Organization | null>(null);
+  /** The settings the organization on screen was actually rolled with. Raw, for the same reason. */
+  let rolledConfig = $state.raw<OrganizationGeneratorConfigRecord>({});
+  /** The culture link, recorded only when the organization on screen was named from it. */
+  let rolledCultureReference = $state.raw<ArtifactReference | undefined>();
 
-  function orgFromGenerate(): Organization {
-    const sizeArg: OrganizationSizeInput | undefined =
-      sizePreset === 'any' ? undefined : { kind: 'preset', value: sizePreset };
-    const worldContext =
-      worldContextPreset === 'none'
-        ? undefined
-        : { kind: 'preset' as const, preset: worldContextPreset };
-    return generateOrganization({
-      rng,
-      characterConfig: buildCharacterConfig(),
-      genre: genreFilter === 'any' ? 'any' : genreFilter,
-      kindId: organizationKindId === 'any' ? 'any' : organizationKindId,
-      size: sizeArg,
-      seedPrefix: 'page',
-      worldContext,
-    });
-  }
+  /**
+   * The organization as shown: wearing the referenced arms when the picker says so.
+   *
+   * Composed over the rolled one rather than written into it, so unticking the picker gives the
+   * rolled emblem back without a re-roll.
+   */
+  const shown = $derived<Organization | null>(
+    organization === null
+      ? null
+      : wearingReferencedArms && referencedArms !== undefined
+        ? {
+            ...organization,
+            visualIdentity: {
+              ...organization.visualIdentity,
+              emblem: { kind: 'heraldry', arms: referencedArms.arms },
+            },
+          }
+        : organization,
+  );
 
-  let org = $state(orgFromGenerate());
-  let name = $state(org.name);
-  let orgDescription = $state(org.description);
-  let profile = $state<OrganizationProfile>(org.profile);
-  let leaderLine = $state(org.leader.description);
-  let notableMembers = $state(org.notableMembers);
-  let relationships = $state(org.relationships);
-  let motto = $state(org.visualIdentity.motto);
+  const snapshot = $derived(
+    shown === null ? null : Organizations.toOrganizationSnapshot(shown, wearingReferencedArms),
+  );
+  const defaultArtifactName = $derived(
+    shown === null ? '' : Organizations.organizationDisplayName(shown),
+  );
+  const references = $derived(
+    [rolledCultureReference, wearingReferencedArms ? armsReference : undefined].filter(
+      (entry): entry is ArtifactReference => entry !== undefined,
+    ),
+  );
 
-  const heraldryWidth = 200;
-  const heraldryHeight = 220;
+  /** The emblem drawn from its parameters, for every kind but a heraldic one, which has a button. */
+  const emblemSvg = $derived(
+    snapshot === null || snapshot.visualIdentity.emblem.kind === 'heraldry'
+      ? null
+      : Organizations.renderOrganizationEmblemSvg(snapshot.visualIdentity.emblem, new RNG(seed)),
+  );
 
-  async function openHeraldryModal(
-    arms: Arms,
-    title: string,
-    applyReplacement: (arms: Arms) => void,
-  ) {
-    const result = await showHeraldryModal({ arms, seed, title });
-    if (result.action === 'replaced') {
-      applyReplacement(result.arms);
+  function requestedNameSet(): string | undefined {
+    if (nameSetName === NAMES_FROM_CULTURE) {
+      return cultureLoaded ? referencedCulture?.nameGenerators.name : undefined;
     }
+    return nameSetName === ANY ? undefined : nameSetName;
   }
 
-  function replaceOrganizationHeraldry(arms: Arms) {
-    org = {
-      ...org,
-      visualIdentity: {
-        ...org.visualIdentity,
-        emblem: { kind: 'heraldry', arms },
-      },
+  /** The settings a roll takes, and the ones provenance records (3.6). */
+  function currentConfig(): OrganizationGeneratorConfigRecord {
+    const nameGeneratorSet = requestedNameSet();
+    return {
+      genre: genreFilter,
+      kindId: organizationKindId,
+      ...(sizePreset === ANY ? {} : { size: sizePreset }),
+      ...(nameGeneratorSet === undefined ? {} : { nameGeneratorSet }),
+      ...(worldContextPreset === 'none' ? {} : { worldContextPreset }),
     };
-  }
-
-  function renderArmsForOrg(o: Organization) {
-    const emblem = o.visualIdentity.emblem;
-    if (isHeraldryEmblem(emblem)) {
-      return;
-    } else if (isMerchantMarkEmblem(emblem)) {
-      const w = 200;
-      const h = 200;
-      const svg = renderMerchantMarkSvg(emblem.mark, w, h);
-      renderSVGAsPNG(svg, w, h, 'org-arms');
-    } else if (isPatternLatticeEmblem(emblem)) {
-      const w = 200;
-      const h = 200;
-      const svg = renderPatternLatticeSvg(emblem.lattice, w, h);
-      renderSVGAsPNG(svg, w, h, 'org-arms');
-    } else if (isDiscEmblem(emblem)) {
-      const w = 200;
-      const h = 200;
-      const svg = renderDiscEmblemSvg(emblem.disc, w, h);
-      renderSVGAsPNG(svg, w, h, 'org-arms');
-    }
   }
 
   function runGenerate() {
     if (!lockSeed) {
       seed = rng.randomString(13);
     }
-    rng.setSeed(seed);
-    if (nameSetName === 'any') {
-      nameSet = rng.item(nameSets);
-    } else {
-      const found = nameSets.find((s) => s.name === nameSetName);
-      if (found) {
-        nameSet = found;
-      }
+    const config = currentConfig();
+    const rolled = Organizations.rollOrganization(seed, config);
+    organization = rolled.organization;
+    // The resolved kind and set, not the requested ones: "any" or a kind this build has since
+    // dropped would otherwise be recorded as provenance a re-roll could not honour.
+    rolledConfig = {
+      ...config,
+      kindId: rolled.organization.kindId,
+      nameGeneratorSet: rolled.nameGeneratorSet,
+    };
+    rolledCultureReference =
+      nameSetName === NAMES_FROM_CULTURE && cultureLoaded ? cultureReference : undefined;
+  }
+
+  async function openHeraldryModal(arms: Arms) {
+    if (organization === null) {
+      return;
     }
-    org = orgFromGenerate();
-    name = org.name;
-    orgDescription = org.description;
-    profile = org.profile;
-    leaderLine = org.leader.description;
-    notableMembers = org.notableMembers;
-    relationships = org.relationships;
-    motto = org.visualIdentity.motto;
-    renderArmsForOrg(org);
+    const result = await showHeraldryModal({ arms, seed, title: organization.name });
+    if (result.action === 'replaced') {
+      // A replacement is the organization's own arms, whatever it was bearing before.
+      useReferencedArms = false;
+      organization = {
+        ...organization,
+        visualIdentity: {
+          ...organization.visualIdentity,
+          emblem: { kind: 'heraldry', arms: result.arms },
+        },
+      };
+    }
+  }
+
+  function exportMarkdown() {
+    if (snapshot === null) {
+      return;
+    }
+    downloadTextFile(
+      Organizations.organizationToMarkdown(snapshot),
+      `${Organizations.organizationFileStem(snapshot)}.md`,
+      'text/markdown',
+    );
+  }
+
+  async function exportPdf() {
+    if (snapshot === null) {
+      return;
+    }
+    await downloadTextPdf(
+      Organizations.organizationDisplayName(snapshot),
+      Organizations.organizationToText(snapshot),
+      `${Organizations.organizationFileStem(snapshot)}.pdf`,
+    );
+  }
+
+  /**
+   * The emblem as SVG, drawn from its parameters — the referenced arms included, since the page
+   * is the holder of that reference and has them.
+   */
+  function exportEmblem() {
+    if (shown === null) {
+      return;
+    }
+    const svg = Organizations.renderOrganizationEmblemSvg(
+      Organizations.toStoredOrganization(shown).visualIdentity.emblem,
+      new RNG(seed),
+    );
+    if (svg === null) {
+      return;
+    }
+    downloadTextFile(
+      svg,
+      `${Organizations.organizationFileStem(shown)}-emblem.svg`,
+      'image/svg+xml',
+    );
   }
 
   onMount(() => {
@@ -177,15 +255,15 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/organization" title="Organization Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Organization Generator">
   {#snippet description()}
     <p>
       Generate organizations with hierarchy, visual identity, and member roles. Fantasy and science
       fiction kinds are available.
     </p>
     <p>
-      If you choose the Name Set &quot;any,&quot; names will follow the default species-driven
-      generators. Otherwise, names will follow the selected name set.
+      If you choose the Name Set &quot;any,&quot; the seed picks a name set. Otherwise, names will
+      follow the selected name set, or the saved culture you pick below.
     </p>
   {/snippet}
 
@@ -200,18 +278,15 @@
       { value: 'fantasy', label: 'Fantasy' },
       { value: 'science_fiction', label: 'Science fiction' },
     ]}
-    onchange={() => (organizationKindId = 'any')}
+    onchange={() => (organizationKindId = ANY)}
   />
 
-  <div class="input-group">
-    <label for="type">Organization kind</label>
-    <select name="type" id="type" bind:value={organizationKindId}>
-      <option value="any">any</option>
-      {#each matchKinds() as k}
-        <option value={k.id}>{k.typeLabel}</option>
-      {/each}
-    </select>
-  </div>
+  <SelectField
+    id="type"
+    label="Organization kind"
+    bind:value={organizationKindId}
+    options={[{ value: ANY, label: 'any' }, ...kindChoices]}
+  />
 
   <SelectField
     id="size"
@@ -225,11 +300,35 @@
     ]}
   />
 
+  <SavedArtifactPicker
+    kind={CULTURE_ARTIFACT_KIND}
+    role="naming-culture"
+    checkboxLabel="Name from a saved culture in this project"
+    selectLabel="Culture"
+    bind:enabled={useReferencedCulture}
+    bind:value={referencedCulture}
+    bind:reference={cultureReference}
+  />
+
   <SelectField
     id="nameSet"
     label="Name Set"
     bind:value={nameSetName}
-    options={['any', ...nameSets.map((ns) => ns.name)]}
+    options={[
+      { value: ANY, label: 'any' },
+      ...(cultureLoaded ? [{ value: NAMES_FROM_CULTURE, label: 'From the saved culture' }] : []),
+      ...nameSetNames.map((name) => ({ value: name, label: name })),
+    ]}
+  />
+
+  <SavedArtifactPicker
+    kind={HERALDRY_ARTIFACT_KIND}
+    role="arms"
+    checkboxLabel="Give this organization a saved coat of arms"
+    selectLabel="Coat of arms"
+    bind:enabled={useReferencedArms}
+    bind:value={referencedArms}
+    bind:reference={armsReference}
   />
 
   <SelectField
@@ -241,83 +340,110 @@
 
   <BaseButton onclick={runGenerate}>Generate</BaseButton>
 
-  <h2>{name}</h2>
+  <SaveArtifactButton
+    kind={Organizations.ORGANIZATION_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    {snapshot}
+    {seed}
+    config={rolledConfig}
+    defaultName={defaultArtifactName}
+    {references}
+  />
 
-  <div class="org-arms">
-    {#if isHeraldryEmblem(org.visualIdentity.emblem)}
-      <HeraldryEmblemButton
-        arms={org.visualIdentity.emblem.arms}
-        title={name}
-        width={heraldryWidth}
-        height={heraldryHeight}
-        {rng}
-        onclick={() => {
-          const emblem = org.visualIdentity.emblem;
-          if (isHeraldryEmblem(emblem)) {
-            void openHeraldryModal(emblem.arms, name, replaceOrganizationHeraldry);
-          }
-        }}
-      />
-    {:else}
-      <img alt="" id="org-arms" />
-    {/if}
-  </div>
+  {#if shown && snapshot}
+    <div class="organization-exports">
+      <BaseButton onclick={exportMarkdown}>Download Markdown</BaseButton>
+      <BaseButton onclick={exportPdf}>Download PDF</BaseButton>
+      {#if shown.visualIdentity.emblem.kind !== 'none'}
+        <BaseButton onclick={exportEmblem}>Download Emblem (SVG)</BaseButton>
+      {/if}
+    </div>
 
-  {#if motto}
-    <p class="motto">"{motto}"</p>
-  {/if}
+    <div class="organization">
+      <h2>{shown.name}</h2>
 
-  <p>{orgDescription}</p>
+      <div class="org-arms">
+        {#if isHeraldryEmblem(shown.visualIdentity.emblem)}
+          {@const arms = shown.visualIdentity.emblem.arms}
+          <HeraldryEmblemButton
+            {arms}
+            title={shown.name}
+            width={Organizations.ORGANIZATION_EMBLEM_WIDTH}
+            height={Organizations.ORGANIZATION_EMBLEM_HEIGHT}
+            rng={new RNG(seed)}
+            onclick={() => void openHeraldryModal(arms)}
+          />
+        {:else if emblemSvg !== null}
+          <!-- Drawn from the emblem's parameters, which is what the payload stores. -->
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+          {@html emblemSvg}
+        {/if}
+      </div>
 
-  <h3>Profile</h3>
-  <ul class="org-profile">
-    <li>
-      <strong>Traits</strong>
-      {profile.personalityTraits.map((t) => t.label).join(' · ')}
-    </li>
-    <li><strong>Goal</strong> {profile.goal.label}</li>
-    <li><strong>Weakness</strong> {profile.weakness.label}</li>
-    <li><strong>Public standing</strong> {profile.publicStanding.label}</li>
-    {#if profile.environmentNarrative}
-      <li>
-        <strong>Environment</strong>
-        {profile.environmentNarrative.shortLabel}
-      </li>
-    {/if}
-  </ul>
-  <p class="org-hook"><strong>Hook</strong> {profile.hook}</p>
+      {#if shown.visualIdentity.motto}
+        <p class="motto">"{shown.visualIdentity.motto}"</p>
+      {/if}
 
-  <p>{leaderLine}</p>
+      <p>{shown.description}</p>
 
-  {#if relationships.length > 0}
-    <h3>Relationships</h3>
-    <ul>
-      {#each relationships as r}
-        <li>{r.kind} → {r.relatedOrganizationId}</li>
-      {/each}
-    </ul>
-  {/if}
+      <h3>Profile</h3>
+      <ul class="org-profile">
+        <li>
+          <strong>Traits</strong>
+          {shown.profile.personalityTraits.map((t) => t.label).join(' · ')}
+        </li>
+        <li><strong>Goal</strong> {shown.profile.goal.label}</li>
+        <li><strong>Weakness</strong> {shown.profile.weakness.label}</li>
+        <li><strong>Public standing</strong> {shown.profile.publicStanding.label}</li>
+        {#if shown.profile.environmentNarrative}
+          <li>
+            <strong>Environment</strong>
+            {shown.profile.environmentNarrative.shortLabel}
+          </li>
+        {/if}
+      </ul>
+      <p class="org-hook"><strong>Hook</strong> {shown.profile.hook}</p>
 
-  <h3>Notable Members</h3>
+      <p>{shown.leader.description}</p>
 
-  {#each notableMembers as member}
-    <p>
-      <strong>
-        {Characters.getHonorific(
+      {#if shown.relationships.length > 0}
+        <h3>Relationships</h3>
+        <ul>
+          {#each shown.relationships as r}
+            <li>{r.kind} → {r.relatedOrganizationId}</li>
+          {/each}
+        </ul>
+      {/if}
+
+      <h3>Notable Members</h3>
+
+      {#each shown.notableMembers as member (member.id)}
+        {@const honorific = Characters.getHonorific(
           member.gender.name,
           Characters.getHighestPrecedenceTitle(member.titles || []),
           member.gender.pronouns,
         )}
-        {member.firstName}
-        {member.lastName}{#if Characters.getHonorific(member.gender.name, Characters.getHighestPrecedenceTitle(member.titles || []), member.gender.pronouns) == ''}
-          ({Characters.getTitle(member)}){/if}:
-      </strong>
-      {member.description}
-    </p>
-  {/each}
+        <p class="member">
+          <strong>
+            {honorific}
+            {member.firstName}
+            {member.lastName}{#if honorific === ''}
+              ({Characters.getTitle(member)}){/if}:
+          </strong>
+          {member.description}
+        </p>
+      {/each}
+    </div>
+  {/if}
 </GeneratorPage>
 
 <style>
+  .organization-exports {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
   div.org-arms {
     width: 200px;
     height: 220px;

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -91,6 +91,11 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // build: the family kind module and everything it statically imports is 198 KB across 16 chunks through
   // this path and 19.6 MB across 35 chunks through the entry point.
   '$lib/families/family_artifact_kind',
+  // The fourteenth. `$lib/organizations`'s entry point reaches the generator and the emblem
+  // renderers, and from there the character generator, every kind's heraldry config and the
+  // charge art. Measured on the build: the organization kind module and everything it statically
+  // imports is 204 KB across 16 chunks through this path and 19.7 MB across 35 chunks through the entry point.
+  '$lib/organizations/organization_artifact_kind',
 ]);
 
 /**

--- a/src/lib/organizations/README.md
+++ b/src/lib/organizations/README.md
@@ -91,3 +91,38 @@ import { addRandomRivalryBetweenPairs } from '$lib/organizations';
 ## Tests
 
 `generate_organization.test.ts` covers a valid `lineChain` and a full mercenary `generateOrganization` run.
+
+## Two registries, not one
+
+This library's **kind registry** (`kind_registry.ts`, `Organization.kindId`, values like
+`mercenary_company` and `noble_house`) says what sort of organization one is. The site's
+**artifact kind registry** (`$lib/artifact_kinds`, `ArtifactKind`, the value `organization`) says
+what sort of payload a saved artifact holds. They predate each other in opposite directions and
+mean different things; in code they stay `kindId` and `ArtifactKind`.
+
+## Saving an organization
+
+The generator is Release-ready (issue #56), which means a rolled organization can be kept:
+
+- `organization_snapshot.ts` — the stored form, `StoredOrganization`, declared here since #56 (it
+  lived in `$lib/settlements`, which now composes it). The hierarchy's three `Map`s travel as entry
+  arrays, the leader and notable members as `StoredCharacter`, and the visual identity as
+  `StoredVisualIdentity` from `$lib/visual_identity` — **imagery as parameters, never as a
+  rendered SVG**. `kindId` was already the right shape: the kind's closures never reached the
+  payload.
+- `organization_rehydrate.ts` — the stored form back into an `Organization`. Nothing is recomputed.
+- `organization_artifact_kind.ts` — the `organization` kind. Each person is validated by the
+  character kind's own validator; referenced arms (`arms: null`) are accepted.
+- `organization_roll.ts` — the single path from a seed and the page's five controls to an
+  organization, and the provenance record a re-roll reads back. A kind or name set this build no
+  longer has is substituted and reported.
+- `organization_editing.ts` — name, description, motto, palette, the profile's traits, goal,
+  weakness, standing and hook, and each person's names and line. Changing a facet does not rewrite
+  the description composed from it.
+- `organization_emblem.ts` — the emblem drawn from its stored parameters, whichever kind, and a
+  sentence about it for text that cannot carry a picture.
+- `organization_presentation.ts` — the sheet as a document, and the Markdown and PDF exports.
+
+The organization can be named from a saved culture and bear a saved coat of arms, both recorded as
+artifact references (5.1). A saved character as leader is not offered: the leader is shaped by the
+kind's role mutators, and a character rolled elsewhere would not fit the role.

--- a/src/lib/organizations/index.ts
+++ b/src/lib/organizations/index.ts
@@ -15,3 +15,10 @@ export type * from './organization_types';
 export * from './science_fiction';
 
 export * as FantasyOrganizations from './fantasy';
+export * from './organization_artifact_kind';
+export * from './organization_editing';
+export * from './organization_emblem';
+export * from './organization_presentation';
+export * from './organization_rehydrate';
+export * from './organization_roll';
+export * from './organization_snapshot';

--- a/src/lib/organizations/organization_artifact_kind.test.ts
+++ b/src/lib/organizations/organization_artifact_kind.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+
+import { readArtifactPayload, type AnyArtifactKindEntry } from '$lib/artifact_kinds';
+
+import {
+  migrateOrganizationSnapshot,
+  organizationArtifactKind,
+  ORGANIZATION_ARTIFACT_KIND,
+  ORGANIZATION_PAYLOAD_VERSION,
+  validateOrganizationSnapshot,
+} from './organization_artifact_kind.js';
+import { rollOrganizationSnapshot } from './organization_roll.js';
+import type { OrganizationSnapshot } from './organization_snapshot.js';
+
+/** Stored payloads, as anything reading one actually receives them. */
+const heraldic = JSON.parse(
+  JSON.stringify(
+    rollOrganizationSnapshot('kind-heraldic', { genre: 'fantasy', kindId: 'noble_house' }),
+  ),
+) as Record<string, unknown>;
+const marked = JSON.parse(
+  JSON.stringify(
+    rollOrganizationSnapshot('kind-marked', { genre: 'fantasy', kindId: 'trading_company' }),
+  ),
+) as Record<string, unknown>;
+
+const identity = heraldic.visualIdentity as Record<string, unknown>;
+const profile = heraldic.profile as Record<string, unknown>;
+
+describe('the organization artifact kind', () => {
+  it('is registered under its own unqualified name, apart from the organization kind registry', () => {
+    expect(ORGANIZATION_ARTIFACT_KIND).toBe('organization');
+    expect(organizationArtifactKind.kind).toBe('organization');
+    expect(organizationArtifactKind.displayName).toBe('Organization');
+    expect(organizationArtifactKind.payloadVersion).toBe(ORGANIZATION_PAYLOAD_VERSION);
+    expect(organizationArtifactKind.icon).not.toBe('');
+    expect(heraldic.kindId).toBe('noble_house');
+  });
+
+  it('names a saved organization after itself, and an unnamed one by its kind', () => {
+    expect(organizationArtifactKind.nameOf(heraldic as unknown as OrganizationSnapshot)).toBe(
+      heraldic.name,
+    );
+    expect(
+      organizationArtifactKind.nameOf({
+        ...heraldic,
+        name: ' ',
+      } as unknown as OrganizationSnapshot),
+    ).toBe('Organization');
+  });
+
+  it('accepts payloads the generator produced, with arms and with a mark', () => {
+    expect(validateOrganizationSnapshot(heraldic).ok).toBe(true);
+    expect(validateOrganizationSnapshot(marked).ok).toBe(true);
+  });
+
+  /** 3.3: an organization with no notables left is well-defined, and so are referenced arms. */
+  it('accepts no notable members, and referenced arms written as null', () => {
+    expect(validateOrganizationSnapshot({ ...heraldic, notableMembers: [] }).ok).toBe(true);
+    expect(
+      validateOrganizationSnapshot({
+        ...heraldic,
+        visualIdentity: { ...identity, emblem: { kind: 'heraldry', arms: null } },
+      }).ok,
+    ).toBe(true);
+  });
+
+  it('rejects something that is not an object at all', () => {
+    for (const payload of [null, 'guild', 42, [heraldic]]) {
+      const result = validateOrganizationSnapshot(payload);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toBe('invalid-payload');
+    }
+  });
+
+  it('rejects a payload missing its own fields', () => {
+    expect(validateOrganizationSnapshot({ ...heraldic, name: undefined }).ok).toBe(false);
+    expect(validateOrganizationSnapshot({ ...heraldic, kindId: 3 }).ok).toBe(false);
+    expect(validateOrganizationSnapshot({ ...heraldic, memberCount: 'many' }).ok).toBe(false);
+    expect(validateOrganizationSnapshot({ ...heraldic, genre: 'western' }).ok).toBe(false);
+    expect(validateOrganizationSnapshot({ ...heraldic, notableMembers: {} }).ok).toBe(false);
+    expect(
+      validateOrganizationSnapshot({ ...heraldic, relationships: [{ kind: 'rival' }] }).ok,
+    ).toBe(false);
+  });
+
+  it('rejects a profile without its facets or hook', () => {
+    expect(validateOrganizationSnapshot({ ...heraldic, profile: { ...profile, hook: 1 } }).ok).toBe(
+      false,
+    );
+    expect(
+      validateOrganizationSnapshot({ ...heraldic, profile: { ...profile, goal: { id: 'x' } } }).ok,
+    ).toBe(false);
+    expect(
+      validateOrganizationSnapshot({
+        ...heraldic,
+        profile: { ...profile, personalityTraits: 'bold' },
+      }).ok,
+    ).toBe(false);
+  });
+
+  it('rejects an emblem of an unknown kind, or one without its parameters', () => {
+    const withEmblem = (emblem: unknown) => ({
+      ...heraldic,
+      visualIdentity: { ...identity, emblem },
+    });
+
+    expect(validateOrganizationSnapshot(withEmblem({ kind: 'tattoo' })).ok).toBe(false);
+    expect(validateOrganizationSnapshot(withEmblem({ kind: 'merchant_mark' })).ok).toBe(false);
+    expect(validateOrganizationSnapshot(withEmblem({ kind: 'heraldry', arms: 'lions' })).ok).toBe(
+      false,
+    );
+    expect(validateOrganizationSnapshot({ ...heraldic, visualIdentity: null }).ok).toBe(false);
+    expect(
+      validateOrganizationSnapshot({ ...heraldic, visualIdentity: { ...identity, motto: 3 } }).ok,
+    ).toBe(false);
+    expect(
+      validateOrganizationSnapshot({ ...heraldic, visualIdentity: { ...identity, colors: {} } }).ok,
+    ).toBe(false);
+  });
+
+  it('rejects a hierarchy that is not three entry lists', () => {
+    expect(validateOrganizationSnapshot({ ...heraldic, hierarchy: {} }).ok).toBe(false);
+    expect(
+      validateOrganizationSnapshot({
+        ...heraldic,
+        hierarchy: { childToParent: [[1, null]], idToOrder: [], roleById: [] },
+      }).ok,
+    ).toBe(false);
+  });
+
+  it('rejects a person who is not a character', () => {
+    expect(validateOrganizationSnapshot({ ...heraldic, leader: { name: 'Tam' } }).ok).toBe(false);
+    expect(
+      validateOrganizationSnapshot({ ...heraldic, notableMembers: [{ name: 'Tam' }] }).ok,
+    ).toBe(false);
+  });
+
+  it('has no migration to offer, and says so rather than guessing', () => {
+    const result = migrateOrganizationSnapshot(heraldic, 0);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toBe('unsupported-version');
+  });
+
+  /** The whole read path, as the store runs it. */
+  it('reads a stored payload of its own version', () => {
+    expect(
+      readArtifactPayload(
+        organizationArtifactKind as AnyArtifactKindEntry,
+        heraldic,
+        ORGANIZATION_PAYLOAD_VERSION,
+      ).ok,
+    ).toBe(true);
+  });
+
+  it('quarantines a payload from a version it has no step for', () => {
+    expect(
+      readArtifactPayload(
+        organizationArtifactKind as AnyArtifactKindEntry,
+        heraldic,
+        ORGANIZATION_PAYLOAD_VERSION + 1,
+      ).ok,
+    ).toBe(false);
+  });
+
+  it('loads a codec that round-trips the payload', async () => {
+    const codec = await organizationArtifactKind.loadCodec();
+    const accepted = validateOrganizationSnapshot(heraldic);
+
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) {
+      return;
+    }
+    const { RNG } = await import('@ironarachne/rng');
+    const live = codec.fromSnapshot(accepted.value as OrganizationSnapshot, new RNG('unused'));
+
+    expect(codec.toSnapshot(live)).toEqual(accepted.value);
+  });
+});

--- a/src/lib/organizations/organization_artifact_kind.ts
+++ b/src/lib/organizations/organization_artifact_kind.ts
@@ -1,0 +1,233 @@
+import scroll from '$lib/assets/icons/set3/scrool-2.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+import { validateCharacterSnapshot } from '$lib/characters/character_artifact_kind';
+
+import type { OrganizationSnapshot } from './organization_snapshot';
+import type { Organization } from './organization_types';
+
+/**
+ * Stable artifact kind id. Unqualified, per the kind table in docs/tool-readiness.md.
+ *
+ * Not to be confused with `Organization.kindId`, which names what sort of organization one is
+ * (`mercenary_company`, `noble_house`) from this library's own kind registry. That registry
+ * predates the artifact kind registry and means something else entirely.
+ */
+export const ORGANIZATION_ARTIFACT_KIND = 'organization' as const;
+
+/** Version 1. The first shape an organization has been stored on its own in. */
+export const ORGANIZATION_PAYLOAD_VERSION = 1 as const;
+
+const EMBLEM_KINDS = ['none', 'heraldry', 'merchant_mark', 'pattern_lattice', 'disc_emblem'];
+const GENRES = ['fantasy', 'science_fiction'];
+
+function isLabeledFacet(value: unknown): boolean {
+  const facet = asRecord(value);
+  return facet !== null && hasStringFields(facet, ['id', 'label']);
+}
+
+/** The profile: the facets the page prints, and the hook line. */
+function validateProfile(value: unknown): PayloadResult<unknown> {
+  const profile = asRecord(value);
+  if (profile === null || typeof profile.hook !== 'string') {
+    return rejectedPayload('invalid-payload', 'organization profile has no hook');
+  }
+  if (
+    !Array.isArray(profile.personalityTraits) ||
+    !profile.personalityTraits.every(isLabeledFacet) ||
+    !isLabeledFacet(profile.goal) ||
+    !isLabeledFacet(profile.weakness) ||
+    !isLabeledFacet(profile.publicStanding)
+  ) {
+    return rejectedPayload(
+      'invalid-payload',
+      'organization profile needs labelled traits, a goal, a weakness and a public standing',
+    );
+  }
+  return acceptedPayload(profile);
+}
+
+/**
+ * A stored coat of arms, or `null` for a referenced one.
+ *
+ * `null` is accepted because it is what a composed organization is *written* with, so a validator
+ * that turned it away would make an organization unreadable by the very build that saved it.
+ */
+function isStoredArmsOrReference(value: unknown): boolean {
+  if (value === null) {
+    return true;
+  }
+  const arms = asRecord(value);
+  if (arms === null || typeof arms.blazon !== 'string') {
+    return false;
+  }
+  const device = asRecord(arms.device);
+  return (
+    device !== null && typeof device.fieldName === 'string' && Array.isArray(device.chargeGroups)
+  );
+}
+
+/** The identity: an emblem of a known kind carrying its parameters, and the optional extras. */
+function validateVisualIdentity(value: unknown): PayloadResult<unknown> {
+  const identity = asRecord(value);
+  if (identity === null) {
+    return rejectedPayload('invalid-payload', 'organization visualIdentity is not an object');
+  }
+  const emblem = asRecord(identity.emblem);
+  if (emblem === null || !EMBLEM_KINDS.includes(emblem.kind as string)) {
+    return rejectedPayload('invalid-payload', 'organization emblem is not of a known kind');
+  }
+  const parameters =
+    (emblem.kind === 'heraldry' && isStoredArmsOrReference(emblem.arms)) ||
+    (emblem.kind === 'merchant_mark' && asRecord(emblem.mark) !== null) ||
+    (emblem.kind === 'pattern_lattice' && asRecord(emblem.lattice) !== null) ||
+    (emblem.kind === 'disc_emblem' && asRecord(emblem.disc) !== null) ||
+    emblem.kind === 'none';
+  if (!parameters) {
+    return rejectedPayload('invalid-payload', 'organization emblem is missing its parameters');
+  }
+  if (identity.motto !== undefined && typeof identity.motto !== 'string') {
+    return rejectedPayload('invalid-payload', 'organization motto is not a string');
+  }
+  if (identity.colors !== undefined) {
+    const colors = asRecord(identity.colors);
+    if (colors === null || typeof colors.primary !== 'string') {
+      return rejectedPayload('invalid-payload', 'organization colors have no primary');
+    }
+  }
+  return acceptedPayload(identity);
+}
+
+function isEntryArray(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) => Array.isArray(entry) && entry.length === 2 && typeof entry[0] === 'string',
+    )
+  );
+}
+
+/** The three maps as entry arrays, which is the whole of what the rebuild depends on. */
+function validateHierarchy(value: unknown): PayloadResult<unknown> {
+  const hierarchy = asRecord(value);
+  if (
+    hierarchy === null ||
+    !isEntryArray(hierarchy.childToParent) ||
+    !isEntryArray(hierarchy.idToOrder) ||
+    !isEntryArray(hierarchy.roleById)
+  ) {
+    return rejectedPayload(
+      'invalid-payload',
+      'organization hierarchy is not three entry lists keyed by role id',
+    );
+  }
+  return acceptedPayload(hierarchy);
+}
+
+function isStoredRelationship(value: unknown): boolean {
+  const relationship = asRecord(value);
+  return relationship !== null && hasStringFields(relationship, ['relatedOrganizationId', 'kind']);
+}
+
+/**
+ * Checks what reading depends on. Each person goes through the character kind's own validator
+ * rather than a copy of it.
+ *
+ * An organization with no notable members is accepted: a user who has removed every one of them
+ * from a saved guild has made an editing decision, and 3.3 asks for a well-defined empty result.
+ */
+export function validateOrganizationSnapshot(
+  payload: unknown,
+): PayloadResult<OrganizationSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'organization payload is not an object');
+  }
+  if (!hasStringFields(record, ['id', 'name', 'description', 'kindId'])) {
+    return rejectedPayload(
+      'invalid-payload',
+      'organization payload needs string id, name, description and kindId',
+    );
+  }
+  if (!Number.isFinite(record.memberCount)) {
+    return rejectedPayload('invalid-payload', 'organization memberCount is not a number');
+  }
+  if (!GENRES.includes(record.genre as string)) {
+    return rejectedPayload('invalid-payload', 'organization genre is not one this build knows');
+  }
+  if (!Array.isArray(record.notableMembers)) {
+    return rejectedPayload('invalid-payload', 'organization notableMembers is not a list');
+  }
+  if (!Array.isArray(record.relationships) || !record.relationships.every(isStoredRelationship)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'organization relationships is not a list of related ids with a kind',
+    );
+  }
+
+  const checks: PayloadResult<unknown>[] = [
+    validateProfile(record.profile),
+    validateVisualIdentity(record.visualIdentity),
+    validateHierarchy(record.hierarchy),
+    validateCharacterSnapshot(record.leader),
+    ...record.notableMembers.map(validateCharacterSnapshot),
+  ];
+  const failed = checks.find((check) => !check.ok);
+  if (failed !== undefined) {
+    return failed as PayloadResult<OrganizationSnapshot>;
+  }
+
+  return acceptedPayload(record as unknown as OrganizationSnapshot);
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day the
+ * shape changes — a kind without one looks complete right up until it silently drops someone's
+ * work, and local-only means there is no server-side migration to fall back on.
+ */
+export function migrateOrganizationSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<OrganizationSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Organizations have no migration from payload version ${from}; version ${ORGANIZATION_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/** What to call a saved organization: its name, or the kind when the name has been emptied. */
+function organizationName(snapshot: OrganizationSnapshot): string {
+  const name = snapshot.name.trim();
+  return name === '' ? 'Organization' : name;
+}
+
+/**
+ * An organization as an artifact.
+ *
+ * The codec is a dynamic import because its reading half reaches the archetype tables and, through
+ * heraldic arms, 18 MB of charge art. Listing a project must not pay for that.
+ */
+export const organizationArtifactKind = defineArtifactKind<Organization, OrganizationSnapshot>({
+  kind: ORGANIZATION_ARTIFACT_KIND,
+  displayName: 'Organization',
+  icon: scroll,
+  payloadVersion: ORGANIZATION_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const [{ toOrganizationSnapshot }, { organizationFromSnapshot }] = await Promise.all([
+      import('./organization_snapshot.js'),
+      import('./organization_rehydrate.js'),
+    ]);
+    return { toSnapshot: toOrganizationSnapshot, fromSnapshot: organizationFromSnapshot };
+  },
+  nameOf: organizationName,
+  validate: validateOrganizationSnapshot,
+  migrate: migrateOrganizationSnapshot,
+});

--- a/src/lib/organizations/organization_editing.test.ts
+++ b/src/lib/organizations/organization_editing.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addOrganizationTrait,
+  removeOrganizationNotable,
+  removeOrganizationTrait,
+  setOrganizationColor,
+  setOrganizationFacetLabel,
+  setOrganizationHook,
+  setOrganizationMotto,
+  setOrganizationPersonField,
+  setOrganizationText,
+  setOrganizationTraitLabel,
+} from './organization_editing.js';
+import { rollOrganizationSnapshot } from './organization_roll.js';
+
+const organization = rollOrganizationSnapshot('editing-fixture', {
+  genre: 'fantasy',
+  kindId: 'noble_house',
+});
+
+describe('editing an organization', () => {
+  it('has a fixture worth testing', () => {
+    expect(organization.notableMembers.length).toBeGreaterThan(1);
+    expect(organization.profile.personalityTraits.length).toBeGreaterThan(1);
+  });
+
+  it('renames the organization and leaves everything else alone', () => {
+    const edited = setOrganizationText(organization, 'name', 'The Ashford Compact');
+
+    expect(edited.name).toBe('The Ashford Compact');
+    expect(edited.description).toBe(organization.description);
+    expect(edited.leader).toEqual(organization.leader);
+  });
+
+  /** 4.2: the paragraph was composed from the profile at roll time; editing one does not rewrite the other. */
+  it('changes a facet label without rewriting the description', () => {
+    const edited = setOrganizationFacetLabel(organization, 'goal', 'to own every mill');
+
+    expect(edited.profile.goal.label).toBe('to own every mill');
+    expect(edited.profile.goal.id).toBe(organization.profile.goal.id);
+    expect(edited.description).toBe(organization.description);
+    expect(edited.profile.weakness).toEqual(organization.profile.weakness);
+  });
+
+  it('edits the hook and the description as the user’s prose', () => {
+    const edited = setOrganizationHook(
+      setOrganizationText(organization, 'description', 'They keep bees.'),
+      'A hive is missing.',
+    );
+
+    expect(edited.description).toBe('They keep bees.');
+    expect(edited.profile.hook).toBe('A hive is missing.');
+  });
+
+  it('sets, adds and removes traits one at a time', () => {
+    const relabelled = setOrganizationTraitLabel(organization, 0, 'stubborn');
+    expect(relabelled.profile.personalityTraits[0].label).toBe('stubborn');
+    expect(relabelled.profile.personalityTraits.slice(1)).toEqual(
+      organization.profile.personalityTraits.slice(1),
+    );
+
+    const added = addOrganizationTrait(organization);
+    expect(added.profile.personalityTraits).toHaveLength(
+      organization.profile.personalityTraits.length + 1,
+    );
+    expect(added.profile.personalityTraits.at(-1)).toEqual({ id: 'custom', label: '' });
+
+    const removed = removeOrganizationTrait(organization, 0);
+    expect(removed.profile.personalityTraits).toEqual(
+      organization.profile.personalityTraits.slice(1),
+    );
+  });
+
+  it('sets a motto, and removes it when emptied', () => {
+    const withMotto = setOrganizationMotto(organization, 'Ever upward');
+    expect(withMotto.visualIdentity.motto).toBe('Ever upward');
+    expect(withMotto.visualIdentity.emblem).toEqual(organization.visualIdentity.emblem);
+
+    const cleared = setOrganizationMotto(withMotto, '  ');
+    expect('motto' in cleared.visualIdentity).toBe(false);
+  });
+
+  it('sets palette colours one slot at a time, and drops the palette with its primary', () => {
+    const primary = setOrganizationColor(organization, 'primary', '#123456');
+    expect(primary.visualIdentity.colors?.primary).toBe('#123456');
+
+    const accent = setOrganizationColor(primary, 'accent', '#abcdef');
+    expect(accent.visualIdentity.colors).toEqual({
+      ...primary.visualIdentity.colors,
+      accent: '#abcdef',
+    });
+
+    const noAccent = setOrganizationColor(accent, 'accent', '');
+    expect('accent' in (noAccent.visualIdentity.colors ?? {})).toBe(false);
+
+    const none = setOrganizationColor(accent, 'primary', '');
+    expect('colors' in none.visualIdentity).toBe(false);
+  });
+
+  /** No kind sets a palette today, so this is the state every rolled organization arrives in. */
+  it('does not invent a palette when an accent is cleared on an organization without one', () => {
+    expect('colors' in organization.visualIdentity).toBe(false);
+    const cleared = setOrganizationColor(organization, 'accent', '');
+    expect(cleared).toEqual(organization);
+    const typedThenCleared = setOrganizationColor(
+      setOrganizationColor(organization, 'accent', 'gold'),
+      'accent',
+      '',
+    );
+    expect('colors' in typedThenCleared.visualIdentity).toBe(false);
+  });
+
+  it('renames the leader and keeps the display name in step', () => {
+    const edited = setOrganizationPersonField(organization, 'leader', 'firstName', 'Tam');
+
+    expect(edited.leader.firstName).toBe('Tam');
+    expect(edited.leader.name).toBe(`Tam ${organization.leader.lastName}`);
+    expect(edited.leader.description).toBe(organization.leader.description);
+    expect(edited.notableMembers).toEqual(organization.notableMembers);
+  });
+
+  it('edits one notable and leaves the others alone', () => {
+    const edited = setOrganizationPersonField(organization, 1, 'description', 'Keeps the ledgers.');
+
+    expect(edited.notableMembers[1].description).toBe('Keeps the ledgers.');
+    expect(edited.notableMembers[1].name).toBe(organization.notableMembers[1].name);
+    expect(edited.notableMembers[0]).toEqual(organization.notableMembers[0]);
+    expect(edited.leader).toEqual(organization.leader);
+  });
+
+  it('removes a notable and leaves the rest in order', () => {
+    const removed = removeOrganizationNotable(organization, 0);
+
+    expect(removed.notableMembers).toEqual(organization.notableMembers.slice(1));
+    expect(removed.leader).toEqual(organization.leader);
+  });
+
+  it('never writes into the snapshot it was given', () => {
+    const before = structuredClone(organization);
+    setOrganizationText(organization, 'name', 'x');
+    setOrganizationMotto(organization, 'x');
+    setOrganizationColor(organization, 'primary', '#000');
+    setOrganizationHook(organization, 'x');
+    setOrganizationFacetLabel(organization, 'goal', 'x');
+    setOrganizationTraitLabel(organization, 0, 'x');
+    addOrganizationTrait(organization);
+    removeOrganizationTrait(organization, 0);
+    setOrganizationPersonField(organization, 'leader', 'lastName', 'x');
+    setOrganizationPersonField(organization, 0, 'firstName', 'x');
+    removeOrganizationNotable(organization, 0);
+
+    expect(organization).toEqual(before);
+  });
+
+  /** An index nothing is at is a no-op, not a throw: the editor is driven by a live list. */
+  it('ignores an index that is not there', () => {
+    expect(setOrganizationTraitLabel(organization, 99, 'x')).toBe(organization);
+    expect(removeOrganizationTrait(organization, -1)).toBe(organization);
+    expect(setOrganizationPersonField(organization, 99, 'firstName', 'x')).toBe(organization);
+    expect(setOrganizationPersonField(organization, 0.5, 'firstName', 'x')).toBe(organization);
+    expect(removeOrganizationNotable(organization, 99)).toBe(organization);
+  });
+});

--- a/src/lib/organizations/organization_editing.ts
+++ b/src/lib/organizations/organization_editing.ts
@@ -1,0 +1,192 @@
+/**
+ * Editing a saved organization, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction — renaming the guild must not
+ * disturb its guildmaster — and it is what lets the editing framework compare what is on screen
+ * against what was read to decide whether anything needs saving.
+ *
+ * **What is editable is what the page shows** (4.1): the name and description, the motto, the
+ * profile's traits, goal, weakness, standing and hook, and each person's names and description.
+ * The emblem's parameters are shown — drawn, from the stored parameters — and the palette's
+ * colours can be changed; the emblem itself is what a re-roll is for, since a merchant mark or a
+ * coat of arms is a whole generated thing rather than a field.
+ *
+ * **Nothing here recomputes anything.** The description was composed from the profile at roll
+ * time; changing a trait's label does not rewrite the paragraph that mentions it, because the two
+ * are separate decisions and a form that silently rewrote a user's prose would overrule them.
+ * Renaming a person sets the two parts and derives the display name from them through the same
+ * helper the character editor uses.
+ */
+
+import { formatCharacterDisplayName, type StoredCharacter } from '$lib/characters';
+
+import type { OrganizationSnapshot } from './organization_snapshot.js';
+
+export type OrganizationTextField = 'name' | 'description';
+export type OrganizationFacetField = 'goal' | 'weakness' | 'publicStanding';
+export type OrganizationColorSlot = 'primary' | 'secondary' | 'accent';
+/** The leader, or a notable member by position. */
+export type OrganizationPerson = 'leader' | number;
+export type OrganizationPersonField = 'firstName' | 'lastName' | 'description';
+
+function hasIndex(length: number, index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < length;
+}
+
+export function setOrganizationText(
+  snapshot: OrganizationSnapshot,
+  field: OrganizationTextField,
+  value: string,
+): OrganizationSnapshot {
+  return { ...snapshot, [field]: value };
+}
+
+export function setOrganizationMotto(
+  snapshot: OrganizationSnapshot,
+  motto: string,
+): OrganizationSnapshot {
+  const { motto: _motto, ...identity } = snapshot.visualIdentity;
+  return {
+    ...snapshot,
+    visualIdentity: motto.trim() === '' ? identity : { ...identity, motto },
+  };
+}
+
+/**
+ * One colour of the palette.
+ *
+ * A palette needs a primary; clearing it removes the palette, and clearing a secondary or an
+ * accent removes that slot. The value is stored as typed — it is a CSS colour string and the page
+ * renders whatever it is given.
+ */
+export function setOrganizationColor(
+  snapshot: OrganizationSnapshot,
+  slot: OrganizationColorSlot,
+  value: string,
+): OrganizationSnapshot {
+  const { colors: existing, ...identity } = snapshot.visualIdentity;
+  const colors = { ...(existing ?? { primary: '' }) };
+  if (value.trim() === '') {
+    delete colors[slot];
+  } else {
+    colors[slot] = value;
+  }
+  // A palette with no primary is no palette: clearing the primary drops it, and clearing an accent
+  // on an organization that never had a palette must not invent one with an empty primary.
+  if ((colors.primary ?? '').trim() === '') {
+    return { ...snapshot, visualIdentity: identity };
+  }
+  return { ...snapshot, visualIdentity: { ...identity, colors } };
+}
+
+export function setOrganizationHook(
+  snapshot: OrganizationSnapshot,
+  hook: string,
+): OrganizationSnapshot {
+  return { ...snapshot, profile: { ...snapshot.profile, hook } };
+}
+
+export function setOrganizationFacetLabel(
+  snapshot: OrganizationSnapshot,
+  facet: OrganizationFacetField,
+  label: string,
+): OrganizationSnapshot {
+  return {
+    ...snapshot,
+    profile: { ...snapshot.profile, [facet]: { ...snapshot.profile[facet], label } },
+  };
+}
+
+export function setOrganizationTraitLabel(
+  snapshot: OrganizationSnapshot,
+  index: number,
+  label: string,
+): OrganizationSnapshot {
+  const traits = snapshot.profile.personalityTraits;
+  if (!hasIndex(traits.length, index)) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    profile: {
+      ...snapshot.profile,
+      personalityTraits: traits.map((trait, position) =>
+        position === index ? { ...trait, label } : trait,
+      ),
+    },
+  };
+}
+
+/** A blank trait: the id is the user's, since no table row produced it. */
+export function addOrganizationTrait(snapshot: OrganizationSnapshot): OrganizationSnapshot {
+  return {
+    ...snapshot,
+    profile: {
+      ...snapshot.profile,
+      personalityTraits: [...snapshot.profile.personalityTraits, { id: 'custom', label: '' }],
+    },
+  };
+}
+
+export function removeOrganizationTrait(
+  snapshot: OrganizationSnapshot,
+  index: number,
+): OrganizationSnapshot {
+  const traits = snapshot.profile.personalityTraits;
+  if (!hasIndex(traits.length, index)) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    profile: {
+      ...snapshot.profile,
+      personalityTraits: traits.filter((_trait, position) => position !== index),
+    },
+  };
+}
+
+function withPersonField(
+  person: StoredCharacter,
+  field: OrganizationPersonField,
+  value: string,
+): StoredCharacter {
+  const changed = { ...person, [field]: value };
+  return field === 'description'
+    ? changed
+    : { ...changed, name: formatCharacterDisplayName(changed.firstName, changed.lastName) };
+}
+
+export function setOrganizationPersonField(
+  snapshot: OrganizationSnapshot,
+  person: OrganizationPerson,
+  field: OrganizationPersonField,
+  value: string,
+): OrganizationSnapshot {
+  if (person === 'leader') {
+    return { ...snapshot, leader: withPersonField(snapshot.leader, field, value) };
+  }
+  if (!hasIndex(snapshot.notableMembers.length, person)) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    notableMembers: snapshot.notableMembers.map((member, position) =>
+      position === person ? withPersonField(member, field, value) : member,
+    ),
+  };
+}
+
+/** The leader cannot be removed — an organization has one by construction — but a notable can. */
+export function removeOrganizationNotable(
+  snapshot: OrganizationSnapshot,
+  index: number,
+): OrganizationSnapshot {
+  if (!hasIndex(snapshot.notableMembers.length, index)) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    notableMembers: snapshot.notableMembers.filter((_member, position) => position !== index),
+  };
+}

--- a/src/lib/organizations/organization_emblem.ts
+++ b/src/lib/organizations/organization_emblem.ts
@@ -1,0 +1,68 @@
+/**
+ * Drawing an organization's emblem from its parameters, whichever kind it is.
+ *
+ * Every emblem the generator can produce has a renderer in the library that owns it; this is the
+ * one switch over them, written once so the page, the editor and the SVG export draw the same
+ * thing. It reads the *stored* shape, so the editor can draw from a snapshot without rebuilding
+ * the arms, and a live identity converts to it in one call.
+ *
+ * A heraldic emblem needs an RNG because the heraldry renderer takes one for its texture noise; the
+ * one handed in is seeded by the caller, so the same arms draw the same way twice.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+
+import { renderDiscEmblemSvg } from '$lib/disc_emblem';
+import { armsFromStored, renderDeviceBlazon, renderHeraldryDeviceSvg } from '$lib/heraldry';
+import { renderMerchantMarkSvg } from '$lib/merchant_marks';
+import { renderPatternLatticeSvg } from '$lib/pattern_lattice';
+import type { StoredVisualEmblem } from '$lib/visual_identity';
+
+export const ORGANIZATION_EMBLEM_WIDTH = 200 as const;
+export const ORGANIZATION_EMBLEM_HEIGHT = 220 as const;
+
+/**
+ * The emblem as SVG, or nothing for an organization with no emblem of its own.
+ *
+ * `null` arms — a referenced coat of arms — draw nothing here too: the caller holding the reference
+ * is the one that can draw them, and it does.
+ */
+export function renderOrganizationEmblemSvg(
+  emblem: StoredVisualEmblem,
+  rng: RNG,
+  width: number = ORGANIZATION_EMBLEM_WIDTH,
+  height: number = ORGANIZATION_EMBLEM_HEIGHT,
+): string | null {
+  switch (emblem.kind) {
+    case 'heraldry':
+      return emblem.arms === null
+        ? null
+        : renderHeraldryDeviceSvg(armsFromStored(emblem.arms).device, width, height, rng);
+    case 'merchant_mark':
+      return renderMerchantMarkSvg(emblem.mark, width, height);
+    case 'pattern_lattice':
+      return renderPatternLatticeSvg(emblem.lattice, width, height);
+    case 'disc_emblem':
+      return renderDiscEmblemSvg(emblem.disc, width, height);
+    default:
+      return null;
+  }
+}
+
+/** A sentence about the emblem for text that cannot carry a picture: the blazon, or a description. */
+export function describeOrganizationEmblem(emblem: StoredVisualEmblem): string {
+  switch (emblem.kind) {
+    case 'heraldry':
+      return emblem.arms === null
+        ? 'Bears a saved coat of arms.'
+        : `Arms: ${renderDeviceBlazon(armsFromStored(emblem.arms).device)}`;
+    case 'merchant_mark':
+      return `Merchant mark: ${emblem.mark.chargeName} in ${emblem.mark.fillHex}.`;
+    case 'pattern_lattice':
+      return `Pattern: a ${emblem.lattice.rows} by ${emblem.lattice.cols} lattice.`;
+    case 'disc_emblem':
+      return `Disc emblem: ${emblem.disc.chargeName} in ${emblem.disc.chargeHex} on ${emblem.disc.groundHex}.`;
+    default:
+      return '';
+  }
+}

--- a/src/lib/organizations/organization_presentation.test.ts
+++ b/src/lib/organizations/organization_presentation.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+
+import { RNG } from '@ironarachne/rng';
+
+import { describeOrganizationEmblem, renderOrganizationEmblemSvg } from './organization_emblem.js';
+import {
+  organizationDisplayName,
+  organizationFileStem,
+  organizationPersonHeading,
+  organizationToDocument,
+  organizationToMarkdown,
+  organizationToText,
+} from './organization_presentation.js';
+import { rollOrganizationSnapshot } from './organization_roll.js';
+
+const house = rollOrganizationSnapshot('presentation-house', {
+  genre: 'fantasy',
+  kindId: 'noble_house',
+});
+const company = rollOrganizationSnapshot('presentation-company', {
+  genre: 'fantasy',
+  kindId: 'trading_company',
+});
+const weavers = rollOrganizationSnapshot('presentation-weavers', {
+  genre: 'fantasy',
+  kindId: 'weavers_collective',
+});
+const circle = rollOrganizationSnapshot('presentation-circle', {
+  genre: 'fantasy',
+  kindId: 'signet_circle',
+});
+
+describe('the organization document', () => {
+  const document = organizationToDocument(house);
+
+  it('heads the document with the organization and lists its profile', () => {
+    expect(document.title).toBe(house.name);
+    expect(document.profile.some((line) => line.startsWith('Traits: '))).toBe(true);
+    expect(document.profile.some((line) => line.startsWith('Goal: '))).toBe(true);
+    expect(document.hook).toBe(house.profile.hook);
+    expect(document.leader.heading).toContain(house.leader.lastName);
+    expect(document.members).toHaveLength(house.notableMembers.length);
+  });
+
+  /** Requirement 6.4, several times over. */
+  it('prints no motto, environment, description or relationships when there are none', () => {
+    const bare = organizationToDocument({
+      ...house,
+      description: ' ',
+      relationships: [],
+      visualIdentity: { ...house.visualIdentity, motto: undefined },
+      profile: { ...house.profile, environmentNarrative: undefined },
+    });
+
+    expect(bare.motto).toBeUndefined();
+    expect(bare.paragraphs).toEqual([]);
+    expect(bare.relationships).toEqual([]);
+    expect(bare.profile.some((line) => line.startsWith('Environment: '))).toBe(false);
+  });
+
+  it('prints a motto, quoted, and relationships when there are some', () => {
+    const full = organizationToDocument({
+      ...house,
+      visualIdentity: { ...house.visualIdentity, motto: 'Ever upward' },
+      relationships: [{ kind: 'rival', relatedOrganizationId: 'the-other-house' }],
+    });
+
+    expect(full.motto).toBe('“Ever upward”');
+    expect(full.relationships).toEqual(['rival: the-other-house']);
+  });
+});
+
+describe('organizationPersonHeading', () => {
+  it('prints the honorific and the name', () => {
+    expect(organizationPersonHeading(house.leader)).toContain(house.leader.firstName);
+  });
+
+  it('stands in for a person with no name', () => {
+    expect(
+      organizationPersonHeading({ ...house.leader, firstName: '', lastName: '', titles: [] }),
+    ).toBe('An unnamed member');
+  });
+});
+
+describe('organizationToMarkdown', () => {
+  const markdown = organizationToMarkdown(house);
+
+  it('leads with the organization, lists the profile, heads the leader and the members', () => {
+    expect(markdown.startsWith(`# ${house.name}`)).toBe(true);
+    expect(markdown).toContain('- Goal: ');
+    expect(markdown).toContain('**Hook** ');
+    expect(markdown).toContain(`## ${organizationToDocument(house).leader.heading}`);
+    expect(markdown).toContain('## Notable members');
+    expect(markdown).toContain('Arms: ');
+  });
+
+  it('ends with a newline, as a text file should', () => {
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('prints no members heading over none', () => {
+    expect(organizationToMarkdown({ ...house, notableMembers: [] })).not.toContain(
+      '## Notable members',
+    );
+  });
+});
+
+describe('organizationToText', () => {
+  it('carries the same content as the Markdown, without the title', () => {
+    const text = organizationToText(house);
+
+    expect(text.startsWith('#')).toBe(false);
+    expect(text).toContain('Goal: ');
+    expect(text).toContain('NOTABLE MEMBERS');
+    expect(text).toContain(organizationToDocument(house).leader.heading.toUpperCase());
+  });
+});
+
+describe('the emblem', () => {
+  it('draws every kind of emblem from its parameters', () => {
+    for (const organization of [house, company, weavers, circle]) {
+      const svg = renderOrganizationEmblemSvg(organization.visualIdentity.emblem, new RNG('draw'));
+      expect(svg, organization.kindId).toContain('<svg');
+    }
+  });
+
+  it('draws the same arms the same way from the same RNG', () => {
+    expect(renderOrganizationEmblemSvg(house.visualIdentity.emblem, new RNG('same'))).toBe(
+      renderOrganizationEmblemSvg(house.visualIdentity.emblem, new RNG('same')),
+    );
+  });
+
+  it('draws nothing for no emblem, or for referenced arms', () => {
+    expect(renderOrganizationEmblemSvg({ kind: 'none' }, new RNG('x'))).toBeNull();
+    expect(renderOrganizationEmblemSvg({ kind: 'heraldry', arms: null }, new RNG('x'))).toBeNull();
+  });
+
+  it('describes each kind of emblem in a sentence', () => {
+    expect(describeOrganizationEmblem(house.visualIdentity.emblem)).toMatch(/^Arms: /);
+    expect(describeOrganizationEmblem(company.visualIdentity.emblem)).toMatch(/^Merchant mark: /);
+    expect(describeOrganizationEmblem(weavers.visualIdentity.emblem)).toMatch(/^Pattern: /);
+    expect(describeOrganizationEmblem(circle.visualIdentity.emblem)).toMatch(/^Disc emblem: /);
+    expect(describeOrganizationEmblem({ kind: 'heraldry', arms: null })).toBe(
+      'Bears a saved coat of arms.',
+    );
+    expect(describeOrganizationEmblem({ kind: 'none' })).toBe('');
+  });
+});
+
+describe('organizationDisplayName and organizationFileStem', () => {
+  it('read the name, and stand in for none', () => {
+    expect(organizationDisplayName({ name: 'The Compact' })).toBe('The Compact');
+    expect(organizationDisplayName({ name: ' ' })).toBe('Organization');
+    expect(organizationFileStem({ name: "Ashford & Sons' Compact" })).toBe('ashford-sons-compact');
+    expect(organizationFileStem({ name: '!!!' })).toBe('organization');
+  });
+});

--- a/src/lib/organizations/organization_presentation.ts
+++ b/src/lib/organizations/organization_presentation.ts
@@ -1,0 +1,176 @@
+/**
+ * An organization arranged for reading, and the Markdown and PDF exports written from it.
+ *
+ * This tool had no export at all before requirement 6.3. What a GM wants at the table is the page
+ * on paper: the name and motto, the paragraph, the profile as a list, the leader, and the notable
+ * members with their lines. The one document model is written once as Markdown and once as plain
+ * text for the PDF so the two cannot drift. The emblem is exported separately, as SVG from its
+ * parameters, because text cannot carry it; the document says what it is instead.
+ *
+ * 6.4: no motto line for an organization without one, no environment line without a narrative,
+ * no "Relationships" heading over an empty list, no "Notable members" heading over none, and a
+ * description a user has emptied prints nothing where the prose was.
+ *
+ * Presentation works on the *stored* shape, so the page and the editor print through one model.
+ */
+
+import type { StoredCharacter } from '$lib/characters';
+import { getHighestPrecedenceTitle, getHonorific } from '$lib/characters';
+
+import { describeOrganizationEmblem } from './organization_emblem.js';
+import type { OrganizationSnapshot } from './organization_snapshot.js';
+
+export type OrganizationMemberSection = {
+  heading: string;
+  paragraphs: string[];
+};
+
+export type OrganizationDocument = {
+  title: string;
+  /** The motto, quoted, when there is one. */
+  motto?: string;
+  paragraphs: string[];
+  /** "Traits: …", "Goal: …" — the profile as the page lists it. */
+  profile: string[];
+  hook: string;
+  emblem: string;
+  leader: OrganizationMemberSection;
+  members: OrganizationMemberSection[];
+  relationships: string[];
+};
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+/** What to head the document with: the organization's name, or the kind when it has none. */
+export function organizationDisplayName(organization: { name: string }): string {
+  const name = organization.name.trim();
+  return name === '' ? 'Organization' : name;
+}
+
+/**
+ * A person's name with their honorific, as the page prints it.
+ *
+ * Reads the stored character: titles and gender travel as they are, so the same helper the page
+ * uses for a live one applies.
+ */
+export function organizationPersonHeading(person: StoredCharacter): string {
+  const honorific = getHonorific(
+    person.gender.name,
+    getHighestPrecedenceTitle(person.titles ?? []),
+    person.gender.pronouns,
+  );
+  const name = `${person.firstName} ${person.lastName}`.trim();
+  const named = name === '' ? 'An unnamed member' : name;
+  return honorific === '' ? named : `${honorific} ${named}`;
+}
+
+function personSection(person: StoredCharacter): OrganizationMemberSection {
+  return {
+    heading: organizationPersonHeading(person),
+    paragraphs: [person.description].filter(isPrintable),
+  };
+}
+
+export function organizationToDocument(organization: OrganizationSnapshot): OrganizationDocument {
+  const { profile, visualIdentity } = organization;
+  const traits = profile.personalityTraits.map((trait) => trait.label).filter(isPrintable);
+  const lines = [
+    ...(traits.length > 0 ? [`Traits: ${traits.join(' · ')}`] : []),
+    ...(isPrintable(profile.goal.label) ? [`Goal: ${profile.goal.label}`] : []),
+    ...(isPrintable(profile.weakness.label) ? [`Weakness: ${profile.weakness.label}`] : []),
+    ...(isPrintable(profile.publicStanding.label)
+      ? [`Public standing: ${profile.publicStanding.label}`]
+      : []),
+    ...(profile.environmentNarrative !== undefined &&
+    isPrintable(profile.environmentNarrative.shortLabel)
+      ? [`Environment: ${profile.environmentNarrative.shortLabel}`]
+      : []),
+  ];
+  const motto = visualIdentity.motto?.trim() ?? '';
+  return {
+    title: organizationDisplayName(organization),
+    ...(motto === '' ? {} : { motto: `“${motto}”` }),
+    paragraphs: [organization.description].filter(isPrintable),
+    profile: lines,
+    hook: profile.hook.trim(),
+    emblem: describeOrganizationEmblem(visualIdentity.emblem),
+    leader: personSection(organization.leader),
+    members: organization.notableMembers.map(personSection),
+    relationships: organization.relationships.map(
+      (relationship) => `${relationship.kind}: ${relationship.relatedOrganizationId}`,
+    ),
+  };
+}
+
+/** An organization as Markdown, for a GM who wants it in their own notes. */
+export function organizationToMarkdown(organization: OrganizationSnapshot): string {
+  const document = organizationToDocument(organization);
+  const blocks = [`# ${document.title}`];
+  if (document.motto !== undefined) {
+    blocks.push(`*${document.motto}*`);
+  }
+  blocks.push(...document.paragraphs);
+  if (document.profile.length > 0) {
+    blocks.push(document.profile.map((line) => `- ${line}`).join('\n'));
+  }
+  if (isPrintable(document.hook)) {
+    blocks.push(`**Hook** ${document.hook}`);
+  }
+  if (isPrintable(document.emblem)) {
+    blocks.push(document.emblem);
+  }
+  blocks.push(`## ${document.leader.heading}`, ...document.leader.paragraphs);
+  if (document.members.length > 0) {
+    blocks.push('## Notable members');
+    for (const member of document.members) {
+      blocks.push(`### ${member.heading}`, ...member.paragraphs);
+    }
+  }
+  if (document.relationships.length > 0) {
+    blocks.push('## Relationships', document.relationships.map((line) => `- ${line}`).join('\n'));
+  }
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** The body of the PDF: the same document as plain text, without the title the PDF draws itself. */
+export function organizationToText(organization: OrganizationSnapshot): string {
+  const document = organizationToDocument(organization);
+  const blocks: string[] = [];
+  if (document.motto !== undefined) {
+    blocks.push(document.motto);
+  }
+  blocks.push(...document.paragraphs);
+  if (document.profile.length > 0) {
+    blocks.push(document.profile.join('\n'));
+  }
+  if (isPrintable(document.hook)) {
+    blocks.push(`Hook: ${document.hook}`);
+  }
+  if (isPrintable(document.emblem)) {
+    blocks.push(document.emblem);
+  }
+  blocks.push([document.leader.heading.toUpperCase(), ...document.leader.paragraphs].join('\n'));
+  if (document.members.length > 0) {
+    blocks.push(
+      [
+        'NOTABLE MEMBERS',
+        ...document.members.map((m) => [m.heading, ...m.paragraphs].join('\n')),
+      ].join('\n\n'),
+    );
+  }
+  if (document.relationships.length > 0) {
+    blocks.push(['RELATIONSHIPS', ...document.relationships].join('\n'));
+  }
+  return blocks.join('\n\n');
+}
+
+/** A filename stem for an exported organization, reduced to something a filesystem takes. */
+export function organizationFileStem(organization: { name: string }): string {
+  const stem = organization.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' ? 'organization' : stem;
+}

--- a/src/lib/organizations/organization_rehydrate.ts
+++ b/src/lib/organizations/organization_rehydrate.ts
@@ -1,0 +1,50 @@
+/**
+ * Rebuilding an organization from its stored form.
+ *
+ * **Nothing here is recomputed.** The maps are rebuilt from their entries, the people come back
+ * through `$lib/characters` — species and archetype by name, unknown names becoming placeholders —
+ * and the identity through `$lib/visual_identity`. `kindId` stays a string: the kind is a table of
+ * closures the generator used, and an organization that has been rolled needs nothing from it.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+
+import { characterFromStored } from '$lib/characters';
+import { visualIdentityFromStored } from '$lib/visual_identity';
+
+import type {
+  OrganizationSnapshot,
+  StoredOrganization,
+  StoredOrganizationHierarchy,
+} from './organization_snapshot.js';
+import type { Organization, OrganizationHierarchy } from './organization_types.js';
+
+export function hierarchyFromStored(stored: StoredOrganizationHierarchy): OrganizationHierarchy {
+  return {
+    childToParent: new Map(stored.childToParent),
+    idToOrder: new Map(stored.idToOrder),
+    roleById: new Map(stored.roleById),
+  };
+}
+
+export function organizationFromStored(stored: StoredOrganization): Organization {
+  return {
+    ...stored,
+    hierarchy: hierarchyFromStored(stored.hierarchy),
+    leader: characterFromStored(stored.leader),
+    notableMembers: stored.notableMembers.map(characterFromStored),
+    visualIdentity: visualIdentityFromStored(stored.visualIdentity),
+    relationships: stored.relationships.map((relationship) => ({ ...relationship })),
+  };
+}
+
+/**
+ * The codec's reading half, with the signature the registry hands it.
+ *
+ * The RNG is unused, and that is the correct amount of use for it: an organization is finished
+ * when it is stored, and drawing anything from a seed on the way back would be regenerating over
+ * the user's edits.
+ */
+export function organizationFromSnapshot(snapshot: OrganizationSnapshot, _rng: RNG): Organization {
+  return organizationFromStored(snapshot);
+}

--- a/src/lib/organizations/organization_roll.test.ts
+++ b/src/lib/organizations/organization_roll.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import { RNG } from '@ironarachne/rng';
+
+import {
+  organizationKindsForGenre,
+  readOrganizationGeneratorConfig,
+  rollOrganization,
+  rollOrganizationSnapshot,
+} from './organization_roll.js';
+
+describe('rollOrganization', () => {
+  /** Requirement 2.2, including the people's names and the emblem. */
+  it('gives the same organization for the same seed and settings', () => {
+    const first = rollOrganization('a-fixed-seed', { genre: 'fantasy' });
+    const second = rollOrganization('a-fixed-seed', { genre: 'fantasy' });
+
+    expect(second.organization.name).toBe(first.organization.name);
+    expect(second.organization.leader.name).toBe(first.organization.leader.name);
+    expect(second.organization.visualIdentity).toEqual(first.organization.visualIdentity);
+    expect(second.organization.notableMembers.map((m) => m.name)).toEqual(
+      first.organization.notableMembers.map((m) => m.name),
+    );
+  });
+
+  it('gives a different organization for a different seed', () => {
+    const names = ['one', 'two', 'three'].map((seed) => rollOrganization(seed).organization.name);
+
+    expect(new Set(names).size).toBeGreaterThan(1);
+  });
+
+  it('rolls the kind asked for, and reports no substitution', () => {
+    const roll = rollOrganization('kind', { genre: 'fantasy', kindId: 'noble_house' });
+
+    expect(roll.organization.kindId).toBe('noble_house');
+    expect(roll.organization.genre).toBe('fantasy');
+    expect(roll.substitutions).toEqual([]);
+  });
+
+  it('names the people from the set asked for, and records which', () => {
+    const roll = rollOrganization('named', { nameGeneratorSet: 'elf' });
+
+    expect(roll.nameGeneratorSet).toBe('elf');
+    expect(roll.substitutions).toEqual([]);
+  });
+
+  it('lets the seed choose a name set for "any", and records the one it chose', () => {
+    const roll = rollOrganization('any-names', { nameGeneratorSet: 'any' });
+
+    expect(roll.nameGeneratorSet).not.toBe('any');
+    expect(roll.substitutions).toEqual([]);
+    expect(rollOrganization('any-names', { nameGeneratorSet: 'any' }).nameGeneratorSet).toBe(
+      roll.nameGeneratorSet,
+    );
+  });
+
+  it('substitutes, and says so, for a kind this build does not have or outside the genre', () => {
+    const missing = rollOrganization('missing', { kindId: 'a kind that never was' });
+    const wrongGenre = rollOrganization('wrong-genre', {
+      genre: 'science_fiction',
+      kindId: 'noble_house',
+    });
+
+    expect(missing.substitutions).toEqual(['kindId']);
+    expect(wrongGenre.substitutions).toEqual(['kindId']);
+    expect(wrongGenre.organization.genre).toBe('science_fiction');
+  });
+
+  it('substitutes, and says so, for a name set this build does not have', () => {
+    expect(rollOrganization('missing-names', { nameGeneratorSet: 'nobody' }).substitutions).toEqual(
+      ['nameGeneratorSet'],
+    );
+  });
+
+  it('applies a size preset and a world context', () => {
+    const roll = rollOrganization('sized', {
+      genre: 'fantasy',
+      kindId: 'mercenary_company',
+      size: 'small',
+      worldContextPreset: 'coastal',
+    });
+
+    expect(roll.organization.memberCount).toBeLessThanOrEqual(50);
+    expect(roll.organization.profile.environmentNarrative).toBeDefined();
+  });
+
+  it('rolls a snapshot from the same seed', () => {
+    const snapshot = rollOrganizationSnapshot('reroll-seed', { genre: 'fantasy' });
+
+    expect(snapshot.name).toBe(
+      rollOrganization('reroll-seed', { genre: 'fantasy' }).organization.name,
+    );
+    expect(typeof snapshot.leader.speciesName).toBe('string');
+  });
+});
+
+describe('organizationKindsForGenre', () => {
+  it('filters the registry by genre, and returns all of it for "any"', () => {
+    const all = organizationKindsForGenre('any', new RNG('kinds'));
+    const fantasy = organizationKindsForGenre('fantasy', new RNG('kinds'));
+
+    expect(all.length).toBeGreaterThan(fantasy.length);
+    expect(fantasy.every((kind) => kind.genre === 'fantasy')).toBe(true);
+    expect(organizationKindsForGenre(undefined, new RNG('kinds')).length).toBe(all.length);
+  });
+});
+
+describe('readOrganizationGeneratorConfig', () => {
+  it('reads the five settings the page has', () => {
+    const config = {
+      genre: 'fantasy',
+      kindId: 'noble_house',
+      size: 'large',
+      nameGeneratorSet: 'elf',
+      worldContextPreset: 'tundra',
+    };
+
+    expect(readOrganizationGeneratorConfig(config)).toEqual(config);
+  });
+
+  it('drops what it does not recognise rather than coercing it', () => {
+    expect(
+      readOrganizationGeneratorConfig({
+        genre: 'western',
+        kindId: '',
+        size: 'huge',
+        nameGeneratorSet: 3,
+        worldContextPreset: 'moon',
+        other: true,
+      }),
+    ).toEqual({});
+  });
+});

--- a/src/lib/organizations/organization_roll.ts
+++ b/src/lib/organizations/organization_roll.ts
@@ -1,0 +1,203 @@
+/**
+ * The single path from a seed to an organization, and the record of how it was rolled.
+ *
+ * Requirement 2.2 of docs/workshop.md wants the same seed and settings to give the same result.
+ * `OrganizationGenerator.svelte` came close — the generator takes an RNG and the page reseeded it
+ * from the seed box — but the name set was drawn from that same RNG *before* reseeding when "any"
+ * was chosen, and the kind list the page offered was built from wherever the RNG happened to be.
+ * Here the kind registry, the name set and the organization are each drawn from a stream named for
+ * the seed and nothing else.
+ *
+ * The config record is the page's five controls, stated as a type so what the generator writes as
+ * provenance and what a re-roll expects to find are one thing that drifts loudly.
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import { getFantasyNameGeneratorSet, getFantasyNameGeneratorSetNames } from '$lib/names';
+
+import { getDefaultOrganizationCharacterConfig } from './fantasy.js';
+import { generateOrganization } from './generate_organization.js';
+import { getOrganizationKindsForRegistry } from './kind_registry.js';
+import type { OrganizationKindDefinition } from './organization_kind.js';
+import { toOrganizationSnapshot, type OrganizationSnapshot } from './organization_snapshot.js';
+import type {
+  Organization,
+  OrganizationGenre,
+  OrganizationWorldContextPreset,
+} from './organization_types.js';
+
+/** The value the page's pickers use for "let the seed choose". */
+export const ORGANIZATION_ANY = 'any' as const;
+
+export type OrganizationGenreFilter = OrganizationGenre | typeof ORGANIZATION_ANY;
+export type OrganizationSizePreset = 'small' | 'medium' | 'large';
+
+const GENRES: OrganizationGenreFilter[] = ['any', 'fantasy', 'science_fiction'];
+const SIZES: OrganizationSizePreset[] = ['small', 'medium', 'large'];
+const WORLD_CONTEXTS: OrganizationWorldContextPreset[] = [
+  'desert_route',
+  'coastal',
+  'mountain_pass',
+  'river_trade',
+  'tundra',
+  'jungle_march',
+  'void_ledger',
+  'rim_wilderness',
+  'dome_sprawl',
+];
+
+/**
+ * What the generator records about how it rolled, and what a re-roll reads back.
+ *
+ * `nameGeneratorSet` is the resolved pattern set the people were named from. An organization
+ * named from a culture records that culture's own pattern set here rather than the culture's id;
+ * the link to the culture is an artifact reference beside the payload. Absent means the seed chose
+ * one, as the page's "any" does.
+ */
+export type OrganizationGeneratorConfigRecord = {
+  genre?: OrganizationGenreFilter;
+  kindId?: string;
+  size?: OrganizationSizePreset;
+  nameGeneratorSet?: string;
+  worldContextPreset?: OrganizationWorldContextPreset;
+};
+
+/** A part of the roll that the recorded config asked for and this build could not supply. */
+export type OrganizationRollSubstitution = 'kindId' | 'nameGeneratorSet';
+
+/** A rolled organization, and what the roll actually used where the config left a choice open. */
+export type OrganizationRoll = {
+  organization: Organization;
+  nameGeneratorSet: string;
+  substitutions: OrganizationRollSubstitution[];
+};
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Anything unrecognisable is dropped rather than coerced: a config written by a build that spelled
+ * these differently should fall back to the defaults, not roll an organization from a field it
+ * misread.
+ */
+export function readOrganizationGeneratorConfig(
+  config: Record<string, unknown>,
+): OrganizationGeneratorConfigRecord {
+  return {
+    ...(GENRES.includes(config.genre as OrganizationGenreFilter)
+      ? { genre: config.genre as OrganizationGenreFilter }
+      : {}),
+    ...(typeof config.kindId === 'string' && config.kindId !== '' ? { kindId: config.kindId } : {}),
+    ...(SIZES.includes(config.size as OrganizationSizePreset)
+      ? { size: config.size as OrganizationSizePreset }
+      : {}),
+    ...(typeof config.nameGeneratorSet === 'string' && config.nameGeneratorSet !== ''
+      ? { nameGeneratorSet: config.nameGeneratorSet }
+      : {}),
+    ...(WORLD_CONTEXTS.includes(config.worldContextPreset as OrganizationWorldContextPreset)
+      ? { worldContextPreset: config.worldContextPreset as OrganizationWorldContextPreset }
+      : {}),
+  };
+}
+
+/** The kinds a genre filter allows, from a registry built for this seed. */
+export function organizationKindsForGenre(
+  genre: OrganizationGenreFilter | undefined,
+  rng: RNG,
+): OrganizationKindDefinition[] {
+  const all = getOrganizationKindsForRegistry(rng);
+  return genre === undefined || genre === ORGANIZATION_ANY
+    ? all
+    : all.filter((kind) => kind.genre === genre);
+}
+
+/**
+ * The kind id a roll passes on: the one asked for if this build has it in the genre, else "any".
+ *
+ * A kind this build no longer has, or one outside the genre the config also names, draws as "any"
+ * would and is reported as a substitution. The generator would otherwise throw, and an
+ * organization of the wrong sort is a better answer than none — and worth saying out loud.
+ */
+function resolveKindId(
+  requested: string | undefined,
+  kinds: OrganizationKindDefinition[],
+): { kindId: string; substituted: boolean } {
+  if (requested === undefined || requested === ORGANIZATION_ANY) {
+    return { kindId: ORGANIZATION_ANY, substituted: false };
+  }
+  return kinds.some((kind) => kind.id === requested)
+    ? { kindId: requested, substituted: false }
+    : { kindId: ORGANIZATION_ANY, substituted: true };
+}
+
+function resolveNameGeneratorSet(
+  requested: string | undefined,
+  seed: string,
+): { name: string; substituted: boolean } {
+  const names = getFantasyNameGeneratorSetNames();
+  if (requested === undefined || requested === '' || requested === ORGANIZATION_ANY) {
+    return { name: new RNG(`${seed}-organization-name-set`).item(names), substituted: false };
+  }
+  return names.includes(requested)
+    ? { name: requested, substituted: false }
+    : { name: new RNG(`${seed}-organization-name-set`).item(names), substituted: true };
+}
+
+/**
+ * Roll an organization from a seed and a set of options — the one path the generator page and a
+ * re-roll both take.
+ */
+export function rollOrganization(
+  seed: string,
+  config: OrganizationGeneratorConfigRecord = {},
+): OrganizationRoll {
+  const substitutions: OrganizationRollSubstitution[] = [];
+  const rng = new RNG(seed);
+
+  const kinds = organizationKindsForGenre(config.genre, new RNG(`${seed}-organization-kinds`));
+  const kind = resolveKindId(config.kindId, kinds);
+  if (kind.substituted) {
+    substitutions.push('kindId');
+  }
+  const nameSet = resolveNameGeneratorSet(config.nameGeneratorSet, seed);
+  if (nameSet.substituted) {
+    substitutions.push('nameGeneratorSet');
+  }
+  const generators = getFantasyNameGeneratorSet(
+    nameSet.name,
+    new RNG(`${seed}-organization-names`),
+  );
+
+  const characterConfig = getDefaultOrganizationCharacterConfig(seed);
+  characterConfig.familyNameGenerator = generators.family;
+  characterConfig.femaleFirstNameGenerator = generators.female;
+  characterConfig.maleFirstNameGenerator = generators.male;
+
+  const organization = generateOrganization({
+    rng,
+    characterConfig,
+    genre: config.genre ?? ORGANIZATION_ANY,
+    kindId: kind.kindId,
+    ...(config.size === undefined ? {} : { size: { kind: 'preset', value: config.size } }),
+    seedPrefix: 'page',
+    ...(config.worldContextPreset === undefined
+      ? {}
+      : { worldContext: { kind: 'preset', preset: config.worldContextPreset } }),
+  });
+
+  return { organization, nameGeneratorSet: nameSet.name, substitutions };
+}
+
+/**
+ * Roll a fresh organization as a snapshot — the destructive half of editing (requirement 4.3), and
+ * what `ARTIFACT_EDITORS` registers as this kind's roller.
+ *
+ * A re-roll never wears referenced arms: the reference was a decision about the organization that
+ * was, and the new one draws its own emblem.
+ */
+export function rollOrganizationSnapshot(
+  seed: string,
+  config: OrganizationGeneratorConfigRecord = {},
+): OrganizationSnapshot {
+  return toOrganizationSnapshot(rollOrganization(seed, config).organization);
+}

--- a/src/lib/organizations/organization_snapshot.test.ts
+++ b/src/lib/organizations/organization_snapshot.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import { RNG } from '@ironarachne/rng';
+
+import { organizationFromSnapshot, organizationFromStored } from './organization_rehydrate.js';
+import { rollOrganization } from './organization_roll.js';
+import { toOrganizationSnapshot, toStoredOrganization } from './organization_snapshot.js';
+
+/** One organization per emblem style, so imagery of every kind round-trips as parameters. */
+const byStyle = {
+  heraldry: rollOrganization('snapshot-heraldry', { genre: 'fantasy', kindId: 'noble_house' }),
+  merchant_mark: rollOrganization('snapshot-mark', { genre: 'fantasy', kindId: 'trading_company' }),
+  pattern_lattice: rollOrganization('snapshot-lattice', {
+    genre: 'fantasy',
+    kindId: 'weavers_collective',
+  }),
+  disc_emblem: rollOrganization('snapshot-disc', { genre: 'fantasy', kindId: 'signet_circle' }),
+};
+
+describe('the organization snapshot', () => {
+  it('has a fixture per emblem style', () => {
+    for (const [style, roll] of Object.entries(byStyle)) {
+      expect(roll.organization.visualIdentity.emblem.kind, style).toBe(style);
+    }
+  });
+
+  /** Requirement 7.2: lossless for everything the page shows, whichever emblem it carries. */
+  for (const [style, roll] of Object.entries(byStyle)) {
+    it(`round-trips an organization with a ${style} emblem`, () => {
+      const restored = organizationFromSnapshot(
+        toOrganizationSnapshot(roll.organization),
+        new RNG('unused'),
+      );
+
+      expect(restored).toEqual(roll.organization);
+    });
+  }
+
+  /** The three maps that `JSON.stringify` would silently empty. */
+  it('stores the hierarchy as entry arrays and rebuilds the maps', () => {
+    const { organization } = byStyle.heraldry;
+    const snapshot = toOrganizationSnapshot(organization);
+    const rebuilt = organizationFromStored(snapshot).hierarchy;
+
+    expect(Array.isArray(snapshot.hierarchy.childToParent)).toBe(true);
+    expect(snapshot.hierarchy.roleById.length).toBe(organization.hierarchy.roleById.size);
+    expect(rebuilt.idToOrder).toEqual(organization.hierarchy.idToOrder);
+    expect(rebuilt.roleById.get('lord')?.roleName).toBe('House lord');
+  });
+
+  it('stores imagery as parameters, never as a rendered SVG', () => {
+    const snapshot = toOrganizationSnapshot(byStyle.merchant_mark.organization);
+    const emblem = snapshot.visualIdentity.emblem;
+
+    expect(emblem.kind).toBe('merchant_mark');
+    expect(JSON.stringify(snapshot)).not.toContain('<svg');
+    expect(emblem.kind === 'merchant_mark' && typeof emblem.mark.chargeName).toBe('string');
+  });
+
+  it('stores arms by their parts, and rebuilds them with their renderers', () => {
+    const snapshot = toOrganizationSnapshot(byStyle.heraldry.organization);
+    const emblem = snapshot.visualIdentity.emblem;
+
+    expect(emblem.kind === 'heraldry' && emblem.arms !== null && typeof emblem.arms.blazon).toBe(
+      'string',
+    );
+    const restored = organizationFromStored(snapshot).visualIdentity.emblem;
+    expect(restored.kind).toBe('heraldry');
+  });
+
+  /** Referenced arms: `null` in the payload, no emblem on the way back, and the null kept. */
+  it('writes null for referenced arms and reads it back as no emblem of its own', () => {
+    const snapshot = toOrganizationSnapshot(byStyle.heraldry.organization, true);
+    const emblem = snapshot.visualIdentity.emblem;
+
+    expect(emblem).toEqual({ kind: 'heraldry', arms: null });
+    const restored = organizationFromStored(snapshot);
+    expect(restored.visualIdentity.emblem).toEqual({ kind: 'none' });
+    expect(
+      toStoredOrganization(byStyle.merchant_mark.organization, true).visualIdentity.emblem.kind,
+    ).toBe('merchant_mark');
+  });
+
+  it('stores people with their species by name', () => {
+    const snapshot = toOrganizationSnapshot(byStyle.heraldry.organization);
+
+    expect(typeof snapshot.leader.speciesName).toBe('string');
+    expect('species' in snapshot.leader).toBe(false);
+    expect(snapshot.notableMembers.every((m) => typeof m.speciesName === 'string')).toBe(true);
+  });
+
+  it('keeps kindId as a string and never the kind itself', () => {
+    const snapshot = toOrganizationSnapshot(byStyle.heraldry.organization);
+
+    expect(snapshot.kindId).toBe('noble_house');
+    expect('generateName' in snapshot).toBe(false);
+  });
+
+  it('is free of the functions IndexedDB refuses', () => {
+    for (const roll of Object.values(byStyle)) {
+      expect(() => structuredClone(toOrganizationSnapshot(roll.organization))).not.toThrow();
+    }
+  });
+
+  it('keeps a description a user has changed rather than recomputing it', () => {
+    const edited = toOrganizationSnapshot(byStyle.heraldry.organization);
+    edited.description = 'They keep bees.';
+
+    expect(organizationFromStored(edited).description).toBe('They keep bees.');
+  });
+
+  it('does not hand out the lists it was given', () => {
+    const { organization } = byStyle.heraldry;
+    const snapshot = toOrganizationSnapshot(organization);
+    snapshot.hierarchy.idToOrder.pop();
+    snapshot.notableMembers.pop();
+
+    expect(organization.hierarchy.idToOrder.size).toBe(snapshot.hierarchy.idToOrder.length + 1);
+    expect(organization.notableMembers.length).toBe(snapshot.notableMembers.length + 1);
+  });
+});

--- a/src/lib/organizations/organization_snapshot.ts
+++ b/src/lib/organizations/organization_snapshot.ts
@@ -1,0 +1,110 @@
+/**
+ * Writing an organization snapshot, and the shapes one is made of. Reading one back is
+ * `organization_rehydrate.ts`, split off for the reason the character's halves are: rebuilding a
+ * member reaches the archetype tables and rebuilding arms reaches `$lib/charges`, and nothing that
+ * merely stores, lists or validates an organization needs either.
+ *
+ * Declared here since #56. `StoredOrganization` and `StoredOrganizationHierarchy` lived in
+ * `src/lib/settlements/settlement_snapshot.ts` until then, because a settlement's organizations
+ * were the first anything stored — the move the stored vocabulary in docs/tool-readiness.md called
+ * for. The settlement kind composes these now and re-exports the names.
+ *
+ * Three parts of an `Organization` are not plain data, and each is handled by name:
+ *
+ * - **The hierarchy is three `Map`s.** `JSON.stringify` turns a `Map` into `{}` without
+ *   complaining, which is how a naively stored settlement once came back with every organization's
+ *   structure silently emptied. They travel as entry arrays.
+ * - **The leader and the notable members are characters**, stored as `StoredCharacter`.
+ * - **The visual identity may be heraldic**, stored as `StoredVisualIdentity`.
+ *
+ * **`kindId` is already the right shape.** An `OrganizationKindDefinition` carries three closures
+ * — `buildVisualExtras`, `generateName`, `prepareCharacterConfigForRole` — and the organization
+ * has only ever recorded the kind's id. Nothing to convert. Note that this kind registry predates
+ * the artifact kind registry and means something else: `kindId` names what sort of organization
+ * this is, and `ArtifactKind` names what sort of payload.
+ *
+ * The final `stripFunctionValuesDeep` is a net rather than the mechanism: everything this module
+ * knows to be a function has already been converted, and the strip is what keeps a closure grown
+ * somewhere new from turning a save into a `DataCloneError`.
+ */
+
+import { toStoredCharacter, type StoredCharacter } from '$lib/characters';
+import { stripFunctionValuesDeep } from '$lib/persistent_save';
+import { toStoredVisualIdentity, type StoredVisualIdentity } from '$lib/visual_identity';
+
+import type {
+  Organization,
+  OrganizationHierarchy,
+  RoleId,
+  RoleInfo,
+} from './organization_types.js';
+
+/** The three `Map`s of an {@link OrganizationHierarchy} as entry arrays, in their own order. */
+export type StoredOrganizationHierarchy = {
+  childToParent: [RoleId, RoleId | null][];
+  idToOrder: [RoleId, number][];
+  roleById: [RoleId, RoleInfo][];
+};
+
+export type StoredOrganization = Omit<
+  Organization,
+  'hierarchy' | 'leader' | 'notableMembers' | 'visualIdentity'
+> & {
+  hierarchy: StoredOrganizationHierarchy;
+  leader: StoredCharacter;
+  notableMembers: StoredCharacter[];
+  visualIdentity: StoredVisualIdentity;
+};
+
+/**
+ * An organization as an artifact payload.
+ *
+ * Identical to {@link StoredOrganization} today, and named separately all the same: this is the
+ * artifact's payload shape, which the kind's `validate` and `migrate` speak, where
+ * `StoredOrganization` is what a settlement embeds. They are free to diverge.
+ */
+export type OrganizationSnapshot = StoredOrganization;
+
+export function toStoredHierarchy(hierarchy: OrganizationHierarchy): StoredOrganizationHierarchy {
+  return {
+    childToParent: [...hierarchy.childToParent],
+    idToOrder: [...hierarchy.idToOrder],
+    roleById: [...hierarchy.roleById],
+  };
+}
+
+/**
+ * An organization with its maps, people and arms written for storage.
+ *
+ * No strip here: this is the conversion a settlement composes into a much larger one, and running
+ * the net over each organization separately would walk the same tree once per organization.
+ * `toOrganizationSnapshot` below is where an organization stored on its own gets it.
+ */
+export function toStoredOrganization(
+  organization: Organization,
+  referencedArms = false,
+): StoredOrganization {
+  return {
+    ...organization,
+    hierarchy: toStoredHierarchy(organization.hierarchy),
+    leader: toStoredCharacter(organization.leader),
+    notableMembers: organization.notableMembers.map(toStoredCharacter),
+    visualIdentity: toStoredVisualIdentity(organization.visualIdentity, referencedArms),
+    relationships: organization.relationships.map((relationship) => ({ ...relationship })),
+  };
+}
+
+/**
+ * An organization as an artifact payload.
+ *
+ * `referencedArms` says the heraldic emblem is a saved coat of arms rather than this
+ * organization's own; the payload then stores `arms: null` and the reference beside it says which.
+ */
+export function toOrganizationSnapshot(
+  organization: Organization,
+  referencedArms = false,
+): OrganizationSnapshot {
+  return stripFunctionValuesDeep(
+    toStoredOrganization(organization, referencedArms),
+  ) as OrganizationSnapshot;
+}

--- a/src/lib/settlements/settlement_rehydrate.ts
+++ b/src/lib/settlements/settlement_rehydrate.ts
@@ -12,48 +12,13 @@
  */
 
 import { characterFromStored } from '$lib/characters';
-import { armsFromStored } from '$lib/heraldry';
-import type { OrganizationHierarchy, Organization } from '$lib/organizations';
-import type { VisualIdentity } from '$lib/visual_identity';
+import { organizationFromStored } from '$lib/organizations';
 
-import type {
-  SettlementSnapshot,
-  StoredOrganization,
-  StoredOrganizationHierarchy,
-  StoredSettlementNotable,
-  StoredVisualIdentity,
-} from './settlement_snapshot.js';
+import type { SettlementSnapshot, StoredSettlementNotable } from './settlement_snapshot.js';
 import type { Settlement, SettlementImportantPerson } from './settlement_types.js';
 
 function notableFromStored(stored: StoredSettlementNotable): SettlementImportantPerson {
   return { ...stored, character: characterFromStored(stored.character) };
-}
-
-function hierarchyFromStored(stored: StoredOrganizationHierarchy): OrganizationHierarchy {
-  return {
-    childToParent: new Map(stored.childToParent),
-    idToOrder: new Map(stored.idToOrder),
-    roleById: new Map(stored.roleById),
-  };
-}
-
-function visualIdentityFromStored(stored: StoredVisualIdentity): VisualIdentity {
-  const { emblem } = stored;
-  return {
-    ...stored,
-    emblem:
-      emblem.kind === 'heraldry' ? { kind: 'heraldry', arms: armsFromStored(emblem.arms) } : emblem,
-  };
-}
-
-function organizationFromStored(stored: StoredOrganization): Organization {
-  return {
-    ...stored,
-    hierarchy: hierarchyFromStored(stored.hierarchy),
-    leader: characterFromStored(stored.leader),
-    notableMembers: stored.notableMembers.map(characterFromStored),
-    visualIdentity: visualIdentityFromStored(stored.visualIdentity),
-  };
 }
 
 /**

--- a/src/lib/settlements/settlement_snapshot.ts
+++ b/src/lib/settlements/settlement_snapshot.ts
@@ -27,10 +27,8 @@
  */
 
 import { toStoredCharacter, type StoredCharacter } from '$lib/characters';
-import { toStoredArms, type StoredArms } from '$lib/heraldry';
-import type { OrganizationHierarchy, Organization, RoleId, RoleInfo } from '$lib/organizations';
+import { toStoredOrganization, type StoredOrganization } from '$lib/organizations';
 import { stripFunctionValuesDeep } from '$lib/persistent_save';
-import type { VisualEmblem, VisualIdentity } from '$lib/visual_identity';
 
 import type { Settlement, SettlementImportantPerson } from './settlement_types.js';
 
@@ -47,31 +45,14 @@ export type StoredSettlementNotable = Omit<SettlementImportantPerson, 'character
   character: StoredCharacter;
 };
 
-/** The three `Map`s of an {@link OrganizationHierarchy} as entry arrays, in their own order. */
-export type StoredOrganizationHierarchy = {
-  childToParent: [RoleId, RoleId | null][];
-  idToOrder: [RoleId, number][];
-  roleById: [RoleId, RoleInfo][];
-};
-
-/** Every emblem variant but heraldry is already plain data and travels as it is. */
-export type StoredVisualEmblem =
-  | Exclude<VisualEmblem, { kind: 'heraldry' }>
-  | { kind: 'heraldry'; arms: StoredArms };
-
-export type StoredVisualIdentity = Omit<VisualIdentity, 'emblem'> & {
-  emblem: StoredVisualEmblem;
-};
-
-export type StoredOrganization = Omit<
-  Organization,
-  'hierarchy' | 'leader' | 'notableMembers' | 'visualIdentity'
-> & {
-  hierarchy: StoredOrganizationHierarchy;
-  leader: StoredCharacter;
-  notableMembers: StoredCharacter[];
-  visualIdentity: StoredVisualIdentity;
-};
+/**
+ * The stored organization and visual identity shapes now live in `$lib/organizations` and
+ * `$lib/visual_identity`, the libraries that own the concepts. They were declared here until #56,
+ * because a settlement's organizations were the first anything stored. Re-exported so the
+ * settlement kind's own consumers keep importing them from where they always did.
+ */
+export type { StoredOrganization, StoredOrganizationHierarchy } from '$lib/organizations';
+export type { StoredVisualEmblem, StoredVisualIdentity } from '$lib/visual_identity';
 
 /**
  * A settlement as it is stored. Everything the settlement itself holds travels straight through;
@@ -85,33 +66,6 @@ export type SettlementSnapshot = Omit<Settlement, 'importantPeople' | 'organizat
 
 function toStoredNotable(notable: SettlementImportantPerson): StoredSettlementNotable {
   return { ...notable, character: toStoredCharacter(notable.character) };
-}
-
-function toStoredHierarchy(hierarchy: OrganizationHierarchy): StoredOrganizationHierarchy {
-  return {
-    childToParent: [...hierarchy.childToParent],
-    idToOrder: [...hierarchy.idToOrder],
-    roleById: [...hierarchy.roleById],
-  };
-}
-
-function toStoredVisualIdentity(identity: VisualIdentity): StoredVisualIdentity {
-  const { emblem } = identity;
-  return {
-    ...identity,
-    emblem:
-      emblem.kind === 'heraldry' ? { kind: 'heraldry', arms: toStoredArms(emblem.arms) } : emblem,
-  };
-}
-
-function toStoredOrganization(organization: Organization): StoredOrganization {
-  return {
-    ...organization,
-    hierarchy: toStoredHierarchy(organization.hierarchy),
-    leader: toStoredCharacter(organization.leader),
-    notableMembers: organization.notableMembers.map(toStoredCharacter),
-    visualIdentity: toStoredVisualIdentity(organization.visualIdentity),
-  };
 }
 
 /**
@@ -132,7 +86,7 @@ export function toSettlementSnapshot(settlement: Settlement): SettlementSnapshot
       : { importantPeople: importantPeople.map(toStoredNotable) }),
     ...(organizations === undefined
       ? {}
-      : { organizations: organizations.map(toStoredOrganization) }),
+      : { organizations: organizations.map((organization) => toStoredOrganization(organization)) }),
   };
   return stripFunctionValuesDeep(converted) as SettlementSnapshot;
 }

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -115,6 +115,7 @@ describe('TOOL_CATALOG', () => {
       '/character',
       '/fantasy/encounter',
       '/fantasy/family',
+      '/fantasy/organization',
       '/culture',
       '/fantasy/dcc/character',
       '/fantasy/religion',
@@ -226,6 +227,7 @@ describe('toolsWithMaturity', () => {
       '/fantasy/dcc/character',
       '/fantasy/encounter',
       '/fantasy/family',
+      '/fantasy/organization',
       '/fantasy/religion',
       '/fantasy/settlement',
       '/heraldry',
@@ -286,6 +288,7 @@ describe('filterTools', () => {
       '/culture',
       '/fantasy/encounter',
       '/fantasy/family',
+      '/fantasy/organization',
       '/fantasy/religion',
       '/fantasy/settlement',
     ]);

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -198,7 +198,16 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     label: 'Fantasy Organization',
     kind: 'generator',
     domain: 'factions',
-    maturity: 'experimental',
+    // Release-ready, assessed section by section against docs/workshop.md and recorded in
+    // docs/readiness-factions.md (#56). It saves as `organization` — the stored vocabulary the
+    // settlement kind has embedded all along, now declared in `$lib/organizations` and
+    // `$lib/visual_identity`: maps as entry arrays, people as `StoredCharacter`, imagery as
+    // parameters and never as SVG — has a bespoke editor in `ARTIFACT_EDITORS`, and exports
+    // Markdown, PDF and the emblem as SVG. Its roll is deterministic from the seed and the five
+    // controls via `organization_roll.ts`. It takes a saved culture for naming and a saved coat
+    // of arms to bear, so 5.1 binds for both and is met; a saved character as leader waits on
+    // the role machinery, as docs/readiness-factions.md records.
+    maturity: 'release-ready',
     genres: ['fantasy'],
     tags: ['organization'],
   }),

--- a/src/lib/visual_identity/README.md
+++ b/src/lib/visual_identity/README.md
@@ -52,3 +52,13 @@ Add new variants to `VisualEmblem` in `visual_identity_types.ts` (e.g. `{ kind: 
 - **`VisualColorPalette`** — `primary` plus optional `secondary`, `accent` (strings, typically hex).
 - **`VisualEmblem`** — `none`, `heraldry` with `Arms`, `merchant_mark` with `MerchantMark`, `pattern_lattice` with `PatternLattice`, or `disc_emblem` with `DiscEmblem`.
 - **`VisualIdentity`** — bundles emblem and optional colors/motto.
+
+## Storing an identity
+
+`StoredVisualIdentity` and `StoredVisualEmblem` (`visual_identity_snapshot.ts`) are an identity as
+it is stored, declared here since #56 (they lived in `$lib/settlements`). Every emblem kind but
+heraldry is already plain data and travels as it is; a coat of arms travels as `StoredArms`, by the
+names of its parts. Imagery is stored as parameters, never as a rendered SVG. `arms: null` marks a
+referenced coat of arms — a saved artifact rather than the identity's own — and
+`visual_identity_rehydrate.ts` reads it back as no emblem, leaving the caller that holds the
+reference to draw it.

--- a/src/lib/visual_identity/index.ts
+++ b/src/lib/visual_identity/index.ts
@@ -1,2 +1,4 @@
 export * from './visual_identity_types';
 export * from './visual_identity';
+export * from './visual_identity_rehydrate';
+export * from './visual_identity_snapshot';

--- a/src/lib/visual_identity/visual_identity_rehydrate.ts
+++ b/src/lib/visual_identity/visual_identity_rehydrate.ts
@@ -1,0 +1,29 @@
+/**
+ * A stored visual identity, live again. Kept apart from the writing half because resolving a coat
+ * of arms reaches `$lib/charges` — 18 MB of glyph art, measured — and nothing that merely stores or
+ * validates an identity needs it.
+ *
+ * An emblem whose arms are `null` comes back as no emblem at all, which is the whole point of that
+ * value: the arms are a referenced artifact, and the caller that holds the reference is the one
+ * that can resolve it. The stored form keeps the `null`, so a payload read and written again does
+ * not lose the statement.
+ */
+
+import { armsFromStored } from '$lib/heraldry';
+
+import type { StoredVisualIdentity } from './visual_identity_snapshot.js';
+import type { VisualIdentity } from './visual_identity_types.js';
+
+export function visualIdentityFromStored(stored: StoredVisualIdentity): VisualIdentity {
+  const { emblem } = stored;
+  if (emblem.kind !== 'heraldry') {
+    return { ...stored, emblem };
+  }
+  return {
+    ...stored,
+    emblem:
+      emblem.arms === null
+        ? { kind: 'none' }
+        : { kind: 'heraldry', arms: armsFromStored(emblem.arms) },
+  };
+}

--- a/src/lib/visual_identity/visual_identity_snapshot.test.ts
+++ b/src/lib/visual_identity/visual_identity_snapshot.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { RNG } from '@ironarachne/rng';
+
+import { generateHeraldry, mergeHeraldryGeneratorConfig } from '$lib/heraldry';
+
+import {
+  createEmptyVisualIdentity,
+  withHeraldryEmblem,
+  withMerchantMarkEmblem,
+} from './visual_identity.js';
+import { visualIdentityFromStored } from './visual_identity_rehydrate.js';
+import { toStoredVisualIdentity } from './visual_identity_snapshot.js';
+
+const arms = generateHeraldry(mergeHeraldryGeneratorConfig({ rng: new RNG('identity-arms') }));
+const heraldic = { ...withHeraldryEmblem(createEmptyVisualIdentity(), arms), motto: 'Onward' };
+const marked = withMerchantMarkEmblem(createEmptyVisualIdentity(), {
+  chargeName: 'anchor',
+  fillHex: '#123456',
+});
+
+describe('the stored visual identity', () => {
+  it('round-trips a heraldic identity, arms by their parts', () => {
+    const stored = toStoredVisualIdentity(heraldic);
+
+    expect(stored.emblem.kind === 'heraldry' && stored.emblem.arms?.blazon).toBe(arms.blazon);
+    expect(() => structuredClone(stored)).not.toThrow();
+    expect(visualIdentityFromStored(stored)).toEqual(heraldic);
+  });
+
+  it('passes a plain-data emblem through untouched', () => {
+    const stored = toStoredVisualIdentity(marked);
+
+    expect(stored).toEqual(marked);
+    expect(visualIdentityFromStored(stored)).toEqual(marked);
+    expect(toStoredVisualIdentity(marked, true)).toEqual(marked);
+  });
+
+  /** Referenced arms are a statement, kept as `null`, and read back as no emblem of one's own. */
+  it('writes null for referenced arms and reads it back as no emblem', () => {
+    const stored = toStoredVisualIdentity(heraldic, true);
+
+    expect(stored.emblem).toEqual({ kind: 'heraldry', arms: null });
+    expect(stored.motto).toBe('Onward');
+    expect(visualIdentityFromStored(stored)).toEqual({ emblem: { kind: 'none' }, motto: 'Onward' });
+  });
+});

--- a/src/lib/visual_identity/visual_identity_snapshot.ts
+++ b/src/lib/visual_identity/visual_identity_snapshot.ts
@@ -1,0 +1,54 @@
+/**
+ * A visual identity as it is stored, and the writing half of the conversion.
+ *
+ * Declared here, in the library that owns the concept, since #56. `StoredVisualIdentity` and
+ * `StoredVisualEmblem` lived in `src/lib/settlements/settlement_snapshot.ts` until then, because
+ * a settlement's organizations were the first identities anything stored — the move the stored
+ * vocabulary in docs/tool-readiness.md called for. The settlement kind re-exports them.
+ *
+ * **Imagery round-trips as parameters, never as a rendered SVG.** A merchant mark, a pattern
+ * lattice and a disc emblem are already plain data — a charge name and some hex colours, a grid of
+ * cells — and travel as they are. A coat of arms carries a render function on every charge group,
+ * so it travels the way the heraldry kind stores it, by the names of its parts. A stored SVG would
+ * be a fossil: it cannot be re-themed, cannot be re-rendered at another size, and pins the payload
+ * to the renderer that made it.
+ *
+ * **`arms: null` is a statement, not a gap.** It says the arms are a referenced artifact — a saved
+ * coat of arms someone may edit later — and the artifact reference beside the payload says which.
+ * Copying the arms in would fork them at the moment of saving, which is the opposite of what
+ * composition is for. It is the same convention `StoredCharacter.heraldry` uses.
+ */
+
+import { toStoredArms, type StoredArms } from '$lib/heraldry';
+
+import type { VisualEmblem, VisualIdentity } from './visual_identity_types.js';
+
+/** Every emblem variant but heraldry is already plain data and travels as it is. */
+export type StoredVisualEmblem =
+  | Exclude<VisualEmblem, { kind: 'heraldry' }>
+  | { kind: 'heraldry'; arms: StoredArms | null };
+
+export type StoredVisualIdentity = Omit<VisualIdentity, 'emblem'> & {
+  emblem: StoredVisualEmblem;
+};
+
+/**
+ * An identity with its arms, if any, written as names.
+ *
+ * `referencedArms` says the heraldic emblem is a saved artifact rather than this identity's own,
+ * and stores `null` in its place. It is ignored for every other emblem kind, which have nothing to
+ * reference.
+ */
+export function toStoredVisualIdentity(
+  identity: VisualIdentity,
+  referencedArms = false,
+): StoredVisualIdentity {
+  const { emblem } = identity;
+  return {
+    ...identity,
+    emblem:
+      emblem.kind === 'heraldry'
+        ? { kind: 'heraldry', arms: referencedArms ? null : toStoredArms(emblem.arms) }
+        : emblem,
+  };
+}

--- a/src/lib/workshop/README.md
+++ b/src/lib/workshop/README.md
@@ -224,8 +224,8 @@ artifact does not restamp contents nobody changed.
 
 `ARTIFACT_EDITORS` maps a kind to the component that edits it, alongside an optional roller.
 **Every registered kind now has one**: heraldry, culture, religion, settlement, Velgarth gifts, the
-arms manufacturer, the encounter, the family, and the AD&D 2E, fantasy, DCC, SWN and Uncharted
-Worlds characters. That is where the readiness pass has got to
+arms manufacturer, the encounter, the family, the organization, and the AD&D 2E, fantasy, DCC,
+SWN and Uncharted Worlds characters. That is where the readiness pass has got to
 rather than a rule — a kind with no entry opens read-only, which is still a state the surface
 renders rather than an error it reports, and `loadViewer` is still in the vocabulary for a kind
 that can be shown and not sensibly edited. #39

--- a/src/lib/workshop/artifact_editors.test.ts
+++ b/src/lib/workshop/artifact_editors.test.ts
@@ -137,6 +137,18 @@ describe('the artifact editor registry', () => {
     expect(hasArtifactEditor('heraldry')).toBe(true);
   });
 
+  it('rolls an organization from provenance through the registered roller', async () => {
+    const roll = await artifactEditorEntry('organization')!.loadRoller!();
+    const rolled = roll({
+      toolPath: '/fantasy/organization',
+      seed: 'registry-seed',
+      config: { genre: 'fantasy', kindId: 'noble_house' },
+    }) as { name: string; kindId: string };
+
+    expect(rolled.name).not.toBe('');
+    expect(rolled.kindId).toBe('noble_house');
+  });
+
   it('rolls a family from provenance through the registered roller', async () => {
     const roll = await artifactEditorEntry('family')!.loadRoller!();
     const rolled = roll({

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -126,6 +126,19 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         rollUwCharacterSnapshot(provenance.seed, readUwCharacterGeneratorConfig(provenance.config));
     },
   },
+  organization: {
+    loadEditor: () => import('$components/factions/OrganizationArtifactEditor.svelte'),
+    /** The page's five controls, read back through the roll module's own reader. */
+    loadRoller: async () => {
+      const { readOrganizationGeneratorConfig, rollOrganizationSnapshot } =
+        await import('$lib/organizations/organization_roll.js');
+      return (provenance) =>
+        rollOrganizationSnapshot(
+          provenance.seed,
+          readOrganizationGeneratorConfig(provenance.config),
+        );
+    },
+  },
   family: {
     loadEditor: () => import('$components/factions/FamilyArtifactEditor.svelte'),
     /** Every control on the page, read back through the roll module's own reader. */

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -24,6 +24,7 @@ describe('artifact kind catalog', () => {
       'arms-manufacturer',
       'encounter',
       'family',
+      'organization',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -18,6 +18,7 @@ import {
 import { adndCharacterArtifactKind } from '$lib/adnd/adnd_character_artifact_kind';
 import { characterArtifactKind } from '$lib/characters/character_artifact_kind';
 import { armsManufacturerArtifactKind } from '$lib/arms_manufacturer/arms_manufacturer_artifact_kind';
+import { organizationArtifactKind } from '$lib/organizations/organization_artifact_kind';
 import { familyArtifactKind } from '$lib/families/family_artifact_kind';
 import { encounterArtifactKind } from '$lib/encounters/encounter_artifact_kind';
 import { cultureArtifactKind } from '$lib/culture/culture_artifact_kind';
@@ -53,6 +54,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, armsManufacturerArtifactKind);
   registerArtifactKind(registry, encounterArtifactKind);
   registerArtifactKind(registry, familyArtifactKind);
+  registerArtifactKind(registry, organizationArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Closes #56. Implements the #56 section of `docs/readiness-factions.md`, part of the readiness pass.

## What changed

- **Wave 0 move**: `StoredOrganization`/`StoredOrganizationHierarchy` now live in `$lib/organizations`, `StoredVisualIdentity`/`StoredVisualEmblem` in `$lib/visual_identity`, each split into snapshot and rehydrate halves. `$lib/settlements` composes and re-exports them; no settlement payload shape changed.
- **Kind `organization`**: maps as entry arrays, people as `StoredCharacter`, imagery as parameters (tested across all four emblem styles, no `<svg` in the payload), `kindId` as the string it always was. `arms: null` marks a referenced coat of arms.
- **`organization_roll.ts`**: deterministic from seed plus the five page controls; kind list and name set no longer depend on how many times Generate was pressed. Substitutes and reports a missing kind or name set.
- **Composition (5.1)**: saved culture for naming and saved coat of arms to bear, both recorded as references. Saved character as leader deliberately not offered; reasoning in the design doc.
- **Bespoke editor** covering name, description, motto, palette, profile facets and hook, each person's names and line, with the emblem redrawn from parameters and roles listed by standing.
- **Markdown, PDF and emblem SVG export** (6.3), 6.4 handled on every optional section.
- README section distinguishing the organization kind registry from the artifact kind registry.
- Deep-import allowlist entry with measurement (204 KB vs 19.7 MB).
- Pins the seed in the family spec's removal test, which the full run showed can roll a family of one.

## Testing

- `npm run verify`: green, 5059 unit tests, 0 svelte-check errors and 0 warnings, coverage gate passed with no new baseline entries.
- `npm run test:e2e`: 514 passed; the one family flake was then pinned and both specs rerun green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DDb1aVQzSNQPUw1zdjysm
