### PR TITLE
Take the dungeon generator to Release-ready

### DIFF
--- a/docs/readiness-locations.md
+++ b/docs/readiness-locations.md
@@ -147,6 +147,45 @@ interactive, render, room and theme subdirectories drawing through Three.js and 
 - **`verify:all` more than once.** This tool touches rendering, and no Playwright suite runs against
   a pull request.
 
+**As built.** Everything above landed as written, with three corrections and one measurement.
+
+- **The dungeon does not draw through Three.js or GLSL, and never did.** Both this document and
+  [#59](https://github.com/ironarachne/ironarachne/issues/59) say it does. Nothing under
+  `src/lib/dungeon` imports `three`, the repository contains no `.glsl` file at all, and the plan is
+  drawn by `render/classic_module_map.ts` onto a 2D canvas. `three` belongs to `$lib/renderers`,
+  which draws the astronomical previews. So 2.5 binds far more mildly here than the design feared:
+  the canvas carries an accessible name and fallback content, the room list under it is the whole
+  dungeon in text, and the Markdown and PDF exports carry the same. There was no WebGL path to
+  degrade from.
+- **The library's determinism defect was in the page, not in the library.** `generateDungeon` was
+  already a pure function of its config — one of the few generators in the pass that was. What was
+  wrong is that the thirty-line environment step feeding it lived in `DungeonGenerator.svelte`,
+  where a re-roll from provenance could not reach it. `dungeon_roll.ts` holds it now, in the order
+  the page drew it, and a golden diff over forty seeds confirms the module reproduces exactly what
+  the page produced before it existed. The five `getDefault*Config` helpers in `$lib/environment`
+  still default their RNG to the clock; every one of them is overwritten on this path before it is
+  used, so the fix stays with [#60](https://github.com/ironarachne/ironarachne/issues/60), which
+  owns them.
+- **5.1 binds on `encounter` only.** `environment` has no kind yet, so the second half does not
+  bind. A saved encounter goes in the room the stairs come up in — a place on the map a referee can
+  point at, where "room 23 of 44" would be a search — and the room's name is re-derived so it stops
+  reading as abandoned. The reference sits beside the payload, so a re-roll does not wear it, which
+  is the position `$lib/organizations` already takes.
+
+**The size measurement this document left open.** A live dungeon runs from 1.2 MB at 20×20 to
+48 MB at the 120×120 maximum, almost all of it combatants embedding a whole `Species` each. As a
+snapshot the same four sizes are 64 KB, 304 KB, 700 KB and 2.7 MB: the stored vocabulary is what
+makes this storable, and the ratio is pinned by a test. So the answer to "tens or hundreds of
+kilobytes" is hundreds at the default and low megabytes at the extreme — nothing about the shape
+changes, and the page now says what saving one will cost before it is saved.
+
+**Editing.** The editor is bespoke and room-shaped as designed. Retheming relabels the dungeon and
+leaves every room as it was rolled, which is 4.2 rather than a shortcut: silently re-rolling forty
+rooms' purposes because a user changed a label would be regenerating over their work, and the
+editor says so in as many words. The geometry — positions, room shapes, door and key coordinates —
+is shown and not edited, because `keys.ts` guarantees a key sits in a zone reachable before the
+door it opens and a text box over a coordinate would break that quietly.
+
 ## Domain model
 
 ### The plain payloads

--- a/e2e/dungeon.spec.ts
+++ b/e2e/dungeon.spec.ts
@@ -1,0 +1,201 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `dungeon` kind: generate, save, reopen, edit.
+ *
+ * This is the half no unit test can settle. The library tests prove a dungeon round-trips through
+ * the codec and that each editing function changes one field without disturbing its neighbours;
+ * what they cannot prove is that a referee can press Generate, keep the result, come back to it in
+ * a different page, change a room, and still have the dungeon they saved. Every step of that
+ * crosses a boundary the unit tests stub out — the artifact store, IndexedDB, the editor registry,
+ * and a page reload — and this is the largest payload the store has ever been asked to hold.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+
+const DUNGEON_TITLE = 'Dungeon Generator | Iron Arachne';
+
+/**
+ * A small map, set before every generate in these tests.
+ *
+ * The page defaults to 40×60, which rolls forty-odd rooms with an encounter in half of them — a
+ * quarter-megabyte payload and a very long editor. Nothing here is testing size, so the tests take
+ * the smallest map the page offers and spend their time on the round trip instead.
+ */
+async function useASmallMap(page: Page): Promise<void> {
+  await page.getByLabel('Map width').fill('20');
+  await page.getByLabel('Map height').fill('20');
+}
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool on this page has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+/** The first room's own fields, which every dungeon has at least one of. */
+const firstRoomName = (
+  panel: ReturnType<typeof openInWorkshop> extends Promise<infer T> ? T : never,
+) => panel.getByRole('textbox', { name: /^Room \S+ name$/ }).first();
+
+test.describe('a dungeon', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'The Northern Marches');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/fantasy/dungeon', { title: DUNGEON_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a dungeon on screen before anything is
+    // pressed; the small map is rolled deliberately over the top of it.
+    await expect(page.locator('.room').first()).toBeVisible();
+    await useASmallMap(page);
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    await expect(page.locator('.room').first()).toBeVisible();
+
+    await saveAs(page, 'The Barrow of Ash');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'The Barrow of Ash');
+
+    // Typed rather than filled: the point is that the editor's own binding carries keystrokes
+    // through to the snapshot it announces. The value is one no roll produces.
+    const roomName = firstRoomName(panel);
+    await roomName.fill('');
+    await roomName.pressSequentially('The Cold Gate');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'The Barrow of Ash');
+    await expect(firstRoomName(reopened)).toHaveValue('The Cold Gate');
+  });
+
+  test('rethemes without re-rolling the rooms it already has', async ({ page }) => {
+    // Requirement 4.2: the edited payload is authoritative. Retheming relabels the dungeon; the
+    // rooms a referee has already read stay exactly as they were.
+    await visitRoute(page, '/fantasy/dungeon', { title: DUNGEON_TITLE });
+    await useASmallMap(page);
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    await saveAs(page, 'The Sunken Hold');
+
+    const panel = await openInWorkshop(page, 'The Sunken Hold');
+    const roomName = await firstRoomName(panel).inputValue();
+
+    await panel.getByLabel('Blueprint').selectOption('Arcane Library');
+    await expect(firstRoomName(panel)).toHaveValue(roomName);
+  });
+
+  test('downloads a dungeon a referee can take to the table', async ({ page }) => {
+    // Requirement 6.3, and the first text exports this tool has ever had — it could produce a
+    // picture of the map and nothing a referee could read from.
+    await visitRoute(page, '/fantasy/dungeon', { title: DUNGEON_TITLE });
+    await useASmallMap(page);
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const firstRoom = await page.locator('.room').first().locator('h3').innerText();
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const markdownFile = await markdown;
+    expect(markdownFile.suggestedFilename()).toMatch(/\.md$/);
+    const contents = await new Response(await markdownFile.createReadStream()).text();
+    // The heading on the page reads "Name (room 3)"; the export heads the same room the same way.
+    expect(contents.toLowerCase()).toContain(firstRoom.split('(')[0].trim().toLowerCase());
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/\.pdf$/);
+  });
+
+  test('reproduces the same dungeon from the same seed', async ({ page }) => {
+    // Requirement 2.2. The library was already a pure function of its config; the environment step
+    // that fed it lived in the component, which is what `dungeon_roll.ts` took over.
+    await visitRoute(page, '/fantasy/dungeon', { title: DUNGEON_TITLE });
+    await useASmallMap(page);
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const rooms = page.locator('.room');
+    const first = await rooms.first().innerText();
+    const count = await rooms.count();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await rooms.count()).toEqual(count);
+    expect(await rooms.first().innerText()).toEqual(first);
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await rooms.first().innerText()).not.toEqual(first);
+  });
+
+  test('says what keeping a dungeon will cost before it is kept', async ({ page }) => {
+    // The measurement decision 7 of docs/tool-readiness.md asked this issue to take, reaching the
+    // user: this is the only payload on the site that can run to megabytes.
+    await visitRoute(page, '/fantasy/dungeon', { title: DUNGEON_TITLE });
+    await useASmallMap(page);
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    await expect(page.locator('.stored-size')).toContainText(/\d+(\.\d+)? (KB|MB)/);
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -43,6 +43,7 @@ const SILENT_TOOL_PAGES = [
   { path: '/arms-manufacturer', title: 'Arms Manufacturer Generator | Iron Arachne' },
   { path: '/star-nation', title: 'Star Nation Generator | Iron Arachne' },
   { path: '/chop-shop', title: 'Chop Shop Generator | Iron Arachne' },
+  { path: '/fantasy/dungeon', title: 'Dungeon Generator | Iron Arachne' },
   { path: '/fantasy/encounter', title: 'Encounter | Iron Arachne' },
   { path: '/fantasy/family', title: 'Fantasy Family Generator | Iron Arachne' },
   { path: '/fantasy/organization', title: 'Organization Generator | Iron Arachne' },

--- a/src/components/locations/DungeonArtifactEditor.svelte
+++ b/src/components/locations/DungeonArtifactEditor.svelte
@@ -1,0 +1,386 @@
+<script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import { describeEncounterMob } from '$lib/encounters';
+  import {
+    BLUEPRINTS,
+    removeRoomEncounter,
+    removeRoomMob,
+    removeRoomTreasureItem,
+    setDoorDescription,
+    setDungeonBlueprint,
+    setDungeonName,
+    setKeyDescription,
+    setRoomDescription,
+    setRoomEncounterDescription,
+    setRoomEncounterName,
+    setRoomMobName,
+    setRoomName,
+    setRoomPurpose,
+    setRoomTreasureItemName,
+    validateDungeonSnapshot,
+    type DungeonSnapshot,
+  } from '$lib/dungeon';
+
+  /**
+   * The editing view for a saved dungeon.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it,
+   * so what is here is the dungeon's name, its blueprint, one section per room, and the doors and
+   * keys.
+   *
+   * A dungeon is a structure rather than a flat record, which is why this is a bespoke editor and
+   * not the declared field editor of decision 5 in docs/tool-readiness.md: rooms repeat, each one
+   * carries an encounter that itself carries groups of combatants, and no descriptor language
+   * short of a framework describes that.
+   *
+   * **The geometry is not here, and that is deliberate.** Where a room sits, what shape it is, and
+   * where the doors and keys physically lie are what make the map drawable and the keys reachable
+   * — the library guarantees a key is placed in a zone reachable before the door it opens — so
+   * they are shown and not edited. Everything a referee reads aloud is editable.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps this editor from rendering fields over
+   * something that is not a dungeon.
+   */
+  const accepted = $derived(validateDungeonSnapshot(snapshot));
+  const dungeon = $derived<DungeonSnapshot | undefined>(accepted.ok ? accepted.value : undefined);
+
+  const blueprintNames = BLUEPRINTS.map((blueprint) => blueprint.name);
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: DungeonSnapshot) => DungeonSnapshot): void {
+    if (dungeon === undefined) {
+      return;
+    }
+    onChange(change(dungeon));
+  }
+</script>
+
+{#if dungeon === undefined}
+  <Notice tone="danger">
+    These contents are stored as a dungeon but do not read as one, so there is nothing safe to edit
+    here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="dungeon-editor">
+    <!-- Qualified as "Dungeon name" rather than "Name": the panel above already has a field
+         labelled "Name" that renames the artifact, and two fields with the same accessible name in
+         one region is the 6.2 failure. -->
+    <div class="input-group input-group--inline">
+      <label for="{uid}-name">Dungeon name</label>
+      <input
+        id="{uid}-name"
+        type="text"
+        value={dungeon.name}
+        oninput={(event) => edit((current) => setDungeonName(current, event.currentTarget.value))}
+        autocomplete="off"
+      />
+    </div>
+
+    <div class="input-group input-group--inline">
+      <label for="{uid}-blueprint">Blueprint</label>
+      <select
+        id="{uid}-blueprint"
+        value={dungeon.theme.blueprint.name}
+        onchange={(event) =>
+          edit((current) => setDungeonBlueprint(current, event.currentTarget.value))}
+      >
+        {#each blueprintNames as name (name)}
+          <option value={name}>{name}</option>
+        {/each}
+      </select>
+    </div>
+    <p class="dungeon-editor__note">
+      Changing the blueprint relabels this dungeon and leaves every room as it was. Re-roll to get
+      rooms that match a new blueprint — which discards these edits.
+    </p>
+
+    {#if dungeon.rooms.length === 0}
+      <!-- A dungeon with nothing in it is an ordinary state, not a fault: the generator can pack
+           no rooms at a low density, and a user may have emptied the ones there were. -->
+      <p class="dungeon-editor__note">No rooms in this dungeon.</p>
+    {/if}
+
+    <!-- Keyed by position rather than by name or id: two rooms may read the same while one is
+         being typed, and a key that changed as the user typed would lose focus on every
+         keystroke. -->
+    {#each dungeon.rooms as room, roomIndex (roomIndex)}
+      <fieldset>
+        <legend>Room {room.id}</legend>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-room-{roomIndex}-name">Room {room.id} name</label>
+          <input
+            id="{uid}-room-{roomIndex}-name"
+            type="text"
+            value={room.name}
+            oninput={(event) =>
+              edit((current) => setRoomName(current, roomIndex, event.currentTarget.value))}
+            autocomplete="off"
+          />
+        </div>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-room-{roomIndex}-purpose">Room {room.id} purpose</label>
+          <input
+            id="{uid}-room-{roomIndex}-purpose"
+            type="text"
+            value={room.purpose}
+            oninput={(event) =>
+              edit((current) => setRoomPurpose(current, roomIndex, event.currentTarget.value))}
+            autocomplete="off"
+          />
+        </div>
+
+        <div class="input-group">
+          <label for="{uid}-room-{roomIndex}-description">Room {room.id} description</label>
+          <textarea
+            id="{uid}-room-{roomIndex}-description"
+            rows="3"
+            value={room.description}
+            oninput={(event) =>
+              edit((current) => setRoomDescription(current, roomIndex, event.currentTarget.value))}
+          ></textarea>
+        </div>
+
+        <!-- Shown and not edited: the shape and the size are what the plan is drawn from. -->
+        <p class="dungeon-editor__note">
+          {room.primitive.style}, {room.primitive.width}×{room.primitive.height}, at
+          {room.x},{room.y}
+        </p>
+
+        {#if room.encounter}
+          <div class="input-group input-group--inline">
+            <label for="{uid}-room-{roomIndex}-encounter-name">Room {room.id} encounter name</label>
+            <input
+              id="{uid}-room-{roomIndex}-encounter-name"
+              type="text"
+              value={room.encounter.name}
+              oninput={(event) =>
+                edit((current) =>
+                  setRoomEncounterName(current, roomIndex, event.currentTarget.value),
+                )}
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="input-group">
+            <label for="{uid}-room-{roomIndex}-encounter-description">
+              Room {room.id} encounter description
+            </label>
+            <textarea
+              id="{uid}-room-{roomIndex}-encounter-description"
+              rows="2"
+              value={room.encounter.description}
+              oninput={(event) =>
+                edit((current) =>
+                  setRoomEncounterDescription(current, roomIndex, event.currentTarget.value),
+                )}
+            ></textarea>
+          </div>
+
+          {#each room.encounter.groups as group, groupIndex (groupIndex)}
+            {#each group.mobs as mob, mobIndex (mobIndex)}
+              {@const line = describeEncounterMob(mob)}
+              <div class="dungeon-editor__mob">
+                <div class="input-group input-group--inline">
+                  <!-- Qualified by room and group as well as position: a panel holds every room,
+                       and "Combatant 1 name" once per room is the same 6.2 failure as two fields
+                       called "Name". -->
+                  <label for="{uid}-room-{roomIndex}-g{groupIndex}-mob-{mobIndex}">
+                    Room {room.id} group {groupIndex + 1} combatant {mobIndex + 1} name
+                  </label>
+                  <input
+                    id="{uid}-room-{roomIndex}-g{groupIndex}-mob-{mobIndex}"
+                    type="text"
+                    value={mob.name}
+                    oninput={(event) =>
+                      edit((current) =>
+                        setRoomMobName(
+                          current,
+                          roomIndex,
+                          groupIndex,
+                          mobIndex,
+                          event.currentTarget.value,
+                        ),
+                      )}
+                    autocomplete="off"
+                  />
+                </div>
+                {#if line.kind !== ''}
+                  <span class="dungeon-editor__kind">{line.kind}</span>
+                {/if}
+                <BaseButton
+                  aria-label="Remove combatant {mobIndex + 1} from group {groupIndex +
+                    1} in room {room.id}"
+                  onclick={() =>
+                    edit((current) => removeRoomMob(current, roomIndex, groupIndex, mobIndex))}
+                >
+                  Remove
+                </BaseButton>
+              </div>
+            {/each}
+          {/each}
+
+          <BaseButton
+            aria-label="Empty room {room.id} of its encounter"
+            onclick={() => edit((current) => removeRoomEncounter(current, roomIndex))}
+          >
+            Remove encounter from room {room.id}
+          </BaseButton>
+        {/if}
+
+        {#if room.treasure && room.treasure.length > 0}
+          {#each room.treasure as item, itemIndex (itemIndex)}
+            <div class="dungeon-editor__mob">
+              <div class="input-group input-group--inline">
+                <label for="{uid}-room-{roomIndex}-item-{itemIndex}">
+                  Room {room.id} treasure {itemIndex + 1} name
+                </label>
+                <input
+                  id="{uid}-room-{roomIndex}-item-{itemIndex}"
+                  type="text"
+                  value={item.name}
+                  oninput={(event) =>
+                    edit((current) =>
+                      setRoomTreasureItemName(
+                        current,
+                        roomIndex,
+                        itemIndex,
+                        event.currentTarget.value,
+                      ),
+                    )}
+                  autocomplete="off"
+                />
+              </div>
+              <BaseButton
+                aria-label="Remove treasure {itemIndex + 1} from room {room.id}"
+                onclick={() =>
+                  edit((current) => removeRoomTreasureItem(current, roomIndex, itemIndex))}
+              >
+                Remove
+              </BaseButton>
+            </div>
+          {/each}
+        {/if}
+      </fieldset>
+    {/each}
+
+    {#if dungeon.doors.length > 0}
+      <fieldset>
+        <legend>Doors</legend>
+        {#each dungeon.doors as door, doorIndex (doorIndex)}
+          <div class="input-group input-group--inline">
+            <label for="{uid}-door-{doorIndex}">Door {doorIndex + 1} description</label>
+            <input
+              id="{uid}-door-{doorIndex}"
+              type="text"
+              value={door.description}
+              oninput={(event) =>
+                edit((current) =>
+                  setDoorDescription(current, doorIndex, event.currentTarget.value),
+                )}
+              autocomplete="off"
+            />
+          </div>
+        {/each}
+      </fieldset>
+    {/if}
+
+    {#if dungeon.keys.length > 0}
+      <fieldset>
+        <legend>Keys</legend>
+        {#each dungeon.keys as key, keyIndex (keyIndex)}
+          <div class="input-group input-group--inline">
+            <label for="{uid}-key-{keyIndex}">Key {keyIndex + 1} description</label>
+            <input
+              id="{uid}-key-{keyIndex}"
+              type="text"
+              value={key.description}
+              oninput={(event) =>
+                edit((current) => setKeyDescription(current, keyIndex, event.currentTarget.value))}
+              autocomplete="off"
+            />
+          </div>
+        {/each}
+      </fieldset>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .dungeon-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+  }
+
+  .dungeon-editor fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s3);
+    align-items: flex-start;
+    margin: 0;
+    /* No border and no radius, matching the encounter and character editors: a fieldset inside an
+       editor panel was a box inside a box, and the legend and the spacing already group these. */
+    padding: var(--s4) 0;
+    min-width: 0;
+  }
+
+  .dungeon-editor legend {
+    padding: 0 var(--s3);
+    color: var(--gold);
+    font-size: var(--t-micro-size);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .dungeon-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .dungeon-editor input[type='text'],
+  .dungeon-editor textarea,
+  .dungeon-editor select {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+
+  .dungeon-editor__mob {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--s3);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .dungeon-editor__kind {
+    font-size: var(--t-small-size);
+    color: color-mix(in srgb, currentColor 70%, transparent);
+  }
+
+  .dungeon-editor__note {
+    font-size: var(--t-small-size);
+    font-style: italic;
+    margin: 0;
+  }
+</style>

--- a/src/components/locations/DungeonGenerator.svelte
+++ b/src/components/locations/DungeonGenerator.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Stat from '$components/common/Stat.svelte';
   import StatBlock from '$components/common/StatBlock.svelte';
-  import * as RNG from '@ironarachne/rng';
+  import { RNG } from '@ironarachne/rng';
   import * as Words from '@ironarachne/words';
   import { onMount, tick } from 'svelte';
   import { Currency } from '$lib/currency';
@@ -12,41 +12,92 @@
   import SelectField from '$components/common/SelectField.svelte';
   import NumberField from '$components/common/NumberField.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
+  import SavedArtifactPicker from '$components/common/SavedArtifactPicker.svelte';
+  import type { ArtifactReference } from '$lib/artifacts';
   import type { Character } from '$lib/characters';
   import type { Creature } from '$lib/creatures';
-  import {
-    generateDungeon,
-    type EngineeredDungeon,
-    BLUEPRINTS,
-    renderClassicModuleMapToCanvas,
-  } from '$lib/dungeon';
-  import {
-    generate as generateEnvironment,
-    getDefaultConfig as getDefaultEnvironmentConfig,
-    describeTerrain,
-    BiomeClassifications,
-    Biomes,
-  } from '$lib/environment';
+  import { ENCOUNTER_ARTIFACT_KIND, type Encounter } from '$lib/encounters';
+  import { downloadTextFile } from '$lib/download';
+  import { downloadTextPdf } from '$lib/pdf';
+  import * as Dungeons from '$lib/dungeon';
 
-  const blueprintOptions = BLUEPRINTS.map((b) => b.name);
-  const environmentOptions = BiomeClassifications.getAll()
-    .filter((b) => !b.isAquatic)
-    .map((b) => b.name);
+  const TOOL_PATH = '/fantasy/dungeon';
 
-  let seed = $state('');
+  /** The page's select value that means "let the seed choose". */
+  const RANDOM = 'Random';
+
+  const blueprintOptions = Dungeons.dungeonBlueprintNames();
+  const biomeOptions = Dungeons.dungeonBiomeNames();
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. It used to be rebuilt from `Date.now()`
+   * on every press to take one string from it, which is the shape every generator in the readiness
+   * pass has been corrected to.
+   */
+  const rng = new RNG(Date.now().toString());
+  let seed = $state(rng.randomString(13));
   let lockSeed = $state(false);
-  let mapWidth = $state(40);
-  let mapHeight = $state(60);
-  let blueprintName = $state('Random');
-  let environmentName = $state('Random');
-  let encounterChancePerRoom = $state(0.4);
-  let treasureChancePerRoom = $state(0.3);
+
+  let mapWidth = $state(Dungeons.DUNGEON_DEFAULT_WIDTH);
+  let mapHeight = $state(Dungeons.DUNGEON_DEFAULT_HEIGHT);
+  let blueprintName = $state(RANDOM);
+  let biomeName = $state(RANDOM);
+  let encounterChancePerRoom = $state(Dungeons.DUNGEON_DEFAULT_ENCOUNTER_CHANCE);
+  let treasureChancePerRoom = $state(Dungeons.DUNGEON_DEFAULT_TREASURE_CHANCE);
   let fullSize = $state(false);
 
-  let mapCanvas = $state<HTMLCanvasElement | undefined>(undefined);
-  let dungeon = $state<EngineeredDungeon | undefined>(undefined);
+  /** The saved encounter to put at the foot of the stairs, when the user has offered one (5.1). */
+  let useReferencedEncounter = $state(false);
+  let referencedEncounter = $state<Encounter | undefined>(undefined);
+  let encounterReference = $state<ArtifactReference | undefined>(undefined);
 
-  function getKeyDescription(keyId: string, doorId: string, d: EngineeredDungeon): string {
+  let mapCanvas = $state<HTMLCanvasElement | undefined>(undefined);
+
+  /**
+   * The rolled dungeon.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every object in the value
+   * in a Proxy, and `structuredClone` — what IndexedDB stores with — refuses a Proxy outright, so
+   * saving fails with `could not be cloned`. A dungeon is the largest value on the site to wrap,
+   * so this is also the difference between a page that renders and one that crawls.
+   */
+  let dungeon = $state.raw<Dungeons.EngineeredDungeon | undefined>(undefined);
+
+  /** What the roll records about itself: the page's six controls, as provenance (3.6). */
+  const generatorConfig = $derived<Dungeons.DungeonGeneratorConfigRecord>({
+    width: mapWidth,
+    height: mapHeight,
+    ...(blueprintName === RANDOM ? {} : { blueprintName }),
+    ...(biomeName === RANDOM ? {} : { biomeName }),
+    encounterChancePerRoom,
+    treasureChancePerRoom,
+  });
+
+  const dungeonSnapshot = $derived(
+    dungeon === undefined ? null : Dungeons.toDungeonSnapshot(dungeon),
+  );
+
+  /**
+   * Roughly what keeping this dungeon costs, shown because it is the one payload on the site that
+   * reaches megabytes: a 120×120 map with an encounter in every room is a storage decision, and a
+   * user making one is entitled to know before the browser tells them it has no room left.
+   */
+  const storedSize = $derived(
+    dungeonSnapshot === null
+      ? ''
+      : Dungeons.describeDungeonSize(Dungeons.dungeonSnapshotByteSize(dungeonSnapshot)),
+  );
+
+  const references = $derived(encounterReference === undefined ? [] : [encounterReference]);
+
+  const defaultArtifactName = $derived(
+    dungeon === undefined ? '' : Dungeons.dungeonDisplayName(dungeon),
+  );
+
+  function getKeyDescription(keyId: string, doorId: string, d: Dungeons.EngineeredDungeon): string {
     const door = d.doors.find((doObj) => doObj.id === doorId);
     if (!door) {
       return 'It unlocks a door elsewhere in the dungeon.';
@@ -93,86 +144,52 @@
     a.click();
   }
 
+  function exportMarkdown() {
+    if (dungeonSnapshot === null) {
+      return;
+    }
+    downloadTextFile(
+      Dungeons.dungeonToMarkdown(dungeonSnapshot),
+      `${Dungeons.dungeonFileStem(dungeonSnapshot)}.md`,
+      'text/markdown',
+    );
+  }
+
+  async function exportPdf() {
+    if (dungeonSnapshot === null) {
+      return;
+    }
+    await downloadTextPdf(
+      Dungeons.dungeonDisplayName(dungeonSnapshot),
+      Dungeons.dungeonToText(dungeonSnapshot),
+      `${Dungeons.dungeonFileStem(dungeonSnapshot)}.pdf`,
+    );
+  }
+
+  /**
+   * Draws the plan, when there is a canvas to draw it on.
+   *
+   * A missing canvas is an ordinary state rather than a failure (2.5): the room list below is the
+   * dungeon, and the plan is a picture of it. Nothing here throws, and nothing below depends on it
+   * having run.
+   */
   async function triggerRender() {
     await tick();
     if (mapCanvas && dungeon) {
-      renderClassicModuleMapToCanvas(dungeon, mapCanvas);
+      Dungeons.renderClassicModuleMapToCanvas(dungeon, mapCanvas);
     }
   }
 
   async function generate() {
-    const rng = new RNG.RNG(Date.now().toString());
-    if (!lockSeed || seed === '') {
+    if (!lockSeed) {
       seed = rng.randomString(13);
     }
-    const dungeonRng = new RNG.RNG(seed);
-
-    let actualBlueprintName = blueprintName;
-    if (actualBlueprintName === 'Random') {
-      actualBlueprintName = dungeonRng.item(blueprintOptions);
-    }
-
-    let actualEnvironmentName = environmentName;
-    if (actualEnvironmentName === 'Random') {
-      actualEnvironmentName = dungeonRng.item(environmentOptions);
-    }
-
-    const environmentConfig = getDefaultEnvironmentConfig();
-    environmentConfig.rng = new RNG.RNG(`${seed}-env`);
-    environmentConfig.latitude = environmentConfig.rng.float(-70, 70);
-    environmentConfig.elevation = environmentConfig.rng.float(0.1, 0.8);
-    environmentConfig.waterDirection = [
-      environmentConfig.rng.float(-20, 20),
-      environmentConfig.rng.float(-20, 20),
-      0,
-    ];
-    environmentConfig.current = [
-      environmentConfig.rng.float(-1, 1),
-      environmentConfig.rng.float(-1, 1),
-      0,
-    ];
-    environmentConfig.terrainVector = [
-      environmentConfig.rng.float(-0.5, 0.5),
-      environmentConfig.rng.float(-0.5, 0.5),
-      0,
-    ];
-
-    let environment = generateEnvironment(environmentConfig);
-
-    if (environment.biome.name !== actualEnvironmentName) {
-      const biomeClassification = BiomeClassifications.getByName(actualEnvironmentName);
-      const forcedBiome = {
-        ...environment.biome,
-        name: biomeClassification.name,
-        features: Biomes.generateBiomeFeatures(biomeClassification, environmentConfig.rng),
-        descriptions: Biomes.generateBiomeDescriptions(biomeClassification, environmentConfig.rng),
-      };
-
-      const biomeDesc = environmentConfig.rng.item(forcedBiome.descriptions);
-      const biomeFeat = environmentConfig.rng.item(forcedBiome.features);
-      const terrainDesc = describeTerrain(environment.terrain, environmentConfig.rng);
-
-      environment = {
-        ...environment,
-        biome: forcedBiome,
-        description: `${biomeDesc} ${biomeFeat} ${environment.climate.description} ${terrainDesc}`,
-      };
-    }
-
-    dungeon = generateDungeon({
-      seed,
-      width: mapWidth,
-      height: mapHeight,
-      environment,
-      blueprintName: actualBlueprintName,
-      encounterChancePerRoom,
-      treasureChancePerRoom,
-    });
-
-    await tick();
-    if (mapCanvas) {
-      renderClassicModuleMapToCanvas(dungeon, mapCanvas);
-    }
+    const rolled = Dungeons.rollDungeon(seed, generatorConfig);
+    dungeon =
+      useReferencedEncounter && referencedEncounter !== undefined
+        ? Dungeons.withEncounterAtEntrance(rolled, referencedEncounter)
+        : rolled;
+    await triggerRender();
   }
 
   onMount(() => {
@@ -180,22 +197,34 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/dungeon" title="Dungeon Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Dungeon Generator">
   {#snippet description()}
     <p>Grid-based dungeons with themed rooms, doors, keys, encounters, and treasure.</p>
   {/snippet}
 
   <SeedControls bind:seed bind:lockSeed inline />
 
-  <NumberField id="mapWidth" label="Map width" bind:value={mapWidth} min={15} max={120} />
-  <NumberField id="mapHeight" label="Map height" bind:value={mapHeight} min={15} max={120} />
+  <NumberField
+    id="mapWidth"
+    label="Map width"
+    bind:value={mapWidth}
+    min={Dungeons.DUNGEON_MIN_DIMENSION}
+    max={Dungeons.DUNGEON_MAX_DIMENSION}
+  />
+  <NumberField
+    id="mapHeight"
+    label="Map height"
+    bind:value={mapHeight}
+    min={Dungeons.DUNGEON_MIN_DIMENSION}
+    max={Dungeons.DUNGEON_MAX_DIMENSION}
+  />
 
   <SelectField
     id="blueprint"
     label="Blueprint"
     bind:value={blueprintName}
     options={[
-      { value: 'Random', label: 'Random' },
+      { value: RANDOM, label: 'Random' },
       ...blueprintOptions.map((n) => ({ value: n, label: n })),
     ]}
   />
@@ -203,10 +232,10 @@
   <SelectField
     id="environment"
     label="Environment (Biome)"
-    bind:value={environmentName}
+    bind:value={biomeName}
     options={[
-      { value: 'Random', label: 'Random' },
-      ...environmentOptions.map((n) => ({ value: n, label: n })),
+      { value: RANDOM, label: 'Random' },
+      ...biomeOptions.map((n) => ({ value: n, label: n })),
     ]}
   />
 
@@ -227,8 +256,20 @@
     step={0.05}
   />
 
+  <SavedArtifactPicker
+    kind={ENCOUNTER_ARTIFACT_KIND}
+    role="entrance-encounter"
+    checkboxLabel="Put a saved encounter at the foot of the stairs"
+    selectLabel="Encounter"
+    bind:enabled={useReferencedEncounter}
+    bind:value={referencedEncounter}
+    bind:reference={encounterReference}
+  />
+
   <div class="actions">
     <BaseButton onclick={() => void generate()}>Generate</BaseButton>
+    <BaseButton onclick={exportMarkdown} disabled={!dungeon}>Download Markdown</BaseButton>
+    <BaseButton onclick={exportPdf} disabled={!dungeon}>Download PDF</BaseButton>
     <BaseButton onclick={() => downloadMap('image/png')} disabled={!mapCanvas || !dungeon}>
       Download PNG
     </BaseButton>
@@ -236,6 +277,20 @@
       Download JPEG
     </BaseButton>
   </div>
+
+  <SaveArtifactButton
+    kind={Dungeons.DUNGEON_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={dungeonSnapshot}
+    {seed}
+    config={generatorConfig}
+    defaultName={defaultArtifactName}
+    {references}
+  />
+
+  {#if dungeon}
+    <p class="stored-size">Saving this dungeon keeps about {storedSize} in this browser.</p>
+  {/if}
 
   <div class="input-group">
     <label class="inline-label">
@@ -259,13 +314,25 @@
     </p>
   {/if}
 
+  <!-- A named canvas with fallback content inside it, because a bare canvas is announced as
+       nothing at all (6.2). The name says what the plan shows; the fallback says where the
+       dungeon itself is, which is the room list below — what a machine with no canvas still gets
+       (2.5), and what the Markdown and PDF exports carry. -->
   <canvas
     bind:this={mapCanvas}
+    aria-label={dungeon
+      ? `Plan of ${dungeon.name}: ${dungeon.rooms.length} rooms on a ${dungeon.layout.width} by ${dungeon.layout.height} grid.`
+      : 'Dungeon plan'}
     class="dungeon-map"
     class:full-size={fullSize}
     width={fullSize && dungeon ? dungeon.layout.width * 25 : 800}
     height={fullSize && dungeon ? dungeon.layout.height * 25 : 600}
-  ></canvas>
+  >
+    <p>
+      This plan is drawn on a canvas. Every room, door, key and encounter it shows is written out
+      below, and the Markdown and PDF downloads carry the same.
+    </p>
+  </canvas>
 
   {#if dungeon}
     {#each dungeon.rooms as room (room.id)}
@@ -395,6 +462,12 @@
   .map-legend {
     font-size: 0.9rem;
     margin: 0.5rem 0 1rem;
+  }
+
+  .stored-size {
+    font: var(--t-small);
+    color: var(--ink-muted);
+    margin: var(--s3) 0 0;
   }
 
   .room-id {

--- a/src/lib/dungeon/README.md
+++ b/src/lib/dungeon/README.md
@@ -49,6 +49,45 @@ The top-level exported macro-factory. When provided a root layout size, an Envir
 4. Uses `Encounter` and `Treasure` libraries to inject native combat groupings and local loot into valid rooms depending on the themes.
 5. Emits the master `EngineeredDungeon` output.
 
+### 7. The artifact kind (library root)
+
+The six modules the readiness pass gives every Release-ready tool (docs/tool-readiness.md), sitting
+flat at the library root rather than in a subdirectory of their own — they are the library's public
+face, where the seven subsystems above are how it works inside.
+
+- **`dungeon_roll.ts`**: the one path from a seed to a dungeon, taken by the generator page and by
+  a re-roll from provenance. It owns the environment step — biome forcing, latitude, terrain
+  vectors — that used to live in `DungeonGenerator.svelte`, which is why a re-roll can now
+  reproduce what was rolled. `withEncounterAtEntrance` is the composition half: a saved encounter
+  placed in the room the stairs come up in.
+- **`dungeon_snapshot.ts`** / **`dungeon_rehydrate.ts`**: writing a dungeon for storage and reading
+  it back. The payload is the blueprint — grid, layout, rooms, doors, keys, entrances, theme — and
+  never the drawing. The two halves are split because reading rebuilds every room's encounter and
+  reaches the archetype tables and the charge art through it; writing, listing and validating reach
+  none of that.
+- **`dungeon_artifact_kind.ts`**: kind `dungeon`, payload version 1, with the validator and the
+  migration stub. Metadata and validation only; the codec is a dynamic import.
+- **`dungeon_editing.ts`**: pure snapshot-to-snapshot field edits — the dungeon's name and
+  blueprint, and per room the name, purpose, description, encounter, combatants, treasure and keys.
+  The geometry is deliberately not editable: the layout is what makes the map drawable and the key
+  placement reachable.
+- **`dungeon_presentation.ts`**: the dungeon as a document of titled sections, empty ones dropped,
+  written once as Markdown and once as plain text for the PDF.
+
+### On payload size
+
+A live `EngineeredDungeon` is very large, because every combatant in every room's encounter embeds
+a whole `Species`. Measured at four sizes: 1.2 MB at 20×20, 6.8 MB at the page's default 40×60,
+14 MB at 60×60 with encounters in most rooms, and 48 MB at the 120×120 maximum with an encounter
+and treasure in every one.
+
+The snapshot is one to two orders of magnitude smaller — 64 KB, 304 KB, 700 KB and 2.7 MB for the
+same four — because `toEncounterSnapshot` converts each mob to the stored vocabulary, which carries
+a species _name_ and rebuilds the species on read. That conversion is the reason a dungeon is
+storable at all, and `dungeon_snapshot.test.ts` pins the ratio so a change that puts a whole
+`Species` back into a payload fails there rather than in somebody's quota warning. The generator
+page shows the figure beside the save control.
+
 ## Example Usage
 
 ```typescript
@@ -71,6 +110,16 @@ const dungeon = generateDungeon({
 
 // Use dungeon.layout.grid to render your maps
 // Access dungeon.rooms[X].encounter to see spawned monsters!
+```
+
+Most callers want `rollDungeon` instead, which takes a seed and the page's own settings and builds
+the environment for you — it is the path the generator and a re-roll from provenance both take:
+
+```typescript
+import { rollDungeon, toDungeonSnapshot } from '$lib/dungeon';
+
+const dungeon = rollDungeon('seed-xyz', { width: 60, height: 60, blueprintName: 'Tomb' });
+const payload = toDungeonSnapshot(dungeon); // what the vault stores
 ```
 
 ## Testing / Visualizing in Terminal Tools

--- a/src/lib/dungeon/dungeon_artifact_kind.test.ts
+++ b/src/lib/dungeon/dungeon_artifact_kind.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DUNGEON_ARTIFACT_KIND,
+  DUNGEON_PAYLOAD_VERSION,
+  dungeonArtifactKind,
+  migrateDungeonSnapshot,
+  validateDungeonSnapshot,
+} from './dungeon_artifact_kind';
+import { rollDungeonSnapshot } from './dungeon_roll';
+import type { DungeonSnapshot } from './dungeon_snapshot';
+
+const snapshot = rollDungeonSnapshot('kind-seed', { width: 20, height: 20 });
+
+/** A copy of the good payload with one part replaced, for the rejection cases. */
+function broken(changes: Record<string, unknown>): unknown {
+  return { ...(snapshot as unknown as Record<string, unknown>), ...changes };
+}
+
+describe('the fixture this file rejects mutations of', () => {
+  it('has the rooms, doors and keys the rejection cases mutate', () => {
+    // Without this the mutation cases below pass vacuously: replacing entry zero of an empty list
+    // changes nothing, and an unchanged payload validates.
+    expect(snapshot.rooms.length).toBeGreaterThan(0);
+    expect(snapshot.doors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('the dungeon artifact kind', () => {
+  it('is registered under a stable, unqualified id', () => {
+    expect(dungeonArtifactKind.kind).toEqual(DUNGEON_ARTIFACT_KIND);
+    expect(DUNGEON_ARTIFACT_KIND).toEqual('dungeon');
+  });
+
+  it('declares the payload version it writes', () => {
+    expect(dungeonArtifactKind.payloadVersion).toEqual(DUNGEON_PAYLOAD_VERSION);
+  });
+
+  it('names a saved dungeon by its own name', () => {
+    expect(dungeonArtifactKind.nameOf(snapshot)).toEqual(snapshot.name);
+  });
+
+  it('falls back to the kind when the name has been emptied', () => {
+    expect(dungeonArtifactKind.nameOf({ ...snapshot, name: '   ' })).toEqual('Dungeon');
+  });
+
+  it('round-trips through its own codec', async () => {
+    const codec = await dungeonArtifactKind.loadCodec();
+    const back = codec.toSnapshot(codec.fromSnapshot(snapshot, undefined as never));
+    expect(back.rooms.map((room) => room.name)).toEqual(snapshot.rooms.map((room) => room.name));
+  });
+});
+
+describe('validating a stored dungeon', () => {
+  it('accepts what the generator wrote', () => {
+    const result = validateDungeonSnapshot(snapshot);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts a dungeon a user has emptied of rooms', () => {
+    // An editing decision, not a broken artifact: 3.3 asks for a well-defined empty result.
+    const result = validateDungeonSnapshot(broken({ rooms: [] }));
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects something that is not an object at all', () => {
+    const result = validateDungeonSnapshot('a dungeon');
+    expect(result).toMatchObject({ ok: false, reason: 'invalid-payload' });
+  });
+
+  it('rejects a payload with no name', () => {
+    const { name: _name, ...rest } = snapshot as unknown as Record<string, unknown>;
+    expect(validateDungeonSnapshot(rest)).toMatchObject({ ok: false });
+  });
+
+  it('rejects a theme with no blueprint', () => {
+    expect(
+      validateDungeonSnapshot(broken({ theme: { ...snapshot.theme, blueprint: undefined } })),
+    ).toMatchObject({ ok: false, reason: 'invalid-payload' });
+  });
+
+  it('rejects a grid whose tiles do not fill its dimensions', () => {
+    // The case a length check exists for: a short grid is not a smaller dungeon, it is one whose
+    // renderer reads past the end of the array.
+    const layout = {
+      ...snapshot.layout,
+      grid: { ...snapshot.layout.grid, data: snapshot.layout.grid.data.slice(0, 4) },
+    };
+    expect(validateDungeonSnapshot(broken({ layout }))).toMatchObject({ ok: false });
+  });
+
+  it('rejects a room with no description', () => {
+    const rooms = snapshot.rooms.map((room, index) =>
+      index === 0 ? { ...room, description: undefined } : room,
+    );
+    expect(validateDungeonSnapshot(broken({ rooms }))).toMatchObject({ ok: false });
+  });
+
+  it('rejects a room whose encounter is not one', () => {
+    const rooms = snapshot.rooms.map((room, index) =>
+      index === 0 ? { ...room, encounter: { name: 'wolves' } } : room,
+    );
+    expect(validateDungeonSnapshot(broken({ rooms }))).toMatchObject({ ok: false });
+  });
+
+  it('rejects a door with no state', () => {
+    const doors = snapshot.doors.map((door, index) =>
+      index === 0 ? { ...door, state: undefined } : door,
+    );
+    expect(validateDungeonSnapshot(broken({ doors }))).toMatchObject({ ok: false });
+  });
+
+  it('rejects a key that unlocks nothing', () => {
+    const keys = [{ id: 'k', x: 1, y: 1, description: 'a key' }];
+    expect(validateDungeonSnapshot(broken({ keys }))).toMatchObject({ ok: false });
+  });
+
+  it('rejects an entrance with no position', () => {
+    const entrances = [{ type: 'stairs', roomId: '0' }];
+    expect(validateDungeonSnapshot(broken({ entrances }))).toMatchObject({ ok: false });
+  });
+
+  it('rejects lists that are not lists', () => {
+    for (const field of ['rooms', 'doors', 'keys', 'entrances']) {
+      expect(validateDungeonSnapshot(broken({ [field]: 'none' }))).toMatchObject({ ok: false });
+    }
+  });
+});
+
+describe('migrating a stored dungeon (7.3)', () => {
+  it('rejects every version, because version 1 is the only shape there has been', () => {
+    // The whole of this kind's migration story today, asserted so that the day a version 2 lands
+    // this test is what has to change rather than something that silently drops a user's dungeon.
+    const result = migrateDungeonSnapshot(snapshot as unknown as DungeonSnapshot, 0);
+    expect(result).toMatchObject({ ok: false, reason: 'unsupported-version' });
+    expect(result.ok ? '' : result.message).toContain('version 0');
+  });
+});

--- a/src/lib/dungeon/dungeon_artifact_kind.ts
+++ b/src/lib/dungeon/dungeon_artifact_kind.ts
@@ -1,0 +1,295 @@
+import door from '$lib/assets/icons/set2/door.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+// Deep, and for the reason the registry's own header gives: `$lib/encounters`'s entry point
+// reaches the encounter generator and from there the species and archetype tables. This module is
+// metadata and validation only, and the registry that imports it is loaded by any page that lists
+// what a project contains.
+import { validateEncounterSnapshot } from '$lib/encounters/encounter_artifact_kind';
+
+import type { DungeonSnapshot } from './dungeon_snapshot.js';
+import type { EngineeredDungeon } from './generator/types.js';
+
+/**
+ * Stable artifact kind id. Unqualified: a dungeon is neither a game system's nor a setting's, per
+ * the kind table in docs/tool-readiness.md.
+ */
+export const DUNGEON_ARTIFACT_KIND = 'dungeon' as const;
+
+/** Version 1. The first shape a dungeon has been stored in. */
+export const DUNGEON_PAYLOAD_VERSION = 1 as const;
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isBooleanArray(value: unknown): value is boolean[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'boolean');
+}
+
+/**
+ * A grid, which is the shape everything geometric here is built on: a width, a height, and one
+ * flat array of tiles rather than nested rows.
+ *
+ * The length is checked against the dimensions rather than taken on trust. A grid whose data is
+ * short is not a smaller dungeon, it is one whose renderer reads past the end of the array and
+ * whose room shapes silently lose their last row.
+ */
+function validateGrid(value: unknown, what: string): PayloadResult<unknown> {
+  const grid = asRecord(value);
+  if (grid === null) {
+    return rejectedPayload('invalid-payload', `${what} is not an object`);
+  }
+  if (!isFiniteNumber(grid.width) || !isFiniteNumber(grid.height)) {
+    return rejectedPayload('invalid-payload', `${what} has no numeric width and height`);
+  }
+  if (!isBooleanArray(grid.data)) {
+    return rejectedPayload('invalid-payload', `${what} data is not an array of booleans`);
+  }
+  if (grid.data.length !== grid.width * grid.height) {
+    return rejectedPayload(
+      'invalid-payload',
+      `${what} holds ${grid.data.length} tiles for a ${grid.width}×${grid.height} grid`,
+    );
+  }
+  return acceptedPayload(grid);
+}
+
+function validatePlacement(value: unknown, what: string): PayloadResult<unknown> {
+  const placed = asRecord(value);
+  if (placed === null) {
+    return rejectedPayload('invalid-payload', `${what} is not an object`);
+  }
+  if (!isFiniteNumber(placed.x) || !isFiniteNumber(placed.y)) {
+    return rejectedPayload('invalid-payload', `${what} has no numeric position`);
+  }
+  const primitive = asRecord(placed.primitive);
+  if (primitive === null) {
+    return rejectedPayload('invalid-payload', `${what} has no room primitive`);
+  }
+  if (!isFiniteNumber(primitive.width) || !isFiniteNumber(primitive.height)) {
+    return rejectedPayload('invalid-payload', `${what} primitive has no numeric size`);
+  }
+  if (typeof primitive.style !== 'string') {
+    return rejectedPayload('invalid-payload', `${what} primitive has no style`);
+  }
+  return validateGrid(primitive.shape, `${what} primitive shape`);
+}
+
+/** The dungeon's theme: what it is called, where it sits, and what it was built as. */
+function validateTheme(value: unknown): PayloadResult<unknown> {
+  const theme = asRecord(value);
+  if (theme === null) {
+    return rejectedPayload('invalid-payload', 'dungeon theme is not an object');
+  }
+  if (typeof theme.name !== 'string') {
+    return rejectedPayload('invalid-payload', 'dungeon theme has no name');
+  }
+  if (asRecord(theme.environment) === null) {
+    return rejectedPayload('invalid-payload', 'dungeon theme has no environment');
+  }
+  const blueprint = asRecord(theme.blueprint);
+  if (blueprint === null) {
+    return rejectedPayload('invalid-payload', 'dungeon theme has no blueprint');
+  }
+  if (!hasStringFields(blueprint, ['name', 'description'])) {
+    return rejectedPayload('invalid-payload', 'dungeon blueprint needs a name and a description');
+  }
+  return acceptedPayload(theme);
+}
+
+function validateLayout(value: unknown): PayloadResult<unknown> {
+  const layout = asRecord(value);
+  if (layout === null) {
+    return rejectedPayload('invalid-payload', 'dungeon layout is not an object');
+  }
+  if (!isFiniteNumber(layout.width) || !isFiniteNumber(layout.height)) {
+    return rejectedPayload('invalid-payload', 'dungeon layout has no numeric size');
+  }
+  const grid = validateGrid(layout.grid, 'dungeon layout grid');
+  if (!grid.ok) {
+    return grid;
+  }
+  if (!Array.isArray(layout.rooms)) {
+    return rejectedPayload('invalid-payload', 'dungeon layout rooms is not a list');
+  }
+  const failed = layout.rooms
+    .map((room, index) => validatePlacement(room, `dungeon layout room ${index}`))
+    .find((check) => !check.ok);
+  return failed ?? acceptedPayload(layout);
+}
+
+/**
+ * One populated room: where it is, what it is called, and what is in it.
+ *
+ * A room with no encounter and no treasure is accepted, and so is a room whose name has been
+ * emptied. Both are editing decisions a user is entitled to make — 3.3 asks for a well-defined
+ * empty result, not a refusal.
+ */
+function validateRoom(value: unknown, index: number): PayloadResult<unknown> {
+  const placement = validatePlacement(value, `dungeon room ${index}`);
+  if (!placement.ok) {
+    return placement;
+  }
+  const room = asRecord(value) as Record<string, unknown>;
+  if (!hasStringFields(room, ['id', 'name', 'purpose', 'description'])) {
+    return rejectedPayload(
+      'invalid-payload',
+      `dungeon room ${index} needs an id, a name, a purpose and a description`,
+    );
+  }
+  if (room.treasure !== undefined && !Array.isArray(room.treasure)) {
+    return rejectedPayload('invalid-payload', `dungeon room ${index} treasure is not a list`);
+  }
+  return room.encounter === undefined
+    ? acceptedPayload(room)
+    : validateEncounterSnapshot(room.encounter);
+}
+
+function validateDoor(value: unknown, index: number): PayloadResult<unknown> {
+  const record = asRecord(value);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', `dungeon door ${index} is not an object`);
+  }
+  if (!hasStringFields(record, ['id', 'type', 'state', 'description'])) {
+    return rejectedPayload(
+      'invalid-payload',
+      `dungeon door ${index} needs an id, a type, a state and a description`,
+    );
+  }
+  if (!isFiniteNumber(record.x) || !isFiniteNumber(record.y)) {
+    return rejectedPayload('invalid-payload', `dungeon door ${index} has no numeric position`);
+  }
+  return acceptedPayload(record);
+}
+
+function validateKey(value: unknown, index: number): PayloadResult<unknown> {
+  const record = asRecord(value);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', `dungeon key ${index} is not an object`);
+  }
+  if (!hasStringFields(record, ['id', 'doorId', 'description'])) {
+    return rejectedPayload(
+      'invalid-payload',
+      `dungeon key ${index} needs an id, a door and a description`,
+    );
+  }
+  if (!isFiniteNumber(record.x) || !isFiniteNumber(record.y)) {
+    return rejectedPayload('invalid-payload', `dungeon key ${index} has no numeric position`);
+  }
+  return acceptedPayload(record);
+}
+
+function validateEntrance(value: unknown, index: number): PayloadResult<unknown> {
+  const record = asRecord(value);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', `dungeon entrance ${index} is not an object`);
+  }
+  if (!hasStringFields(record, ['type', 'roomId'])) {
+    return rejectedPayload('invalid-payload', `dungeon entrance ${index} needs a type and a room`);
+  }
+  if (!isFiniteNumber(record.x) || !isFiniteNumber(record.y)) {
+    return rejectedPayload('invalid-payload', `dungeon entrance ${index} has no numeric position`);
+  }
+  return acceptedPayload(record);
+}
+
+function validateList(
+  value: unknown,
+  what: string,
+  check: (entry: unknown, index: number) => PayloadResult<unknown>,
+): PayloadResult<unknown> {
+  if (!Array.isArray(value)) {
+    return rejectedPayload('invalid-payload', `dungeon ${what} is not a list`);
+  }
+  return value.map(check).find((result) => !result.ok) ?? acceptedPayload(value);
+}
+
+/**
+ * Checks what reading and drawing depend on: the name, the theme, the layout and its grid, and the
+ * four lists a dungeon is populated with.
+ *
+ * A dungeon with no rooms is accepted. The generator can produce one — a layout at low density on a
+ * small grid sometimes packs nothing — and a payload that failed its own validator would be a
+ * broken artifact rather than an empty one.
+ */
+export function validateDungeonSnapshot(payload: unknown): PayloadResult<DungeonSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'dungeon payload is not an object');
+  }
+  if (typeof record.name !== 'string') {
+    return rejectedPayload('invalid-payload', 'dungeon payload needs a name');
+  }
+
+  const checks = [
+    validateTheme(record.theme),
+    validateLayout(record.layout),
+    validateList(record.rooms, 'rooms', validateRoom),
+    validateList(record.doors, 'doors', validateDoor),
+    validateList(record.keys, 'keys', validateKey),
+    validateList(record.entrances, 'entrances', validateEntrance),
+  ];
+  const failed = checks.find((check) => !check.ok);
+  if (failed !== undefined) {
+    return failed as PayloadResult<DungeonSnapshot>;
+  }
+
+  return acceptedPayload(record as unknown as DungeonSnapshot);
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day the
+ * shape changes — a kind without one looks complete right up until it silently drops someone's
+ * work, and local-only means there is no server-side migration to fall back on.
+ */
+export function migrateDungeonSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<DungeonSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Dungeons have no migration from payload version ${from}; version ${DUNGEON_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/** What to call a saved dungeon: its name, or the kind when the name has been emptied. */
+function dungeonName(snapshot: DungeonSnapshot): string {
+  const name = snapshot.name.trim();
+  return name === '' ? 'Dungeon' : name;
+}
+
+/**
+ * A dungeon as an artifact.
+ *
+ * The codec is a dynamic import because its reading half rebuilds every room's encounter, and that
+ * reaches the archetype tables and, through a character's arms, 18 MB of charge art. Listing a
+ * project must not pay for that.
+ */
+export const dungeonArtifactKind = defineArtifactKind<EngineeredDungeon, DungeonSnapshot>({
+  kind: DUNGEON_ARTIFACT_KIND,
+  displayName: 'Dungeon',
+  icon: door,
+  payloadVersion: DUNGEON_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const [{ toDungeonSnapshot }, { dungeonFromSnapshotWithRng }] = await Promise.all([
+      import('./dungeon_snapshot.js'),
+      import('./dungeon_rehydrate.js'),
+    ]);
+    return {
+      toSnapshot: toDungeonSnapshot,
+      fromSnapshot: dungeonFromSnapshotWithRng,
+    };
+  },
+  nameOf: dungeonName,
+  validate: validateDungeonSnapshot,
+  migrate: migrateDungeonSnapshot,
+});

--- a/src/lib/dungeon/dungeon_editing.test.ts
+++ b/src/lib/dungeon/dungeon_editing.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  removeRoomEncounter,
+  removeRoomMob,
+  removeRoomTreasureItem,
+  setDoorDescription,
+  setDungeonBlueprint,
+  setDungeonName,
+  setKeyDescription,
+  setRoomDescription,
+  setRoomEncounterDescription,
+  setRoomEncounterName,
+  setRoomMobName,
+  setRoomName,
+  setRoomPurpose,
+  setRoomTreasureItemName,
+} from './dungeon_editing';
+import { rollDungeonSnapshot } from './dungeon_roll';
+import type { DungeonSnapshot } from './dungeon_snapshot';
+
+/** A dungeon with something in most of its rooms, so the encounter and treasure edits have work. */
+const snapshot: DungeonSnapshot = rollDungeonSnapshot('editing-seed', {
+  width: 20,
+  height: 20,
+  blueprintName: 'Tomb',
+  biomeName: 'tundra',
+  encounterChancePerRoom: 1,
+  treasureChancePerRoom: 1,
+});
+
+const occupied = snapshot.rooms.findIndex(
+  (room) => (room.encounter?.groups[0]?.mobs.length ?? 0) > 0,
+);
+const stocked = snapshot.rooms.findIndex((room) => (room.treasure?.length ?? 0) > 0);
+
+describe('the fixture these edits are made against', () => {
+  it('has a room with a combatant in it and a room with treasure in it', () => {
+    expect(occupied).toBeGreaterThanOrEqual(0);
+    expect(stocked).toBeGreaterThanOrEqual(0);
+    expect(snapshot.keys.length + snapshot.doors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('editing a dungeon', () => {
+  it('renames the dungeon and nothing else', () => {
+    const edited = setDungeonName(snapshot, 'The Frozen Vault');
+    expect(edited.name).toEqual('The Frozen Vault');
+    expect(edited.rooms).toEqual(snapshot.rooms);
+  });
+
+  it('leaves the original untouched', () => {
+    const before = snapshot.name;
+    setDungeonName(snapshot, 'somewhere else');
+    expect(snapshot.name).toEqual(before);
+  });
+
+  it('rethemes to another blueprint without re-rolling the rooms', () => {
+    // 4.2: the edited payload is authoritative. Retheming relabels; it does not rebuild.
+    const edited = setDungeonBlueprint(snapshot, 'Stronghold');
+    expect(edited.theme.blueprint.name).toEqual('Stronghold');
+    expect(edited.theme.name).toContain('Stronghold');
+    expect(edited.theme.environment).toEqual(snapshot.theme.environment);
+    expect(edited.rooms).toEqual(snapshot.rooms);
+  });
+
+  it('ignores a blueprint this build does not have', () => {
+    expect(setDungeonBlueprint(snapshot, 'Sunken Ziggurat')).toEqual(snapshot);
+  });
+});
+
+describe('editing one room', () => {
+  it('changes its name, purpose and description without disturbing its neighbours (4.4)', () => {
+    const renamed = setRoomName(snapshot, 0, 'The Cold Gate');
+    const repurposed = setRoomPurpose(renamed, 0, 'Gatehouse');
+    const rewritten = setRoomDescription(repurposed, 0, 'Frost has cracked the lintel.');
+
+    expect(rewritten.rooms[0].name).toEqual('The Cold Gate');
+    expect(rewritten.rooms[0].purpose).toEqual('Gatehouse');
+    expect(rewritten.rooms[0].description).toEqual('Frost has cracked the lintel.');
+    expect(rewritten.rooms.slice(1)).toEqual(snapshot.rooms.slice(1));
+  });
+
+  it('ignores a room index that is not there', () => {
+    expect(setRoomName(snapshot, 999, 'nowhere')).toEqual(snapshot);
+    expect(setRoomName(snapshot, -1, 'nowhere')).toEqual(snapshot);
+    expect(setRoomName(snapshot, 1.5, 'nowhere')).toEqual(snapshot);
+  });
+});
+
+describe("editing a room's encounter", () => {
+  it('renames it and rewrites what it is doing there', () => {
+    const named = setRoomEncounterName(snapshot, occupied, 'The Honour Guard');
+    const described = setRoomEncounterDescription(named, occupied, 'They have not moved in years.');
+    expect(described.rooms[occupied].encounter?.name).toEqual('The Honour Guard');
+    expect(described.rooms[occupied].encounter?.description).toEqual(
+      'They have not moved in years.',
+    );
+  });
+
+  it('renames one combatant through the encounters library', () => {
+    const edited = setRoomMobName(snapshot, occupied, 0, 0, 'Kethra');
+    expect(edited.rooms[occupied].encounter?.groups[0].mobs[0].name).toEqual('Kethra');
+  });
+
+  it('removes one combatant and leaves the rest', () => {
+    const before = snapshot.rooms[occupied].encounter?.groups[0].mobs ?? [];
+    const edited = removeRoomMob(snapshot, occupied, 0, 0);
+    expect(edited.rooms[occupied].encounter?.groups[0].mobs.length).toEqual(before.length - 1);
+  });
+
+  it('empties a room of whatever was living in it, keeping the room', () => {
+    const edited = removeRoomEncounter(snapshot, occupied);
+    expect(edited.rooms[occupied].encounter).toBeUndefined();
+    expect(edited.rooms[occupied].name).toEqual(snapshot.rooms[occupied].name);
+  });
+
+  it('does nothing to a room that has no encounter', () => {
+    const emptied = removeRoomEncounter(snapshot, occupied);
+    expect(setRoomEncounterName(emptied, occupied, 'nobody')).toEqual(emptied);
+    expect(removeRoomMob(emptied, occupied, 0, 0)).toEqual(emptied);
+  });
+});
+
+describe("editing a room's treasure", () => {
+  it('renames one item', () => {
+    const edited = setRoomTreasureItemName(snapshot, stocked, 0, 'The Barrow Crown');
+    expect(edited.rooms[stocked].treasure?.[0].name).toEqual('The Barrow Crown');
+  });
+
+  it('removes one item and leaves the rest', () => {
+    const before = snapshot.rooms[stocked].treasure ?? [];
+    const edited = removeRoomTreasureItem(snapshot, stocked, 0);
+    expect(edited.rooms[stocked].treasure?.length).toEqual(before.length - 1);
+  });
+
+  it('ignores an item index that is not there', () => {
+    expect(setRoomTreasureItemName(snapshot, stocked, 999, 'nothing')).toEqual(snapshot);
+    expect(removeRoomTreasureItem(snapshot, stocked, 999)).toEqual(snapshot);
+  });
+});
+
+describe('editing the doors and the keys', () => {
+  it('rewrites a door description', () => {
+    const edited = setDoorDescription(snapshot, 0, 'a slab of frost-rimed iron');
+    expect(edited.doors[0].description).toEqual('a slab of frost-rimed iron');
+    expect(edited.doors.slice(1)).toEqual(snapshot.doors.slice(1));
+  });
+
+  it('rewrites a key description', () => {
+    // Keys exist only where the layout locked a chokepoint, which a small tomb may not do at all,
+    // so the key is supplied here rather than fished out of the roll.
+    const keyed = {
+      ...snapshot,
+      keys: [{ id: 'k1', doorId: 'd1', x: 2, y: 2, description: 'a brass key' }],
+    };
+    expect(setKeyDescription(keyed, 0, 'a key of black glass').keys[0].description).toEqual(
+      'a key of black glass',
+    );
+  });
+
+  it('ignores a door or key index that is not there', () => {
+    expect(setDoorDescription(snapshot, 999, 'nothing')).toEqual(snapshot);
+    expect(setKeyDescription(snapshot, 999, 'nothing')).toEqual(snapshot);
+  });
+});

--- a/src/lib/dungeon/dungeon_editing.ts
+++ b/src/lib/dungeon/dungeon_editing.ts
@@ -1,0 +1,230 @@
+/**
+ * Editing a saved dungeon, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction — renaming one room must not
+ * disturb its neighbours, and removing one room's treasure must not touch the room next door — and
+ * it is what lets the editing framework compare what is on screen against what was read to decide
+ * whether anything needs saving.
+ *
+ * **What is editable is what the page shows** (4.1): the dungeon's name, its blueprint, and per
+ * room the name, purpose and description, the encounter's name and description, each combatant's
+ * name, each treasure item's name, and each key's description — plus removing an encounter, a
+ * combatant, an item or a key outright. The mob edits delegate to `$lib/encounters`' own editing
+ * module rather than reaching into a stored encounter here: a room's encounter is an encounter,
+ * and two spellings of "rename a combatant" is one of them going stale.
+ *
+ * **The geometry is not editable, and that is a decision rather than an omission.** A room's
+ * position, its shape grid, the corridor layout, and where the doors and keys physically sit are
+ * what make the map drawable and the keys reachable — `keys.ts` guarantees a key is placed in a
+ * zone reachable before the door it opens, and a text box over a coordinate would let a user break
+ * that quietly. A referee who wants a different map re-rolls; a referee who wants a different
+ * *dungeon* edits every word of it, which is what is here.
+ *
+ * **Retheming relabels; it does not rebuild.** Choosing another blueprint changes what the dungeon
+ * says it is — its theme name, the blueprint's own name and description, and the tags the theme
+ * carries — and leaves every room exactly as it was rolled. That is requirement 4.2: the edited
+ * payload is authoritative, and silently re-rolling forty rooms' purposes because a user changed a
+ * label would be regenerating over their work. A dungeon whose rooms should match a new blueprint
+ * is a re-roll, which is the button next to this one.
+ */
+
+import {
+  removeEncounterMob,
+  setEncounterMobName,
+  setEncounterName,
+  type EncounterSnapshot,
+} from '$lib/encounters';
+
+import type { DungeonSnapshot, StoredPopulatedRoom } from './dungeon_snapshot.js';
+import { BLUEPRINTS, buildTheme } from './theme/theme.js';
+
+function hasIndex(length: number, index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < length;
+}
+
+function replaceAt<T>(list: T[], index: number, value: T): T[] {
+  return list.map((entry, position) => (position === index ? value : entry));
+}
+
+function removeAt<T>(list: T[], index: number): T[] {
+  return list.filter((_entry, position) => position !== index);
+}
+
+function editRoom(
+  snapshot: DungeonSnapshot,
+  index: number,
+  change: (room: StoredPopulatedRoom) => StoredPopulatedRoom,
+): DungeonSnapshot {
+  return hasIndex(snapshot.rooms.length, index)
+    ? { ...snapshot, rooms: replaceAt(snapshot.rooms, index, change(snapshot.rooms[index])) }
+    : snapshot;
+}
+
+/**
+ * Applies a change to a room's encounter, and does nothing at all to a room that has none.
+ *
+ * An empty room is an ordinary state rather than a fault, so this is a no-op there rather than a
+ * place that invents an encounter to edit.
+ */
+function editRoomEncounter(
+  snapshot: DungeonSnapshot,
+  roomIndex: number,
+  change: (encounter: EncounterSnapshot) => EncounterSnapshot,
+): DungeonSnapshot {
+  return editRoom(snapshot, roomIndex, (room) =>
+    room.encounter === undefined ? room : { ...room, encounter: change(room.encounter) },
+  );
+}
+
+export function setDungeonName(snapshot: DungeonSnapshot, name: string): DungeonSnapshot {
+  return { ...snapshot, name };
+}
+
+/**
+ * Rebuild the theme around another blueprint, keeping the environment the dungeon was dug into.
+ *
+ * `buildTheme` does the work rather than a second spelling of it here: the theme's name and its
+ * encounter and treasure tags are derived from the blueprint and the biome together, and a copy of
+ * that derivation is the half that goes stale.
+ *
+ * A blueprint this build does not have, or a payload whose biome is one `buildTheme` refuses,
+ * leaves the dungeon alone. The select cannot offer either, so reaching here with one means a
+ * hand-edited payload — and relabelling a dungeon to something arbitrary, or throwing out of an
+ * editing function, are both worse answers than doing nothing.
+ */
+export function setDungeonBlueprint(
+  snapshot: DungeonSnapshot,
+  blueprintName: string,
+): DungeonSnapshot {
+  const known = BLUEPRINTS.some((candidate) => candidate.name === blueprintName);
+  if (!known || snapshot.theme.environment.biome.isAquatic) {
+    return snapshot;
+  }
+  return { ...snapshot, theme: buildTheme(snapshot.theme.environment, blueprintName) };
+}
+
+export function setRoomName(
+  snapshot: DungeonSnapshot,
+  roomIndex: number,
+  name: string,
+): DungeonSnapshot {
+  return editRoom(snapshot, roomIndex, (room) => ({ ...room, name }));
+}
+
+export function setRoomPurpose(
+  snapshot: DungeonSnapshot,
+  roomIndex: number,
+  purpose: string,
+): DungeonSnapshot {
+  return editRoom(snapshot, roomIndex, (room) => ({ ...room, purpose }));
+}
+
+export function setRoomDescription(
+  snapshot: DungeonSnapshot,
+  roomIndex: number,
+  description: string,
+): DungeonSnapshot {
+  return editRoom(snapshot, roomIndex, (room) => ({ ...room, description }));
+}
+
+export function setRoomEncounterName(
+  snapshot: DungeonSnapshot,
+  roomIndex: number,
+  name: string,
+): DungeonSnapshot {
+  return editRoomEncounter(snapshot, roomIndex, (encounter) => setEncounterName(encounter, name));
+}
+
+export function setRoomEncounterDescription(
+  snapshot: DungeonSnapshot,
+  roomIndex: number,
+  description: string,
+): DungeonSnapshot {
+  return editRoomEncounter(snapshot, roomIndex, (encounter) => ({ ...encounter, description }));
+}
+
+export function setRoomMobName(
+  snapshot: DungeonSnapshot,
+  roomIndex: number,
+  groupIndex: number,
+  mobIndex: number,
+  name: string,
+): DungeonSnapshot {
+  return editRoomEncounter(snapshot, roomIndex, (encounter) =>
+    setEncounterMobName(encounter, groupIndex, mobIndex, name),
+  );
+}
+
+export function removeRoomMob(
+  snapshot: DungeonSnapshot,
+  roomIndex: number,
+  groupIndex: number,
+  mobIndex: number,
+): DungeonSnapshot {
+  return editRoomEncounter(snapshot, roomIndex, (encounter) =>
+    removeEncounterMob(encounter, groupIndex, mobIndex),
+  );
+}
+
+/** Empty a room of whatever was living in it. The room stays; what was in it does not. */
+export function removeRoomEncounter(snapshot: DungeonSnapshot, roomIndex: number): DungeonSnapshot {
+  return editRoom(snapshot, roomIndex, ({ encounter: _encounter, ...room }) => room);
+}
+
+export function setRoomTreasureItemName(
+  snapshot: DungeonSnapshot,
+  roomIndex: number,
+  itemIndex: number,
+  name: string,
+): DungeonSnapshot {
+  return editRoom(snapshot, roomIndex, (room) =>
+    room.treasure !== undefined && hasIndex(room.treasure.length, itemIndex)
+      ? {
+          ...room,
+          treasure: replaceAt(room.treasure, itemIndex, { ...room.treasure[itemIndex], name }),
+        }
+      : room,
+  );
+}
+
+export function removeRoomTreasureItem(
+  snapshot: DungeonSnapshot,
+  roomIndex: number,
+  itemIndex: number,
+): DungeonSnapshot {
+  return editRoom(snapshot, roomIndex, (room) =>
+    room.treasure !== undefined && hasIndex(room.treasure.length, itemIndex)
+      ? { ...room, treasure: removeAt(room.treasure, itemIndex) }
+      : room,
+  );
+}
+
+export function setKeyDescription(
+  snapshot: DungeonSnapshot,
+  keyIndex: number,
+  description: string,
+): DungeonSnapshot {
+  return hasIndex(snapshot.keys.length, keyIndex)
+    ? {
+        ...snapshot,
+        keys: replaceAt(snapshot.keys, keyIndex, { ...snapshot.keys[keyIndex], description }),
+      }
+    : snapshot;
+}
+
+export function setDoorDescription(
+  snapshot: DungeonSnapshot,
+  doorIndex: number,
+  description: string,
+): DungeonSnapshot {
+  return hasIndex(snapshot.doors.length, doorIndex)
+    ? {
+        ...snapshot,
+        doors: replaceAt(snapshot.doors, doorIndex, {
+          ...snapshot.doors[doorIndex],
+          description,
+        }),
+      }
+    : snapshot;
+}

--- a/src/lib/dungeon/dungeon_presentation.test.ts
+++ b/src/lib/dungeon/dungeon_presentation.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  removeRoomEncounter,
+  removeRoomTreasureItem,
+  setDungeonName,
+  setRoomDescription,
+  setRoomName,
+  setRoomPurpose,
+} from './dungeon_editing';
+import {
+  dungeonDisplayName,
+  dungeonFileStem,
+  dungeonRoomHeading,
+  dungeonRoomMetaLine,
+  dungeonToDocument,
+  dungeonToMarkdown,
+  dungeonToText,
+} from './dungeon_presentation';
+import { rollDungeonSnapshot } from './dungeon_roll';
+
+const snapshot = rollDungeonSnapshot('presentation-seed', {
+  width: 20,
+  height: 20,
+  blueprintName: 'Tomb',
+  biomeName: 'tundra',
+  encounterChancePerRoom: 1,
+  treasureChancePerRoom: 1,
+});
+
+const occupied = snapshot.rooms.findIndex((room) => room.encounter !== undefined);
+
+describe('arranging a dungeon for reading', () => {
+  const document = dungeonToDocument(snapshot);
+
+  it('is headed by the dungeon and opens with where it is and what it was built as', () => {
+    expect(document.title).toEqual(snapshot.name);
+    expect(document.paragraphs).toEqual([
+      snapshot.theme.environment.description,
+      snapshot.theme.blueprint.description,
+    ]);
+  });
+
+  it('gives every room a section', () => {
+    expect(document.sections.length).toEqual(snapshot.rooms.length);
+  });
+
+  it('heads a room with its name and the number on the map', () => {
+    expect(dungeonRoomHeading(snapshot.rooms[0])).toContain(`(room ${snapshot.rooms[0].id})`);
+  });
+
+  it('says what a room was for, what shape it is and how big', () => {
+    const room = snapshot.rooms[0];
+    expect(dungeonRoomMetaLine(room)).toContain(`${room.primitive.width}×${room.primitive.height}`);
+    expect(dungeonRoomMetaLine(room)).toContain(room.primitive.style);
+  });
+
+  it('lists what is living in an occupied room', () => {
+    const section = document.sections[occupied];
+    const encounter = section.lists.find((list) => list.heading.startsWith('Encounter'));
+    expect(encounter?.items.length).toBeGreaterThan(0);
+  });
+});
+
+describe('dropping what is empty (6.4)', () => {
+  it('prints no encounter list for a room that has nobody in it', () => {
+    const emptied = removeRoomEncounter(snapshot, occupied);
+    const section = dungeonToDocument(emptied).sections[occupied];
+    expect(section.lists.some((list) => list.heading.startsWith('Encounter'))).toBe(false);
+  });
+
+  it('prints no treasure list once the last item is taken', () => {
+    let stripped = snapshot;
+    const room = snapshot.rooms[occupied];
+    for (let index = (room.treasure?.length ?? 0) - 1; index >= 0; index--) {
+      stripped = removeRoomTreasureItem(stripped, occupied, index);
+    }
+    const section = dungeonToDocument(stripped).sections[occupied];
+    expect(section.lists.some((list) => list.heading === 'Treasure')).toBe(false);
+  });
+
+  it('prints no blank paragraph for a room whose description has been emptied', () => {
+    const blanked = setRoomDescription(snapshot, 0, '   ');
+    const section = dungeonToDocument(blanked).sections[0];
+    expect(section.paragraphs.every((paragraph) => paragraph.trim() !== '')).toBe(true);
+  });
+
+  it('still gives a room with nothing in it a heading', () => {
+    const bare = removeRoomEncounter(setRoomDescription(snapshot, occupied, ''), occupied);
+    expect(dungeonToDocument(bare).sections[occupied].heading).not.toEqual('');
+  });
+
+  it('names a room that has been left nameless', () => {
+    expect(dungeonRoomHeading({ ...snapshot.rooms[0], name: '  ' })).toContain('Unnamed room');
+  });
+
+  it('says a room has an unknown purpose rather than printing an empty dash', () => {
+    const meta = dungeonRoomMetaLine({ ...snapshot.rooms[0], purpose: '' });
+    expect(meta).toContain('unknown purpose');
+  });
+});
+
+describe('the keys lying in a room', () => {
+  it('are listed under the room that holds them', () => {
+    // Keys exist only where the layout locked a chokepoint, which a small tomb may not do, so one
+    // is placed here on the first room's own floor rather than fished out of the roll.
+    const room = snapshot.rooms[0];
+    const keyed = {
+      ...snapshot,
+      keys: [{ id: 'k1', doorId: 'd1', x: room.x, y: room.y, description: 'a brass key' }],
+    };
+    const document = dungeonToDocument(keyed);
+    expect(document.sections[0].lists.find((list) => list.heading === 'Keys')?.items).toEqual([
+      'a brass key',
+    ]);
+    // And under that room alone: a key on one floor is not in every room.
+    expect(
+      document.sections
+        .slice(1)
+        .some((section) => section.lists.some((list) => list.heading === 'Keys')),
+    ).toBe(false);
+  });
+
+  it('are not listed at all for a dungeon with no keys', () => {
+    expect(
+      dungeonToDocument({ ...snapshot, keys: [] }).sections.some((section) =>
+        section.lists.some((list) => list.heading === 'Keys'),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('exporting a dungeon (6.3)', () => {
+  it('writes Markdown a referee can drop into their notes', () => {
+    const markdown = dungeonToMarkdown(snapshot);
+    expect(markdown).toContain(`# ${snapshot.name}`);
+    expect(markdown).toContain(`## ${dungeonRoomHeading(snapshot.rooms[0])}`);
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('writes the same document as plain text, without repeating the title', () => {
+    const text = dungeonToText(snapshot);
+    expect(text).toContain(dungeonRoomHeading(snapshot.rooms[0]).toUpperCase());
+    expect(text.startsWith(snapshot.name)).toBe(false);
+  });
+
+  it('never leaves a blank line where a room had nothing to say', () => {
+    const emptied = removeRoomEncounter(setRoomDescription(snapshot, occupied, ''), occupied);
+    expect(dungeonToMarkdown(emptied)).not.toContain('\n\n\n');
+    expect(dungeonToText(emptied)).not.toContain('\n\n\n');
+  });
+
+  it('carries an edited room straight into the export', () => {
+    const edited = setRoomPurpose(setRoomName(snapshot, 0, 'The Cold Gate'), 0, 'Gatehouse');
+    const markdown = dungeonToMarkdown(edited);
+    expect(markdown).toContain('The Cold Gate');
+    expect(markdown).toContain('Gatehouse');
+  });
+});
+
+describe('naming a dungeon for a file and a heading', () => {
+  it('uses the dungeon name', () => {
+    expect(dungeonDisplayName(snapshot)).toEqual(snapshot.name);
+    expect(dungeonFileStem({ name: 'The Frozen Vault' })).toEqual('dungeon-the-frozen-vault');
+  });
+
+  it('falls back to the kind for a dungeon with no name', () => {
+    expect(dungeonDisplayName(setDungeonName(snapshot, '  '))).toEqual('Dungeon');
+    expect(dungeonFileStem({ name: '' })).toEqual('dungeon');
+  });
+
+  it('reduces punctuation a filesystem would not take', () => {
+    expect(dungeonFileStem({ name: '!!The Tomb of Yth!!' })).toEqual('dungeon-the-tomb-of-yth');
+  });
+});

--- a/src/lib/dungeon/dungeon_presentation.ts
+++ b/src/lib/dungeon/dungeon_presentation.ts
@@ -1,0 +1,185 @@
+/**
+ * A dungeon arranged for reading, and the Markdown and PDF exports written from it.
+ *
+ * This is what requirement 6.3 asks for, and it is also the whole of the tool's answer to 2.5. The
+ * page draws a plan on a canvas; the canvas is an enhancement. What a referee actually runs the
+ * dungeon from is the room list — every room's name, purpose and description, what lives in it,
+ * what it holds, and which keys are lying in it — and that reads on a machine with no canvas at
+ * all, in a text file, and on paper.
+ *
+ * 6.4 has teeth here, because most rooms are empty of most things. A room with no encounter prints
+ * no encounter heading, a room with nothing in it prints its description alone, and a dungeon with
+ * no keys prints no key list. Every list in the document model is dropped when it is empty rather
+ * than being rendered as a heading over nothing.
+ *
+ * Presentation works on the **stored** shape rather than the live one. The page holds a live
+ * `EngineeredDungeon` and converts it for saving anyway, and the editor holds a snapshot; one model
+ * both can print is cheaper than two, and a stored mob already carries the species name a sheet
+ * wants to print where a live one carries the whole species.
+ */
+
+import { Currency } from '$lib/currency';
+import { describeEncounterMob, encounterGroupHeading } from '$lib/encounters';
+
+import type { DungeonSnapshot, StoredPopulatedRoom } from './dungeon_snapshot.js';
+
+/** A titled list inside a section; dropped entirely when it has no items. */
+export type DungeonList = {
+  heading: string;
+  items: string[];
+};
+
+/** One room arranged for reading. */
+export type DungeonSection = {
+  heading: string;
+  paragraphs: string[];
+  lists: DungeonList[];
+};
+
+/** A dungeon arranged for reading, independent of the format it is finally written in. */
+export type DungeonDocument = {
+  title: string;
+  paragraphs: string[];
+  sections: DungeonSection[];
+};
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+/** What to head the document with: the dungeon's name, or the kind when it has none. */
+export function dungeonDisplayName(dungeon: { name: string }): string {
+  const name = dungeon.name.trim();
+  return name === '' ? 'Dungeon' : name.trim();
+}
+
+/** The heading a room gets: what it is called, and the number the map is labelled with. */
+export function dungeonRoomHeading(room: StoredPopulatedRoom): string {
+  const name = isPrintable(room.name) ? room.name.trim() : 'Unnamed room';
+  return `${name} (room ${room.id})`;
+}
+
+/** The line under a room's heading: what it was for, what shape it is, and how big. */
+export function dungeonRoomMetaLine(room: StoredPopulatedRoom): string {
+  const purpose = isPrintable(room.purpose) ? room.purpose.trim() : 'unknown purpose';
+  return `${purpose} — ${room.primitive.style}, ${room.primitive.width}×${room.primitive.height}`;
+}
+
+function encounterList(room: StoredPopulatedRoom): DungeonList[] {
+  const { encounter } = room;
+  if (encounter === undefined) {
+    return [];
+  }
+  const items = encounter.groups.flatMap((group, index) => [
+    encounterGroupHeading(group, index),
+    ...group.mobs.map((mob) => {
+      const line = describeEncounterMob(mob);
+      return isPrintable(line.kind) ? `${line.name} — ${line.kind}` : line.name;
+    }),
+  ]);
+  const description = isPrintable(encounter.description) ? [encounter.description.trim()] : [];
+  const heading = isPrintable(encounter.name) ? `Encounter: ${encounter.name.trim()}` : 'Encounter';
+  const all = [...description, ...items];
+  return all.length === 0 ? [] : [{ heading, items: all }];
+}
+
+function treasureList(room: StoredPopulatedRoom): DungeonList[] {
+  const treasure = room.treasure ?? [];
+  if (treasure.length === 0) {
+    return [];
+  }
+  return [
+    {
+      heading: 'Treasure',
+      items: treasure.map(
+        (item) =>
+          `${item.name} — ${item.description} (${Currency.valueToString(item.value, undefined, true)})`,
+      ),
+    },
+  ];
+}
+
+/** Which tiles a room covers, so a key lying on the floor can be attributed to it. */
+function roomHolds(room: StoredPopulatedRoom, x: number, y: number): boolean {
+  return (
+    x >= room.x &&
+    x < room.x + room.primitive.width &&
+    y >= room.y &&
+    y < room.y + room.primitive.height
+  );
+}
+
+function keyList(snapshot: DungeonSnapshot, room: StoredPopulatedRoom): DungeonList[] {
+  const keys = snapshot.keys.filter((key) => roomHolds(room, key.x, key.y));
+  return keys.length === 0 ? [] : [{ heading: 'Keys', items: keys.map((key) => key.description) }];
+}
+
+function roomSection(snapshot: DungeonSnapshot, room: StoredPopulatedRoom): DungeonSection {
+  return {
+    heading: dungeonRoomHeading(room),
+    paragraphs: [dungeonRoomMetaLine(room), room.description].filter(isPrintable),
+    lists: [...encounterList(room), ...treasureList(room), ...keyList(snapshot, room)],
+  };
+}
+
+/**
+ * Arrange a dungeon for reading.
+ *
+ * The overview paragraphs are the theme's own two sentences — where the place is and what it was
+ * built as — and both are dropped when a user has emptied them, which retheming and editing both
+ * allow.
+ */
+export function dungeonToDocument(snapshot: DungeonSnapshot): DungeonDocument {
+  return {
+    title: dungeonDisplayName(snapshot),
+    paragraphs: [
+      snapshot.theme.environment.description,
+      snapshot.theme.blueprint.description,
+    ].filter(isPrintable),
+    sections: snapshot.rooms.map((room) => roomSection(snapshot, room)),
+  };
+}
+
+/** A dungeon as Markdown, for a referee who wants it in their own notes. */
+export function dungeonToMarkdown(snapshot: DungeonSnapshot): string {
+  const document = dungeonToDocument(snapshot);
+  const blocks = [`# ${document.title}`, ...document.paragraphs];
+
+  for (const section of document.sections) {
+    blocks.push(`## ${section.heading}`, ...section.paragraphs);
+    for (const list of section.lists) {
+      blocks.push(`### ${list.heading}`, list.items.map((item) => `- ${item}`).join('\n'));
+    }
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** The body of the PDF: the same document as plain text, without the title the PDF draws itself. */
+export function dungeonToText(snapshot: DungeonSnapshot): string {
+  const document = dungeonToDocument(snapshot);
+  const blocks = [...document.paragraphs];
+
+  for (const section of document.sections) {
+    blocks.push([section.heading.toUpperCase(), ...section.paragraphs].join('\n'));
+    for (const list of section.lists) {
+      blocks.push([list.heading, ...list.items].join('\n'));
+    }
+  }
+
+  return blocks.join('\n\n');
+}
+
+/**
+ * A filename stem for an exported dungeon, reduced to something a filesystem takes.
+ *
+ * A dungeon with no name of its own gets the bare stem rather than `dungeon-dungeon`: the fallback
+ * display name is already the word this prefixes with.
+ */
+export function dungeonFileStem(dungeon: { name: string }): string {
+  const stem = dungeonDisplayName(dungeon)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' || stem === 'dungeon' ? 'dungeon' : `dungeon-${stem}`;
+}

--- a/src/lib/dungeon/dungeon_rehydrate.ts
+++ b/src/lib/dungeon/dungeon_rehydrate.ts
@@ -1,0 +1,51 @@
+/**
+ * Rebuilding a dungeon from a snapshot.
+ *
+ * **Nothing here is recomputed.** Every room name, every door state, every description comes back
+ * exactly as it was stored, per requirement 4.2 in docs/workshop.md. The one part that is rebuilt
+ * rather than copied is a room's encounter, and `$lib/encounters` owns that rule: species and
+ * archetypes resolve by name, and a name this build no longer has becomes an inert placeholder
+ * rather than a refusal.
+ *
+ * Split from `dungeon_snapshot.ts` for what that import costs. Reading reaches the character and
+ * creature rehydrators, and from there the archetype tables and the charge art; writing, listing
+ * and validating a dungeon reach none of it.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+
+import { encounterFromSnapshot } from '$lib/encounters';
+
+import type { EngineeredDungeon, PopulatedRoom } from './generator/types.js';
+import type { DungeonSnapshot, StoredPopulatedRoom } from './dungeon_snapshot.js';
+
+function roomFromStored(stored: StoredPopulatedRoom): PopulatedRoom {
+  const { encounter, ...rest } = stored;
+  return encounter === undefined ? rest : { ...rest, encounter: encounterFromSnapshot(encounter) };
+}
+
+export function dungeonFromSnapshot(snapshot: DungeonSnapshot): EngineeredDungeon {
+  return {
+    name: snapshot.name,
+    theme: snapshot.theme,
+    layout: snapshot.layout,
+    rooms: snapshot.rooms.map(roomFromStored),
+    doors: snapshot.doors,
+    keys: snapshot.keys,
+    entrances: snapshot.entrances,
+  };
+}
+
+/**
+ * The codec's reading half, with the signature the registry hands it.
+ *
+ * The RNG is unused, and that is the correct amount of use for it: a dungeon is finished when it
+ * is stored, and drawing anything from a seed on the way back would be regenerating over the
+ * user's edits.
+ */
+export function dungeonFromSnapshotWithRng(
+  snapshot: DungeonSnapshot,
+  _rng: RNG,
+): EngineeredDungeon {
+  return dungeonFromSnapshot(snapshot);
+}

--- a/src/lib/dungeon/dungeon_roll.test.ts
+++ b/src/lib/dungeon/dungeon_roll.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DUNGEON_DEFAULT_ENCOUNTER_CHANCE,
+  DUNGEON_DEFAULT_HEIGHT,
+  DUNGEON_DEFAULT_TREASURE_CHANCE,
+  DUNGEON_DEFAULT_WIDTH,
+  DUNGEON_MAX_DIMENSION,
+  DUNGEON_MIN_DIMENSION,
+  buildDungeonEnvironment,
+  dungeonBiomeNames,
+  dungeonBlueprintNames,
+  readDungeonGeneratorConfig,
+  rollDungeon,
+  entranceRoomIndex,
+  rollDungeonSnapshot,
+  withEncounterAtEntrance,
+} from './dungeon_roll';
+
+const SMALL = { width: 20, height: 20 };
+
+describe('rolling a dungeon', () => {
+  it('gives the same dungeon for the same seed and settings (2.2)', () => {
+    const first = rollDungeon('repeatable', SMALL);
+    const second = rollDungeon('repeatable', SMALL);
+    expect(second).toEqual(first);
+  });
+
+  it('gives a different dungeon for a different seed', () => {
+    const first = rollDungeon('one', SMALL);
+    const second = rollDungeon('two', SMALL);
+    expect(second.name).not.toEqual(first.name);
+  });
+
+  it('honours a named blueprint', () => {
+    const dungeon = rollDungeon('blueprinted', { ...SMALL, blueprintName: 'Arcane Library' });
+    expect(dungeon.theme.blueprint.name).toEqual('Arcane Library');
+  });
+
+  it('honours a named biome', () => {
+    const dungeon = rollDungeon('biomed', { ...SMALL, biomeName: 'tundra' });
+    expect(dungeon.theme.environment.biome.name).toEqual('tundra');
+  });
+
+  it('draws the blueprint and the biome from the seed when the config leaves them open', () => {
+    // Both are absent, so both come from the seed's own stream — which is what "Random" meant on
+    // the page, and what makes a re-roll from a provenance that recorded neither reproducible.
+    const first = rollDungeon('open', SMALL);
+    const second = rollDungeon('open', SMALL);
+    expect(second.theme.name).toEqual(first.theme.name);
+  });
+
+  it('fills empty rooms when the chances are zero', () => {
+    const dungeon = rollDungeon('barren', {
+      ...SMALL,
+      encounterChancePerRoom: 0,
+      treasureChancePerRoom: 0,
+    });
+    expect(dungeon.rooms.every((room) => room.encounter === undefined)).toBe(true);
+    expect(dungeon.rooms.every((room) => room.treasure === undefined)).toBe(true);
+  });
+
+  it('rolls to the defaults when handed no config at all', () => {
+    const dungeon = rollDungeon('defaulted');
+    expect(dungeon.layout.width).toEqual(DUNGEON_DEFAULT_WIDTH);
+    expect(dungeon.layout.height).toEqual(DUNGEON_DEFAULT_HEIGHT);
+  });
+
+  it('rolls a snapshot by the same path', () => {
+    const snapshot = rollDungeonSnapshot('snapshotted', SMALL);
+    expect(snapshot.name).toEqual(rollDungeon('snapshotted', SMALL).name);
+  });
+});
+
+describe('the environment a dungeon is dug into', () => {
+  it('is the same land for the same seed', () => {
+    expect(buildDungeonEnvironment('land', 'tundra')).toEqual(
+      buildDungeonEnvironment('land', 'tundra'),
+    );
+  });
+
+  it('forces the biome that was asked for', () => {
+    const environment = buildDungeonEnvironment('forced', 'cold desert');
+    expect(environment.biome.name).toEqual('cold desert');
+    expect(environment.description).not.toEqual('');
+  });
+
+  it('offers no aquatic biome, because a dungeon is dug into ground', () => {
+    expect(dungeonBiomeNames()).not.toContain('coral reef');
+    expect(dungeonBiomeNames().length).toBeGreaterThan(0);
+  });
+
+  it('offers every blueprint the library has', () => {
+    expect(dungeonBlueprintNames()).toContain('Tomb');
+  });
+});
+
+describe('reading a stored generator config', () => {
+  it('reads back what the page recorded', () => {
+    expect(
+      readDungeonGeneratorConfig({
+        width: 50,
+        height: 45,
+        blueprintName: 'Stronghold',
+        biomeName: 'tundra',
+        encounterChancePerRoom: 0.7,
+        treasureChancePerRoom: 0.1,
+      }),
+    ).toEqual({
+      width: 50,
+      height: 45,
+      blueprintName: 'Stronghold',
+      biomeName: 'tundra',
+      encounterChancePerRoom: 0.7,
+      treasureChancePerRoom: 0.1,
+    });
+  });
+
+  it('falls back to the defaults for anything it does not recognise', () => {
+    expect(readDungeonGeneratorConfig({ width: 'wide', encounterChancePerRoom: null })).toEqual({
+      width: DUNGEON_DEFAULT_WIDTH,
+      height: DUNGEON_DEFAULT_HEIGHT,
+      encounterChancePerRoom: DUNGEON_DEFAULT_ENCOUNTER_CHANCE,
+      treasureChancePerRoom: DUNGEON_DEFAULT_TREASURE_CHANCE,
+    });
+  });
+
+  it('drops a blueprint or biome this build no longer has', () => {
+    // Dropped rather than kept: an unknown name means the seed chooses, which is a dungeon, where
+    // passing it through would make `buildTheme` throw on the way to one.
+    const config = readDungeonGeneratorConfig({
+      blueprintName: 'Sunken Ziggurat',
+      biomeName: 'the moon',
+    });
+    expect(config.blueprintName).toBeUndefined();
+    expect(config.biomeName).toBeUndefined();
+  });
+
+  it('clamps a map to the sizes the page offers', () => {
+    const huge = readDungeonGeneratorConfig({ width: 10_000, height: 1 });
+    expect(huge.width).toEqual(DUNGEON_MAX_DIMENSION);
+    expect(huge.height).toEqual(DUNGEON_MIN_DIMENSION);
+  });
+
+  it('clamps the chances to a probability', () => {
+    const wild = readDungeonGeneratorConfig({
+      encounterChancePerRoom: 4,
+      treasureChancePerRoom: -1,
+    });
+    expect(wild.encounterChancePerRoom).toEqual(1);
+    expect(wild.treasureChancePerRoom).toEqual(0);
+  });
+
+  it('rounds a fractional map size, because a grid has whole tiles', () => {
+    expect(readDungeonGeneratorConfig({ width: 30.6 }).width).toEqual(31);
+  });
+});
+
+describe('composing a dungeon with a saved encounter (5.1)', () => {
+  const dungeon = rollDungeon('composed', {
+    ...SMALL,
+    encounterChancePerRoom: 0,
+    treasureChancePerRoom: 0,
+  });
+  const encounter = {
+    name: 'The Doorkeeper',
+    description: 'It has been waiting.',
+    difficulty: 3,
+    groups: [],
+  };
+
+  it('puts it in the room the dungeon is entered through', () => {
+    const index = entranceRoomIndex(dungeon);
+    expect(index).toBeGreaterThanOrEqual(0);
+    const composed = withEncounterAtEntrance(dungeon, encounter);
+    expect(composed.rooms[index].encounter?.name).toEqual('The Doorkeeper');
+  });
+
+  it('stops calling that room abandoned once something is standing in it', () => {
+    const index = entranceRoomIndex(dungeon);
+    expect(dungeon.rooms[index].name).toContain('Abandoned');
+    expect(withEncounterAtEntrance(dungeon, encounter).rooms[index].name).toContain('Occupied');
+  });
+
+  it('leaves every other room alone', () => {
+    const index = entranceRoomIndex(dungeon);
+    const composed = withEncounterAtEntrance(dungeon, encounter);
+    expect(composed.rooms.filter((_room, position) => position !== index)).toEqual(
+      dungeon.rooms.filter((_room, position) => position !== index),
+    );
+  });
+
+  it('hands back a dungeon with no rooms unchanged', () => {
+    const empty = { ...dungeon, rooms: [], entrances: [] };
+    expect(entranceRoomIndex(empty)).toEqual(-1);
+    expect(withEncounterAtEntrance(empty, encounter)).toEqual(empty);
+  });
+
+  it('falls back to the first room when the entrance names one that is gone', () => {
+    const orphaned = {
+      ...dungeon,
+      entrances: [{ x: 0, y: 0, type: 'stairs' as const, roomId: 'nowhere' }],
+    };
+    expect(entranceRoomIndex(orphaned)).toEqual(0);
+  });
+});

--- a/src/lib/dungeon/dungeon_roll.ts
+++ b/src/lib/dungeon/dungeon_roll.ts
@@ -1,0 +1,247 @@
+/**
+ * The single path from a seed to a dungeon, and the record of how it was rolled.
+ *
+ * `generateDungeon` was already a pure function of its config, which makes this tool one of the
+ * few in the readiness pass that did not have a determinism defect in its library. The defect was
+ * in the page: `DungeonGenerator.svelte` held the whole environment step — thirty lines of biome
+ * forcing and terrain vectors — in a component, so the one thing a re-roll from provenance would
+ * have to reproduce lived somewhere a re-roll could not reach. That step is here now, and the page
+ * calls this.
+ *
+ * **Everything the roll chooses is drawn from the seed**, in the order the page drew it, so a
+ * dungeon rolled by this module from a given seed is the dungeon the page produced from that seed
+ * before it existed. The blueprint and the biome consume from the seed's RNG only when the config
+ * leaves them open, which is what "Random" meant on the page.
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import type { Encounter } from '$lib/encounters';
+import {
+  BiomeClassifications,
+  Biomes,
+  describeTerrain,
+  generate as generateEnvironment,
+  getDefaultConfig as getDefaultEnvironmentConfig,
+  type Environment,
+} from '$lib/environment';
+
+import { generateDungeon, roomName } from './generator/generator.js';
+import type { EngineeredDungeon, PopulatedRoom } from './generator/types.js';
+import { toDungeonSnapshot, type DungeonSnapshot } from './dungeon_snapshot.js';
+import { BLUEPRINTS } from './theme/theme.js';
+
+/** The map dimensions the page offers, and the bounds a stored config is read back within. */
+export const DUNGEON_MIN_DIMENSION = 15;
+export const DUNGEON_MAX_DIMENSION = 120;
+export const DUNGEON_DEFAULT_WIDTH = 40;
+export const DUNGEON_DEFAULT_HEIGHT = 60;
+export const DUNGEON_DEFAULT_ENCOUNTER_CHANCE = 0.4;
+export const DUNGEON_DEFAULT_TREASURE_CHANCE = 0.3;
+
+/**
+ * What the generator records about how it rolled, and what a re-roll reads back.
+ *
+ * Stated as a type so the two ends — what is written as provenance and what a re-roll expects to
+ * find — are in one place and drift loudly instead of quietly. It is the page's six controls and
+ * nothing else. `blueprintName` and `biomeName` are absent when the page was left on "Random",
+ * which is the same spelling the organization's config uses for a choice the seed made.
+ */
+export type DungeonGeneratorConfigRecord = {
+  width?: number;
+  height?: number;
+  blueprintName?: string;
+  biomeName?: string;
+  encounterChancePerRoom?: number;
+  treasureChancePerRoom?: number;
+};
+
+/** The blueprints a dungeon may be built to, by name. */
+export function dungeonBlueprintNames(): string[] {
+  return BLUEPRINTS.map((blueprint) => blueprint.name);
+}
+
+/**
+ * The biomes a dungeon may sit in, by name.
+ *
+ * Aquatic classifications are left out: the generator digs rooms and corridors into ground, and a
+ * dungeon in open ocean is a description nothing else in the roll would honour.
+ */
+export function dungeonBiomeNames(): string[] {
+  return BiomeClassifications.getAll()
+    .filter((classification) => !classification.isAquatic)
+    .map((classification) => classification.name);
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(Math.max(value, low), high);
+}
+
+function readDimension(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.round(clamp(value, DUNGEON_MIN_DIMENSION, DUNGEON_MAX_DIMENSION))
+    : fallback;
+}
+
+function readChance(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? clamp(value, 0, 1) : fallback;
+}
+
+function readName(value: unknown, known: string[]): string | undefined {
+  return typeof value === 'string' && known.includes(value) ? value : undefined;
+}
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Anything unrecognisable is dropped rather than coerced, and a name this build no longer has is
+ * dropped with it: a config written by a build that spelled a blueprint differently should fall
+ * back to the seed's own choice, not roll a dungeon to a blueprint it misread. Dimensions and
+ * chances are clamped to the range the page offers, because a stored 10,000-wide map is not a
+ * dungeon anyone asked for and is one the browser would spend a minute packing.
+ */
+export function readDungeonGeneratorConfig(
+  config: Record<string, unknown>,
+): DungeonGeneratorConfigRecord {
+  const blueprintName = readName(config.blueprintName, dungeonBlueprintNames());
+  const biomeName = readName(config.biomeName, dungeonBiomeNames());
+  return {
+    width: readDimension(config.width, DUNGEON_DEFAULT_WIDTH),
+    height: readDimension(config.height, DUNGEON_DEFAULT_HEIGHT),
+    ...(blueprintName === undefined ? {} : { blueprintName }),
+    ...(biomeName === undefined ? {} : { biomeName }),
+    encounterChancePerRoom: readChance(
+      config.encounterChancePerRoom,
+      DUNGEON_DEFAULT_ENCOUNTER_CHANCE,
+    ),
+    treasureChancePerRoom: readChance(
+      config.treasureChancePerRoom,
+      DUNGEON_DEFAULT_TREASURE_CHANCE,
+    ),
+  };
+}
+
+/**
+ * The land the dungeon was dug into.
+ *
+ * Its own stream, `${seed}-env`, so that changing the map size or the treasure chance does not
+ * move the biome under a referee who had settled on one. The generator is run first and the
+ * requested biome forced onto its result afterwards, rather than the biome being asked for up
+ * front, because `generate` picks a biome from the climate it derived and there is no input that
+ * asks it for a particular one — the forcing is what the page did, kept because it is the only
+ * thing that makes the biome control do anything.
+ */
+export function buildDungeonEnvironment(seed: string, biomeName: string): Environment {
+  const config = getDefaultEnvironmentConfig();
+  const rng = new RNG(`${seed}-env`);
+  config.rng = rng;
+  config.latitude = rng.float(-70, 70);
+  config.elevation = rng.float(0.1, 0.8);
+  config.waterDirection = [rng.float(-20, 20), rng.float(-20, 20), 0];
+  config.current = [rng.float(-1, 1), rng.float(-1, 1), 0];
+  config.terrainVector = [rng.float(-0.5, 0.5), rng.float(-0.5, 0.5), 0];
+
+  const environment = generateEnvironment(config);
+  if (environment.biome.name === biomeName) {
+    return environment;
+  }
+
+  const classification = BiomeClassifications.getByName(biomeName);
+  const biome = {
+    ...environment.biome,
+    name: classification.name,
+    features: Biomes.generateBiomeFeatures(classification, rng),
+    descriptions: Biomes.generateBiomeDescriptions(classification, rng),
+  };
+
+  const description = [
+    rng.item(biome.descriptions),
+    rng.item(biome.features),
+    environment.climate.description,
+    describeTerrain(environment.terrain, rng),
+  ].join(' ');
+
+  return { ...environment, biome, description };
+}
+
+/** Roll a dungeon from a seed and a set of options — the one path the page and a re-roll take. */
+export function rollDungeon(
+  seed: string,
+  config: DungeonGeneratorConfigRecord = {},
+): EngineeredDungeon {
+  const rng = new RNG(seed);
+  const blueprintName = config.blueprintName ?? rng.item(dungeonBlueprintNames());
+  const biomeName = config.biomeName ?? rng.item(dungeonBiomeNames());
+
+  return generateDungeon({
+    seed,
+    width: config.width ?? DUNGEON_DEFAULT_WIDTH,
+    height: config.height ?? DUNGEON_DEFAULT_HEIGHT,
+    environment: buildDungeonEnvironment(seed, biomeName),
+    blueprintName,
+    encounterChancePerRoom: config.encounterChancePerRoom ?? DUNGEON_DEFAULT_ENCOUNTER_CHANCE,
+    treasureChancePerRoom: config.treasureChancePerRoom ?? DUNGEON_DEFAULT_TREASURE_CHANCE,
+  });
+}
+
+/**
+ * Roll a fresh dungeon as a snapshot — the destructive half of editing (requirement 4.3), and what
+ * `ARTIFACT_EDITORS` registers as this kind's roller.
+ */
+export function rollDungeonSnapshot(
+  seed: string,
+  config: DungeonGeneratorConfigRecord = {},
+): DungeonSnapshot {
+  return toDungeonSnapshot(rollDungeon(seed, config));
+}
+
+/**
+ * The room a referee walks into first: the one the stairs come up in, or the first room there is.
+ *
+ * Rooms carry their index as their id, so a dungeon whose entrance names a room that is no longer
+ * there falls back to the first rather than to nothing — a dungeon with rooms always has somewhere
+ * to put a referenced encounter.
+ */
+export function entranceRoomIndex(dungeon: EngineeredDungeon): number {
+  const entrance = dungeon.entrances[0];
+  const named =
+    entrance === undefined ? -1 : dungeon.rooms.findIndex((room) => room.id === entrance.roomId);
+  return named >= 0 ? named : dungeon.rooms.length > 0 ? 0 : -1;
+}
+
+/**
+ * Put a saved encounter in the room the dungeon is entered through — requirement 5.1, for the one
+ * kind this tool composes that exists today.
+ *
+ * The entrance room rather than a room drawn from the seed, because a referee who has attached a
+ * particular encounter to a particular dungeon wants to be able to find it: "the thing waiting at
+ * the bottom of the stairs" is a place on the map, where "room 23 of 44" is a search. Whatever the
+ * roll put there is replaced, and the room's name is re-derived so that a room the roll left empty
+ * does not stay labelled abandoned with a guard standing in it.
+ *
+ * A dungeon with no rooms is handed back unchanged. That is a real roll — a low density on a small
+ * grid packs nothing — and there is no room to put an encounter in.
+ *
+ * The reference lives beside the payload as an `ArtifactReference` rather than in the config, and a
+ * re-roll from provenance therefore does not wear it: the same position `$lib/organizations` takes
+ * for referenced arms. The reference was a decision about the dungeon that was.
+ */
+export function withEncounterAtEntrance(
+  dungeon: EngineeredDungeon,
+  encounter: Encounter,
+): EngineeredDungeon {
+  const index = entranceRoomIndex(dungeon);
+  if (index < 0) {
+    return dungeon;
+  }
+  const room = dungeon.rooms[index];
+  const populated: PopulatedRoom = {
+    ...room,
+    name: roomName(room.purpose, encounter, room.treasure),
+    encounter,
+  };
+  return {
+    ...dungeon,
+    rooms: dungeon.rooms.map((entry, position) => (position === index ? populated : entry)),
+  };
+}

--- a/src/lib/dungeon/dungeon_snapshot.test.ts
+++ b/src/lib/dungeon/dungeon_snapshot.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollDungeon } from './dungeon_roll';
+import { dungeonFromSnapshot } from './dungeon_rehydrate';
+import {
+  describeDungeonSize,
+  dungeonSnapshotByteSize,
+  toDungeonSnapshot,
+} from './dungeon_snapshot';
+
+/**
+ * Requirement 7.2: `fromSnapshot(toSnapshot(x))` preserves everything that matters.
+ *
+ * "Everything that matters" for a dungeon is the blueprint — the geometry, the words, and what is
+ * in the rooms. What deliberately does not survive is the live `Species` object behind each
+ * combatant, which `$lib/creatures` rebuilds from its name; the assertions below check the name
+ * rather than the object for that reason.
+ */
+const SEED = 'round-trip-seed';
+const SMALL = {
+  width: 20,
+  height: 20,
+  blueprintName: 'Tomb',
+  biomeName: 'temperate deciduous forest',
+};
+
+describe('a dungeon snapshot', () => {
+  const dungeon = rollDungeon(SEED, SMALL);
+  const snapshot = toDungeonSnapshot(dungeon);
+  const restored = dungeonFromSnapshot(snapshot);
+
+  it('keeps the name, the theme and the geometry', () => {
+    expect(restored.name).toEqual(dungeon.name);
+    expect(restored.theme).toEqual(dungeon.theme);
+    expect(restored.layout).toEqual(dungeon.layout);
+    expect(restored.entrances).toEqual(dungeon.entrances);
+  });
+
+  it('keeps every door and key exactly as they were placed', () => {
+    expect(restored.doors).toEqual(dungeon.doors);
+    expect(restored.keys).toEqual(dungeon.keys);
+  });
+
+  it('keeps every room, its words and its treasure', () => {
+    expect(restored.rooms.length).toEqual(dungeon.rooms.length);
+    for (const [index, room] of dungeon.rooms.entries()) {
+      const back = restored.rooms[index];
+      expect(back.id).toEqual(room.id);
+      expect(back.name).toEqual(room.name);
+      expect(back.purpose).toEqual(room.purpose);
+      expect(back.description).toEqual(room.description);
+      expect(back.primitive).toEqual(room.primitive);
+      expect(back.treasure).toEqual(room.treasure);
+    }
+  });
+
+  it('keeps every combatant in every room that had one', () => {
+    const occupied = dungeon.rooms.filter((room) => room.encounter !== undefined);
+    // A guard, not decoration: the assertions below pass vacuously on a dungeon that rolled empty.
+    expect(occupied.length).toBeGreaterThan(0);
+
+    for (const [index, room] of dungeon.rooms.entries()) {
+      const back = restored.rooms[index].encounter;
+      if (room.encounter === undefined) {
+        expect(back).toBeUndefined();
+        continue;
+      }
+      expect(back?.name).toEqual(room.encounter.name);
+      expect(back?.difficulty).toEqual(room.encounter.difficulty);
+      expect(back?.groups.map((group) => group.mobs.map((mob) => mob.name))).toEqual(
+        room.encounter.groups.map((group) => group.mobs.map((mob) => mob.name)),
+      );
+    }
+  });
+
+  it('carries no functions into storage', () => {
+    expect(() => structuredClone(snapshot)).not.toThrow();
+  });
+
+  it('is a fraction of the size of the dungeon it was taken from', () => {
+    // The measurement decision 7 of docs/tool-readiness.md asked #59 to take, pinned as a test so a
+    // change that puts a whole `Species` back into a payload fails here rather than in a quota
+    // warning. A live 20×20 dungeon is over a megabyte; its snapshot is tens of kilobytes.
+    const live = new TextEncoder().encode(JSON.stringify(dungeon)).length;
+    const stored = dungeonSnapshotByteSize(snapshot);
+    expect(stored).toBeGreaterThan(0);
+    expect(stored * 5).toBeLessThan(live);
+  });
+});
+
+describe('describing a dungeon payload size', () => {
+  it('reads in kilobytes below a megabyte', () => {
+    expect(describeDungeonSize(300 * 1024)).toEqual('300 KB');
+  });
+
+  it('never rounds a payload that exists down to nothing', () => {
+    expect(describeDungeonSize(12)).toEqual('1 KB');
+  });
+
+  it('reads in megabytes above one', () => {
+    expect(describeDungeonSize(2.5 * 1024 * 1024)).toEqual('2.5 MB');
+  });
+});
+
+describe('sizing a payload that will not serialize', () => {
+  it('answers zero rather than throwing', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(dungeonSnapshotByteSize(circular as never)).toEqual(0);
+  });
+});

--- a/src/lib/dungeon/dungeon_snapshot.ts
+++ b/src/lib/dungeon/dungeon_snapshot.ts
@@ -1,0 +1,91 @@
+/**
+ * Writing a dungeon for storage. Reading one back is `dungeon_rehydrate.ts`, split off for the
+ * reason the encounter's halves are: rebuilding a room's encounter reaches `$lib/characters` and
+ * from there the archetype tables and the charge art, and nothing that merely stores, lists or
+ * validates a dungeon needs any of it.
+ *
+ * **The payload is the blueprint, and only the blueprint** — decision 4 of
+ * docs/readiness-locations.md. The grid, the rooms, the doors, the keys, the entrances and the
+ * theme are what a referee reads and edits; the map drawn on a canvas is a rendering of them and
+ * is never stored, because a picture cannot be re-themed, re-rendered larger, or read by anything
+ * but the renderer that made it.
+ *
+ * **One conversion, and it is the one that matters.** Everything an `EngineeredDungeon` holds is
+ * already a plain record of strings, numbers and booleans except a room's `encounter`, whose mobs
+ * embed a whole `Species` each. That single conversion — through the stored vocabulary
+ * `$lib/encounters` already owns — is what makes the payload storable at all: measured over four
+ * sizes, a live dungeon is 1.2 MB at 20×20 and 48 MB at the 120×120 maximum, and the same dungeons
+ * as snapshots are 64 KB and 2.7 MB. See `dungeon_presentation.ts` for what the page tells a user
+ * about that.
+ *
+ * The final `stripFunctionValuesDeep` is a net rather than the mechanism, as it is for an
+ * encounter: nothing here is expected to carry a closure, and the strip is what keeps one grown
+ * somewhere new from turning a save into a `DataCloneError`.
+ */
+
+import { toEncounterSnapshot, type EncounterSnapshot } from '$lib/encounters';
+import { stripFunctionValuesDeep } from '$lib/persistent_save';
+
+import type { EngineeredDungeon, PopulatedRoom } from './generator/types.js';
+
+/** A room as it is stored: everything the generator placed, with its encounter in stored form. */
+export type StoredPopulatedRoom = Omit<PopulatedRoom, 'encounter'> & {
+  encounter?: EncounterSnapshot;
+};
+
+/** A dungeon as it is stored. */
+export type DungeonSnapshot = Omit<EngineeredDungeon, 'rooms'> & {
+  rooms: StoredPopulatedRoom[];
+};
+
+function toStoredRoom(room: PopulatedRoom): StoredPopulatedRoom {
+  const { encounter, ...rest } = room;
+  return encounter === undefined ? rest : { ...rest, encounter: toEncounterSnapshot(encounter) };
+}
+
+export function toDungeonSnapshot(dungeon: EngineeredDungeon): DungeonSnapshot {
+  const converted: DungeonSnapshot = {
+    name: dungeon.name,
+    theme: dungeon.theme,
+    layout: dungeon.layout,
+    rooms: dungeon.rooms.map(toStoredRoom),
+    doors: dungeon.doors,
+    keys: dungeon.keys,
+    entrances: dungeon.entrances,
+  };
+  return stripFunctionValuesDeep(converted) as DungeonSnapshot;
+}
+
+/**
+ * Roughly what this dungeon will occupy in the vault, in bytes.
+ *
+ * The store keeps a payload as JSON, so the serialized length is the honest measure rather than an
+ * estimate from the room count — a room with a six-creature encounter is an order of magnitude
+ * larger than an empty one, and the whole point of showing a number is that a user picking 120×120
+ * with every room occupied can see what they are about to ask their browser to keep.
+ *
+ * Zero for a payload that will not serialize, which is the same answer the save path would give
+ * it: there is nothing to store.
+ */
+export function dungeonSnapshotByteSize(snapshot: DungeonSnapshot): number {
+  try {
+    return new TextEncoder().encode(JSON.stringify(snapshot)).length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * That size in the words a quota warning needs, which is kilobytes or megabytes and never bytes.
+ *
+ * The page shows it beside the save control because this is the one tool in the pass whose payload
+ * can reach megabytes, and a user choosing a 120×120 map with an encounter in every room is making
+ * a storage decision without being told so otherwise. The vault reports its own limits; this
+ * reports what one dungeon costs against them.
+ */
+export function describeDungeonSize(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+}

--- a/src/lib/dungeon/generator/generator.ts
+++ b/src/lib/dungeon/generator/generator.ts
@@ -245,8 +245,17 @@ function doorsOnRoomWalls(room: PlacedRoom, doors: Door[]): { door: Door; wall: 
   return roomDoors;
 }
 
-/** What a room is called, given what ended up in it. */
-function roomName(purpose: string, encounter: Encounter | undefined, treasure: Item[] | undefined) {
+/**
+ * What a room is called, given what ended up in it.
+ *
+ * Exported because composition re-derives it: dropping a saved encounter into a room the roll left
+ * empty would otherwise leave it labelled "Abandoned Crypt" with a guard standing in it.
+ */
+export function roomName(
+  purpose: string,
+  encounter: Encounter | undefined,
+  treasure: Item[] | undefined,
+) {
   if (encounter) {
     return `Occupied ${purpose}`;
   }

--- a/src/lib/dungeon/index.ts
+++ b/src/lib/dungeon/index.ts
@@ -19,3 +19,10 @@ export * from './generator/types';
 export * from './generator/generator';
 
 export * from './render/classic_module_map';
+
+export * from './dungeon_artifact_kind';
+export * from './dungeon_editing';
+export * from './dungeon_presentation';
+export * from './dungeon_rehydrate';
+export * from './dungeon_roll';
+export * from './dungeon_snapshot';

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -100,6 +100,14 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // made-up-names package, and through the star nation roll module the whole of
   // `$lib/astronomical_bodies`. The kind module holds metadata and validation only.
   '$lib/civilizations/star_nation_artifact_kind',
+  // The sixteenth. `$lib/dungeon`'s entry point reaches the dungeon generator, and from there the
+  // encounter generator, the treasure hoard tables and the species tables. The kind module holds
+  // metadata and validation only; its codec is a dynamic import, which is what keeps the
+  // rehydrator's reach into the archetype tables and the charge art out of the registry's chunk.
+  // Measured on the build, the way the entries above were: through this path the registry chunk
+  // and everything it statically imports is 130 KB across 16 chunks, and through the entry point
+  // it is 19.2 MB across 39 — the dungeon alone is the difference between those two figures.
+  '$lib/dungeon/dungeon_artifact_kind',
 ]);
 
 /**

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -113,6 +113,7 @@ describe('TOOL_CATALOG', () => {
     const assessedHigher = [
       '/arms-manufacturer',
       '/chop-shop',
+      '/fantasy/dungeon',
       '/star-nation',
       '/character',
       '/fantasy/encounter',
@@ -228,6 +229,7 @@ describe('toolsWithMaturity', () => {
       '/fantasy/adnd/character',
       '/fantasy/adnd/character/build',
       '/fantasy/dcc/character',
+      '/fantasy/dungeon',
       '/fantasy/encounter',
       '/fantasy/family',
       '/fantasy/organization',
@@ -294,6 +296,7 @@ describe('filterTools', () => {
       '/fantasy/family',
       '/fantasy/organization',
       '/fantasy/religion',
+      '/fantasy/dungeon',
       '/fantasy/settlement',
     ]);
   });

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -257,12 +257,23 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     maturity: 'release-ready',
     genres: ['cyberpunk'],
   }),
+  // Assessed release-ready under #59 against docs/workshop.md, section by section. 1: catalog
+  // entry, `TOOL_PANELS`, and its own route. 2: `dungeon_roll.ts` is the one path from a seed, and
+  // the environment step it now holds used to live in the component where a re-roll could not
+  // reach it; the plan is drawn on a 2D canvas and the room list below it is the dungeon, which is
+  // 2.5. 3: kind `dungeon`, payload the blueprint and never the drawing (decision 4 of
+  // docs/readiness-locations.md), provenance carrying the seed and all six controls. 4: a bespoke
+  // room-shaped editor; retheming relabels and never re-rolls. 5: a saved encounter can be placed
+  // at the foot of the stairs; `environment` has no kind yet, so that half does not bind. 6:
+  // mobile widths via the page manifest, a named canvas over a written-out room list, Markdown and
+  // PDF exports, empty sections dropped. 7: round-trip, migration and Playwright tests. 8: the
+  // library README documents the six kind modules beside its seven subsystems.
   defineTool({
     path: '/fantasy/dungeon',
     label: 'Dungeon',
     kind: 'generator',
     domain: 'locations',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     genres: ['fantasy'],
     tags: ['map'],
   }),

--- a/src/lib/workshop/artifact_editors.test.ts
+++ b/src/lib/workshop/artifact_editors.test.ts
@@ -172,6 +172,20 @@ describe('the artifact editor registry', () => {
     expect(rolled).toEqual(roll({ toolPath: '/chop-shop', seed: 'registry-seed', config: {} }));
   });
 
+  it('rolls a dungeon from provenance through the registered roller', async () => {
+    const roll = await artifactEditorEntry('dungeon')!.loadRoller!();
+    const rolled = roll({
+      toolPath: '/fantasy/dungeon',
+      seed: 'registry-seed',
+      config: { width: 20, height: 20, blueprintName: 'Tomb' },
+    }) as { name: string; theme: { blueprint: { name: string } } };
+
+    expect(rolled.name).not.toBe('');
+    // The recorded blueprint is honoured rather than redrawn, which is the whole claim provenance
+    // makes about a re-roll.
+    expect(rolled.theme.blueprint.name).toBe('Tomb');
+  });
+
   it('rolls a star nation from provenance through the registered roller', async () => {
     const roll = await artifactEditorEntry('star-nation')!.loadRoller!();
     const rolled = roll({

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -177,6 +177,16 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
       return (provenance) => rollChopShopSnapshot(provenance.seed);
     },
   },
+  dungeon: {
+    loadEditor: () => import('$components/locations/DungeonArtifactEditor.svelte'),
+    /** The page's six controls, read back through the roll module's own reader. */
+    loadRoller: async () => {
+      const { readDungeonGeneratorConfig, rollDungeonSnapshot } =
+        await import('$lib/dungeon/dungeon_roll.js');
+      return (provenance) =>
+        rollDungeonSnapshot(provenance.seed, readDungeonGeneratorConfig(provenance.config));
+    },
+  },
   'arms-manufacturer': {
     loadEditor: () => import('$components/factions/ArmsManufacturerArtifactEditor.svelte'),
     /**

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -27,6 +27,7 @@ describe('artifact kind catalog', () => {
       'organization',
       'star-nation',
       'chop-shop',
+      'dungeon',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -27,6 +27,7 @@ import { familyArtifactKind } from '$lib/families/family_artifact_kind';
 import { encounterArtifactKind } from '$lib/encounters/encounter_artifact_kind';
 import { cultureArtifactKind } from '$lib/culture/culture_artifact_kind';
 import { dccCharacterArtifactKind } from '$lib/dcc/dcc_character_artifact_kind';
+import { dungeonArtifactKind } from '$lib/dungeon/dungeon_artifact_kind';
 import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
 import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
 import { settlementArtifactKind } from '$lib/settlements/settlement_artifact_kind';
@@ -61,6 +62,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, organizationArtifactKind);
   registerArtifactKind(registry, starNationArtifactKind);
   registerArtifactKind(registry, chopShopArtifactKind);
+  registerArtifactKind(registry, dungeonArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Closes #59. Takes `/fantasy/dungeon` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the design in `docs/readiness-locations.md` and the shape the pass gives every tool.

## What changed

- **`$lib/dungeon` grows the six kind modules**, flat at the library root beside its seven subsystems: `dungeon_roll.ts`, `dungeon_snapshot.ts`, `dungeon_rehydrate.ts`, `dungeon_artifact_kind.ts`, `dungeon_editing.ts`, `dungeon_presentation.ts` — one test file each.
- **Kind `dungeon`**: the payload is the blueprint (grid, layout, rooms, doors, keys, entrances, theme) and never the drawing. The validator checks a grid's tile count against its own dimensions — a short grid is not a smaller dungeon, it is one whose renderer reads past the end of the array. A dungeon with no rooms is accepted; the generator can pack none at a low density.
- **`DungeonGenerator.svelte`** rolls through the library, saves with all six controls as provenance, exports Markdown and PDF, and keeps its PNG/JPEG map downloads. Its RNG is seeded from the clock once at mount rather than rebuilt on every press.
- **`DungeonArtifactEditor.svelte`** is bespoke and room-shaped: the dungeon's name and blueprint, and per room the name, purpose, description, encounter, combatants, treasure and keys.

## Three corrections

Each verified in the code, and each recorded in `docs/readiness-locations.md`:

- **The dungeon does not draw through Three.js or GLSL, and never did.** Both the issue and the design say it does. Nothing under `src/lib/dungeon` imports `three`, the repository holds no `.glsl` file at all, and the plan is drawn onto a 2D canvas by `render/classic_module_map.ts`. `three` belongs to `$lib/renderers`, which draws the astronomical previews. So 2.5 binds far more mildly than the design feared: the canvas carries an accessible name and fallback content, and the room list under it is the whole dungeon in text, as are the exports. There was no WebGL path to degrade from.
- **The determinism defect was in the page, not the library.** `generateDungeon` was already a pure function of its config — one of the few generators in the pass that was. What was wrong is that the thirty-line environment step feeding it lived in the component, where a re-roll from provenance could not reach it. `dungeon_roll.ts` holds it now, in the order the page drew it; a golden diff over forty seeds confirms the module reproduces exactly what the page produced before it existed. The five clock-defaulting `getDefault*Config` helpers in `$lib/environment` are all overwritten on this path before use, so they stay with #60, which owns them.
- **5.1 binds on `encounter` only**, `environment` having no kind yet. A saved encounter goes in the room the stairs come up in — a place on the map a referee can point at, where "room 23 of 44" would be a search — and the room's name is re-derived so it stops reading as abandoned. The reference sits beside the payload, so a re-roll does not wear it, which is the position `$lib/organizations` already takes.

## The size measurement

Decision 7 of `docs/tool-readiness.md` asked #59 to take it before writing the kind. A live dungeon runs from **1.2 MB at 20×20 to 48 MB at the 120×120 maximum**, almost all of it combatants embedding a whole `Species` each. As snapshots the same four sizes are **64 KB, 304 KB, 700 KB and 2.7 MB**: the stored vocabulary is what makes a dungeon storable at all. `dungeon_snapshot.test.ts` pins the ratio so a change that puts a whole `Species` back into a payload fails there rather than in somebody's quota warning, and the page says what saving one will cost before it is saved.

`$lib/dungeon/dungeon_artifact_kind` joins the deep-import allowlist with a build measurement, as that list requires: through the kind module the registry chunk and everything it statically imports is 130 KB across 16 chunks, and through `$lib/dungeon`'s entry point it is 19.2 MB across 39.

## Editing

Retheming relabels the dungeon and leaves every room as it was rolled, which is 4.2 rather than a shortcut — silently re-rolling forty rooms' purposes because a user changed a label would be regenerating over their work, and the editor says so in as many words. The geometry — positions, room shapes, door and key coordinates — is shown and not edited, because `keys.ts` guarantees a key sits in a zone reachable before the door it opens and a text box over a coordinate would break that quietly.

## Verification

- `npm run verify` green.
- `npm run verify:all`: 527 passed, 3 failed. Two are the `preview_goldens.spec.ts` WebGL cases that the spec documents as expected to differ on a developer GPU. The third, `dcc_character.spec.ts` "offers the derived arithmetic as a command", rolls an unpinned character and then asserts a recalculated Fortitude save differs from 7 — untrue for a draw whose birth augur adds luck to that save. It passes three times running on its own, and nothing here touches DCC.
- New `e2e/dungeon.spec.ts`: generate → save → reopen → edit → reload; retheme without re-rolling; Markdown and PDF exports; same seed reproduces the dungeon; the stored size is shown. All five pass, as do the mobile-width checks for `/fantasy/dungeon`.

## Left as found

- **The library keeps its seven subdirectories.** CODE_STYLE.md prefers a flat library, but grid, room, layout, interactive, theme, generator and render are genuinely this library's subsystems and its README documents them as such. The new modules are flat at the root, which is where the preference points for a library's public face.
- **The map is still a picture and not an artifact.** PNG and JPEG downloads are 6.3 output; nothing stores a rendered map, per decision 3 of `docs/readiness-locations.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiNEQcwu29qi81SrrYg6co
