### PR TITLE
Take the star nation generator to Release-ready

### DIFF
--- a/docs/readiness-factions.md
+++ b/docs/readiness-factions.md
@@ -268,6 +268,39 @@ about to be removed is a migration nobody needed. So: **#57 does not start until
 It is the one tool in the pass with a hard external dependency, and pretending otherwise is how a
 payload version 2 gets written three weeks after version 1.
 
+**As built.** #57 landed with #11 still open, on a reading of #11's own scope: it is marked
+additive — "don't drop existing fields yet", with the numeric fields kept and disclosed — so the
+step it forces is version 1 to version 2 _adding_ optional prose fields with empty defaults, not
+the reshaping the paragraph above feared. That is the cheapest migration a kind can have, and
+`migrateStarNationSnapshot` is where it goes. If #11 is later decided the other way, the cost is
+the one this document predicted, and it was taken knowingly.
+
+Everything else landed as written, with three things to record:
+
+- **The editor is bespoke, though every control is one decision 5 allows** — text, number, and a
+  select over a named table. `SnapshotFieldEditor` is still unbuilt, because the two tools before
+  this that were called flat turned out not to be, and building the declared component against
+  its first genuinely flat consumer would be designing it from one example. Each fieldset in
+  `StarNationArtifactEditor.svelte` maps to one descriptor for the day it exists.
+- **The home system is embedded, not referenced.** There is no `star-system` kind yet, so the
+  payload carries the system's bodies — seventeen plain fields each, which is what
+  `renderStarSystemPreviewImage` takes. The nation's further systems are _not_ carried: the page
+  never showed them, only their count and what they add to the population, and a payload holding
+  twenty star systems nobody looks at would be the size case for no reason. When `star-system`
+  becomes a kind, the region of control is where the reference goes (5.2).
+- **The description is derived and kept.** `getCivilizationDescription` assembles it from the
+  figures, and editing a figure deliberately leaves it alone (4.2); `restoreStarNationDescription`
+  rebuilds it on an explicit command, which is 4.4 for the one field derived from the others.
+  The regions of control are found by their region type rather than by position, so a stored
+  nation with one missing still opens and the sentence that needed it is dropped (6.4).
+
+The clock left four config helpers on the way: `getDefaultCivilizationGenerationConfig`,
+`getDefaultRegionOfControlGenerationConfig`, `getDefaultStarSystemGeneratorConfig` and, beneath
+it, the star and planet helpers all take a required RNG now, which is decision 1 of the pass
+applied to the helpers this tool calls. `getDefaultMoonGenerationConfig` is the one in
+`$lib/astronomical_bodies` still on the clock; nothing here calls it, and it belongs to the planet
+tool's own item.
+
 ## Domain model
 
 ### The two flat payloads

--- a/e2e/star_nation.spec.ts
+++ b/e2e/star_nation.spec.ts
@@ -1,0 +1,189 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `star-nation` kind: generate, save, reopen, edit.
+ *
+ * This is the half no unit test can settle. The library tests prove a nation round-trips through
+ * the codec and that each editing function changes one field; what they cannot prove is that a
+ * user can press Generate, keep the result, come back to it in a different page, change
+ * something, and still have the nation they saved. Every step of that crosses a boundary the unit
+ * tests stub out — the artifact store, IndexedDB, the editor registry, and a page reload.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+
+const NATION_TITLE = 'Star Nation Generator | Iron Arachne';
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool on this page has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+test.describe('a star nation', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'Outer Rim');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/star-nation', { title: NATION_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a nation to keep straight away.
+    await expect(page.locator('.nation h2')).toBeVisible();
+    await saveAs(page, 'Kingdom of Vesh');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'Kingdom of Vesh');
+
+    // Typed rather than filled: `fill` sets the value in one go, and the point of this assertion is
+    // that the editor's own bindings carry a user's keystrokes through to the snapshot it
+    // announces. The value is one no roll produces, so there is always something to save.
+    const description = panel.getByRole('textbox', { name: 'Nation description' });
+    await description.fill('');
+    await description.pressSequentially('They are mostly harmless.');
+    await panel.getByRole('combobox', { name: 'Economy type' }).selectOption('Barter');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'Kingdom of Vesh');
+    await expect(reopened.getByRole('textbox', { name: 'Nation description' })).toHaveValue(
+      'They are mostly harmless.',
+    );
+    await expect(reopened.getByRole('combobox', { name: 'Economy type' })).toHaveValue('Barter');
+  });
+
+  test('changes a figure without rewriting the description, until asked', async ({ page }) => {
+    // Requirement 4.2: the figures and the prose are separate decisions, and a form that silently
+    // rewrote the sentence would overrule the user. The rewrite is a button, which is 4.4's "one
+    // part without the whole" for the one field that is derived from the others.
+    await visitRoute(page, '/star-nation', { title: NATION_TITLE });
+    await saveAs(page, 'Vesh Dominion');
+
+    const panel = await openInWorkshop(page, 'Vesh Dominion');
+    const description = panel.getByRole('textbox', { name: 'Nation description' });
+    const before = await description.inputValue();
+
+    await panel.getByRole('combobox', { name: 'Government type' }).selectOption('Theocracy');
+    await expect(description).toHaveValue(before);
+
+    await panel.getByRole('button', { name: 'Rewrite description from the figures' }).click();
+    await expect(description).toHaveValue(/theocratic/);
+
+    // Moving the homeworld is a select over the system's own planets.
+    const homePlanet = panel.getByRole('combobox', { name: 'Home planet' });
+    const options = await homePlanet.locator('option').allTextContents();
+    if (options.length > 1) {
+      await homePlanet.selectOption({ index: options.length - 1 });
+      await expect(homePlanet).toHaveValue(String(options.length - 1));
+    }
+  });
+
+  test('downloads the nation a referee can take to the table', async ({ page }) => {
+    // Requirement 6.3, and the first exports this tool has ever had.
+    await visitRoute(page, '/star-nation', { title: NATION_TITLE });
+
+    const heading = await page.locator('.nation h2').innerText();
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const markdownFile = await markdown;
+    expect(markdownFile.suggestedFilename()).toMatch(/\.md$/);
+    // And it is this nation, not a template: the file opens with the name on the page.
+    const contents = await new Response(await markdownFile.createReadStream()).text();
+    expect(contents.startsWith(`# ${heading}`)).toBe(true);
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/\.pdf$/);
+  });
+
+  test('reproduces the same nation from the same seed', async ({ page }) => {
+    // Requirement 2.2: the page threaded one RNG through every config, but each config had seeded
+    // itself from the clock first, and the preview took a seed drawn after the roll.
+    await visitRoute(page, '/star-nation', { title: NATION_TITLE });
+
+    const nation = page.locator('.nation');
+    const composite = nation.locator('.image-container-system img');
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await page.getByLabel('Planet Count').selectOption('4');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const first = await nation.innerText();
+    await expect(composite).toBeVisible();
+    const firstComposite = await composite.getAttribute('src');
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await nation.innerText()).toEqual(first);
+    // The preview too: its seed is derived from the page's, not drawn after the roll.
+    await expect(composite).toHaveAttribute('src', firstComposite ?? '');
+
+    // And a different seed is a different nation, so the reproduction above is not the page
+    // simply failing to re-roll.
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await nation.innerText()).not.toEqual(first);
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -41,6 +41,7 @@ const SILENT_TOOL_PAGES = [
   { path: '/heraldry', title: 'Heraldry Generator | Iron Arachne' },
   { path: '/velgarth-gifts', title: 'Velgarth Gifts Generator | Iron Arachne' },
   { path: '/arms-manufacturer', title: 'Arms Manufacturer Generator | Iron Arachne' },
+  { path: '/star-nation', title: 'Star Nation Generator | Iron Arachne' },
   { path: '/fantasy/encounter', title: 'Encounter | Iron Arachne' },
   { path: '/fantasy/family', title: 'Fantasy Family Generator | Iron Arachne' },
   { path: '/fantasy/organization', title: 'Organization Generator | Iron Arachne' },

--- a/src/components/factions/StarNationArtifactEditor.svelte
+++ b/src/components/factions/StarNationArtifactEditor.svelte
@@ -1,0 +1,339 @@
+<script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import {
+    getEconomyTypes,
+    getGovernmentTypes,
+    restoreStarNationDescription,
+    setStarNationEconomyType,
+    setStarNationGovernmentType,
+    setStarNationHomePlanet,
+    setStarNationHomeSystemName,
+    setStarNationMilitaryQuality,
+    setStarNationNumber,
+    setStarNationPlanetName,
+    setStarNationRegionPopulation,
+    setStarNationText,
+    STAR_NATION_MILITARY_QUALITY_RANGE,
+    STAR_NATION_TECHNOLOGY_LEVEL_RANGE,
+    validateStarNationSnapshot,
+    type StarNationNumberField,
+    type StarNationSnapshot,
+  } from '$lib/civilizations';
+
+  /**
+   * The editing view for a saved star nation.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it.
+   * What is here is every field the generator page prints (requirement 4.1): the nation's name
+   * and description, its four figures, its two table rows, its territory, and the home system —
+   * its name, its planets' names, which one is the homeworld, and the populations of its regions.
+   *
+   * **This is the `SnapshotFieldEditor` case docs/readiness-factions.md called it, built bespoke
+   * all the same.** Every control here is a text, a number or a select over a named table, which
+   * is exactly what decision 5 of docs/tool-readiness.md allows the declared component — and the
+   * component is still unbuilt, because the two tools before this that were called flat turned
+   * out not to be. Building it against a single consumer would be designing it from one example;
+   * this editor is written so that the day it exists, each fieldset below maps to one descriptor.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  const governmentTypes = getGovernmentTypes();
+  const economyTypes = getEconomyTypes();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps this editor from rendering fields over
+   * something that is not a star nation.
+   */
+  const accepted = $derived(validateStarNationSnapshot(snapshot));
+  const nation = $derived<StarNationSnapshot | undefined>(accepted.ok ? accepted.value : undefined);
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: StarNationSnapshot) => StarNationSnapshot): void {
+    if (nation === undefined) {
+      return;
+    }
+    onChange(change(nation));
+  }
+
+  function editNumber(field: StarNationNumberField, raw: string): void {
+    edit((current) => setStarNationNumber(current, field, Number(raw)));
+  }
+</script>
+
+{#if nation === undefined}
+  <Notice tone="danger">
+    These contents are stored as a star nation but do not read as one, so there is nothing safe to
+    edit here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="nation-editor">
+    <fieldset>
+      <legend>Nation</legend>
+
+      <!-- Qualified as "Nation name" rather than "Name", like every other editor: the panel above
+           already has a field labelled "Name" that renames the artifact, and two fields with the
+           same accessible name in one region is the 6.2 failure. -->
+      <div class="input-group input-group--inline">
+        <label for="{uid}-name">Nation name</label>
+        <input
+          id="{uid}-name"
+          type="text"
+          value={nation.name}
+          oninput={(event) =>
+            edit((current) => setStarNationText(current, 'name', event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+
+      <!-- The description was assembled from the figures when the nation was rolled, and changing
+           a figure below deliberately does not rewrite it: it is the user's prose. The button
+           under it rebuilds the sentence on request, which is the one explicit way back. -->
+      <div class="input-group input-group--inline">
+        <label for="{uid}-description">Nation description</label>
+        <textarea
+          id="{uid}-description"
+          rows="4"
+          value={nation.description}
+          oninput={(event) =>
+            edit((current) => setStarNationText(current, 'description', event.currentTarget.value))}
+        ></textarea>
+      </div>
+
+      <BaseButton onclick={() => edit(restoreStarNationDescription)}>
+        Rewrite description from the figures
+      </BaseButton>
+    </fieldset>
+
+    <fieldset>
+      <legend>Figures</legend>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-government">Government type</label>
+        <select
+          id="{uid}-government"
+          value={nation.governmentType.name}
+          onchange={(event) =>
+            edit((current) => setStarNationGovernmentType(current, event.currentTarget.value))}
+        >
+          {#each governmentTypes as type (type.name)}
+            <option value={type.name}>{type.name}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-economy">Economy type</label>
+        <select
+          id="{uid}-economy"
+          value={nation.economyType.name}
+          onchange={(event) =>
+            edit((current) => setStarNationEconomyType(current, event.currentTarget.value))}
+        >
+          {#each economyTypes as type (type.name)}
+            <option value={type.name}>{type.name}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-military">Military quality</label>
+        <input
+          id="{uid}-military"
+          type="number"
+          min={STAR_NATION_MILITARY_QUALITY_RANGE[0]}
+          max={STAR_NATION_MILITARY_QUALITY_RANGE[1]}
+          step="1"
+          value={nation.military.quality}
+          oninput={(event) =>
+            edit((current) =>
+              setStarNationMilitaryQuality(current, Number(event.currentTarget.value)),
+            )}
+        />
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-technology">Technology level</label>
+        <input
+          id="{uid}-technology"
+          type="number"
+          min={STAR_NATION_TECHNOLOGY_LEVEL_RANGE[0]}
+          max={STAR_NATION_TECHNOLOGY_LEVEL_RANGE[1]}
+          step="1"
+          value={nation.technologyLevel}
+          oninput={(event) => editNumber('technologyLevel', event.currentTarget.value)}
+        />
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-population">Population</label>
+        <input
+          id="{uid}-population"
+          type="number"
+          min="0"
+          step="1"
+          value={nation.population}
+          oninput={(event) => editNumber('population', event.currentTarget.value)}
+        />
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Territory</legend>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-systems">Star systems controlled</label>
+        <input
+          id="{uid}-systems"
+          type="number"
+          min="1"
+          step="1"
+          value={nation.systemsControlled}
+          oninput={(event) => editNumber('systemsControlled', event.currentTarget.value)}
+        />
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-populated">Populated planets in all</label>
+        <input
+          id="{uid}-populated"
+          type="number"
+          min="0"
+          step="1"
+          value={nation.populatedPlanets}
+          oninput={(event) => editNumber('populatedPlanets', event.currentTarget.value)}
+        />
+      </div>
+
+      {#each nation.regionsOfControl as region, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-region-{index}">{region.region_type.name} population</label>
+          <input
+            id="{uid}-region-{index}"
+            type="number"
+            min="0"
+            step="1"
+            value={region.population}
+            oninput={(event) =>
+              edit((current) =>
+                setStarNationRegionPopulation(current, index, Number(event.currentTarget.value)),
+              )}
+          />
+        </div>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Home system</legend>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-system-name">Home system name</label>
+        <input
+          id="{uid}-system-name"
+          type="text"
+          value={nation.homeSystem.name}
+          oninput={(event) =>
+            edit((current) => setStarNationHomeSystemName(current, event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-home-planet">Home planet</label>
+        <select
+          id="{uid}-home-planet"
+          value={String(nation.homePlanetIndex)}
+          onchange={(event) =>
+            edit((current) => setStarNationHomePlanet(current, Number(event.currentTarget.value)))}
+        >
+          {#each nation.homeSystem.planets as planet, index (index)}
+            <option value={String(index)}>{index + 1}: {planet.name}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-home-populated">Populated planets in the home system</label>
+        <input
+          id="{uid}-home-populated"
+          type="number"
+          min="0"
+          step="1"
+          value={nation.homeSystemPopulatedPlanets}
+          oninput={(event) => editNumber('homeSystemPopulatedPlanets', event.currentTarget.value)}
+        />
+      </div>
+
+      <!-- Keyed by position rather than by name: two planets may read the same while one is being
+           typed, and a key that changed as the user typed would lose focus on every keystroke. -->
+      {#each nation.homeSystem.planets as planet, index (index)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-planet-{index}">Planet {index + 1} name</label>
+          <input
+            id="{uid}-planet-{index}"
+            type="text"
+            value={planet.name}
+            oninput={(event) =>
+              edit((current) => setStarNationPlanetName(current, index, event.currentTarget.value))}
+            autocomplete="off"
+          />
+        </div>
+      {/each}
+    </fieldset>
+  </div>
+{/if}
+
+<style>
+  .nation-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+  }
+
+  .nation-editor fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s3);
+    align-items: flex-start;
+    margin: 0;
+    /* No border and no radius, matching the other editors: a fieldset inside an editor panel was
+       a box inside a box, and the legend and the spacing already group these. */
+    padding: var(--s4) 0;
+    min-width: 0;
+  }
+
+  .nation-editor legend {
+    padding: 0 var(--s3);
+    color: var(--gold);
+    font-size: var(--t-micro-size);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .nation-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .nation-editor input[type='text'],
+  .nation-editor input[type='number'],
+  .nation-editor textarea,
+  .nation-editor select {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+</style>

--- a/src/components/factions/StarNationGenerator.svelte
+++ b/src/components/factions/StarNationGenerator.svelte
@@ -1,94 +1,90 @@
 <script lang="ts">
   import Stat from '$components/common/Stat.svelte';
   import StatBlock from '$components/common/StatBlock.svelte';
-  import * as RNG from '@ironarachne/rng';
-  import * as Words from '@ironarachne/words';
+  import { RNG } from '@ironarachne/rng';
   import { renderStarSystemPreviewImage } from '$lib/renderers/astronomical_preview';
   import { browser } from '$app/environment';
   import { onMount } from 'svelte';
-  import {
-    generateCivilization,
-    getCivilizationDescription,
-    getDefaultCivilizationGenerationConfig,
-    getFriendlyPopulation,
-    type Civilization,
-    generateRegionOfControl,
-    getDefaultRegionOfControlGenerationConfig,
-    getRegionTypeByName,
-    type RegionOfControl,
-    type RegionOfControlGenerationConfig,
-  } from '$lib/civilizations';
-  import {
-    generateStarSystem,
-    getDefaultStarSystemGeneratorConfig,
-    type StarSystem,
-    type StarSystemGenerationConfig,
-  } from '$lib/astronomical_bodies';
-  import { getTechnologyLevelByLevel } from '$lib/technology_levels';
+  import * as Nations from '$lib/civilizations';
+  import type { StarNation } from '$lib/civilizations';
+  import { downloadTextFile } from '$lib/download';
+  import { downloadTextPdf } from '$lib/pdf';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
   import SeedControls from '$components/common/SeedControls.svelte';
   import RendererOverrideControls from '$components/common/RendererOverrideControls.svelte';
   import SelectField from '$components/common/SelectField.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
 
-  const rng = new RNG.RNG(Date.now().toString());
+  const TOOL_PATH = '/star-nation';
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. The roll itself is a pure function of
+   * the seed box and the planet count control — `rollStarNation` in `$lib/civilizations` — so
+   * the same seed gives the same nation here, in a panel, and on a re-roll from provenance.
+   */
+  const rng = new RNG(Date.now().toString());
   let seed = $state(rng.randomString(13));
   let lockSeed = $state(false);
 
-  const config = getDefaultCivilizationGenerationConfig();
-  config.rng = rng;
-  config.technology_level_range = [7, 9];
-  // Every config draws from the page's RNG. A config factory seeds itself from `Date.now()`, so
-  // one left unwired generates from a clock rather than from the seed, and the seed control stops
-  // meaning anything for whatever it produces.
-  const systemConfig: StarSystemGenerationConfig = $state(getDefaultStarSystemGeneratorConfig());
-  systemConfig.rng = rng;
-  const systemRegionConfig: RegionOfControlGenerationConfig =
-    getDefaultRegionOfControlGenerationConfig();
-  systemRegionConfig.region_types = [getRegionTypeByName('Star System')];
-  systemRegionConfig.population_density_range = [0.05, 0.3];
-  systemRegionConfig.technology_level = 7;
-  systemRegionConfig.rng = rng;
-  const homePlanetRegionConfig: RegionOfControlGenerationConfig =
-    getDefaultRegionOfControlGenerationConfig();
-  homePlanetRegionConfig.region_types = [getRegionTypeByName('Planet')];
-  homePlanetRegionConfig.technology_level = 7;
-  homePlanetRegionConfig.rng = rng;
-
-  let nation: Civilization | null = $state(null);
-  let homeSystem: StarSystem | null = $state(null);
-  let homeSystemRegion: RegionOfControl | null = $state(null);
-  let populatedPlanets = $state(1);
-  let homeSystemPopulatedPlanets = $state(1);
-  let extraDescription = $state('');
-
-  let homePlanet: number = $state(0);
-  let homePlanetRegion: RegionOfControl | null = $state(null);
-
-  let homeSystemCompositeSrc = $state('');
-  let homeSystemPreviewSeed = $state('');
+  /**
+   * The rolled nation.
+   *
+   * `$state.raw`, and not as a preference: deep-reactive `$state` wraps every object in a Proxy,
+   * and `structuredClone` — what IndexedDB stores with — refuses a Proxy outright. See the note
+   * beside `saveToolArtifact` in `$lib/workshop`'s README.
+   */
+  let nation = $state.raw<StarNation | null>(null);
 
   let planetCountControl: string = $state('random');
+
+  let homeSystemCompositeSrc = $state('');
 
   const imageWidth = 64;
   const imageHeight = 64;
 
-  const planetCountOptions = $derived([
+  const planetCountOptions = [
     { value: 'random', label: 'Random' },
-    ...Array.from({ length: 20 }, (_, i) => ({
+    ...Array.from({ length: Nations.STAR_NATION_MAX_PLANET_COUNT }, (_, i) => ({
       value: (i + 1).toString(),
       label: (i + 1).toString(),
     })),
-  ]);
+  ];
 
+  /** The one control besides the seed, as the roll reads it and as provenance records it. */
+  const generatorConfig = $derived<Nations.StarNationGeneratorConfigRecord>(
+    planetCountControl === 'random' ? {} : { planetCount: parseInt(planetCountControl, 10) },
+  );
+
+  const nationSnapshot = $derived(nation === null ? null : Nations.toStarNationSnapshot(nation));
+  const defaultArtifactName = $derived(
+    nation === null ? '' : Nations.starNationDisplayName(nation),
+  );
+
+  const homePlanet = $derived(nation === null ? undefined : Nations.homePlanetOf(nation));
+  const technology = $derived(
+    nation === null ? undefined : Nations.starNationTechnologyLevel(nation),
+  );
+  const territory = $derived(nation === null ? '' : Nations.starNationTerritorySentence(nation));
+  const homeSystemParagraph = $derived(
+    nation === null ? '' : Nations.starNationHomeSystemParagraph(nation),
+  );
+
+  /**
+   * The composite is drawn from the seed, not from a draw made after the roll: the seed control's
+   * promise is that a seed reproduces what you saw, previews included.
+   */
   function refreshHomeSystemComposite() {
-    if (!browser || homeSystemPreviewSeed === '' || !homeSystem) return;
+    if (!browser || nation === null) return;
+    const system = nation.homeSystem;
     homeSystemCompositeSrc = renderStarSystemPreviewImage(
       document,
-      homeSystem,
-      imageWidth * (homeSystem.stars.length + homeSystem.planets.length),
+      system,
+      imageWidth * (system.stars.length + system.planets.length),
       imageHeight,
-      homeSystemPreviewSeed,
+      Nations.starNationPreviewSeed(seed),
     );
   }
 
@@ -96,47 +92,30 @@
     if (!lockSeed) {
       seed = rng.randomString(13);
     }
-    rng.setSeed(seed);
-    extraDescription = '';
+    nation = Nations.rollStarNation(seed, generatorConfig);
+    refreshHomeSystemComposite();
+  }
 
-    if (planetCountControl !== 'random') {
-      systemConfig.planet_count = parseInt(planetCountControl, 10);
-    } else {
-      systemConfig.planet_count = Math.max(1, Math.round(rng.bellFloat(1, 12)));
+  function exportMarkdown() {
+    if (nation === null) {
+      return;
     }
+    downloadTextFile(
+      Nations.starNationToMarkdown(nation),
+      `${Nations.starNationFileStem(nation)}.md`,
+      'text/markdown',
+    );
+  }
 
-    nation = generateCivilization(config);
-    homeSystem = generateStarSystem(systemConfig);
-    homePlanet = rng.int(0, homeSystem.planets.length - 1);
-    homeSystemRegion = generateRegionOfControl(systemRegionConfig);
-    homeSystemRegion.name = homeSystem.name;
-    homePlanetRegion = generateRegionOfControl(homePlanetRegionConfig);
-    homePlanetRegion.name = homeSystem.planets[homePlanet].name;
-    const populated = rng.int(1, homeSystem.planets.length - 1);
-    populatedPlanets = populated;
-    homeSystemPopulatedPlanets = populated;
-    nation.population = homeSystemRegion.population;
-
-    if (nation.technology_level > 7) {
-      const total_systems_controlled = rng.int(1, 20);
-      const systems = [];
-      let total_population = homeSystemRegion.population;
-      for (let i = 0; i < total_systems_controlled; i++) {
-        systems.push(generateStarSystem(systemConfig));
-        populatedPlanets += rng.int(1, systems[i].planets.length - 1);
-        total_population += rng.int(1, systems[i].planets.length - 1) * rng.int(100000, 10000000);
-      }
-      nation.population = total_population;
-      extraDescription = `The nation controls ${total_systems_controlled + 1} star systems, with a total of ${populatedPlanets} planets.`;
+  async function exportPdf() {
+    if (nation === null) {
+      return;
     }
-
-    nation.description = getCivilizationDescription(nation);
-    homePlanetRegion.population = nation.population / populatedPlanets;
-
-    if (browser) {
-      homeSystemPreviewSeed = rng.randomString(13);
-      refreshHomeSystemComposite();
-    }
+    await downloadTextPdf(
+      Nations.starNationDisplayName(nation),
+      Nations.starNationToText(nation),
+      `${Nations.starNationFileStem(nation)}.pdf`,
+    );
   }
 
   onMount(() => {
@@ -144,7 +123,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/star-nation" title="Star Nation Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Star Nation Generator">
   {#snippet description()}
     <p>
       The previews pick how to draw themselves from what this machine can do; the controls below
@@ -165,54 +144,74 @@
 
   <BaseButton onclick={generate}>Generate</BaseButton>
 
-  {#if nation && homeSystem && homeSystemRegion && homePlanetRegion}
-    <h2>{nation.name}</h2>
+  <SaveArtifactButton
+    kind={Nations.STAR_NATION_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={nationSnapshot}
+    {seed}
+    config={generatorConfig}
+    defaultName={defaultArtifactName}
+  />
 
-    <p>{nation.description}</p>
-    {#if extraDescription}
-      <p>{extraDescription}</p>
-    {/if}
+  {#if nation}
+    <div class="nation-exports">
+      <BaseButton onclick={exportMarkdown}>Download Markdown</BaseButton>
+      <BaseButton onclick={exportPdf}>Download PDF</BaseButton>
+    </div>
 
-    <StatBlock>
-      <Stat label="Government Type">{nation.government_type.name}</Stat>
-      <Stat label="Economy">{nation.economy_type.name}</Stat>
-      <Stat label="Military">{nation.military.quality}</Stat>
-    </StatBlock>
-    <Stat label="Technology">
-      {nation.technology_level} (<span
-        class="tooltip"
-        title={getTechnologyLevelByLevel(nation.technology_level).description}
-        >{getTechnologyLevelByLevel(nation.technology_level).name}</span
-      >)
-    </Stat>
-    <StatBlock>
-      <Stat label="Home Planet">{homeSystem.planets[homePlanet].name}</Stat>
-    </StatBlock>
+    <div class="nation">
+      <h2>{Nations.starNationDisplayName(nation)}</h2>
 
-    <h3>The {homeSystemRegion.name} System</h3>
-
-    <p>
-      There are {homeSystemPopulatedPlanets} populated planets in this system. {homePlanetRegion.name}
-      is the {homePlanet + 1}{Words.getOrdinal(homePlanet + 1)} planet. It has a population of {getFriendlyPopulation(
-        homePlanetRegion.population,
-      )}.
-    </p>
-
-    <div class="star-system">
-      {#if browser && homeSystemCompositeSrc}
-        <div class="image-container-system" style="width: 100%;">
-          <img
-            alt="{homeSystem.name} system composite"
-            style="max-width: 100%; height: auto; display: block;"
-            src={homeSystemCompositeSrc}
-          />
-        </div>
+      <p>{nation.civilization.description}</p>
+      {#if territory}
+        <p>{territory}</p>
       {/if}
+
+      <StatBlock>
+        <Stat label="Government Type">{nation.civilization.government_type.name}</Stat>
+        <Stat label="Economy">{nation.civilization.economy_type.name}</Stat>
+        <Stat label="Military">{nation.civilization.military.quality}</Stat>
+      </StatBlock>
+      {#if technology}
+        <Stat label="Technology">
+          {nation.civilization.technology_level} (<span
+            class="tooltip"
+            title={technology.description}>{technology.name}</span
+          >)
+        </Stat>
+      {/if}
+      {#if homePlanet}
+        <StatBlock>
+          <Stat label="Home Planet">{homePlanet.name}</Stat>
+        </StatBlock>
+      {/if}
+
+      <h3>{Nations.starNationHomeSystemHeading(nation)}</h3>
+
+      <p>{homeSystemParagraph}</p>
+
+      <div class="star-system">
+        {#if browser && homeSystemCompositeSrc}
+          <div class="image-container-system" style="width: 100%;">
+            <img
+              alt="{nation.homeSystem.name} system composite"
+              style="max-width: 100%; height: auto; display: block;"
+              src={homeSystemCompositeSrc}
+            />
+          </div>
+        {/if}
+      </div>
     </div>
   {/if}
 </GeneratorPage>
 
 <style>
+  .nation-exports {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
   .star-system {
     display: flex;
     width: 100%;

--- a/src/components/locations/PlanetGenerator.svelte
+++ b/src/components/locations/PlanetGenerator.svelte
@@ -43,8 +43,7 @@
 
   let planetType = $state('random');
   let forceRings = $state(false);
-  let planetGenConfig = getDefaultPlanetGenerationConfig();
-  planetGenConfig.rng = rng;
+  let planetGenConfig = getDefaultPlanetGenerationConfig(rng);
   let planet: AstronomicalBody | undefined = $state();
   let planetImageSrc = $state('');
   let planetImageSeed = $state('');
@@ -55,8 +54,7 @@
 
   let is_inhabited = $state(false);
 
-  let civilization_config = getDefaultCivilizationGenerationConfig();
-  civilization_config.rng = rng;
+  let civilization_config = getDefaultCivilizationGenerationConfig(rng);
   civilization_config.population_range = [100000, 1000000000];
   let civilization: Civilization | null = $state(null);
 
@@ -88,7 +86,7 @@
     if (forceRings) {
       planetGenConfig.rings_chance = 100;
     } else {
-      planetGenConfig.rings_chance = getDefaultPlanetGenerationConfig().rings_chance;
+      planetGenConfig.rings_chance = getDefaultPlanetGenerationConfig(rng).rings_chance;
     }
 
     planet = generatePlanet(planetGenConfig);
@@ -96,8 +94,7 @@
     is_inhabited = rng.int(1, 100) < 30;
 
     if (is_inhabited) {
-      civilization_config = getDefaultCivilizationGenerationConfig();
-      civilization_config.rng = rng;
+      civilization_config = getDefaultCivilizationGenerationConfig(rng);
       civilization_config.population_range = [100000, 1000000000];
       civilization = generateCivilization(civilization_config);
     }
@@ -124,8 +121,7 @@
   }
 
   onMount(() => {
-    planetGenConfig = getDefaultPlanetGenerationConfig();
-    planetGenConfig.rng = rng;
+    planetGenConfig = getDefaultPlanetGenerationConfig(rng);
     planet = generatePlanet(planetGenConfig);
     if (planet !== undefined) {
       planetImageSeed = rng.randomString(13);

--- a/src/components/locations/StarSystemGenerator.svelte
+++ b/src/components/locations/StarSystemGenerator.svelte
@@ -34,7 +34,7 @@
     rng.setSeed(seed);
   });
 
-  let config = getDefaultStarSystemGeneratorConfig();
+  let config = getDefaultStarSystemGeneratorConfig(rng);
   let system: StarSystem | undefined = $state();
   let systemCompositeSrc = $state('');
   let starImageSrcs = $state<string[]>([]);
@@ -83,16 +83,14 @@
   }
 
   /**
-   * Builds the config from the controls and, importantly, from this page's RNG.
+   * Builds the config from the controls and from this page's RNG.
    *
-   * `getDefaultStarSystemGeneratorConfig` seeds itself from `Date.now()` and picks a planet count
-   * with it. Left unwired, as it was, the seed control changed nothing about the system: the same
-   * locked seed generated a different system on every click, and every reload. The mount path has
-   * to do this too, or the first system on screen is the one nobody can reproduce.
+   * `getDefaultStarSystemGeneratorConfig` takes the RNG it draws from, so the planet count it
+   * picks is the seed's rather than the clock's. The mount path has to go through here too, or
+   * the first system on screen is the one nobody can reproduce.
    */
   function applySystemConfig() {
-    config = getDefaultStarSystemGeneratorConfig();
-    config.rng = rng;
+    config = getDefaultStarSystemGeneratorConfig(rng);
     config.planet_count =
       planetCountControl === 'random'
         ? Math.max(1, Math.round(rng.bellFloat(1, 12)))

--- a/src/lib/astronomical_bodies/README.md
+++ b/src/lib/astronomical_bodies/README.md
@@ -34,13 +34,14 @@ set of numbers.
 ## Usage
 
 ```typescript
+import { RNG } from '@ironarachne/rng';
 import {
   convertAUToKM,
   generateStarSystem,
   getDefaultStarSystemGeneratorConfig,
 } from '$lib/astronomical_bodies';
 
-const config = getDefaultStarSystemGeneratorConfig();
+const config = getDefaultStarSystemGeneratorConfig(new RNG('my-seed'));
 const system = generateStarSystem(config);
 
 const firstPlanet = system.planets[0];
@@ -48,12 +49,14 @@ firstPlanet.surface_temperature; // Kelvin
 convertAUToKM(firstPlanet.orbital_distance); // km
 ```
 
-Generating a single body works the same way:
+Every `getDefault*Config` helper takes the RNG it should draw from — none seeds itself from the
+clock, so a run is reproducible from the seed that made its RNG. Generating a single body works
+the same way:
 
 ```typescript
 import { generatePlanet, getDefaultPlanetGenerationConfig } from '$lib/astronomical_bodies';
 
-const planet = generatePlanet(getDefaultPlanetGenerationConfig());
+const planet = generatePlanet(getDefaultPlanetGenerationConfig(new RNG('my-seed')));
 ```
 
 Rendering these bodies is a separate concern — see [`$lib/renderers`](../renderers/README.md) for

--- a/src/lib/astronomical_bodies/planet/planets.test.ts
+++ b/src/lib/astronomical_bodies/planet/planets.test.ts
@@ -4,8 +4,7 @@ import { generatePlanet, getDefaultPlanetGenerationConfig } from './planets';
 import { getPlanetClassificationByName, getPlanetClassifications } from './planet_classifications';
 
 function generate(seed: string) {
-  const config = getDefaultPlanetGenerationConfig();
-  config.rng = new RNG(seed);
+  const config = getDefaultPlanetGenerationConfig(new RNG(seed));
   return generatePlanet(config);
 }
 
@@ -15,25 +14,26 @@ function classificationOf(planet: { classification: string }) {
 
 describe('getDefaultPlanetGenerationConfig', () => {
   it('offers the full classification table', () => {
-    expect(getDefaultPlanetGenerationConfig().possible_classifications).toHaveLength(
-      getPlanetClassifications().length,
-    );
+    expect(
+      getDefaultPlanetGenerationConfig(new RNG('default')).possible_classifications,
+    ).toHaveLength(getPlanetClassifications().length);
   });
 
   it('defaults the star temperature to the Sun', () => {
-    expect(getDefaultPlanetGenerationConfig().star_temperature).toBe(5773);
+    expect(getDefaultPlanetGenerationConfig(new RNG('default')).star_temperature).toBe(5773);
   });
 
   it('defaults the rings, starport and habitable chances', () => {
-    const config = getDefaultPlanetGenerationConfig();
+    const config = getDefaultPlanetGenerationConfig(new RNG('default'));
 
     expect(config.rings_chance).toBe(5);
     expect(config.starport_chance).toBe(85);
     expect(config.habitable_chance).toBe(60);
   });
 
-  it('supplies an RNG', () => {
-    expect(getDefaultPlanetGenerationConfig().rng).toBeInstanceOf(RNG);
+  it('carries the RNG it was handed', () => {
+    const rng = new RNG('carried');
+    expect(getDefaultPlanetGenerationConfig(rng).rng).toBe(rng);
   });
 });
 
@@ -185,8 +185,7 @@ describe('generatePlanet', () => {
 
   it('never gives rings when the chance is zero', () => {
     for (let index = 0; index < 20; index++) {
-      const config = getDefaultPlanetGenerationConfig();
-      config.rng = new RNG(`norings-${index}`);
+      const config = getDefaultPlanetGenerationConfig(new RNG(`norings-${index}`));
       config.rings_chance = 0;
 
       expect(generatePlanet(config).has_ring_system).toBe(false);
@@ -195,8 +194,7 @@ describe('generatePlanet', () => {
 
   it('always gives rings when the chance is certain', () => {
     for (let index = 0; index < 20; index++) {
-      const config = getDefaultPlanetGenerationConfig();
-      config.rng = new RNG(`rings-${index}`);
+      const config = getDefaultPlanetGenerationConfig(new RNG(`rings-${index}`));
       config.rings_chance = 101;
 
       expect(generatePlanet(config).has_ring_system).toBe(true);
@@ -204,21 +202,18 @@ describe('generatePlanet', () => {
   });
 
   it('honours a config narrowed to a single classification', () => {
-    const config = getDefaultPlanetGenerationConfig();
-    config.rng = new RNG('narrow');
+    const config = getDefaultPlanetGenerationConfig(new RNG('narrow'));
     config.possible_classifications = [getPlanetClassificationByName('arid')];
 
     expect(generatePlanet(config).classification).toBe('arid planet');
   });
 
   it('makes a planet hotter around a hotter star', () => {
-    const cool = getDefaultPlanetGenerationConfig();
-    cool.rng = new RNG('temperature');
+    const cool = getDefaultPlanetGenerationConfig(new RNG('temperature'));
     cool.star_temperature = 3000;
     cool.possible_classifications = [getPlanetClassificationByName('arid')];
 
-    const hot = getDefaultPlanetGenerationConfig();
-    hot.rng = new RNG('temperature');
+    const hot = getDefaultPlanetGenerationConfig(new RNG('temperature'));
     hot.star_temperature = 30000;
     hot.possible_classifications = [getPlanetClassificationByName('arid')];
 

--- a/src/lib/astronomical_bodies/planet/planets.ts
+++ b/src/lib/astronomical_bodies/planet/planets.ts
@@ -79,13 +79,14 @@ export function generatePlanet(config: PlanetGenerationConfig): AstronomicalBody
   };
 }
 
-export function getDefaultPlanetGenerationConfig(): PlanetGenerationConfig {
+/** The RNG is required, not defaulted from the clock — see `getDefaultStarGeneratorConfig`. */
+export function getDefaultPlanetGenerationConfig(rng: RNG.RNG): PlanetGenerationConfig {
   return {
     possible_classifications: getPlanetClassifications(),
     rings_chance: 5,
     starport_chance: 85,
     star_temperature: 5773, // default to the Sun's temperature
     habitable_chance: 60,
-    rng: new RNG.RNG(Date.now().toString()),
+    rng,
   };
 }

--- a/src/lib/astronomical_bodies/star/stars.test.ts
+++ b/src/lib/astronomical_bodies/star/stars.test.ts
@@ -4,20 +4,20 @@ import { generateStar, getDefaultStarGeneratorConfig } from './stars';
 import { getStarClassificationByName, getStarClassifications } from './star_classifications';
 
 function generate(seed: string) {
-  const config = getDefaultStarGeneratorConfig();
-  config.rng = new RNG(seed);
+  const config = getDefaultStarGeneratorConfig(new RNG(seed));
   return generateStar(config);
 }
 
 describe('getDefaultStarGeneratorConfig', () => {
   it('offers the full classification table', () => {
-    expect(getDefaultStarGeneratorConfig().star_classifications).toHaveLength(
+    expect(getDefaultStarGeneratorConfig(new RNG('default')).star_classifications).toHaveLength(
       getStarClassifications().length,
     );
   });
 
-  it('supplies an RNG', () => {
-    expect(getDefaultStarGeneratorConfig().rng).toBeInstanceOf(RNG);
+  it('carries the RNG it was handed', () => {
+    const rng = new RNG('carried');
+    expect(getDefaultStarGeneratorConfig(rng).rng).toBe(rng);
   });
 });
 
@@ -135,8 +135,7 @@ describe('generateStar', () => {
   });
 
   it('honours a config narrowed to a single classification', () => {
-    const config = getDefaultStarGeneratorConfig();
-    config.rng = new RNG('narrow');
+    const config = getDefaultStarGeneratorConfig(new RNG('narrow'));
     config.star_classifications = [getStarClassificationByName('G2V')];
 
     expect(generateStar(config).classification).toBe('G2V');

--- a/src/lib/astronomical_bodies/star/stars.ts
+++ b/src/lib/astronomical_bodies/star/stars.ts
@@ -46,10 +46,15 @@ export type StarGenerationConfig = {
   rng: RNG.RNG;
 };
 
-export function getDefaultStarGeneratorConfig(): StarGenerationConfig {
+/**
+ * The RNG is required rather than defaulted from the clock: a config that seeded itself from
+ * `Date.now()` gave clock-driven output to any caller that forgot to overwrite it, which is the
+ * requirement 2.2 failure docs/tool-readiness.md counts across this library four times.
+ */
+export function getDefaultStarGeneratorConfig(rng: RNG.RNG): StarGenerationConfig {
   return {
     star_classifications: getStarClassifications(),
-    rng: new RNG.RNG(Date.now().toString()),
+    rng,
   };
 }
 

--- a/src/lib/astronomical_bodies/star_systems.test.ts
+++ b/src/lib/astronomical_bodies/star_systems.test.ts
@@ -17,12 +17,12 @@ function configFor(seed: string, overrides: Record<string, unknown> = {}) {
 
 describe('getDefaultStarSystemGeneratorConfig', () => {
   it('defaults to a single star', () => {
-    expect(getDefaultStarSystemGeneratorConfig().star_count).toBe(1);
+    expect(getDefaultStarSystemGeneratorConfig(new RNG('default')).star_count).toBe(1);
   });
 
   it('defaults to between one and twelve planets', () => {
     for (let index = 0; index < 20; index++) {
-      const config = getDefaultStarSystemGeneratorConfig();
+      const config = getDefaultStarSystemGeneratorConfig(new RNG(`count-${index}`));
 
       expect(config.planet_count).toBeGreaterThanOrEqual(1);
       expect(config.planet_count).toBeLessThanOrEqual(12);
@@ -30,14 +30,19 @@ describe('getDefaultStarSystemGeneratorConfig', () => {
   });
 
   it('offers the full star and planet classification tables', () => {
-    const config = getDefaultStarSystemGeneratorConfig();
+    const config = getDefaultStarSystemGeneratorConfig(new RNG('tables'));
 
     expect(config.star_classifications).toHaveLength(getStarClassifications().length);
     expect(config.planet_classifications).toHaveLength(getPlanetClassifications().length);
   });
 
-  it('supplies an RNG', () => {
-    expect(getDefaultStarSystemGeneratorConfig().rng).toBeInstanceOf(RNG);
+  it('carries the RNG it was handed, and draws the planet count from it', () => {
+    const rng = new RNG('carried');
+
+    expect(getDefaultStarSystemGeneratorConfig(rng).rng).toBe(rng);
+    expect(getDefaultStarSystemGeneratorConfig(new RNG('same')).planet_count).toBe(
+      getDefaultStarSystemGeneratorConfig(new RNG('same')).planet_count,
+    );
   });
 });
 

--- a/src/lib/astronomical_bodies/star_systems.ts
+++ b/src/lib/astronomical_bodies/star_systems.ts
@@ -27,23 +27,24 @@ export type StarSystemGenerationConfig = {
   rng: RNG.RNG;
 };
 
-export function getDefaultStarSystemGeneratorConfig(): StarSystemGenerationConfig {
-  const rng = new RNG.RNG(Date.now().toString());
-
+/**
+ * The RNG is required, not defaulted from the clock — see `getDefaultStarGeneratorConfig`. The
+ * planet count is drawn from it here, so two configs built from RNGs at the same state agree.
+ */
+export function getDefaultStarSystemGeneratorConfig(rng: RNG.RNG): StarSystemGenerationConfig {
   return {
     star_count: 1,
-    planet_count: Math.round(rng.bellFloat(1, 12)),
+    planet_count: Math.max(1, Math.round(rng.bellFloat(1, 12))),
     star_classifications: getStarClassifications(),
     planet_classifications: getPlanetClassifications(),
-    rng: rng,
+    rng,
   };
 }
 
 export function generateStarSystem(config: StarSystemGenerationConfig): StarSystem {
   const stars = [];
-  const star_config = getDefaultStarGeneratorConfig();
+  const star_config = getDefaultStarGeneratorConfig(config.rng);
   star_config.star_classifications = config.star_classifications;
-  star_config.rng = config.rng;
 
   for (let i = 0; i < config.star_count; i++) {
     const star = generateStar(star_config);
@@ -56,8 +57,7 @@ export function generateStarSystem(config: StarSystemGenerationConfig): StarSyst
   }
 
   const planets = [];
-  const planet_config = getDefaultPlanetGenerationConfig();
-  planet_config.rng = config.rng;
+  const planet_config = getDefaultPlanetGenerationConfig(config.rng);
   planet_config.possible_classifications = config.planet_classifications;
 
   for (let i = 0; i < config.planet_count; i++) {

--- a/src/lib/civilizations/README.md
+++ b/src/lib/civilizations/README.md
@@ -5,6 +5,9 @@ government and economy types, and a military. It also models **regions of contro
 territory a civilization holds, sized to its technology (a bronze-age city-state and a spacefaring
 polity do not carve up space the same way).
 
+It also carries the **star nation**: a spacefaring civilization, the territory it holds, and the
+star system it calls home — what `/star-nation` generates, stores, edits and prints.
+
 ## Features
 
 - **Types** — `Civilization`, `CivilizationGenerationConfig`, `GovernmentType`, `EconomyType`,
@@ -17,28 +20,36 @@ polity do not carve up space the same way).
   `getDefaultRegionOfControlGenerationConfig`, and the lookups `getRegionTypes`,
   `getRegionTypeByName`, `getRegionTypeByScale`, and `getRegionTypesForTechnologyLevel`.
 
+- **Star nation** — `StarNation` and the `star-nation` artifact kind, in the shape every
+  Release-ready tool takes (docs/tool-readiness.md): `rollStarNation` and
+  `readStarNationGeneratorConfig` (the one path from a seed), `toStarNationSnapshot` and
+  `starNationFromSnapshot` (the codec), `validateStarNationSnapshot` and
+  `starNationArtifactKind` (the registration), the `setStarNation*` editing functions, and
+  `starNationToMarkdown`, `starNationToText` and `starNationToDocument` (the exports).
+
 ## Usage
 
 ```typescript
+import { RNG } from '@ironarachne/rng';
 import {
   generateCivilization,
   getCivilizationDescription,
   getDefaultCivilizationGenerationConfig,
 } from '$lib/civilizations';
 
-const config = getDefaultCivilizationGenerationConfig();
+const config = getDefaultCivilizationGenerationConfig(new RNG('my-seed'));
 const civilization = generateCivilization(config);
 
 getCivilizationDescription(civilization);
 ```
 
-The config carries its own `RNG` along with the ranges the generator samples from
+The config carries the `RNG` it was handed along with the ranges the generator samples from
 (`population_range`, `technology_level_range`, `military_strength_range`), so narrowing a range is
-how you constrain a run:
+how you constrain a run. The RNG is a required argument rather than a clock-seeded default, so a
+run is reproducible from whatever seed made it:
 
 ```typescript
-const config = getDefaultCivilizationGenerationConfig();
-config.rng = rng;
+const config = getDefaultCivilizationGenerationConfig(rng);
 config.technology_level_range = [7, 9];
 
 const spacefaring = generateCivilization(config);
@@ -47,7 +58,33 @@ const spacefaring = generateCivilization(config);
 Technology level also decides what kind of territory a civilization can hold:
 
 ```typescript
-import { getRegionTypesForTechnologyLevel } from '$lib/civilizations';
+import { getRegionTypes, getRegionTypesForTechnologyLevel } from '$lib/civilizations';
 
-const regionTypes = getRegionTypesForTechnologyLevel(civilization.technology_level);
+const regionTypes = getRegionTypesForTechnologyLevel(
+  civilization.technology_level,
+  getRegionTypes(),
+);
 ```
+
+## Star nations
+
+A star nation is rolled from a seed and, optionally, a planet count for the home system:
+
+```typescript
+import { rollStarNation, starNationToMarkdown } from '$lib/civilizations';
+
+const nation = rollStarNation('my-seed', { planetCount: 5 });
+nation.civilization.name; // 'Republic of Vesh'
+nation.homeSystem.planets[nation.homePlanetIndex].name; // the homeworld
+starNationToMarkdown(nation);
+```
+
+The same seed and config give the same nation, on the page and on a re-roll from a saved
+artifact's provenance. The stored shape (`StarNationSnapshot`) is flat: the civilization's fields at
+the top level, the regions of control beside them, and the home system embedded as the parameters
+the preview renderer takes — never the image it draws. The home system is embedded rather than
+referenced because no `star-system` artifact kind exists yet; when one does, the region of control
+is where the reference goes.
+
+The description is assembled from the figures when the nation is rolled, and editing a figure
+does not rewrite it: `restoreStarNationDescription` rebuilds it on request, and nothing else does.

--- a/src/lib/civilizations/civilizations.test.ts
+++ b/src/lib/civilizations/civilizations.test.ts
@@ -15,23 +15,26 @@ function configFor(
   seed: string,
   overrides: Partial<CivilizationGenerationConfig> = {},
 ): CivilizationGenerationConfig {
-  return { ...getDefaultCivilizationGenerationConfig(), rng: new RNG(seed), ...overrides };
+  return { ...getDefaultCivilizationGenerationConfig(new RNG(seed)), ...overrides };
 }
 
 describe('getDefaultCivilizationGenerationConfig', () => {
   it('spans populations from a thousand to a billion', () => {
-    expect(getDefaultCivilizationGenerationConfig().population_range).toEqual([1000, 1000000000]);
+    expect(getDefaultCivilizationGenerationConfig(new RNG('default')).population_range).toEqual([
+      1000, 1000000000,
+    ]);
   });
 
   it('spans technology and military strength from 1 to 10', () => {
-    const config = getDefaultCivilizationGenerationConfig();
+    const config = getDefaultCivilizationGenerationConfig(new RNG('default'));
 
     expect(config.technology_level_range).toEqual([1, 10]);
     expect(config.military_strength_range).toEqual([1, 10]);
   });
 
-  it('supplies an RNG', () => {
-    expect(getDefaultCivilizationGenerationConfig().rng).toBeInstanceOf(RNG);
+  it('carries the RNG it was handed', () => {
+    const rng = new RNG('default');
+    expect(getDefaultCivilizationGenerationConfig(rng).rng).toBe(rng);
   });
 });
 

--- a/src/lib/civilizations/civilizations.ts
+++ b/src/lib/civilizations/civilizations.ts
@@ -123,12 +123,18 @@ export function generateMilitary(
   };
 }
 
-export function getDefaultCivilizationGenerationConfig(): CivilizationGenerationConfig {
+/**
+ * The RNG is required rather than defaulted from the clock. This helper used to seed itself from
+ * `Date.now()`, so a caller that forgot to overwrite `rng` got clock-driven output while looking
+ * seeded — the requirement 2.2 failure docs/tool-readiness.md counts fifteen times across six
+ * libraries. Taking the RNG as a parameter is the one-line fix it prescribes.
+ */
+export function getDefaultCivilizationGenerationConfig(rng: RNG.RNG): CivilizationGenerationConfig {
   return {
     population_range: [1000, 1000000000],
     technology_level_range: [1, 10],
     military_strength_range: [1, 10],
-    rng: new RNG.RNG(Date.now().toString()),
+    rng,
   };
 }
 
@@ -165,7 +171,22 @@ export function getFriendlyPopulation(population: number): string {
   return `${Math.round(population / 1000000000000)} trillion`;
 }
 
-function getEconomyTypes(): EconomyType[] {
+/**
+ * The economy table, and a lookup by name.
+ *
+ * Exported so the star nation editor can offer the table as a select and resolve a choice back
+ * to its row. A row is plain data, so a saved nation embeds the one it was rolled with rather
+ * than a name to resolve on read — a renamed row then costs nothing anyone stored.
+ */
+export function getEconomyTypeByName(name: string): EconomyType | undefined {
+  return getEconomyTypes().find((type) => type.name === name);
+}
+
+export function getGovernmentTypeByName(name: string): GovernmentType | undefined {
+  return getGovernmentTypes().find((type) => type.name === name);
+}
+
+export function getEconomyTypes(): EconomyType[] {
   return [
     {
       name: 'Capitalist',
@@ -230,7 +251,7 @@ function getEconomyTypes(): EconomyType[] {
   ];
 }
 
-function getGovernmentTypes(): GovernmentType[] {
+export function getGovernmentTypes(): GovernmentType[] {
   return [
     {
       name: 'Democracy',

--- a/src/lib/civilizations/index.ts
+++ b/src/lib/civilizations/index.ts
@@ -1,2 +1,9 @@
 export * from './civilizations';
 export * from './regions_of_control';
+export * from './star_nation';
+export * from './star_nation_artifact_kind';
+export * from './star_nation_editing';
+export * from './star_nation_presentation';
+export * from './star_nation_roll';
+export * from './star_nation_snapshot';
+export type * from './star_nation_types';

--- a/src/lib/civilizations/regions_of_control.test.ts
+++ b/src/lib/civilizations/regions_of_control.test.ts
@@ -14,7 +14,7 @@ function configFor(
   seed: string,
   overrides: Partial<RegionOfControlGenerationConfig> = {},
 ): RegionOfControlGenerationConfig {
-  return { ...getDefaultRegionOfControlGenerationConfig(), rng: new RNG(seed), ...overrides };
+  return { ...getDefaultRegionOfControlGenerationConfig(new RNG(seed)), ...overrides };
 }
 
 describe('getRegionTypes', () => {
@@ -148,18 +148,20 @@ describe('getRegionTypesForTechnologyLevel', () => {
 describe('getDefaultRegionOfControlGenerationConfig', () => {
   it('offers every region type', () => {
     expect(
-      getDefaultRegionOfControlGenerationConfig().region_types.map((type) => type.name),
+      getDefaultRegionOfControlGenerationConfig(new RNG('default')).region_types.map(
+        (type) => type.name,
+      ),
     ).toEqual(getRegionTypes().map((type) => type.name));
   });
 
   it('defaults to a population density between 50 and 60 per cent of capacity', () => {
-    expect(getDefaultRegionOfControlGenerationConfig().population_density_range).toEqual([
-      0.5, 0.6,
-    ]);
+    expect(
+      getDefaultRegionOfControlGenerationConfig(new RNG('default')).population_density_range,
+    ).toEqual([0.5, 0.6]);
   });
 
   it('starts with no controlling civilization and technology level zero', () => {
-    const config = getDefaultRegionOfControlGenerationConfig();
+    const config = getDefaultRegionOfControlGenerationConfig(new RNG('default'));
 
     expect(config.controlling_civilization).toBe('');
     expect(config.technology_level).toBe(0);

--- a/src/lib/civilizations/regions_of_control.ts
+++ b/src/lib/civilizations/regions_of_control.ts
@@ -50,13 +50,16 @@ export function generateRegionOfControl(config: RegionOfControlGenerationConfig)
   return region_of_control;
 }
 
-export function getDefaultRegionOfControlGenerationConfig(): RegionOfControlGenerationConfig {
+/** The RNG is required, not defaulted from the clock — see `getDefaultCivilizationGenerationConfig`. */
+export function getDefaultRegionOfControlGenerationConfig(
+  rng: RNG.RNG,
+): RegionOfControlGenerationConfig {
   return {
     region_types: getRegionTypes(),
     population_density_range: [0.5, 0.6],
     controlling_civilization: '',
     technology_level: 0,
-    rng: new RNG.RNG(Date.now().toString()),
+    rng,
   };
 }
 

--- a/src/lib/civilizations/star_nation.test.ts
+++ b/src/lib/civilizations/star_nation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { homePlanetOf, homePlanetRegionOf, homeSystemRegionOf } from './star_nation';
+import { rollStarNation } from './star_nation_roll';
+
+const nation = rollStarNation('helpers-fixture', { planetCount: 2 });
+
+describe('the star nation region helpers', () => {
+  it('find each region by its type, whatever the order', () => {
+    const reversed = { ...nation, regionsOfControl: [...nation.regionsOfControl].reverse() };
+
+    expect(homeSystemRegionOf(reversed)?.region_type.name).toBe('Star System');
+    expect(homePlanetRegionOf(reversed)?.region_type.name).toBe('Planet');
+  });
+
+  it('answer undefined when a region is missing', () => {
+    expect(homeSystemRegionOf({ regionsOfControl: [] })).toBeUndefined();
+    expect(homePlanetRegionOf({ regionsOfControl: [] })).toBeUndefined();
+  });
+
+  it('find the homeworld by index, or nothing outside the system', () => {
+    expect(homePlanetOf(nation)).toBe(nation.homeSystem.planets[nation.homePlanetIndex]);
+    expect(homePlanetOf({ ...nation, homePlanetIndex: 7 })).toBeUndefined();
+  });
+});

--- a/src/lib/civilizations/star_nation.ts
+++ b/src/lib/civilizations/star_nation.ts
@@ -1,0 +1,63 @@
+/**
+ * Reading the parts of a star nation the page and the exports both need.
+ *
+ * The two regions of control are told apart by their region type, not by their position in the
+ * list. That is what lets a stored nation with one region missing still open — the sentence that
+ * needed it is dropped (requirement 6.4) rather than the whole artifact refused.
+ */
+
+import type { AstronomicalBody } from '$lib/astronomical_bodies';
+import { getTechnologyLevels } from '$lib/technology_levels';
+
+import type { RegionOfControl } from './regions_of_control';
+
+/** The region type names the generator assigns to a nation's two regions. */
+export const STAR_NATION_SYSTEM_REGION_TYPE = 'Star System';
+export const STAR_NATION_PLANET_REGION_TYPE = 'Planet';
+
+/**
+ * The technology levels a nation may have: the table's own range, so the validator, the editor
+ * and the page cannot drift from the rows `getTechnologyLevelByLevel` can actually find.
+ */
+export const STAR_NATION_TECHNOLOGY_LEVEL_RANGE: [number, number] = (() => {
+  const levels = getTechnologyLevels().map((level) => level.level);
+  return [Math.min(...levels), Math.max(...levels)];
+})();
+
+/** The range of the military quality table `describeMilitary` indexes. */
+export const STAR_NATION_MILITARY_QUALITY_RANGE: [number, number] = [1, 10];
+
+/** The default name for a nation with none. What the vault and the exports both call it. */
+export const STAR_NATION_FALLBACK_NAME = 'Star Nation';
+
+function regionOfType(regions: RegionOfControl[], typeName: string): RegionOfControl | undefined {
+  return regions.find((region) => region.region_type.name === typeName);
+}
+
+/** The region that stands for the home system, when the nation has one. */
+export function homeSystemRegionOf(nation: {
+  regionsOfControl: RegionOfControl[];
+}): RegionOfControl | undefined {
+  return regionOfType(nation.regionsOfControl, STAR_NATION_SYSTEM_REGION_TYPE);
+}
+
+/** The region that stands for the home planet, when the nation has one. */
+export function homePlanetRegionOf(nation: {
+  regionsOfControl: RegionOfControl[];
+}): RegionOfControl | undefined {
+  return regionOfType(nation.regionsOfControl, STAR_NATION_PLANET_REGION_TYPE);
+}
+
+/** The homeworld itself, or undefined when the index points outside the system. */
+export function homePlanetOf(nation: {
+  homeSystem: { planets: AstronomicalBody[] };
+  homePlanetIndex: number;
+}): AstronomicalBody | undefined {
+  return nation.homeSystem.planets[nation.homePlanetIndex];
+}
+
+/** What to call a nation: its name, or the kind when the name has been emptied. */
+export function starNationDisplayName(nation: { civilization: { name: string } }): string {
+  const name = nation.civilization.name.trim();
+  return name === '' ? STAR_NATION_FALLBACK_NAME : name;
+}

--- a/src/lib/civilizations/star_nation_artifact_kind.test.ts
+++ b/src/lib/civilizations/star_nation_artifact_kind.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest';
+
+import { readArtifactPayload, type AnyArtifactKindEntry } from '$lib/artifact_kinds';
+
+import {
+  migrateStarNationSnapshot,
+  STAR_NATION_ARTIFACT_KIND,
+  STAR_NATION_PAYLOAD_VERSION,
+  starNationArtifactKind,
+  validateStarNationSnapshot,
+} from './star_nation_artifact_kind';
+import { rollStarNationSnapshot } from './star_nation_roll';
+import type { StarNationSnapshot } from './star_nation_snapshot';
+
+/** A stored payload, as anything reading one actually receives it. */
+const snapshot = JSON.parse(
+  JSON.stringify(rollStarNationSnapshot('kind-fixture', { planetCount: 3 })),
+) as StarNationSnapshot;
+
+function withField(field: string, value: unknown): Record<string, unknown> {
+  return { ...snapshot, [field]: value };
+}
+
+function without(record: Record<string, unknown>, field: string): Record<string, unknown> {
+  const broken = { ...record };
+  delete broken[field];
+  return broken;
+}
+
+describe('the star nation artifact kind', () => {
+  /** Its own kind, unqualified: neither a game system nor a setting, and not an `organization`. */
+  it('is registered under its own name', () => {
+    expect(STAR_NATION_ARTIFACT_KIND).toBe('star-nation');
+    expect(starNationArtifactKind.kind).toBe('star-nation');
+    expect(starNationArtifactKind.displayName).toBe('Star Nation');
+    expect(starNationArtifactKind.payloadVersion).toBe(STAR_NATION_PAYLOAD_VERSION);
+    expect(starNationArtifactKind.icon).not.toBe('');
+  });
+
+  it('names a saved nation after itself', () => {
+    expect(starNationArtifactKind.nameOf({ ...snapshot, name: 'Kingdom of Vesh' })).toBe(
+      'Kingdom of Vesh',
+    );
+  });
+
+  it('names a nation with no name by its kind', () => {
+    expect(starNationArtifactKind.nameOf({ ...snapshot, name: '  ' })).toBe('Star Nation');
+  });
+
+  it('accepts a payload the generator produced', () => {
+    expect(validateStarNationSnapshot(snapshot).ok).toBe(true);
+  });
+
+  /** 3.3: an emptied nation is a well-defined result, not a refusal. */
+  it('accepts a nation with its name, description and regions emptied', () => {
+    expect(
+      validateStarNationSnapshot({ ...snapshot, name: '', description: '', regionsOfControl: [] })
+        .ok,
+    ).toBe(true);
+  });
+
+  it('rejects something that is not an object at all', () => {
+    for (const payload of [null, 'Vesh', 42, [snapshot]]) {
+      const result = validateStarNationSnapshot(payload);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toBe('invalid-payload');
+    }
+  });
+
+  it('rejects a payload missing any top-level field', () => {
+    for (const field of Object.keys(snapshot)) {
+      expect(validateStarNationSnapshot(without({ ...snapshot }, field)).ok).toBe(false);
+    }
+  });
+
+  it('rejects a technology level the table has no row for', () => {
+    expect(validateStarNationSnapshot(withField('technologyLevel', 11)).ok).toBe(false);
+    expect(validateStarNationSnapshot(withField('technologyLevel', -1)).ok).toBe(false);
+    expect(validateStarNationSnapshot(withField('technologyLevel', 7.5)).ok).toBe(false);
+    expect(validateStarNationSnapshot(withField('technologyLevel', 0)).ok).toBe(true);
+    expect(validateStarNationSnapshot(withField('technologyLevel', 10)).ok).toBe(true);
+  });
+
+  it('accepts every technology level the table names, so the label never throws', async () => {
+    const { getTechnologyLevels } = await import('$lib/technology_levels');
+    const { starNationTechnologyLabel } = await import('./star_nation_presentation');
+    const { starNationFromSnapshot } = await import('./star_nation_snapshot');
+    for (const { level } of getTechnologyLevels()) {
+      const accepted = validateStarNationSnapshot(withField('technologyLevel', level));
+      expect(accepted.ok).toBe(true);
+      if (accepted.ok) {
+        expect(() =>
+          starNationTechnologyLabel(starNationFromSnapshot(accepted.value)),
+        ).not.toThrow();
+      }
+    }
+  });
+
+  it('rejects a count that is negative or not whole', () => {
+    expect(validateStarNationSnapshot(withField('homeSystemPopulatedPlanets', -2)).ok).toBe(false);
+    expect(validateStarNationSnapshot(withField('systemsControlled', 2.5)).ok).toBe(false);
+    expect(validateStarNationSnapshot(withField('populatedPlanets', 0)).ok).toBe(true);
+  });
+
+  it('rejects a military quality the description table cannot name', () => {
+    expect(
+      validateStarNationSnapshot(withField('military', { ...snapshot.military, quality: 0 })).ok,
+    ).toBe(false);
+    expect(
+      validateStarNationSnapshot(withField('military', { ...snapshot.military, quality: 11 })).ok,
+    ).toBe(false);
+    expect(
+      validateStarNationSnapshot(withField('military', without({ ...snapshot.military }, 'size')))
+        .ok,
+    ).toBe(false);
+  });
+
+  it('rejects a government or economy type missing its fields', () => {
+    expect(
+      validateStarNationSnapshot(
+        withField('governmentType', without({ ...snapshot.governmentType }, 'name_options')),
+      ).ok,
+    ).toBe(false);
+    expect(
+      validateStarNationSnapshot(
+        withField('economyType', without({ ...snapshot.economyType }, 'adjective')),
+      ).ok,
+    ).toBe(false);
+  });
+
+  it('rejects a region without a region type or a population', () => {
+    const region = snapshot.regionsOfControl[0];
+    expect(
+      validateStarNationSnapshot(
+        withField('regionsOfControl', [without({ ...region }, 'region_type')]),
+      ).ok,
+    ).toBe(false);
+    expect(
+      validateStarNationSnapshot(withField('regionsOfControl', [{ ...region, population: 'many' }]))
+        .ok,
+    ).toBe(false);
+    expect(validateStarNationSnapshot(withField('regionsOfControl', 'none')).ok).toBe(false);
+  });
+
+  it('rejects a home system whose bodies lack a parameter the renderer reads', () => {
+    const planet = without({ ...snapshot.homeSystem.planets[0] }, 'radius');
+    expect(
+      validateStarNationSnapshot(
+        withField('homeSystem', { ...snapshot.homeSystem, planets: [planet] }),
+      ).ok,
+    ).toBe(false);
+    const star = { ...snapshot.homeSystem.stars[0], has_atmosphere: 'no' };
+    expect(
+      validateStarNationSnapshot(withField('homeSystem', { ...snapshot.homeSystem, stars: [star] }))
+        .ok,
+    ).toBe(false);
+  });
+
+  it('rejects a home planet outside the home system', () => {
+    expect(validateStarNationSnapshot(withField('homePlanetIndex', 3)).ok).toBe(false);
+    expect(validateStarNationSnapshot(withField('homePlanetIndex', -1)).ok).toBe(false);
+    expect(validateStarNationSnapshot(withField('homePlanetIndex', 1.5)).ok).toBe(false);
+    expect(
+      validateStarNationSnapshot({
+        ...snapshot,
+        homePlanetIndex: 0,
+        homeSystem: { ...snapshot.homeSystem, planets: [] },
+      }).ok,
+    ).toBe(false);
+  });
+
+  it('has no migration to offer, and says so rather than guessing', () => {
+    const result = migrateStarNationSnapshot(snapshot, 0);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toBe('unsupported-version');
+  });
+
+  /** The whole read path, as the store runs it. */
+  it('reads a stored payload of its own version', () => {
+    expect(
+      readArtifactPayload(
+        starNationArtifactKind as AnyArtifactKindEntry,
+        snapshot,
+        STAR_NATION_PAYLOAD_VERSION,
+      ).ok,
+    ).toBe(true);
+  });
+
+  it('quarantines a payload from a version it has no step for', () => {
+    expect(
+      readArtifactPayload(
+        starNationArtifactKind as AnyArtifactKindEntry,
+        snapshot,
+        STAR_NATION_PAYLOAD_VERSION + 1,
+      ).ok,
+    ).toBe(false);
+  });
+
+  it('loads a codec that round-trips the payload', async () => {
+    const codec = await starNationArtifactKind.loadCodec();
+    const accepted = validateStarNationSnapshot(snapshot);
+
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) {
+      return;
+    }
+    const { RNG } = await import('@ironarachne/rng');
+    const live = codec.fromSnapshot(accepted.value, new RNG('unused'));
+
+    expect(codec.toSnapshot(live)).toEqual(accepted.value);
+  });
+});

--- a/src/lib/civilizations/star_nation_artifact_kind.ts
+++ b/src/lib/civilizations/star_nation_artifact_kind.ts
@@ -1,0 +1,261 @@
+import star from '$lib/assets/icons/set1/star.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  isStringArray,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import {
+  STAR_NATION_FALLBACK_NAME,
+  STAR_NATION_MILITARY_QUALITY_RANGE,
+  STAR_NATION_TECHNOLOGY_LEVEL_RANGE,
+} from './star_nation';
+import type { StarNationSnapshot } from './star_nation_snapshot';
+import type { StarNation } from './star_nation_types';
+
+/**
+ * Stable artifact kind id.
+ *
+ * Its own kind rather than a discriminator on `organization`, which is the question issue #57
+ * asks. A star nation holds territory — regions of control and a home system — and an
+ * organization holds a roster and a hierarchy; the two share a name field and nothing else, so one
+ * kind would be one validator and one migration path over two shapes. Unqualified, because it is
+ * neither a game system nor a setting.
+ */
+export const STAR_NATION_ARTIFACT_KIND = 'star-nation' as const;
+
+/** Version 1. The first shape a star nation has been stored in. */
+export const STAR_NATION_PAYLOAD_VERSION = 1 as const;
+
+/** Every numeric field of an `AstronomicalBody`, which is what the preview renderer reads. */
+const BODY_NUMBER_FIELDS = [
+  'albedo',
+  'axis_of_rotation',
+  'gravity',
+  'luminosity',
+  'mass',
+  'orbital_distance',
+  'orbital_period',
+  'radius',
+  'rotation_period',
+  'surface_pressure',
+  'surface_temperature',
+];
+
+function hasNumberFields(record: Record<string, unknown>, keys: string[]): boolean {
+  return keys.every((key) => typeof record[key] === 'number' && Number.isFinite(record[key]));
+}
+
+function isIntegerWithin(value: unknown, [min, max]: [number, number]): boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value >= min && value <= max;
+}
+
+/** A count: a whole number, zero or more. */
+function isCount(value: unknown): boolean {
+  return isIntegerWithin(value, [0, Number.MAX_SAFE_INTEGER]);
+}
+
+function hasBooleanFields(record: Record<string, unknown>, keys: string[]): boolean {
+  return keys.every((key) => typeof record[key] === 'boolean');
+}
+
+function isStoredBody(entry: unknown): boolean {
+  const body = asRecord(entry);
+  return (
+    body !== null &&
+    hasStringFields(body, ['name', 'description', 'classification']) &&
+    hasNumberFields(body, BODY_NUMBER_FIELDS) &&
+    hasBooleanFields(body, ['has_atmosphere', 'has_ring_system'])
+  );
+}
+
+function isStoredStarSystem(entry: unknown): boolean {
+  const system = asRecord(entry);
+  return (
+    system !== null &&
+    hasStringFields(system, ['name', 'description']) &&
+    hasNumberFields(system, ['star_count', 'planet_count']) &&
+    Array.isArray(system.stars) &&
+    system.stars.every(isStoredBody) &&
+    Array.isArray(system.planets) &&
+    system.planets.every(isStoredBody)
+  );
+}
+
+function isStoredRegionType(entry: unknown): boolean {
+  const type = asRecord(entry);
+  return (
+    type !== null &&
+    hasStringFields(type, ['name', 'description']) &&
+    hasNumberFields(type, [
+      'scale',
+      'population_capacity',
+      'technology_level_requirement',
+      'commonality',
+    ])
+  );
+}
+
+function isStoredRegion(entry: unknown): boolean {
+  const region = asRecord(entry);
+  return (
+    region !== null &&
+    hasStringFields(region, ['name', 'description', 'controlling_civilization']) &&
+    hasNumberFields(region, ['population']) &&
+    isStoredRegionType(region.region_type)
+  );
+}
+
+function isStoredGovernmentType(entry: unknown): boolean {
+  const type = asRecord(entry);
+  return (
+    type !== null &&
+    hasStringFields(type, ['name', 'adjective', 'description']) &&
+    isStringArray(type.name_options) &&
+    hasNumberFields(type, ['commonality'])
+  );
+}
+
+function isStoredEconomyType(entry: unknown): boolean {
+  const type = asRecord(entry);
+  return (
+    type !== null &&
+    hasStringFields(type, ['name', 'adjective', 'description']) &&
+    hasNumberFields(type, ['commonality'])
+  );
+}
+
+/** The military's four figures. Quality indexes a ten-entry table, so it must be 1–10. */
+function isStoredMilitary(entry: unknown): boolean {
+  const military = asRecord(entry);
+  return (
+    military !== null &&
+    hasNumberFields(military, ['quality', 'size', 'equipment_level', 'training_level']) &&
+    isIntegerWithin(military.quality, STAR_NATION_MILITARY_QUALITY_RANGE)
+  );
+}
+
+/**
+ * Checks what reading depends on: the civilization's fields, its two table rows, the regions, and
+ * a home system whose bodies the renderer can draw, with a home planet inside it.
+ *
+ * An empty name and an empty description are accepted, and so is an empty region list: a user who
+ * has cleared them has made an editing decision, and 3.3 asks for a well-defined empty result
+ * rather than a refusal. The technology level is checked against the table's own range because
+ * the page looks its name up, and a level with no row would throw where a blank should print; the
+ * counts are checked as whole numbers because the prose prints them as such.
+ */
+export function validateStarNationSnapshot(payload: unknown): PayloadResult<StarNationSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'Star nation payload is not an object');
+  }
+  if (!hasStringFields(record, ['name', 'description'])) {
+    return rejectedPayload('invalid-payload', 'Star nation payload needs a name and a description');
+  }
+  if (
+    !hasNumberFields(record, ['population']) ||
+    !['homeSystemPopulatedPlanets', 'systemsControlled', 'populatedPlanets'].every((field) =>
+      isCount(record[field]),
+    )
+  ) {
+    return rejectedPayload(
+      'invalid-payload',
+      'Star nation payload needs a population and whole-number planet and system counts',
+    );
+  }
+  if (!isIntegerWithin(record.technologyLevel, STAR_NATION_TECHNOLOGY_LEVEL_RANGE)) {
+    return rejectedPayload(
+      'invalid-payload',
+      `Star nation payload needs a technology level between ${STAR_NATION_TECHNOLOGY_LEVEL_RANGE[0]} and ${STAR_NATION_TECHNOLOGY_LEVEL_RANGE[1]}`,
+    );
+  }
+  if (!isStoredGovernmentType(record.governmentType) || !isStoredEconomyType(record.economyType)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'Star nation payload needs a government type and an economy type',
+    );
+  }
+  if (!isStoredMilitary(record.military)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'Star nation payload needs a military with a quality from 1 to 10, a size, an equipment level and a training level',
+    );
+  }
+  if (!Array.isArray(record.regionsOfControl) || !record.regionsOfControl.every(isStoredRegion)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'Star nation payload needs a list of regions of control, each with a region type and a population',
+    );
+  }
+  if (!isStoredStarSystem(record.homeSystem)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'Star nation payload needs a home system whose stars and planets each carry every parameter the preview draws from',
+    );
+  }
+  const planets = (record.homeSystem as { planets: unknown[] }).planets;
+  if (
+    !Number.isInteger(record.homePlanetIndex) ||
+    (record.homePlanetIndex as number) < 0 ||
+    (record.homePlanetIndex as number) >= planets.length
+  ) {
+    return rejectedPayload(
+      'invalid-payload',
+      'Star nation payload needs a home planet that is one of the home system’s planets',
+    );
+  }
+
+  return acceptedPayload(record as unknown as StarNationSnapshot);
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day
+ * the shape changes. #11 proposes adding setting flavour to a civilization; when it lands, the
+ * step from 1 to 2 belongs here and is additive.
+ */
+export function migrateStarNationSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<StarNationSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Star nations have no migration from payload version ${from}; version ${STAR_NATION_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/** What to call a saved nation: its name, or the kind when the name has been emptied. */
+function starNationName(snapshot: StarNationSnapshot): string {
+  const name = snapshot.name.trim();
+  return name === '' ? STAR_NATION_FALLBACK_NAME : name;
+}
+
+/**
+ * A star nation as an artifact.
+ *
+ * The codec is deferred like every other kind's, so that listing a project costs the metadata
+ * and the validator alone.
+ */
+export const starNationArtifactKind = defineArtifactKind<StarNation, StarNationSnapshot>({
+  kind: STAR_NATION_ARTIFACT_KIND,
+  displayName: 'Star Nation',
+  icon: star,
+  payloadVersion: STAR_NATION_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { toStarNationSnapshot, starNationFromSnapshotWithRng } =
+      await import('./star_nation_snapshot.js');
+    return {
+      toSnapshot: toStarNationSnapshot,
+      fromSnapshot: starNationFromSnapshotWithRng,
+    };
+  },
+  nameOf: starNationName,
+  validate: validateStarNationSnapshot,
+  migrate: migrateStarNationSnapshot,
+});

--- a/src/lib/civilizations/star_nation_editing.test.ts
+++ b/src/lib/civilizations/star_nation_editing.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCivilizationDescription } from './civilizations';
+import { homePlanetRegionOf, homeSystemRegionOf } from './star_nation';
+import {
+  restoreStarNationDescription,
+  setStarNationEconomyType,
+  setStarNationGovernmentType,
+  setStarNationHomePlanet,
+  setStarNationHomeSystemName,
+  setStarNationMilitaryQuality,
+  setStarNationNumber,
+  setStarNationPlanetName,
+  setStarNationRegionPopulation,
+  setStarNationText,
+} from './star_nation_editing';
+import { rollStarNationSnapshot } from './star_nation_roll';
+import { civilizationFromStarNationSnapshot } from './star_nation_snapshot';
+
+const snapshot = rollStarNationSnapshot('editing-fixture', { planetCount: 3 });
+
+describe('editing a star nation', () => {
+  it('sets a text field and leaves the rest alone', () => {
+    const edited = setStarNationText(snapshot, 'name', 'Kingdom of Vesh');
+
+    expect(edited.name).toBe('Kingdom of Vesh');
+    expect(edited.description).toBe(snapshot.description);
+    expect(edited.homeSystem).toBe(snapshot.homeSystem);
+    expect(snapshot.name).not.toBe('Kingdom of Vesh');
+  });
+
+  it('sets a figure without touching the description', () => {
+    const edited = setStarNationNumber(snapshot, 'population', 12);
+
+    expect(edited.population).toBe(12);
+    expect(edited.description).toBe(snapshot.description);
+  });
+
+  it('clamps the technology level to the table', () => {
+    expect(setStarNationNumber(snapshot, 'technologyLevel', 40).technologyLevel).toBe(10);
+    expect(setStarNationNumber(snapshot, 'technologyLevel', -3).technologyLevel).toBe(0);
+    expect(setStarNationNumber(snapshot, 'technologyLevel', 8.4).technologyLevel).toBe(8);
+  });
+
+  it('holds the counts to whole numbers with a floor', () => {
+    expect(
+      setStarNationNumber(snapshot, 'homeSystemPopulatedPlanets', -2).homeSystemPopulatedPlanets,
+    ).toBe(0);
+    expect(setStarNationNumber(snapshot, 'populatedPlanets', 2.5).populatedPlanets).toBe(3);
+    expect(setStarNationNumber(snapshot, 'systemsControlled', 0).systemsControlled).toBe(1);
+    expect(setStarNationRegionPopulation(snapshot, 0, -5).regionsOfControl[0].population).toBe(0);
+  });
+
+  it('ignores a figure that is not a number, as a cleared input reports', () => {
+    expect(setStarNationNumber(snapshot, 'population', Number.NaN)).toBe(snapshot);
+    expect(setStarNationMilitaryQuality(snapshot, Number.NaN)).toBe(snapshot);
+    expect(setStarNationRegionPopulation(snapshot, 0, Number.NaN)).toBe(snapshot);
+  });
+
+  it('clamps the military quality to the table', () => {
+    expect(setStarNationMilitaryQuality(snapshot, 0).military.quality).toBe(1);
+    expect(setStarNationMilitaryQuality(snapshot, 99).military.quality).toBe(10);
+    expect(setStarNationMilitaryQuality(snapshot, 4).military.size).toBe(snapshot.military.size);
+  });
+
+  it('sets the government and the economy from the tables by name', () => {
+    const edited = setStarNationEconomyType(
+      setStarNationGovernmentType(snapshot, 'Theocracy'),
+      'Barter',
+    );
+
+    expect(edited.governmentType.name).toBe('Theocracy');
+    expect(edited.governmentType.adjective).toBe('theocratic');
+    expect(edited.economyType.name).toBe('Barter');
+    expect(edited.economyType.adjective).toBe('barter');
+  });
+
+  it('leaves a row the tables lack unchanged', () => {
+    expect(setStarNationGovernmentType(snapshot, 'Hive Mind')).toBe(snapshot);
+    expect(setStarNationEconomyType(snapshot, 'Post-scarcity')).toBe(snapshot);
+  });
+
+  it('moves the homeworld and renames the planet region with it', () => {
+    const index = (snapshot.homePlanetIndex + 1) % snapshot.homeSystem.planets.length;
+    const edited = setStarNationHomePlanet(snapshot, index);
+
+    expect(edited.homePlanetIndex).toBe(index);
+    expect(homePlanetRegionOf(edited)?.name).toBe(snapshot.homeSystem.planets[index].name);
+    expect(homeSystemRegionOf(edited)?.name).toBe(homeSystemRegionOf(snapshot)?.name);
+  });
+
+  it('leaves a homeworld outside the system unchanged', () => {
+    expect(setStarNationHomePlanet(snapshot, 3)).toBe(snapshot);
+    expect(setStarNationHomePlanet(snapshot, -1)).toBe(snapshot);
+    expect(setStarNationHomePlanet(snapshot, 0.5)).toBe(snapshot);
+  });
+
+  it('renames the home system and the region that stands for it', () => {
+    const edited = setStarNationHomeSystemName(snapshot, 'Tau Ceti');
+
+    expect(edited.homeSystem.name).toBe('Tau Ceti');
+    expect(homeSystemRegionOf(edited)?.name).toBe('Tau Ceti');
+    expect(homePlanetRegionOf(edited)?.name).toBe(homePlanetRegionOf(snapshot)?.name);
+  });
+
+  it('renames a planet, and the planet region only when it is the homeworld', () => {
+    const home = snapshot.homePlanetIndex;
+    const other = (home + 1) % snapshot.homeSystem.planets.length;
+
+    const renamedHome = setStarNationPlanetName(snapshot, home, 'Vesh Prime');
+    expect(renamedHome.homeSystem.planets[home].name).toBe('Vesh Prime');
+    expect(homePlanetRegionOf(renamedHome)?.name).toBe('Vesh Prime');
+
+    const renamedOther = setStarNationPlanetName(snapshot, other, 'Vesh Minor');
+    expect(renamedOther.homeSystem.planets[other].name).toBe('Vesh Minor');
+    expect(homePlanetRegionOf(renamedOther)?.name).toBe(homePlanetRegionOf(snapshot)?.name);
+
+    expect(setStarNationPlanetName(snapshot, 9, 'Nowhere')).toBe(snapshot);
+  });
+
+  it('sets one region’s population and leaves the other', () => {
+    const edited = setStarNationRegionPopulation(snapshot, 1, 500);
+
+    expect(edited.regionsOfControl[1].population).toBe(500);
+    expect(edited.regionsOfControl[0]).toBe(snapshot.regionsOfControl[0]);
+    expect(setStarNationRegionPopulation(snapshot, 5, 500)).toBe(snapshot);
+  });
+
+  it('rebuilds the description from the figures only on request', () => {
+    const changed = setStarNationText(
+      setStarNationGovernmentType(snapshot, 'Theocracy'),
+      'description',
+      'Their own words.',
+    );
+    expect(changed.description).toBe('Their own words.');
+
+    const restored = restoreStarNationDescription(changed);
+    expect(restored.description).toBe(
+      getCivilizationDescription(civilizationFromStarNationSnapshot(changed)),
+    );
+    expect(restored.description).toContain('theocratic');
+  });
+});

--- a/src/lib/civilizations/star_nation_editing.ts
+++ b/src/lib/civilizations/star_nation_editing.ts
@@ -1,0 +1,223 @@
+/**
+ * Editing a saved star nation, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 satisfied by construction — changing the economy must not disturb the home
+ * system — and it is what lets the editing framework compare what is on screen against what was
+ * read to decide whether anything needs saving.
+ *
+ * **The description is the user's.** It was assembled from the figures at generation time, and
+ * changing a figure deliberately does not rewrite it: a user who has written their own account of
+ * the nation has made a decision no field edit may overrule (4.2). What they get instead is
+ * `restoreStarNationDescription`, an explicit command that rebuilds the sentence from the figures
+ * as they now stand — which is 4.4's "one part without re-rolling the whole" for the one field
+ * that is derived from the others.
+ *
+ * The two table rows — government and economy — are set by name and resolved against the table
+ * here, so an editor offers a select and never writes a row the library does not have. The home
+ * planet is set by index and the planet region is renamed with it, because that region's name
+ * *is* the home planet's name and the two drifting apart would be a nation whose homeworld is
+ * called two things.
+ */
+
+import {
+  getCivilizationDescription,
+  getEconomyTypeByName,
+  getGovernmentTypeByName,
+} from './civilizations';
+import type { RegionOfControl } from './regions_of_control';
+import {
+  STAR_NATION_MILITARY_QUALITY_RANGE,
+  STAR_NATION_PLANET_REGION_TYPE,
+  STAR_NATION_SYSTEM_REGION_TYPE,
+  STAR_NATION_TECHNOLOGY_LEVEL_RANGE,
+} from './star_nation';
+import {
+  civilizationFromStarNationSnapshot,
+  type StarNationSnapshot,
+} from './star_nation_snapshot';
+
+/** The two prose fields. */
+export type StarNationTextField = 'name' | 'description';
+
+/** The figures the page prints, each a number field of its own. */
+export type StarNationNumberField =
+  | 'population'
+  | 'technologyLevel'
+  | 'homeSystemPopulatedPlanets'
+  | 'systemsControlled'
+  | 'populatedPlanets';
+
+function clampInteger(value: number, [min, max]: [number, number]): number {
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+function isUsableNumber(value: number): boolean {
+  return Number.isFinite(value);
+}
+
+function renameRegionOfType(
+  regions: RegionOfControl[],
+  typeName: string,
+  name: string,
+): RegionOfControl[] {
+  return regions.map((region) =>
+    region.region_type.name === typeName ? { ...region, name } : region,
+  );
+}
+
+export function setStarNationText(
+  snapshot: StarNationSnapshot,
+  field: StarNationTextField,
+  value: string,
+): StarNationSnapshot {
+  return { ...snapshot, [field]: value };
+}
+
+/** The floor each figure is held to: a nation controls at least its home system. */
+const NUMBER_FIELD_FLOORS: Record<StarNationNumberField, number> = {
+  population: 0,
+  technologyLevel: STAR_NATION_TECHNOLOGY_LEVEL_RANGE[0],
+  homeSystemPopulatedPlanets: 0,
+  systemsControlled: 1,
+  populatedPlanets: 0,
+};
+
+/**
+ * Sets one of the figures. A value that is not a number — what a cleared number input reports —
+ * leaves the snapshot alone rather than storing something the validator would refuse. Every
+ * figure is a whole number with a floor, and the technology level has the table's ceiling too,
+ * so what is stored is what the prose can print.
+ */
+export function setStarNationNumber(
+  snapshot: StarNationSnapshot,
+  field: StarNationNumberField,
+  value: number,
+): StarNationSnapshot {
+  if (!isUsableNumber(value)) {
+    return snapshot;
+  }
+  const ceiling =
+    field === 'technologyLevel' ? STAR_NATION_TECHNOLOGY_LEVEL_RANGE[1] : Number.MAX_SAFE_INTEGER;
+  return { ...snapshot, [field]: clampInteger(value, [NUMBER_FIELD_FLOORS[field], ceiling]) };
+}
+
+export function setStarNationMilitaryQuality(
+  snapshot: StarNationSnapshot,
+  quality: number,
+): StarNationSnapshot {
+  if (!isUsableNumber(quality)) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    military: {
+      ...snapshot.military,
+      quality: clampInteger(quality, STAR_NATION_MILITARY_QUALITY_RANGE),
+    },
+  };
+}
+
+/** Sets the government by the table row's name. A name the table lacks changes nothing. */
+export function setStarNationGovernmentType(
+  snapshot: StarNationSnapshot,
+  name: string,
+): StarNationSnapshot {
+  const type = getGovernmentTypeByName(name);
+  return type === undefined
+    ? snapshot
+    : { ...snapshot, governmentType: { ...type, name_options: [...type.name_options] } };
+}
+
+/** Sets the economy by the table row's name. A name the table lacks changes nothing. */
+export function setStarNationEconomyType(
+  snapshot: StarNationSnapshot,
+  name: string,
+): StarNationSnapshot {
+  const type = getEconomyTypeByName(name);
+  return type === undefined ? snapshot : { ...snapshot, economyType: { ...type } };
+}
+
+/**
+ * Picks a different homeworld from the home system's planets, and renames the planet region to
+ * match. An index outside the system changes nothing.
+ */
+export function setStarNationHomePlanet(
+  snapshot: StarNationSnapshot,
+  index: number,
+): StarNationSnapshot {
+  const planet = snapshot.homeSystem.planets[index];
+  if (!Number.isInteger(index) || planet === undefined) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    homePlanetIndex: index,
+    regionsOfControl: renameRegionOfType(
+      snapshot.regionsOfControl,
+      STAR_NATION_PLANET_REGION_TYPE,
+      planet.name,
+    ),
+  };
+}
+
+/** Renames the home system, and the region that stands for it. */
+export function setStarNationHomeSystemName(
+  snapshot: StarNationSnapshot,
+  name: string,
+): StarNationSnapshot {
+  return {
+    ...snapshot,
+    homeSystem: { ...snapshot.homeSystem, name },
+    regionsOfControl: renameRegionOfType(
+      snapshot.regionsOfControl,
+      STAR_NATION_SYSTEM_REGION_TYPE,
+      name,
+    ),
+  };
+}
+
+/** Renames one of the home system's planets. Renaming the homeworld renames its region with it. */
+export function setStarNationPlanetName(
+  snapshot: StarNationSnapshot,
+  index: number,
+  name: string,
+): StarNationSnapshot {
+  if (snapshot.homeSystem.planets[index] === undefined) {
+    return snapshot;
+  }
+  const planets = snapshot.homeSystem.planets.map((planet, position) =>
+    position === index ? { ...planet, name } : planet,
+  );
+  const regionsOfControl =
+    index === snapshot.homePlanetIndex
+      ? renameRegionOfType(snapshot.regionsOfControl, STAR_NATION_PLANET_REGION_TYPE, name)
+      : snapshot.regionsOfControl;
+  return { ...snapshot, homeSystem: { ...snapshot.homeSystem, planets }, regionsOfControl };
+}
+
+/** Sets the population of one region of control, by its position in the list. */
+export function setStarNationRegionPopulation(
+  snapshot: StarNationSnapshot,
+  index: number,
+  population: number,
+): StarNationSnapshot {
+  if (snapshot.regionsOfControl[index] === undefined || !isUsableNumber(population)) {
+    return snapshot;
+  }
+  const stored = clampInteger(population, [0, Number.MAX_SAFE_INTEGER]);
+  return {
+    ...snapshot,
+    regionsOfControl: snapshot.regionsOfControl.map((region, position) =>
+      position === index ? { ...region, population: stored } : region,
+    ),
+  };
+}
+
+/** Rebuilds the description from the figures as they now stand. Explicit, never automatic. */
+export function restoreStarNationDescription(snapshot: StarNationSnapshot): StarNationSnapshot {
+  return {
+    ...snapshot,
+    description: getCivilizationDescription(civilizationFromStarNationSnapshot(snapshot)),
+  };
+}

--- a/src/lib/civilizations/star_nation_presentation.test.ts
+++ b/src/lib/civilizations/star_nation_presentation.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import { homePlanetOf, starNationDisplayName } from './star_nation';
+import {
+  starNationFileStem,
+  starNationHomeSystemHeading,
+  starNationHomeSystemParagraph,
+  starNationTechnologyLabel,
+  starNationTechnologyLevel,
+  starNationTerritorySentence,
+  starNationToDocument,
+  starNationToMarkdown,
+  starNationToText,
+} from './star_nation_presentation';
+import { rollStarNation } from './star_nation_roll';
+import type { StarNation } from './star_nation_types';
+
+const nation = rollStarNation('presentation-fixture', { planetCount: 3 });
+
+function named(name: string): StarNation {
+  return { ...nation, civilization: { ...nation.civilization, name } };
+}
+
+describe('starNationDisplayName', () => {
+  it('is the nation’s name, or the kind when it has none', () => {
+    expect(starNationDisplayName(named('Kingdom of Vesh'))).toBe('Kingdom of Vesh');
+    expect(starNationDisplayName(named('  '))).toBe('Star Nation');
+  });
+});
+
+describe('starNationTerritorySentence', () => {
+  it('says nothing for a nation that holds only its home system', () => {
+    expect(starNationTerritorySentence({ ...nation, systemsControlled: 1 })).toBe('');
+  });
+
+  it('counts the systems and the populated planets otherwise', () => {
+    expect(
+      starNationTerritorySentence({ ...nation, systemsControlled: 4, populatedPlanets: 9 }),
+    ).toBe('The nation controls 4 star systems, with a total of 9 populated planets.');
+  });
+});
+
+describe('starNationTechnologyLabel', () => {
+  it('pairs the level with the table’s name for it', () => {
+    const label = starNationTechnologyLabel(nation);
+
+    expect(label).toBe(
+      `${nation.civilization.technology_level} (${starNationTechnologyLevel(nation).name})`,
+    );
+    expect(starNationTechnologyLevel(nation).level).toBe(nation.civilization.technology_level);
+  });
+});
+
+describe('starNationHomeSystemHeading', () => {
+  it('names the system, or falls back when the name has been emptied', () => {
+    expect(starNationHomeSystemHeading(nation)).toBe(`The ${nation.homeSystem.name} System`);
+    expect(
+      starNationHomeSystemHeading({ ...nation, homeSystem: { ...nation.homeSystem, name: '' } }),
+    ).toBe('The home system');
+  });
+});
+
+describe('starNationHomeSystemParagraph', () => {
+  it('describes the populated count, the homeworld and its population', () => {
+    const paragraph = starNationHomeSystemParagraph({
+      ...nation,
+      homeSystemPopulatedPlanets: 2,
+      homePlanetIndex: 1,
+    });
+
+    expect(paragraph).toContain('There are 2 populated planets in this system.');
+    expect(paragraph).toContain(`${nation.homeSystem.planets[1].name} is the 2nd planet.`);
+    expect(paragraph).toMatch(/It has a population of .+\.$/);
+  });
+
+  it('uses the singular for one populated planet', () => {
+    expect(starNationHomeSystemParagraph({ ...nation, homeSystemPopulatedPlanets: 1 })).toContain(
+      'There is 1 populated planet in this system.',
+    );
+  });
+
+  /** 6.4: a missing part drops its sentence, not the paragraph. */
+  it('drops the population sentence when the planet region is missing', () => {
+    const paragraph = starNationHomeSystemParagraph({ ...nation, regionsOfControl: [] });
+
+    expect(paragraph).not.toContain('population');
+    expect(paragraph).toContain(homePlanetOf(nation)?.name);
+  });
+
+  it('drops the homeworld sentence when its name has been emptied', () => {
+    const planets = nation.homeSystem.planets.map((planet, index) =>
+      index === nation.homePlanetIndex ? { ...planet, name: '' } : planet,
+    );
+    const paragraph = starNationHomeSystemParagraph({
+      ...nation,
+      homeSystem: { ...nation.homeSystem, planets },
+    });
+
+    expect(paragraph).not.toContain(' planet.');
+    expect(paragraph).toContain('population');
+  });
+});
+
+describe('starNationToDocument', () => {
+  it('carries the description, the figures and the home system', () => {
+    const document = starNationToDocument(nation);
+
+    expect(document.title).toBe(nation.civilization.name);
+    expect(document.paragraphs[0]).toBe(nation.civilization.description);
+    expect(document.figures.map((figure) => figure.label)).toEqual([
+      'Government',
+      'Economy',
+      'Military',
+      'Technology',
+      'Population',
+      'Home planet',
+      'Home system population',
+    ]);
+    expect(document.homeSystem.heading).toBe(`The ${nation.homeSystem.name} System`);
+    expect(document.homeSystem.paragraphs).toHaveLength(1);
+  });
+
+  /** 6.4 by construction. */
+  it('drops an emptied description and a territory of one system', () => {
+    const document = starNationToDocument({
+      ...nation,
+      civilization: { ...nation.civilization, description: '  ' },
+      systemsControlled: 1,
+    });
+
+    expect(document.paragraphs).toEqual([]);
+  });
+
+  it('drops a figure that has nothing to say', () => {
+    const document = starNationToDocument({ ...nation, regionsOfControl: [] });
+
+    expect(document.figures.map((figure) => figure.label)).not.toContain('Home system population');
+  });
+});
+
+describe('starNationToMarkdown', () => {
+  it('writes the title, the paragraphs, the figures and the home system', () => {
+    const markdown = starNationToMarkdown(named('Kingdom of Vesh'));
+
+    expect(markdown.startsWith('# Kingdom of Vesh\n\n')).toBe(true);
+    expect(markdown).toContain('- **Government:** ');
+    expect(markdown).toContain(`## The ${nation.homeSystem.name} System`);
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('starNationToText', () => {
+  it('leaves the title to the PDF and upper-cases the home system heading', () => {
+    const text = starNationToText(named('Kingdom of Vesh'));
+
+    expect(text.startsWith('# ')).toBe(false);
+    expect(text).toContain('Government: ');
+    expect(text).toContain(`THE ${nation.homeSystem.name.toUpperCase()} SYSTEM`);
+  });
+});
+
+describe('starNationFileStem', () => {
+  it('reduces the name to something a filesystem takes', () => {
+    expect(starNationFileStem(named("Holy Empire of K'tharr"))).toBe('holy-empire-of-k-tharr');
+    expect(starNationFileStem(named('   '))).toBe('star-nation');
+  });
+});

--- a/src/lib/civilizations/star_nation_presentation.ts
+++ b/src/lib/civilizations/star_nation_presentation.ts
@@ -1,0 +1,167 @@
+/**
+ * A star nation arranged for reading, and the Markdown and PDF exports written from it.
+ *
+ * This tool had no export before requirement 6.3 asked for one. What a referee wants at the table
+ * is the page on paper: the nation as a paragraph, its figures as a short list, and the home
+ * system as a paragraph of its own. The same document is written once as Markdown and once as
+ * plain text for the PDF so the two cannot drift.
+ *
+ * 6.4 is the reason the document model exists rather than a template string: a nation whose
+ * description has been emptied prints its name without a blank paragraph, a nation that holds one
+ * system prints no territory sentence, and a nation whose planet region is missing prints its
+ * home system without a population it does not have.
+ */
+
+import * as Words from '@ironarachne/words';
+
+import { getTechnologyLevelByLevel, type TechnologyLevel } from '$lib/technology_levels';
+
+import { getFriendlyPopulation } from './civilizations';
+import {
+  homePlanetOf,
+  homePlanetRegionOf,
+  homeSystemRegionOf,
+  starNationDisplayName,
+} from './star_nation';
+import type { StarNation } from './star_nation_types';
+
+/** One labelled figure. */
+export type StarNationFigure = {
+  label: string;
+  value: string;
+};
+
+/** A nation arranged for reading, independent of the format it is finally written in. */
+export type StarNationDocument = {
+  title: string;
+  paragraphs: string[];
+  figures: StarNationFigure[];
+  homeSystem: {
+    heading: string;
+    paragraphs: string[];
+  };
+};
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+/** The territory sentence, for a nation that holds more than its home system. */
+export function starNationTerritorySentence(nation: StarNation): string {
+  if (nation.systemsControlled <= 1) {
+    return '';
+  }
+  return `The nation controls ${nation.systemsControlled} star systems, with a total of ${nation.populatedPlanets} populated planets.`;
+}
+
+/** The table row for the nation's technology level — the page's tooltip reads its description. */
+export function starNationTechnologyLevel(nation: StarNation): TechnologyLevel {
+  return getTechnologyLevelByLevel(nation.civilization.technology_level);
+}
+
+/** The technology level as the page prints it: the number, and the table's name for it. */
+export function starNationTechnologyLabel(nation: StarNation): string {
+  return `${nation.civilization.technology_level} (${starNationTechnologyLevel(nation).name})`;
+}
+
+/** The home system's heading: the system's name, or a placeholder when it has been emptied. */
+export function starNationHomeSystemHeading(nation: StarNation): string {
+  const name = nation.homeSystem.name.trim();
+  return name === '' ? 'The home system' : `The ${name} System`;
+}
+
+/**
+ * The home system as the page describes it: how many planets are populated, which is the
+ * homeworld, and how many people live there. Each sentence stands on its own so that a missing
+ * part drops its sentence and nothing else.
+ */
+export function starNationHomeSystemParagraph(nation: StarNation): string {
+  const sentences: string[] = [];
+  const planet = homePlanetOf(nation);
+  const region = homePlanetRegionOf(nation);
+  const count = nation.homeSystemPopulatedPlanets;
+  sentences.push(
+    `There ${count === 1 ? 'is' : 'are'} ${count} populated ${count === 1 ? 'planet' : 'planets'} in this system.`,
+  );
+  if (planet !== undefined && isPrintable(planet.name)) {
+    const position = nation.homePlanetIndex + 1;
+    sentences.push(`${planet.name} is the ${position}${Words.getOrdinal(position)} planet.`);
+  }
+  if (region !== undefined) {
+    sentences.push(`It has a population of ${getFriendlyPopulation(region.population)}.`);
+  }
+  return sentences.join(' ');
+}
+
+/** Arrange a nation for reading. */
+export function starNationToDocument(nation: StarNation): StarNationDocument {
+  const civilization = nation.civilization;
+  const planet = homePlanetOf(nation);
+  const systemRegion = homeSystemRegionOf(nation);
+  const figures: StarNationFigure[] = [
+    { label: 'Government', value: civilization.government_type.name },
+    { label: 'Economy', value: civilization.economy_type.name },
+    { label: 'Military', value: `${civilization.military.quality}` },
+    { label: 'Technology', value: starNationTechnologyLabel(nation) },
+    { label: 'Population', value: getFriendlyPopulation(civilization.population) },
+    { label: 'Home planet', value: planet?.name ?? '' },
+    {
+      label: 'Home system population',
+      value: systemRegion === undefined ? '' : getFriendlyPopulation(systemRegion.population),
+    },
+  ].filter((figure) => isPrintable(figure.value));
+
+  return {
+    title: starNationDisplayName(nation),
+    paragraphs: [civilization.description, starNationTerritorySentence(nation)].filter(isPrintable),
+    figures,
+    homeSystem: {
+      heading: starNationHomeSystemHeading(nation),
+      paragraphs: [starNationHomeSystemParagraph(nation)].filter(isPrintable),
+    },
+  };
+}
+
+/** A nation as Markdown, for a referee who wants it in their own notes. */
+export function starNationToMarkdown(nation: StarNation): string {
+  const document = starNationToDocument(nation);
+  const blocks = [`# ${document.title}`, ...document.paragraphs];
+
+  if (document.figures.length > 0) {
+    blocks.push(
+      document.figures.map((figure) => `- **${figure.label}:** ${figure.value}`).join('\n'),
+    );
+  }
+
+  blocks.push(`## ${document.homeSystem.heading}`);
+  blocks.push(...document.homeSystem.paragraphs);
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/**
+ * The body of the PDF: the same document as plain text, without the title, which the PDF draws
+ * as its own heading.
+ */
+export function starNationToText(nation: StarNation): string {
+  const document = starNationToDocument(nation);
+  const blocks = [...document.paragraphs];
+
+  if (document.figures.length > 0) {
+    blocks.push(document.figures.map((figure) => `${figure.label}: ${figure.value}`).join('\n'));
+  }
+
+  blocks.push(document.homeSystem.heading.toUpperCase());
+  blocks.push(...document.homeSystem.paragraphs);
+
+  return blocks.join('\n\n');
+}
+
+/** A filename stem for an exported nation, reduced to something a filesystem takes. */
+export function starNationFileStem(nation: StarNation): string {
+  const stem = starNationDisplayName(nation)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' ? 'star-nation' : stem;
+}

--- a/src/lib/civilizations/star_nation_roll.test.ts
+++ b/src/lib/civilizations/star_nation_roll.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import { homePlanetRegionOf, homeSystemRegionOf } from './star_nation';
+import {
+  readStarNationGeneratorConfig,
+  rollStarNation,
+  rollStarNationSnapshot,
+  STAR_NATION_MAX_PLANET_COUNT,
+  starNationPreviewSeed,
+} from './star_nation_roll';
+
+describe('readStarNationGeneratorConfig', () => {
+  it('reads a planet count the page offers', () => {
+    expect(readStarNationGeneratorConfig({ planetCount: 4 })).toEqual({ planetCount: 4 });
+    expect(readStarNationGeneratorConfig({ planetCount: STAR_NATION_MAX_PLANET_COUNT })).toEqual({
+      planetCount: STAR_NATION_MAX_PLANET_COUNT,
+    });
+  });
+
+  it('drops a planet count it does not recognise rather than coercing it', () => {
+    expect(readStarNationGeneratorConfig({})).toEqual({});
+    expect(readStarNationGeneratorConfig({ planetCount: '4' })).toEqual({});
+    expect(readStarNationGeneratorConfig({ planetCount: 0 })).toEqual({});
+    expect(readStarNationGeneratorConfig({ planetCount: 2.5 })).toEqual({});
+    expect(
+      readStarNationGeneratorConfig({ planetCount: STAR_NATION_MAX_PLANET_COUNT + 1 }),
+    ).toEqual({});
+  });
+});
+
+describe('rollStarNation', () => {
+  /** Requirement 2.2. */
+  it('gives the same nation for the same seed and settings', () => {
+    expect(rollStarNation('a-fixed-seed', { planetCount: 5 })).toEqual(
+      rollStarNation('a-fixed-seed', { planetCount: 5 }),
+    );
+    expect(rollStarNation('a-fixed-seed')).toEqual(rollStarNation('a-fixed-seed'));
+  });
+
+  it('gives a different nation for a different seed', () => {
+    const seeds = ['one', 'two', 'three', 'four', 'five'].map((seed) =>
+      JSON.stringify(rollStarNation(seed)),
+    );
+
+    expect(new Set(seeds).size).toBeGreaterThan(1);
+  });
+
+  it('honours the planet count', () => {
+    expect(rollStarNation('count', { planetCount: 1 }).homeSystem.planets).toHaveLength(1);
+    expect(rollStarNation('count', { planetCount: 12 }).homeSystem.planets).toHaveLength(12);
+  });
+
+  it('lets the seed choose a planet count between one and twelve', () => {
+    for (const seed of ['a', 'b', 'c', 'd', 'e', 'f']) {
+      const count = rollStarNation(seed).homeSystem.planets.length;
+      expect(count).toBeGreaterThanOrEqual(1);
+      expect(count).toBeLessThanOrEqual(12);
+    }
+  });
+
+  it('rolls a spacefaring civilization', () => {
+    for (const seed of ['a', 'b', 'c', 'd', 'e', 'f']) {
+      const level = rollStarNation(seed).civilization.technology_level;
+      expect(level).toBeGreaterThanOrEqual(7);
+      expect(level).toBeLessThanOrEqual(9);
+    }
+  });
+
+  it('names the regions after the home system and the home planet, held by the nation', () => {
+    const nation = rollStarNation('regions', { planetCount: 3 });
+    const system = homeSystemRegionOf(nation);
+    const planet = homePlanetRegionOf(nation);
+
+    expect(system?.name).toBe(nation.homeSystem.name);
+    expect(planet?.name).toBe(nation.homeSystem.planets[nation.homePlanetIndex].name);
+    expect(system?.controlling_civilization).toBe(nation.civilization.name);
+    expect(planet?.controlling_civilization).toBe(nation.civilization.name);
+  });
+
+  it('picks a home planet inside the system and a populated count within it', () => {
+    for (const seed of ['a', 'b', 'c', 'd', 'e', 'f']) {
+      const nation = rollStarNation(seed);
+      expect(nation.homePlanetIndex).toBeGreaterThanOrEqual(0);
+      expect(nation.homePlanetIndex).toBeLessThan(nation.homeSystem.planets.length);
+      expect(nation.homeSystemPopulatedPlanets).toBeGreaterThanOrEqual(1);
+      expect(nation.homeSystemPopulatedPlanets).toBeLessThanOrEqual(
+        nation.homeSystem.planets.length,
+      );
+    }
+  });
+
+  it('gives a nation beyond technology level 7 more systems than its home, and no others fewer', () => {
+    const seeds = Array.from({ length: 40 }, (_, index) => `territory-${index}`);
+    const nations = seeds.map((seed) => rollStarNation(seed));
+    const expansive = nations.filter((nation) => nation.civilization.technology_level > 7);
+    const homebound = nations.filter((nation) => nation.civilization.technology_level <= 7);
+
+    expect(expansive.length).toBeGreaterThan(0);
+    expect(homebound.length).toBeGreaterThan(0);
+    for (const nation of expansive) {
+      expect(nation.systemsControlled).toBeGreaterThan(1);
+      expect(nation.populatedPlanets).toBeGreaterThanOrEqual(nation.homeSystemPopulatedPlanets);
+    }
+    for (const nation of homebound) {
+      expect(nation.systemsControlled).toBe(1);
+      expect(nation.populatedPlanets).toBe(nation.homeSystemPopulatedPlanets);
+    }
+  });
+
+  it('describes the civilization from its final population', () => {
+    const nation = rollStarNation('described');
+
+    expect(nation.civilization.description).toContain(nation.civilization.name);
+    expect(homePlanetRegionOf(nation)?.population).toBe(
+      Math.round(nation.civilization.population / nation.populatedPlanets),
+    );
+  });
+
+  it('rolls a snapshot from the same seed', () => {
+    expect(rollStarNationSnapshot('reroll-seed', { planetCount: 2 }).name).toBe(
+      rollStarNation('reroll-seed', { planetCount: 2 }).civilization.name,
+    );
+  });
+
+  it('derives the preview seed from the page seed', () => {
+    expect(starNationPreviewSeed('abc')).toBe(starNationPreviewSeed('abc'));
+    expect(starNationPreviewSeed('abc')).not.toBe(starNationPreviewSeed('abd'));
+  });
+});

--- a/src/lib/civilizations/star_nation_roll.ts
+++ b/src/lib/civilizations/star_nation_roll.ts
@@ -1,0 +1,180 @@
+/**
+ * The single path from a seed to a star nation, and the record of how it was rolled.
+ *
+ * Requirement 2.2 of docs/workshop.md wants the same seed and settings to give the same result.
+ * `StarNationGenerator.svelte` came close — it threaded one RNG through every config — but the
+ * configs it threaded it through each seeded themselves from `Date.now()` first, and the preview
+ * image took a seed drawn after generation rather than derived from the page's. Here every draw
+ * comes from one RNG made from the seed, and the helpers it calls take that RNG rather than the
+ * clock.
+ *
+ * The config record is the page's one control besides the seed, stated as a type so that what
+ * the generator writes as provenance and what a re-roll expects to find are one thing.
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import { generateStarSystem, getDefaultStarSystemGeneratorConfig } from '$lib/astronomical_bodies';
+
+import {
+  generateCivilization,
+  getCivilizationDescription,
+  getDefaultCivilizationGenerationConfig,
+} from './civilizations';
+import {
+  generateRegionOfControl,
+  getDefaultRegionOfControlGenerationConfig,
+  getRegionTypeByName,
+  type RegionOfControlGenerationConfig,
+} from './regions_of_control';
+import { STAR_NATION_PLANET_REGION_TYPE, STAR_NATION_SYSTEM_REGION_TYPE } from './star_nation';
+import { toStarNationSnapshot, type StarNationSnapshot } from './star_nation_snapshot';
+import type { StarNation } from './star_nation_types';
+
+/** The most planets the page's control offers. */
+export const STAR_NATION_MAX_PLANET_COUNT = 20;
+
+/** A spacefaring nation, by the technology table: interstellar travel starts at 7. */
+const TECHNOLOGY_LEVEL_RANGE: [number, number] = [7, 9];
+const SPACEFARING_TECHNOLOGY_LEVEL = 7;
+
+/**
+ * What the generator records about how it rolled, and what a re-roll reads back.
+ *
+ * `planetCount` absent means the seed chose the home system's planet count, as the page's
+ * "Random" does.
+ */
+export type StarNationGeneratorConfigRecord = {
+  planetCount?: number;
+};
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Anything unrecognisable is dropped rather than coerced: a planet count outside what the page
+ * offers falls back to the seed's choice rather than rolling a nation from a field it misread.
+ */
+export function readStarNationGeneratorConfig(
+  config: Record<string, unknown>,
+): StarNationGeneratorConfigRecord {
+  const count = config.planetCount;
+  return typeof count === 'number' &&
+    Number.isInteger(count) &&
+    count >= 1 &&
+    count <= STAR_NATION_MAX_PLANET_COUNT
+    ? { planetCount: count }
+    : {};
+}
+
+function regionConfigFor(
+  rng: RNG,
+  typeName: string,
+  civilizationName: string,
+): RegionOfControlGenerationConfig {
+  const config = getDefaultRegionOfControlGenerationConfig(rng);
+  config.region_types = [getRegionTypeByName(typeName)];
+  config.technology_level = SPACEFARING_TECHNOLOGY_LEVEL;
+  config.controlling_civilization = civilizationName;
+  return config;
+}
+
+/**
+ * The territory beyond the home system, for a nation advanced enough to hold any.
+ *
+ * The other systems are not generated — only how many there are and what they add to the count of
+ * populated planets and to the population. The page never showed them, and a payload that stored
+ * twenty star systems nobody looks at would be the size case for no reason.
+ */
+function rollFurtherTerritory(rng: RNG): {
+  systems: number;
+  populatedPlanets: number;
+  population: number;
+} {
+  const systems = rng.int(1, 20);
+  let populatedPlanets = 0;
+  let population = 0;
+  for (let index = 0; index < systems; index++) {
+    const planets = Math.max(1, Math.round(rng.bellFloat(1, 12)));
+    populatedPlanets += rng.int(1, planets);
+    population += rng.int(1, planets) * rng.int(100000, 10000000);
+  }
+  return { systems, populatedPlanets, population };
+}
+
+/**
+ * Roll a star nation from a seed and a set of options — the one path the generator page and a
+ * re-roll both take.
+ */
+export function rollStarNation(
+  seed: string,
+  config: StarNationGeneratorConfigRecord = {},
+): StarNation {
+  const rng = new RNG(seed);
+
+  const civilizationConfig = getDefaultCivilizationGenerationConfig(rng);
+  civilizationConfig.technology_level_range = TECHNOLOGY_LEVEL_RANGE;
+  const civilization = generateCivilization(civilizationConfig);
+
+  const systemConfig = getDefaultStarSystemGeneratorConfig(rng);
+  if (config.planetCount !== undefined) {
+    systemConfig.planet_count = config.planetCount;
+  }
+  const homeSystem = generateStarSystem(systemConfig);
+  const homePlanetIndex = rng.int(0, homeSystem.planets.length - 1);
+
+  const systemRegionConfig = regionConfigFor(
+    rng,
+    STAR_NATION_SYSTEM_REGION_TYPE,
+    civilization.name,
+  );
+  systemRegionConfig.population_density_range = [0.05, 0.3];
+  const homeSystemRegion = generateRegionOfControl(systemRegionConfig);
+  homeSystemRegion.name = homeSystem.name;
+
+  const homePlanetRegion = generateRegionOfControl(
+    regionConfigFor(rng, STAR_NATION_PLANET_REGION_TYPE, civilization.name),
+  );
+  homePlanetRegion.name = homeSystem.planets[homePlanetIndex].name;
+
+  const homeSystemPopulatedPlanets = rng.int(1, homeSystem.planets.length);
+  let populatedPlanets = homeSystemPopulatedPlanets;
+  let population = homeSystemRegion.population;
+  let systemsControlled = 1;
+
+  if (civilization.technology_level > SPACEFARING_TECHNOLOGY_LEVEL) {
+    const further = rollFurtherTerritory(rng);
+    systemsControlled += further.systems;
+    populatedPlanets += further.populatedPlanets;
+    population += further.population;
+  }
+
+  civilization.population = population;
+  civilization.description = getCivilizationDescription(civilization);
+  homePlanetRegion.population = Math.round(population / populatedPlanets);
+
+  return {
+    civilization,
+    homeSystem,
+    homePlanetIndex,
+    regionsOfControl: [homeSystemRegion, homePlanetRegion],
+    homeSystemPopulatedPlanets,
+    systemsControlled,
+    populatedPlanets,
+  };
+}
+
+/**
+ * Roll a fresh nation as a snapshot — the destructive half of editing (requirement 4.3), and
+ * what `ARTIFACT_EDITORS` registers as this kind's roller.
+ */
+export function rollStarNationSnapshot(
+  seed: string,
+  config: StarNationGeneratorConfigRecord = {},
+): StarNationSnapshot {
+  return toStarNationSnapshot(rollStarNation(seed, config));
+}
+
+/** The seed the home system's preview is drawn with: the page's seed, and nothing drawn after it. */
+export function starNationPreviewSeed(seed: string): string {
+  return `${seed}:home-system`;
+}

--- a/src/lib/civilizations/star_nation_snapshot.test.ts
+++ b/src/lib/civilizations/star_nation_snapshot.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollStarNation } from './star_nation_roll';
+import {
+  civilizationFromStarNationSnapshot,
+  starNationFromSnapshot,
+  toStarNationSnapshot,
+} from './star_nation_snapshot';
+
+const nation = rollStarNation('snapshot-fixture', { planetCount: 4 });
+
+describe('the star nation snapshot', () => {
+  /** Requirement 7.2: lossless for everything the page shows. */
+  it('round-trips a rolled nation', () => {
+    expect(starNationFromSnapshot(toStarNationSnapshot(nation))).toEqual(nation);
+  });
+
+  it('flattens the civilization into the stored record', () => {
+    const snapshot = toStarNationSnapshot(nation);
+
+    expect(snapshot.name).toBe(nation.civilization.name);
+    expect(snapshot.technologyLevel).toBe(nation.civilization.technology_level);
+    expect(snapshot.governmentType).toEqual(nation.civilization.government_type);
+    expect(civilizationFromStarNationSnapshot(snapshot)).toEqual(nation.civilization);
+  });
+
+  it('round-trips a nation with no regions, which is an ordinary state', () => {
+    const bare = { ...nation, regionsOfControl: [] };
+
+    expect(starNationFromSnapshot(toStarNationSnapshot(bare))).toEqual(bare);
+  });
+
+  it('keeps a description a user has changed rather than recomputing it', () => {
+    const edited = toStarNationSnapshot(nation);
+    edited.description = 'They are mostly harmless.';
+
+    expect(starNationFromSnapshot(edited).civilization.description).toBe(
+      'They are mostly harmless.',
+    );
+  });
+
+  it('is free of the functions IndexedDB refuses', () => {
+    expect(() => structuredClone(toStarNationSnapshot(nation))).not.toThrow();
+  });
+
+  it('does not hand out the objects it was given', () => {
+    const snapshot = toStarNationSnapshot(nation);
+    snapshot.homeSystem.planets[0].name = 'Something else entirely';
+    snapshot.regionsOfControl[0].population = 1;
+    snapshot.governmentType.name_options.push('{name} Hegemony');
+    snapshot.homeSystem.planets.pop();
+
+    expect(nation.homeSystem.planets[0].name).not.toBe('Something else entirely');
+    expect(nation.regionsOfControl[0].population).not.toBe(1);
+    expect(nation.civilization.government_type.name_options).not.toContain('{name} Hegemony');
+    expect(nation.homeSystem.planets.length).toBe(snapshot.homeSystem.planets.length + 1);
+  });
+
+  it('does not hand a restored value the snapshot’s own objects', () => {
+    const snapshot = toStarNationSnapshot(nation);
+    const restored = starNationFromSnapshot(snapshot);
+    restored.homeSystem.stars[0].name = 'Sol';
+    restored.regionsOfControl[1].region_type.name = 'Moon';
+
+    expect(snapshot.homeSystem.stars[0].name).not.toBe('Sol');
+    expect(snapshot.regionsOfControl[1].region_type.name).not.toBe('Moon');
+  });
+});

--- a/src/lib/civilizations/star_nation_snapshot.ts
+++ b/src/lib/civilizations/star_nation_snapshot.ts
@@ -1,0 +1,115 @@
+/**
+ * Writing a star nation, and reading one back.
+ *
+ * The stored shape is the flat one docs/readiness-factions.md drew: the civilization's fields at
+ * the top level, the regions of control beside them, and the home system embedded. The live value
+ * nests the civilization, because that is the type the rest of this library generates and
+ * describes; the codec's work is the flattening and nothing else. Nothing is recomputed on the
+ * way back — a description the user rewrote comes back as written (requirement 4.2).
+ *
+ * Every copy is deep. The snapshot must not share its bodies, its regions or its name option list
+ * with the value it was made from, or an edit to one would show up in the other.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+import type { AstronomicalBody, StarSystem } from '$lib/astronomical_bodies';
+
+import type { Civilization, EconomyType, GovernmentType, Military } from './civilizations';
+import type { RegionOfControl } from './regions_of_control';
+import type { StarNation } from './star_nation_types';
+
+/** A star system as stored: the bodies' parameters, which is what the preview renderer takes. */
+export type StoredStarSystem = StarSystem;
+
+/** A star nation as it is stored. Flat, as the design's diagram declared it. */
+export type StarNationSnapshot = {
+  name: string;
+  description: string;
+  population: number;
+  technologyLevel: number;
+  governmentType: GovernmentType;
+  economyType: EconomyType;
+  military: Military;
+  regionsOfControl: RegionOfControl[];
+  homeSystem: StoredStarSystem;
+  homePlanetIndex: number;
+  homeSystemPopulatedPlanets: number;
+  systemsControlled: number;
+  populatedPlanets: number;
+};
+
+function copyBody(body: AstronomicalBody): AstronomicalBody {
+  return { ...body };
+}
+
+function copyStarSystem(system: StarSystem): StarSystem {
+  return {
+    ...system,
+    stars: system.stars.map(copyBody),
+    planets: system.planets.map(copyBody),
+  };
+}
+
+function copyRegion(region: RegionOfControl): RegionOfControl {
+  return { ...region, region_type: { ...region.region_type } };
+}
+
+function copyGovernmentType(type: GovernmentType): GovernmentType {
+  return { ...type, name_options: [...type.name_options] };
+}
+
+export function toStarNationSnapshot(nation: StarNation): StarNationSnapshot {
+  const civilization = nation.civilization;
+  return {
+    name: civilization.name,
+    description: civilization.description,
+    population: civilization.population,
+    technologyLevel: civilization.technology_level,
+    governmentType: copyGovernmentType(civilization.government_type),
+    economyType: { ...civilization.economy_type },
+    military: { ...civilization.military },
+    regionsOfControl: nation.regionsOfControl.map(copyRegion),
+    homeSystem: copyStarSystem(nation.homeSystem),
+    homePlanetIndex: nation.homePlanetIndex,
+    homeSystemPopulatedPlanets: nation.homeSystemPopulatedPlanets,
+    systemsControlled: nation.systemsControlled,
+    populatedPlanets: nation.populatedPlanets,
+  };
+}
+
+/** The civilization a stored nation describes, as the rest of this library expects it. */
+export function civilizationFromStarNationSnapshot(snapshot: StarNationSnapshot): Civilization {
+  return {
+    name: snapshot.name,
+    description: snapshot.description,
+    population: snapshot.population,
+    technology_level: snapshot.technologyLevel,
+    government_type: copyGovernmentType(snapshot.governmentType),
+    economy_type: { ...snapshot.economyType },
+    military: { ...snapshot.military },
+  };
+}
+
+/** A stored nation back into the value the library works with. */
+export function starNationFromSnapshot(snapshot: StarNationSnapshot): StarNation {
+  return {
+    civilization: civilizationFromStarNationSnapshot(snapshot),
+    homeSystem: copyStarSystem(snapshot.homeSystem),
+    homePlanetIndex: snapshot.homePlanetIndex,
+    regionsOfControl: snapshot.regionsOfControl.map(copyRegion),
+    homeSystemPopulatedPlanets: snapshot.homeSystemPopulatedPlanets,
+    systemsControlled: snapshot.systemsControlled,
+    populatedPlanets: snapshot.populatedPlanets,
+  };
+}
+
+/**
+ * The codec's reading half, with the signature the registry hands it.
+ *
+ * The RNG is unused, and that is the correct amount of use for it: a nation is finished when it is
+ * stored, and drawing anything from a seed on the way back would be regenerating over the user's
+ * edits.
+ */
+export function starNationFromSnapshotWithRng(snapshot: StarNationSnapshot, _rng: RNG): StarNation {
+  return starNationFromSnapshot(snapshot);
+}

--- a/src/lib/civilizations/star_nation_types.ts
+++ b/src/lib/civilizations/star_nation_types.ts
@@ -1,0 +1,34 @@
+/**
+ * A star nation: a spacefaring civilization, the territory it holds, and the star system it calls
+ * home.
+ *
+ * This is the value `/star-nation` generates, declared here rather than left as a handful of
+ * component variables so that it can be rolled, stored, edited and printed by modules that never
+ * see the page. Everything in it is plain data: the star system's bodies are the parameters the
+ * preview renderer takes, never the image it draws (docs/readiness-factions.md, decision 5).
+ */
+
+import type { StarSystem } from '$lib/astronomical_bodies';
+
+import type { Civilization } from './civilizations';
+import type { RegionOfControl } from './regions_of_control';
+
+export type StarNation = {
+  civilization: Civilization;
+  /** The system the nation grew up in. Embedded, because there is no `star-system` kind yet. */
+  homeSystem: StarSystem;
+  /** Which of the home system's planets is the homeworld, by position from the star. */
+  homePlanetIndex: number;
+  /**
+   * The territory the nation holds, as the generator draws it: the home system and the home
+   * planet, each a region typed by its own scale. Found by region type rather than by position,
+   * so a payload with one missing still reads.
+   */
+  regionsOfControl: RegionOfControl[];
+  /** How many of the home system's planets are populated. */
+  homeSystemPopulatedPlanets: number;
+  /** How many star systems the nation controls, the home system included. */
+  systemsControlled: number;
+  /** How many populated planets the nation has across every system it controls. */
+  populatedPlanets: number;
+};

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -96,6 +96,10 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // charge art. Measured on the build: the organization kind module and everything it statically
   // imports is 204 KB across 16 chunks through this path and 19.7 MB across 35 chunks through the entry point.
   '$lib/organizations/organization_artifact_kind',
+  // The fifteenth. `$lib/civilizations`'s entry point reaches the civilization generator and the
+  // made-up-names package, and through the star nation roll module the whole of
+  // `$lib/astronomical_bodies`. The kind module holds metadata and validation only.
+  '$lib/civilizations/star_nation_artifact_kind',
 ]);
 
 /**

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -112,6 +112,7 @@ describe('TOOL_CATALOG', () => {
     // effect of editing a catalog entry for some other reason.
     const assessedHigher = [
       '/arms-manufacturer',
+      '/star-nation',
       '/character',
       '/fantasy/encounter',
       '/fantasy/family',
@@ -231,6 +232,7 @@ describe('toolsWithMaturity', () => {
       '/fantasy/religion',
       '/fantasy/settlement',
       '/heraldry',
+      '/star-nation',
       '/swn/character',
       '/unchartedworlds/character',
       '/velgarth-gifts',

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -221,12 +221,21 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     genres: ['fantasy'],
     tags: ['worldbuilding'],
   }),
+  // Assessed release-ready under #57 against docs/workshop.md, section by section. 1: catalog
+  // entry, `TOOL_PANELS`, and its own route. 2: one roll module (`star_nation_roll.ts`) that the
+  // page and a re-roll both take, with the four config helpers it calls no longer seeding from
+  // the clock. 3: kind `star-nation` with a versioned, validated payload, provenance carrying the
+  // seed and the planet count, and `SaveArtifactButton` on the route. 4: an editor over every
+  // printed field, the description kept as the user's, re-roll destructive. 5: the home system is
+  // embedded because no `star-system` kind exists yet. 6: mobile widths via the page manifest,
+  // named controls, Markdown and PDF exports, empty sentences dropped. 7: round-trip, migration
+  // and Playwright tests. 8: README and entry point. #11's reframing is additive when it lands.
   defineTool({
     path: '/star-nation',
     label: 'Star Nation',
     kind: 'generator',
     domain: 'factions',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     genres: ['scifi'],
     tags: ['organization', 'worldbuilding'],
   }),

--- a/src/lib/workshop/artifact_editors.test.ts
+++ b/src/lib/workshop/artifact_editors.test.ts
@@ -149,6 +149,31 @@ describe('the artifact editor registry', () => {
     expect(rolled.kindId).toBe('noble_house');
   });
 
+  /**
+   * Every editor's loader resolves to a component. The specifiers are written out in full for
+   * the bundler's sake, which is also how one can be mistyped without anything noticing until a
+   * user opens that kind — this is the one place they are all followed.
+   */
+  it('loads a component for every registered editor', async () => {
+    for (const kind of kindsWithArtifactEditors()) {
+      const loaded = await artifactEditorEntry(kind)!.loadEditor!();
+
+      expect(loaded.default, kind).toBeDefined();
+    }
+  });
+
+  it('rolls a star nation from provenance through the registered roller', async () => {
+    const roll = await artifactEditorEntry('star-nation')!.loadRoller!();
+    const rolled = roll({
+      toolPath: '/star-nation',
+      seed: 'registry-seed',
+      config: { planetCount: 4 },
+    }) as { name: string; homeSystem: { planets: unknown[] } };
+
+    expect(rolled.name).not.toBe('');
+    expect(rolled.homeSystem.planets).toHaveLength(4);
+  });
+
   it('rolls a family from provenance through the registered roller', async () => {
     const roll = await artifactEditorEntry('family')!.loadRoller!();
     const rolled = roll({

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -159,6 +159,16 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         rollEncounterSnapshot(provenance.seed, readEncounterGeneratorConfig(provenance.config));
     },
   },
+  'star-nation': {
+    loadEditor: () => import('$components/factions/StarNationArtifactEditor.svelte'),
+    /** The page's one control besides the seed, read back through the roll module's own reader. */
+    loadRoller: async () => {
+      const { readStarNationGeneratorConfig, rollStarNationSnapshot } =
+        await import('$lib/civilizations/star_nation_roll.js');
+      return (provenance) =>
+        rollStarNationSnapshot(provenance.seed, readStarNationGeneratorConfig(provenance.config));
+    },
+  },
   'arms-manufacturer': {
     loadEditor: () => import('$components/factions/ArmsManufacturerArtifactEditor.svelte'),
     /**

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -25,6 +25,7 @@ describe('artifact kind catalog', () => {
       'encounter',
       'family',
       'organization',
+      'star-nation',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -19,6 +19,7 @@ import { adndCharacterArtifactKind } from '$lib/adnd/adnd_character_artifact_kin
 import { characterArtifactKind } from '$lib/characters/character_artifact_kind';
 import { armsManufacturerArtifactKind } from '$lib/arms_manufacturer/arms_manufacturer_artifact_kind';
 import { organizationArtifactKind } from '$lib/organizations/organization_artifact_kind';
+import { starNationArtifactKind } from '$lib/civilizations/star_nation_artifact_kind';
 import { familyArtifactKind } from '$lib/families/family_artifact_kind';
 import { encounterArtifactKind } from '$lib/encounters/encounter_artifact_kind';
 import { cultureArtifactKind } from '$lib/culture/culture_artifact_kind';
@@ -55,6 +56,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, encounterArtifactKind);
   registerArtifactKind(registry, familyArtifactKind);
   registerArtifactKind(registry, organizationArtifactKind);
+  registerArtifactKind(registry, starNationArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Closes #57. Takes `/star-nation` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the arms manufacturer (#53) and organization (#56) worked examples.

## What changed

- **Kind `star-nation`** in `$lib/civilizations`: `star_nation_roll.ts` (the one path from a seed, with a `planetCount` config record), `star_nation_snapshot.ts` (flat payload, version 1, deep copies both ways), `star_nation_artifact_kind.ts` (validator over every field the renderer and the prose read; migration rejects, as there is only one version), `star_nation_editing.ts` (pure field edits; the description is the user's and is rebuilt only on an explicit command), `star_nation_presentation.ts` (document model → Markdown and PDF, empty sentences dropped).
- **`StarNationGenerator.svelte`** now rolls through the library, saves with `SaveArtifactButton` (seed + planet count as provenance), exports Markdown and PDF, and draws the preview from a seed derived from the page's rather than one drawn after the roll.
- **`StarNationArtifactEditor.svelte`** covers every printed field: name, description, government and economy (selects over the tables), military quality, technology level, population, territory counts, region populations, home system name, home planet, and planet names.
- **The clock leaves the config helpers this tool calls.** `getDefaultCivilizationGenerationConfig`, `getDefaultRegionOfControlGenerationConfig`, `getDefaultStarSystemGeneratorConfig`, `getDefaultStarGeneratorConfig` and `getDefaultPlanetGenerationConfig` take a required RNG (decision 1 of `docs/tool-readiness.md`). Planet and star system generators updated; `getDefaultMoonGenerationConfig` is left for the planet tool's own item.
- Registrations: `ARTIFACT_KINDS`, `ARTIFACT_EDITORS`, the deep-import allowlist, catalog maturity with the section-by-section comment, and the maturity e2e list.
- Docs: `docs/readiness-factions.md` gains an "As built" section for #57, including why it landed with #11 still open (#11 is additive by its own scope, so the forced migration is a version-2 step adding optional fields).

## Verification

- `npm run verify` green.
- `npm run verify:all`: 518 passed; the two failures are `preview_goldens.spec.ts` `star-webgl-full` and `system-webgl-full`, which the spec itself documents as expected to differ on a developer GPU (baselines are SwiftShader renders from CI). The rendered star is the same one the baseline names, and nothing above the previews on those routes moved.
- New `e2e/star_nation.spec.ts` (generate → save → reopen → edit → reload; figure edits leave the description alone until asked; exports carry the nation's name; same seed reproduces the nation and the preview) and the mobile-width page checks for `/star-nation` pass after the final build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TABkHxHafpiecgCRe2VEVY
