### PR TITLE
Take the environment generator to Release-ready

### DIFF
--- a/docs/readiness-locations.md
+++ b/docs/readiness-locations.md
@@ -31,6 +31,41 @@ strings, numbers and number arrays. No closures, no `Map`s, no imagery.
   encounter and dungeon generators both reference it, and a genre-neutral kind is one every project
   can use.
 
+**As built.** The kind, the payload and the genre-neutrality landed as written. Three things did
+not.
+
+- **The editor is bespoke, not a `SnapshotFieldEditor` case.** This document said it would be one,
+  and the payload turned out not to be flat: an environment is four nested records, two of which
+  hold lists of strings and one of which holds a list of _season_ records. The descriptor language
+  in [decision 5](tool-readiness.md#5-flat-payloads-get-a-declared-field-editor-not-twenty-five-bespoke-components)
+  addresses `field: string` — a key on the snapshot — so it cannot reach `terrain.elevationMin`,
+  and none of its four controls says "repeat these three fields per row". That decision's own guard
+  is what applies. **`SnapshotFieldEditor` is still unbuilt, and this is the third tool to decline
+  to build it** after #52 and #53, each for the same reason: the payload was not as flat as the
+  design assumed. The remaining candidates on that list are worth re-checking against their actual
+  types before the next tool plans around it.
+- **The five clock-defaulting `getDefault*Config` helpers are gone**, which is
+  [decision 1](tool-readiness.md#1-every-generator-in-the-pass-grows-a-_rollts-and-the-clock-leaves-it)
+  reaching the library rather than the page. Every caller already overwrote the RNG on the next
+  line, so the clock never reached a generated environment; what the default did was make the
+  helper look like a source of randomness a caller could forget about. It is a required parameter
+  in all five now, and `$lib/dungeon`, `$lib/regions`, `$lib/settlements` and
+  `scripts/render_dungeon.ts` each lost the assignment line that followed the call.
+- **The kind needed no deep-import exception, and it is the first in the pass that did not.** The
+  module was written to sit in `ALLOWED_DEEP_IMPORTS` beside the other sixteen and the measurement
+  said not to: the registry chunk is 136.1 KB across 17 chunks whether the kind is imported through
+  `$lib/environment` or past it. This library is tables of numbers and five small sub-generators,
+  with no generator reaching a species list or an image.
+
+**Two defects found while assessing rather than building.** The wind arrow was fetched with
+`document.getElementById('windArrow')`, which finds the first element with that id on the page — so
+two of this tool mounted at once, which the workshop can do, would have drawn both arrows onto one
+canvas and left the other blank. That is 2.1, and it is now `bind:this`. And the page rendered its
+output as a debugging readout — raw floats for humidity, a bare `[0.4, -0.2, 0]` for the wind, and
+the environment's own generated description not shown at all. It renders the presentation document
+now, the same one the exports write, so what a referee reads on screen and what they take away
+cannot drift.
+
 ## #58 — Cyberpunk chop shop
 
 `src/lib/chopshop/index.ts` is a single file whose `generate(rng)` returns **a string** — a

--- a/e2e/environment.spec.ts
+++ b/e2e/environment.spec.ts
@@ -1,0 +1,178 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `environment` kind: generate, save, reopen, edit.
+ *
+ * This is the half no unit test can settle. The library tests prove an environment round-trips
+ * through the codec and that each editing function changes one field; what they cannot prove is
+ * that a referee can press Generate, keep the result, come back to it in a different page, change
+ * something, and still have the place they saved. Every step of that crosses a boundary the unit
+ * tests stub out — the artifact store, IndexedDB, the editor registry, and a page reload.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+
+const ENVIRONMENT_TITLE = 'Environment Generator | Iron Arachne';
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool on this page has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+test.describe('an environment', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'The Cold Coast');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/environment', { title: ENVIRONMENT_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a place to keep straight away.
+    await expect(page.locator('.environment')).toBeVisible();
+    await saveAs(page, 'The Saltmarsh');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'The Saltmarsh');
+
+    // Typed rather than filled: the point is that the editor's own binding carries keystrokes
+    // through to the snapshot it announces. The value is one no roll produces.
+    const biomeName = panel.getByRole('textbox', { name: 'Biome name' });
+    await biomeName.fill('');
+    await biomeName.pressSequentially('drowned fen');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'The Saltmarsh');
+    await expect(reopened.getByRole('textbox', { name: 'Biome name' })).toHaveValue('drowned fen');
+  });
+
+  test('edits a measurement without reclassifying anything around it', async ({ page }) => {
+    // Requirement 4.2: the edited payload is authoritative. Raising the humidity must not silently
+    // pick a different biome, which is what a generator would do with the same number.
+    await visitRoute(page, '/environment', { title: ENVIRONMENT_TITLE });
+    await saveAs(page, 'The Dry Reach');
+
+    const panel = await openInWorkshop(page, 'The Dry Reach');
+    const biomeName = await panel.getByRole('textbox', { name: 'Biome name' }).inputValue();
+
+    await panel.getByRole('spinbutton', { name: 'Biome humidity (0 to 1)' }).fill('0.95');
+    await expect(panel.getByRole('textbox', { name: 'Biome name' })).toHaveValue(biomeName);
+  });
+
+  test('downloads an environment a referee can take to the table', async ({ page }) => {
+    // Requirement 6.3, and the first export this tool has ever had.
+    await visitRoute(page, '/environment', { title: ENVIRONMENT_TITLE });
+    const heading = await page.locator('.environment h2').innerText();
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const markdownFile = await markdown;
+    expect(markdownFile.suggestedFilename()).toMatch(/\.md$/);
+    const contents = await new Response(await markdownFile.createReadStream()).text();
+    expect(contents).toContain(`# ${heading}`);
+    // 6.4: `Ecosystems.generate` is a stub, so an Ecosystem heading would be empty on every sheet.
+    expect(contents).not.toContain('## Ecosystem');
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/\.pdf$/);
+  });
+
+  test('reproduces the same environment from the same seed', async ({ page }) => {
+    // Requirement 2.2. The library was deterministic given a config; what the page lacked was any
+    // record of the eleven numbers that made one, which `environment_roll.ts` now owns.
+    await visitRoute(page, '/environment', { title: ENVIRONMENT_TITLE });
+    const output = page.locator('.environment');
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const first = await output.innerText();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await output.innerText()).toEqual(first);
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await output.innerText()).not.toEqual(first);
+  });
+
+  test('randomizing the parameters does not move what the seed produces', async ({ page }) => {
+    // The button used to draw from the same stream the environment was rolled from, so what
+    // Generate produced depended on how many times Randomize had been pressed.
+    await visitRoute(page, '/environment', { title: ENVIRONMENT_TITLE });
+    await page.getByLabel('Seed', { exact: true }).fill('stable-seed');
+    await page.getByLabel('Lock Seed').check();
+
+    await page.getByRole('button', { name: 'Randomize Parameters' }).click();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const first = await page.locator('.environment').innerText();
+
+    await page.getByRole('button', { name: 'Randomize Parameters' }).click();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await page.locator('.environment').innerText()).toEqual(first);
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -44,6 +44,7 @@ const SILENT_TOOL_PAGES = [
   { path: '/star-nation', title: 'Star Nation Generator | Iron Arachne' },
   { path: '/chop-shop', title: 'Chop Shop Generator | Iron Arachne' },
   { path: '/fantasy/dungeon', title: 'Dungeon Generator | Iron Arachne' },
+  { path: '/environment', title: 'Environment Generator | Iron Arachne' },
   { path: '/fantasy/encounter', title: 'Encounter | Iron Arachne' },
   { path: '/fantasy/family', title: 'Fantasy Family Generator | Iron Arachne' },
   { path: '/fantasy/organization', title: 'Organization Generator | Iron Arachne' },

--- a/scripts/render_dungeon.ts
+++ b/scripts/render_dungeon.ts
@@ -28,7 +28,7 @@ function renderDungeonTerminal() {
   const passedSeed = typeof values.seed === 'string' ? values.seed : `dungeon-test-${Date.now()}`;
   const seedRng = new RNG(passedSeed);
 
-  const environmentConfig = getDefaultEnvironmentConfig();
+  const environmentConfig = getDefaultEnvironmentConfig(seedRng);
   const environment = generateEnvironment(environmentConfig);
 
   const availableBlueprints = BLUEPRINTS.map((b) => b.name);

--- a/src/components/locations/EnvironmentArtifactEditor.svelte
+++ b/src/components/locations/EnvironmentArtifactEditor.svelte
@@ -1,0 +1,456 @@
+<script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import {
+    addBiomeListEntry,
+    addTerrainListEntry,
+    removeBiomeListEntry,
+    removeTerrainListEntry,
+    setBiomeAquatic,
+    setBiomeListEntry,
+    setBiomeName,
+    setBiomeNumber,
+    setClimateNumber,
+    setClimateText,
+    setClimateWindComponent,
+    setEnvironmentDescription,
+    setSeasonAdjustment,
+    setSeasonName,
+    setTerrainListEntry,
+    setTerrainNumber,
+    setTerrainSlopeComponent,
+    setWaterCurrentComponent,
+    setWaterNumber,
+    setWaterType,
+    validateEnvironmentSnapshot,
+    type BiomeListField,
+    type EnvironmentSnapshot,
+    type TerrainListField,
+  } from '$lib/environment';
+
+  /**
+   * The editing view for a saved environment.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it.
+   *
+   * **Bespoke, and not the declared field editor.** `docs/readiness-locations.md` expected this to
+   * be a `SnapshotFieldEditor` case, and the payload turned out not to be flat: an environment is
+   * four nested records, two of which hold lists of strings and one of which holds a list of
+   * *season* records. The descriptor language in decision 5 of `docs/tool-readiness.md` addresses
+   * `field: string` — a key on the snapshot — so it cannot reach `terrain.elevationMin`, and its
+   * four controls have no way to say "repeat these three fields per row". That decision's own
+   * guard is what applies: a kind that needs a fifth control gets a bespoke editor instead.
+   *
+   * **Nothing here recomputes.** Raising the biome's temperature does not reclassify it and moving
+   * the slope does not re-erode the terrain — both would be regenerating over the user's edits,
+   * which is what 4.2 forbids. A user who wants the arithmetic back re-rolls.
+   *
+   * **Ecosystems are absent because they are empty.** `Ecosystems.generate` is a documented stub,
+   * so there is nothing to edit; the export drops the section for the same reason. When the
+   * sub-generator is written, its fields go here.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps this editor from rendering fields over
+   * something that is not an environment.
+   */
+  const accepted = $derived(validateEnvironmentSnapshot(snapshot));
+  const environment = $derived<EnvironmentSnapshot | undefined>(
+    accepted.ok ? accepted.value : undefined,
+  );
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: EnvironmentSnapshot) => EnvironmentSnapshot): void {
+    if (environment === undefined) {
+      return;
+    }
+    onChange(change(environment));
+  }
+
+  /** The biome's and the terrain's list sections, so the markup below states each one once. */
+  const BIOME_LISTS: { field: BiomeListField; label: string }[] = [
+    { field: 'descriptions', label: 'Biome description' },
+    { field: 'features', label: 'Biome feature' },
+  ];
+
+  const TERRAIN_LISTS: { field: TerrainListField; label: string }[] = [
+    { field: 'landforms', label: 'Landform' },
+    { field: 'soilTypes', label: 'Soil' },
+    { field: 'rockTypes', label: 'Rock' },
+  ];
+
+  function terrainListOf(current: EnvironmentSnapshot, field: TerrainListField): string[] {
+    return field === 'landforms'
+      ? current.terrain.landforms
+      : current.terrain.geologicalMakeup[field];
+  }
+</script>
+
+{#snippet numberRow(id: string, label: string, value: number, apply: (next: number) => void)}
+  <div class="input-group input-group--inline">
+    <label for={id}>{label}</label>
+    <input
+      {id}
+      type="number"
+      step="any"
+      {value}
+      oninput={(event) => apply(event.currentTarget.valueAsNumber)}
+    />
+  </div>
+{/snippet}
+
+{#snippet textRow(id: string, label: string, value: string, apply: (next: string) => void)}
+  <div class="input-group input-group--inline">
+    <label for={id}>{label}</label>
+    <input
+      {id}
+      type="text"
+      {value}
+      oninput={(event) => apply(event.currentTarget.value)}
+      autocomplete="off"
+    />
+  </div>
+{/snippet}
+
+{#if environment === undefined}
+  <Notice tone="danger">
+    These contents are stored as an environment but do not read as one, so there is nothing safe to
+    edit here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="environment-editor">
+    <div class="input-group">
+      <!-- Qualified as "Environment description" rather than "Description": the panel above has a
+           field labelled "Name" that renames the artifact, and the climate has a description of its
+           own further down. Two fields with the same accessible name in one region is the 6.2
+           failure. -->
+      <label for="{uid}-description">Environment description</label>
+      <textarea
+        id="{uid}-description"
+        rows="3"
+        value={environment.description}
+        oninput={(event) =>
+          edit((current) => setEnvironmentDescription(current, event.currentTarget.value))}
+      ></textarea>
+    </div>
+
+    <fieldset>
+      <legend>Biome</legend>
+
+      {@render textRow(`${uid}-biome-name`, 'Biome name', environment.biome.name, (next) =>
+        edit((current) => setBiomeName(current, next)),
+      )}
+      {@render numberRow(
+        `${uid}-biome-temperature`,
+        'Biome temperature (°C)',
+        environment.biome.temperature,
+        (next) => edit((current) => setBiomeNumber(current, 'temperature', next)),
+      )}
+      {@render numberRow(
+        `${uid}-biome-altitude`,
+        'Biome altitude (−1 to 1)',
+        environment.biome.altitude,
+        (next) => edit((current) => setBiomeNumber(current, 'altitude', next)),
+      )}
+      {@render numberRow(
+        `${uid}-biome-humidity`,
+        'Biome humidity (0 to 1)',
+        environment.biome.humidity,
+        (next) => edit((current) => setBiomeNumber(current, 'humidity', next)),
+      )}
+
+      <label class="environment-editor__check" for="{uid}-biome-aquatic">
+        <input
+          id="{uid}-biome-aquatic"
+          type="checkbox"
+          checked={environment.biome.isAquatic}
+          onchange={(event) =>
+            edit((current) => setBiomeAquatic(current, event.currentTarget.checked))}
+        />
+        This biome is under water
+      </label>
+
+      {#each BIOME_LISTS as list (list.field)}
+        {#each environment.biome[list.field] as entry, index (index)}
+          <div class="environment-editor__row">
+            {@render textRow(
+              `${uid}-biome-${list.field}-${index}`,
+              `${list.label} ${index + 1}`,
+              entry,
+              (next) => edit((current) => setBiomeListEntry(current, list.field, index, next)),
+            )}
+            <BaseButton
+              aria-label="Remove {list.label.toLowerCase()} {index + 1}"
+              onclick={() => edit((current) => removeBiomeListEntry(current, list.field, index))}
+            >
+              Remove
+            </BaseButton>
+          </div>
+        {/each}
+        <BaseButton onclick={() => edit((current) => addBiomeListEntry(current, list.field))}>
+          Add {list.label.toLowerCase()}
+        </BaseButton>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Climate</legend>
+
+      {@render textRow(`${uid}-climate-name`, 'Climate name', environment.climate.name, (next) =>
+        edit((current) => setClimateText(current, 'name', next)),
+      )}
+
+      <div class="input-group">
+        <label for="{uid}-climate-description">Climate description</label>
+        <textarea
+          id="{uid}-climate-description"
+          rows="2"
+          value={environment.climate.description}
+          oninput={(event) =>
+            edit((current) => setClimateText(current, 'description', event.currentTarget.value))}
+        ></textarea>
+      </div>
+
+      {@render numberRow(
+        `${uid}-climate-temperature`,
+        'Average temperature (°C)',
+        environment.climate.temperature,
+        (next) => edit((current) => setClimateNumber(current, 'temperature', next)),
+      )}
+      {@render numberRow(
+        `${uid}-climate-temperature-min`,
+        'Night temperature (°C)',
+        environment.climate.temperatureMin,
+        (next) => edit((current) => setClimateNumber(current, 'temperatureMin', next)),
+      )}
+      {@render numberRow(
+        `${uid}-climate-temperature-max`,
+        'Midday temperature (°C)',
+        environment.climate.temperatureMax,
+        (next) => edit((current) => setClimateNumber(current, 'temperatureMax', next)),
+      )}
+      {@render numberRow(
+        `${uid}-climate-humidity`,
+        'Climate humidity (0 to 1)',
+        environment.climate.humidity,
+        (next) => edit((current) => setClimateNumber(current, 'humidity', next)),
+      )}
+      {@render numberRow(
+        `${uid}-climate-cloud`,
+        'Cloud cover (0 to 1)',
+        environment.climate.cloudCover,
+        (next) => edit((current) => setClimateNumber(current, 'cloudCover', next)),
+      )}
+      {@render numberRow(
+        `${uid}-climate-precipitation-amount`,
+        'Precipitation amount (0 to 1)',
+        environment.climate.precipitationAmount,
+        (next) => edit((current) => setClimateNumber(current, 'precipitationAmount', next)),
+      )}
+      {@render numberRow(
+        `${uid}-climate-precipitation-frequency`,
+        'Precipitation frequency (0 to 1)',
+        environment.climate.precipitationFrequency,
+        (next) => edit((current) => setClimateNumber(current, 'precipitationFrequency', next)),
+      )}
+      {@render numberRow(
+        `${uid}-wind-x`,
+        'Wind east–west',
+        environment.climate.wind[0] ?? 0,
+        (next) => edit((current) => setClimateWindComponent(current, 0, next)),
+      )}
+      {@render numberRow(
+        `${uid}-wind-y`,
+        'Wind north–south',
+        environment.climate.wind[1] ?? 0,
+        (next) => edit((current) => setClimateWindComponent(current, 1, next)),
+      )}
+
+      {#each environment.climate.seasons as season, index (index)}
+        {@render textRow(
+          `${uid}-season-${index}-name`,
+          `Season ${index + 1} name`,
+          season.name,
+          (next) => edit((current) => setSeasonName(current, index, next)),
+        )}
+        {@render numberRow(
+          `${uid}-season-${index}-temperature`,
+          `Season ${index + 1} temperature shift (°C)`,
+          season.temperatureAdjustment,
+          (next) =>
+            edit((current) => setSeasonAdjustment(current, index, 'temperatureAdjustment', next)),
+        )}
+        {@render numberRow(
+          `${uid}-season-${index}-humidity`,
+          `Season ${index + 1} humidity shift`,
+          season.humidityAdjustment,
+          (next) =>
+            edit((current) => setSeasonAdjustment(current, index, 'humidityAdjustment', next)),
+        )}
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Terrain</legend>
+
+      {@render numberRow(
+        `${uid}-terrain-elevation-min`,
+        'Lowest elevation (−1 to 1)',
+        environment.terrain.elevationMin,
+        (next) => edit((current) => setTerrainNumber(current, 'elevationMin', next)),
+      )}
+      {@render numberRow(
+        `${uid}-terrain-elevation-max`,
+        'Highest elevation (−1 to 1)',
+        environment.terrain.elevationMax,
+        (next) => edit((current) => setTerrainNumber(current, 'elevationMax', next)),
+      )}
+      {@render numberRow(
+        `${uid}-terrain-relief`,
+        'Relief energy (0 to 1)',
+        environment.terrain.reliefEnergy,
+        (next) => edit((current) => setTerrainNumber(current, 'reliefEnergy', next)),
+      )}
+      {@render numberRow(
+        `${uid}-slope-x`,
+        'Slope east–west',
+        environment.terrain.normalVector[0] ?? 0,
+        (next) => edit((current) => setTerrainSlopeComponent(current, 0, next)),
+      )}
+      {@render numberRow(
+        `${uid}-slope-y`,
+        'Slope north–south',
+        environment.terrain.normalVector[1] ?? 0,
+        (next) => edit((current) => setTerrainSlopeComponent(current, 1, next)),
+      )}
+
+      {#each TERRAIN_LISTS as list (list.field)}
+        {#each terrainListOf(environment, list.field) as entry, index (index)}
+          <div class="environment-editor__row">
+            {@render textRow(
+              `${uid}-terrain-${list.field}-${index}`,
+              `${list.label} ${index + 1}`,
+              entry,
+              (next) => edit((current) => setTerrainListEntry(current, list.field, index, next)),
+            )}
+            <BaseButton
+              aria-label="Remove {list.label.toLowerCase()} {index + 1}"
+              onclick={() => edit((current) => removeTerrainListEntry(current, list.field, index))}
+            >
+              Remove
+            </BaseButton>
+          </div>
+        {/each}
+        <BaseButton onclick={() => edit((current) => addTerrainListEntry(current, list.field))}>
+          Add {list.label.toLowerCase()}
+        </BaseButton>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Water</legend>
+
+      {@render textRow(
+        `${uid}-water-type`,
+        'Water type',
+        environment.waterSystem.waterType,
+        (next) => edit((current) => setWaterType(current, next)),
+      )}
+      {@render numberRow(
+        `${uid}-water-level`,
+        'Water surface level (−1 to 1)',
+        environment.waterSystem.surfaceLevel,
+        (next) => edit((current) => setWaterNumber(current, 'surfaceLevel', next)),
+      )}
+      {@render numberRow(
+        `${uid}-water-temperature`,
+        'Water temperature (°C)',
+        environment.waterSystem.temperature,
+        (next) => edit((current) => setWaterNumber(current, 'temperature', next)),
+      )}
+      {@render numberRow(
+        `${uid}-current-x`,
+        'Current east–west',
+        environment.waterSystem.current[0] ?? 0,
+        (next) => edit((current) => setWaterCurrentComponent(current, 0, next)),
+      )}
+      {@render numberRow(
+        `${uid}-current-y`,
+        'Current north–south',
+        environment.waterSystem.current[1] ?? 0,
+        (next) => edit((current) => setWaterCurrentComponent(current, 1, next)),
+      )}
+    </fieldset>
+  </div>
+{/if}
+
+<style>
+  .environment-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+  }
+
+  .environment-editor fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s3);
+    align-items: flex-start;
+    margin: 0;
+    /* No border and no radius, matching the encounter, dungeon and character editors: a fieldset
+       inside an editor panel was a box inside a box, and the legend and the spacing already group
+       these. */
+    padding: var(--s4) 0;
+    min-width: 0;
+  }
+
+  .environment-editor legend {
+    padding: 0 var(--s3);
+    color: var(--gold);
+    font-size: var(--t-micro-size);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .environment-editor :global(.input-group) {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .environment-editor :global(input[type='text']),
+  .environment-editor :global(input[type='number']),
+  .environment-editor textarea {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+
+  .environment-editor__row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--s3);
+    width: 100%;
+    min-width: 0;
+  }
+
+  .environment-editor__check {
+    display: flex;
+    align-items: center;
+    gap: var(--s3);
+  }
+</style>

--- a/src/components/locations/EnvironmentGenerator.svelte
+++ b/src/components/locations/EnvironmentGenerator.svelte
@@ -1,241 +1,300 @@
 <script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import { RNG } from '@ironarachne/rng';
   import Stat from '$components/common/Stat.svelte';
   import StatBlock from '$components/common/StatBlock.svelte';
-  import * as RNG from '@ironarachne/rng';
-  import { Directions } from '$lib/geometry';
-  import { Environments } from '$lib/environment';
-  import * as Temperature from '$lib/temperature';
-  import * as MathTranslation from '$lib/math_translation';
-  import type { Environment } from '$lib/environment';
-  import { onMount } from 'svelte';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
   import SeedControls from '$components/common/SeedControls.svelte';
   import NumberField from '$components/common/NumberField.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
+  import { downloadTextFile } from '$lib/download';
+  import { downloadTextPdf } from '$lib/pdf';
+  import * as Environments from '$lib/environment';
+  import type { Environment, EnvironmentGeneratorConfigRecord } from '$lib/environment';
 
-  const rng = new RNG.RNG(Date.now().toString());
+  const TOOL_PATH = '/environment';
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. It used to be the generator's RNG as
+   * well, reseeded from the seed box on every press and handed straight to the config — so the one
+   * object was doing two jobs, and `randomizeParameters` drew its eleven numbers from the same
+   * stream the environment was about to be rolled from. `environment_roll.ts` owns both draws now,
+   * each from its own stream.
+   */
+  const rng = new RNG(Date.now().toString());
   let seed = $state(rng.randomString(13));
-  $effect(() => {
-    rng.setSeed(seed);
-  });
   let lockSeed = $state(false);
 
-  let environment: Environment | undefined = $state();
-  let canvas: HTMLCanvasElement;
-  const config = $state(Environments.getDefaultConfig());
-  config.rng = rng;
+  const defaults = Environments.defaultEnvironmentGeneratorConfig();
+  let latitude = $state(defaults.latitude);
+  let elevation = $state(defaults.elevation);
+  let erosionIterations = $state(defaults.erosionIterations);
+  let erosionStrength = $state(defaults.erosionStrength);
+  let reliefEnergy = $state(defaults.reliefEnergy);
+  let terrainVectorX = $state(defaults.terrainVector[0]);
+  let terrainVectorY = $state(defaults.terrainVector[1]);
+  let currentX = $state(defaults.current[0]);
+  let currentY = $state(defaults.current[1]);
+  let waterDirectionX = $state(defaults.waterDirection[0]);
+  let waterDirectionY = $state(defaults.waterDirection[1]);
 
-  function elevationToFeet(elevation: number): number {
-    const max = 30000;
-    const min = -30000;
+  /**
+   * The wind arrow's canvas.
+   *
+   * `bind:this`, and that is a fix rather than a tidy-up: this was
+   * `document.getElementById('windArrow')`, which finds the *first* element with that id on the
+   * page. A tool must work identically in a panel and on its own route (2.1), and the workshop can
+   * mount two of anything — two of these would have drawn both arrows onto one canvas and left the
+   * other blank.
+   */
+  let windCanvas = $state<HTMLCanvasElement | undefined>(undefined);
 
-    const result = MathTranslation.linearMap(elevation, -1, 1, min, max);
+  /**
+   * The rolled environment.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every object in the value
+   * in a Proxy, and `structuredClone` — what IndexedDB stores with — refuses a Proxy outright, so
+   * saving fails with `could not be cloned`.
+   */
+  let environment = $state.raw<Environment | undefined>(undefined);
 
-    return Math.floor(result);
-  }
-
-  function generate() {
-    if (!lockSeed) {
-      seed = rng.randomString(13);
-    }
-    rng.setSeed(seed);
-    environment = Environments.generate(config);
-    if (canvas !== null && typeof canvas === 'object') {
-      drawWindArrow(canvas, environment.climate.wind);
-    }
-  }
-
-  function describeSlope(vector: number[]): string {
-    if (vector[0] === 0 && vector[1] === 0) {
-      return 'flat';
-    }
-
-    return `sloping ${Directions.getWordForVector(vector)}`;
-  }
-
-  function randomizeParameters(rng: RNG.RNG) {
-    config.latitude = rng.float(-70, 70);
-    config.elevation = rng.float(0.1, 0.8);
-    config.waterDirection = [rng.float(-20, 20), rng.float(-20, 20), 0];
-    config.current = [rng.float(-1, 1), rng.float(-1, 1), 0];
-    config.terrainVector = [rng.float(-0.5, 0.5), rng.float(-0.5, 0.5), 0];
-  }
-
-  onMount(() => {
-    canvas = document.getElementById('windArrow') as HTMLCanvasElement;
-    generate();
+  /** What the roll records about itself: the page's eleven controls, as provenance (3.6). */
+  const generatorConfig = $derived<EnvironmentGeneratorConfigRecord>({
+    latitude,
+    elevation,
+    erosionIterations,
+    erosionStrength,
+    reliefEnergy,
+    terrainVector: [terrainVectorX, terrainVectorY],
+    current: [currentX, currentY],
+    waterDirection: [waterDirectionX, waterDirectionY],
   });
 
-  function drawWindArrow(canvas: HTMLCanvasElement, wind: number[]) {
-    const ctx = canvas.getContext('2d');
+  const environmentSnapshot = $derived(
+    environment === undefined ? null : Environments.toEnvironmentSnapshot(environment),
+  );
 
+  const document_ = $derived(
+    environmentSnapshot === null ? null : Environments.environmentToDocument(environmentSnapshot),
+  );
+
+  const defaultArtifactName = $derived(
+    environmentSnapshot === null ? '' : Environments.environmentDisplayName(environmentSnapshot),
+  );
+
+  function applyConfig(config: EnvironmentGeneratorConfigRecord): void {
+    latitude = config.latitude;
+    elevation = config.elevation;
+    erosionIterations = config.erosionIterations;
+    erosionStrength = config.erosionStrength;
+    reliefEnergy = config.reliefEnergy;
+    [terrainVectorX, terrainVectorY] = config.terrainVector;
+    [currentX, currentY] = config.current;
+    [waterDirectionX, waterDirectionY] = config.waterDirection;
+  }
+
+  /**
+   * Draws the wind as an arrow, when there is a canvas to draw it on.
+   *
+   * A missing canvas is an ordinary state rather than a failure (2.5): the wind is printed as a
+   * compass direction and a strength beside it, and the arrow is a picture of that.
+   */
+  async function drawWindArrow(): Promise<void> {
+    await tick();
+    const canvas = windCanvas;
+    if (canvas === undefined || environment === undefined) {
+      return;
+    }
+    const ctx = canvas.getContext('2d');
     if (ctx === null) {
-      console.debug('no context');
       return;
     }
 
+    const wind = environment.climate.wind;
+    const size = canvas.width;
+    const centre = size / 2;
+    const wedge = 3;
+    const length = ((size / 2) * (wind[0] + wind[1])) / 2;
+
     ctx.reset();
-
-    const width = 100;
-    const height = 100;
-    const centerX = width / 2;
-    const centerY = height / 2;
-    const wedgeLength = 3;
-    const arrowLength = ((width / 2) * (wind[0] + wind[1])) / 2;
-    const windDirection = wind;
-    const r = Math.atan2(windDirection[1], windDirection[0]);
-
-    ctx.clearRect(0, 0, width, height);
-
+    ctx.clearRect(0, 0, size, size);
+    ctx.strokeStyle = getComputedStyle(canvas).color;
     ctx.save();
-
-    ctx.translate(centerX, centerY);
-    ctx.rotate(r);
+    ctx.translate(centre, centre);
+    ctx.rotate(Math.atan2(wind[1], wind[0]));
 
     ctx.beginPath();
     ctx.moveTo(0, 0);
-    ctx.lineTo(arrowLength, 0);
+    ctx.lineTo(length, 0);
     ctx.stroke();
 
     ctx.beginPath();
-    ctx.moveTo(arrowLength - wedgeLength, -wedgeLength);
-    ctx.lineTo(arrowLength, 0);
-    ctx.lineTo(arrowLength - wedgeLength, wedgeLength);
+    ctx.moveTo(length - wedge, -wedge);
+    ctx.lineTo(length, 0);
+    ctx.lineTo(length - wedge, wedge);
     ctx.stroke();
 
     ctx.restore();
   }
+
+  async function generate(): Promise<void> {
+    if (!lockSeed) {
+      seed = rng.randomString(13);
+    }
+    environment = Environments.rollEnvironment(seed, generatorConfig);
+    await drawWindArrow();
+  }
+
+  /**
+   * Draw a fresh set of physical parameters.
+   *
+   * Derived from the seed rather than from the page's RNG, so that pressing this twice with a
+   * locked seed gives the same place twice — the button used to draw from the same stream the
+   * environment was rolled from, which made what Generate produced depend on how many times this
+   * had been pressed.
+   */
+  function randomizeParameters(): void {
+    applyConfig(Environments.randomEnvironmentGeneratorConfig(seed));
+  }
+
+  function exportMarkdown(): void {
+    if (environmentSnapshot === null) {
+      return;
+    }
+    downloadTextFile(
+      Environments.environmentToMarkdown(environmentSnapshot),
+      `${Environments.environmentFileStem(environmentSnapshot)}.md`,
+      'text/markdown',
+    );
+  }
+
+  async function exportPdf(): Promise<void> {
+    if (environmentSnapshot === null) {
+      return;
+    }
+    await downloadTextPdf(
+      Environments.environmentDisplayName(environmentSnapshot),
+      Environments.environmentToText(environmentSnapshot),
+      `${Environments.environmentFileStem(environmentSnapshot)}.pdf`,
+    );
+  }
+
+  onMount(() => {
+    void generate();
+  });
 </script>
 
-<GeneratorPage toolPath="/environment" title="Environment Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Environment Generator">
   {#snippet description()}
-    <p>This generates fictional environments. This is mostly useful for debugging.</p>
+    <p>
+      The natural setting of a place: its biome, climate, terrain and water. Genre-neutral, and the
+      land the dungeon and region generators build on.
+    </p>
   {/snippet}
-
-  <NumberField id="latitude" label="Latitude" bind:value={config.latitude} />
-  <NumberField id="elevation" label="Elevation" bind:value={config.elevation} />
-  <NumberField
-    id="erosionIterations"
-    label="Erosion Iterations"
-    bind:value={config.erosionIterations}
-  />
-  <NumberField id="erosionStrength" label="Erosion Strength" bind:value={config.erosionStrength} />
-  <NumberField id="reliefEnergy" label="Relief Energy" bind:value={config.reliefEnergy} />
-  <NumberField id="terrainVector0" label="Terrain Vector X" bind:value={config.terrainVector[0]} />
-  <NumberField id="terrainVector1" label="Terrain Vector Y" bind:value={config.terrainVector[1]} />
-  <NumberField id="current0" label="Current X" bind:value={config.current[0]} />
-  <NumberField id="current1" label="Current Y" bind:value={config.current[1]} />
-  <NumberField
-    id="waterDirection0"
-    label="Water Direction X"
-    bind:value={config.waterDirection[0]}
-  />
-  <NumberField
-    id="waterDirection1"
-    label="Water Direction Y"
-    bind:value={config.waterDirection[1]}
-  />
 
   <SeedControls bind:seed bind:lockSeed />
 
-  <BaseButton onclick={generate}>Generate</BaseButton>
-  <BaseButton
-    onclick={() => {
-      randomizeParameters(rng);
-    }}>Randomize Parameters</BaseButton
-  >
+  <NumberField id="latitude" label="Latitude" bind:value={latitude} min={-90} max={90} />
+  <NumberField id="elevation" label="Elevation" bind:value={elevation} step={0.05} />
+  <NumberField
+    id="erosionIterations"
+    label="Erosion Iterations"
+    bind:value={erosionIterations}
+    min={0}
+  />
+  <NumberField id="erosionStrength" label="Erosion Strength" bind:value={erosionStrength} min={0} />
+  <NumberField id="reliefEnergy" label="Relief Energy" bind:value={reliefEnergy} step={0.05} />
+  <NumberField
+    id="terrainVector0"
+    label="Terrain Vector X"
+    bind:value={terrainVectorX}
+    step={0.1}
+  />
+  <NumberField
+    id="terrainVector1"
+    label="Terrain Vector Y"
+    bind:value={terrainVectorY}
+    step={0.1}
+  />
+  <NumberField id="current0" label="Current X" bind:value={currentX} step={0.1} />
+  <NumberField id="current1" label="Current Y" bind:value={currentY} step={0.1} />
+  <NumberField id="waterDirection0" label="Water Direction X" bind:value={waterDirectionX} />
+  <NumberField id="waterDirection1" label="Water Direction Y" bind:value={waterDirectionY} />
 
-  {#if environment}
-    <h2>Terrain</h2>
+  <div class="actions">
+    <BaseButton onclick={() => void generate()}>Generate</BaseButton>
+    <BaseButton onclick={randomizeParameters}>Randomize Parameters</BaseButton>
+    <BaseButton onclick={exportMarkdown} disabled={!environment}>Download Markdown</BaseButton>
+    <BaseButton onclick={exportPdf} disabled={!environment}>Download PDF</BaseButton>
+  </div>
 
-    <Stat label="Elevation Min">
-      {environment.terrain.elevationMin} ({elevationToFeet(environment.terrain.elevationMin)} ft.)
-    </Stat>
-    <Stat label="Elevation Max">
-      {environment.terrain.elevationMax} ({elevationToFeet(environment.terrain.elevationMax)} ft.)
-    </Stat>
-    <StatBlock>
-      <Stat label="Relief Energy">{environment.terrain.reliefEnergy}</Stat>
-    </StatBlock>
-    <Stat label="Normal Vector">
-      {environment.terrain.normalVector} ({describeSlope(environment.terrain.normalVector)})
-    </Stat>
+  <SaveArtifactButton
+    kind={Environments.ENVIRONMENT_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={environmentSnapshot}
+    {seed}
+    config={generatorConfig}
+    defaultName={defaultArtifactName}
+  />
 
-    <h2>Water System</h2>
+  {#if document_}
+    <!-- The page renders the same document the exports do, so what a referee reads on screen and
+         what they take away cannot drift, and an empty part is absent from both (6.4). -->
+    <div class="environment">
+      <h2>{document_.title}</h2>
 
-    <Stat label="Water Level">
-      {environment.waterSystem.surfaceLevel} ({elevationToFeet(
-        environment.waterSystem.surfaceLevel,
-      )} ft.)
-    </Stat>
-    <StatBlock>
-      <Stat label="Water Type">{environment.waterSystem.waterType}</Stat>
-    </StatBlock>
-    <Stat label="Temperature">
-      {Temperature.getComparativeString(environment.waterSystem.temperature, 'celsius')}
-    </Stat>
-    <StatBlock>
-      <Stat label="Current">{environment.waterSystem.current}</Stat>
-    </StatBlock>
+      {#each document_.paragraphs as paragraph, index (index)}
+        <p>{paragraph}</p>
+      {/each}
 
-    <h2>Climate</h2>
+      {#each document_.sections as section (section.heading)}
+        <h3>{section.heading}</h3>
+        <StatBlock>
+          {#each section.lines.filter((line) => line.label !== undefined) as line, index (index)}
+            <Stat label={line.label ?? ''}>{line.value}</Stat>
+          {/each}
+        </StatBlock>
 
-    <p>{environment.climate.description}</p>
+        <!-- A biome feature is a sentence rather than a measurement, so it reads as one. -->
+        {#each section.lines.filter((line) => line.label === undefined) as line, index (index)}
+          <p>{line.value}</p>
+        {/each}
 
-    <StatBlock>
-      <Stat label="Climate Type">{environment.climate.name}</Stat>
-      <Stat label="Cloud Cover">{environment.climate.cloudCover}</Stat>
-      <Stat label="Wind">{environment.climate.wind}</Stat>
-    </StatBlock>
-
-    <canvas id="windArrow" width="100" height="100"></canvas>
-
-    <Stat label="Temperature Min">
-      {Temperature.getComparativeString(environment.climate.temperatureMin, 'celsius')}
-    </Stat>
-    <Stat label="Temperature Max">
-      {Temperature.getComparativeString(environment.climate.temperatureMax, 'celsius')}
-    </Stat>
-    <StatBlock>
-      <Stat label="Precipitation Amount">{environment.climate.precipitationAmount}</Stat>
-      <Stat label="Precipitation Frequency">{environment.climate.precipitationFrequency}</Stat>
-      <Stat label="Humidity">{environment.climate.humidity}</Stat>
-    </StatBlock>
-
-    <h3>Seasons</h3>
-
-    {#each environment.climate.seasons as season}
-      <StatBlock>
-        <Stat label="Season Name">{season.name}</Stat>
-        <Stat label="Temperature Adjustment">{season.temperatureAdjustment}</Stat>
-        <Stat label="Humidity Adjustment">{season.humidityAdjustment}</Stat>
-      </StatBlock>
-    {/each}
-
-    <h2>Biome</h2>
-
-    <StatBlock>
-      <Stat label="Biome Name">{environment.biome.name}</Stat>
-      <Stat label="Temperature">{environment.biome.temperature}</Stat>
-    </StatBlock>
-    <Stat label="Altitude">
-      {environment.biome.altitude} ({elevationToFeet(environment.biome.altitude)} ft.)
-    </Stat>
-    <StatBlock>
-      <Stat label="Humidity">{environment.biome.humidity}</Stat>
-      <Stat label="Is Aquatic">{environment.biome.isAquatic}</Stat>
-    </StatBlock>
-
-    <h3>Descriptions</h3>
-
-    {#each environment.biome.descriptions as description}
-      <p>{description}</p>
-    {/each}
-
-    <h3>Features</h3>
-
-    {#each environment.biome.features as feature}
-      <p>{feature}</p>
-    {/each}
+        {#if section.heading === 'Climate'}
+          <!-- The arrow is a picture of the wind line above it, which is why the canvas can be
+               missing without anything being lost (2.5). -->
+          <canvas
+            bind:this={windCanvas}
+            width="100"
+            height="100"
+            class="wind-arrow"
+            aria-label="Wind direction: {Environments.describeVector(
+              environmentSnapshot?.climate.wind ?? [],
+            )}"
+          >
+            <p>
+              The wind blows {Environments.describeVector(environmentSnapshot?.climate.wind ?? [])}.
+            </p>
+          </canvas>
+        {/if}
+      {/each}
+    </div>
   {/if}
 </GeneratorPage>
+
+<style>
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+  }
+
+  .wind-arrow {
+    display: block;
+    max-width: 100%;
+  }
+</style>

--- a/src/lib/dungeon/dungeon_roll.ts
+++ b/src/lib/dungeon/dungeon_roll.ts
@@ -132,9 +132,8 @@ export function readDungeonGeneratorConfig(
  * thing that makes the biome control do anything.
  */
 export function buildDungeonEnvironment(seed: string, biomeName: string): Environment {
-  const config = getDefaultEnvironmentConfig();
   const rng = new RNG(`${seed}-env`);
-  config.rng = rng;
+  const config = getDefaultEnvironmentConfig(rng);
   config.latitude = rng.float(-70, 70);
   config.elevation = rng.float(0.1, 0.8);
   config.waterDirection = [rng.float(-20, 20), rng.float(-20, 20), 0];

--- a/src/lib/environment/README.md
+++ b/src/lib/environment/README.md
@@ -28,6 +28,40 @@ exports `generate` and `getDefaultConfig`, which is why the index namespaces the
 - **Weather events** — `PrecipitationTypes.getRandomWeatherEvents`, used by
   [`$lib/weather`](../weather/README.md).
 
+## The artifact kind
+
+The five modules the readiness pass gives every Release-ready tool
+([docs/tool-readiness.md](../../../docs/tool-readiness.md)), flat at the library root beside the
+sub-libraries:
+
+- **`environment_roll.ts`** — the one path from a seed to an environment, taken by the generator
+  page and by a re-roll from provenance. `EnvironmentGeneratorConfigRecord` is the eleven physical
+  inputs the page offers and nothing else; the four sub-configs are not recorded, because `generate`
+  overwrites every field of them it uses. `randomEnvironmentGeneratorConfig` draws the
+  "Randomize Parameters" numbers from a stream of their own, so pressing that button does not move
+  what the seed produces.
+- **`environment_snapshot.ts`** — writing an environment for storage and reading it back, both
+  halves in one file because reading pulls nothing heavy. `dominantEcosystem` is not stored: it is
+  `ecosystems[0]`, and storing both would write the same ecosystem twice.
+- **`environment_artifact_kind.ts`** — kind `environment`, payload version 1, with the validator and
+  the migration stub. A saved environment is named by its biome and climate, because an environment
+  has no name of its own.
+- **`environment_editing.ts`** — pure snapshot-to-snapshot field edits, grouped by the part they
+  belong to and keyed by a field union. Nothing recomputes: raising a biome's temperature does not
+  reclassify it, and moving the terrain's slope does not re-erode it.
+- **`environment_presentation.ts`** — the environment as a document of titled sections, empty ones
+  dropped, written once as Markdown and once as plain text for the PDF. It is also what the
+  generator page renders, so what a referee reads on screen and what they take away cannot drift.
+
+### The RNG is a parameter, not a default
+
+`getDefaultConfig` here and in each of the four sub-libraries takes the `RNG` the caller is
+generating from. It used to default to `new RNG(Date.now())`. Every caller overwrote it on the next
+line, so the clock never actually reached a generated environment — what the default did was make
+the helper look like a source of randomness a caller could safely forget about, which is
+[decision 1](../../../docs/tool-readiness.md) of the readiness pass and was true of fifteen helpers
+across six libraries.
+
 ## Usage
 
 ```typescript
@@ -44,8 +78,7 @@ For full control, build a config and hand it in:
 ```typescript
 import { Climates, generate, getDefaultConfig } from '$lib/environment';
 
-const config = getDefaultConfig();
-config.rng = rng;
+const config = getDefaultConfig(rng);
 config.latitude = 55;
 config.elevation = 1200;
 config.erosionIterations = 4;
@@ -57,7 +90,21 @@ const environment = generate(config);
 The config carries the `RNG` along with the physical inputs — latitude, elevation, relief energy,
 terrain and water vectors, erosion settings — plus one config per sub-generator.
 
+Most callers want `rollEnvironment` instead, which takes a seed and the eleven physical inputs and
+builds the config for you — it is the path the generator page and a re-roll from provenance both
+take:
+
+```typescript
+import { rollEnvironment, toEnvironmentSnapshot } from '$lib/environment';
+
+const environment = rollEnvironment('seed-xyz', { latitude: 55 /* ... */ });
+const payload = toEnvironmentSnapshot(environment); // what the vault stores
+```
+
 ## Status
 
 `Ecosystems.generate` is currently a stub returning an empty ecosystem; the other four
-sub-generators are implemented.
+sub-generators are implemented. That stub is why the presentation drops its Ecosystem section and
+why the editor has no ecosystem fields: every environment this build makes carries one nameless
+ecosystem with no flora and no fauna, and a section over it would be an empty heading on every
+sheet ever exported. Both are written to fill themselves in when the sub-generator is.

--- a/src/lib/environment/biomes/biomes.test.ts
+++ b/src/lib/environment/biomes/biomes.test.ts
@@ -10,7 +10,7 @@ import { RNG } from '@ironarachne/rng';
 
 describe('biomes generator', () => {
   it('generates a biome successfully using default config', () => {
-    const config = getDefaultConfig();
+    const config = getDefaultConfig(new RNG('default-config-seed'));
     const biome = generate(config);
 
     expect(biome).toBeDefined();
@@ -20,7 +20,7 @@ describe('biomes generator', () => {
   });
 
   it('generates a terrestrial biome when isAquatic is false', () => {
-    const config = getDefaultConfig();
+    const config = getDefaultConfig(new RNG('base-seed'));
     config.isAquatic = false;
     config.temperatureMin = 25;
     config.temperatureMax = 40;
@@ -33,7 +33,7 @@ describe('biomes generator', () => {
   });
 
   it('generates an aquatic biome when isAquatic is true', () => {
-    const config = getDefaultConfig();
+    const config = getDefaultConfig(new RNG('base-seed'));
     config.isAquatic = true;
     config.temperatureMin = 25;
     config.temperatureMax = 35;

--- a/src/lib/environment/biomes/biomes.ts
+++ b/src/lib/environment/biomes/biomes.ts
@@ -129,7 +129,14 @@ export function generateBiomeFeatures(
   return features;
 }
 
-export function getDefaultConfig(): BiomeGeneratorConfig {
+/**
+ * The default biome settings, with the RNG the caller is generating from.
+ *
+ * The RNG is a required parameter rather than a clock-seeded default. It defaulted to
+ * `new RNG(Date.now())`, which made a caller that forgot to overwrite it look seeded and not be —
+ * decision 1 of docs/tool-readiness.md, and one of the fifteen helpers that shared the shape.
+ */
+export function getDefaultConfig(rng: RNG.RNG): BiomeGeneratorConfig {
   return {
     altitude: 0,
     humidityMin: 0,
@@ -137,7 +144,7 @@ export function getDefaultConfig(): BiomeGeneratorConfig {
     isAquatic: false,
     temperatureMin: 0,
     temperatureMax: 30,
-    rng: new RNG.RNG(Date.now().toString()),
+    rng,
   };
 }
 

--- a/src/lib/environment/climates/climates.test.ts
+++ b/src/lib/environment/climates/climates.test.ts
@@ -54,7 +54,7 @@ describe('Climates Generator', () => {
 
   it('returns valid seasons', () => {
     const config: ClimateGeneratorConfig = {
-      ...Climates.getDefaultConfig(),
+      ...Climates.getDefaultConfig(new RNG('base-seed')),
       latitude: 80, // Polar
     };
     const climate = Climates.generate(config);
@@ -64,7 +64,7 @@ describe('Climates Generator', () => {
   });
 
   it('describes a climate', () => {
-    const config = Climates.getDefaultConfig();
+    const config = Climates.getDefaultConfig(new RNG('base-seed'));
     const climate = Climates.generate(config);
     const description = Climates.describe(climate, 'test-seed');
     expect(description).toContain('seasons');

--- a/src/lib/environment/climates/climates.ts
+++ b/src/lib/environment/climates/climates.ts
@@ -186,7 +186,13 @@ export function getClimateTypes(): ClimateType[] {
   ];
 }
 
-export function getDefaultConfig(): ClimateGeneratorConfig {
+/**
+ * The default climate settings, with the RNG the caller is generating from.
+ *
+ * Required rather than clock-defaulted, per decision 1 of docs/tool-readiness.md; see
+ * `biomes.ts` for the whole of the reasoning.
+ */
+export function getDefaultConfig(rng: RNG.RNG): ClimateGeneratorConfig {
   return {
     elevation: 0.5,
     latitude: 0,
@@ -195,7 +201,7 @@ export function getDefaultConfig(): ClimateGeneratorConfig {
     current: [0, 0, 0], // current is not present
     temperatureAtEquator: 35,
     terrainNormalVector: [0, 0, 0], // flat terrain
-    rng: new RNG.RNG(Date.now().toString()),
+    rng,
   };
 }
 

--- a/src/lib/environment/environment_artifact_kind.test.ts
+++ b/src/lib/environment/environment_artifact_kind.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ENVIRONMENT_ARTIFACT_KIND,
+  ENVIRONMENT_PAYLOAD_VERSION,
+  environmentArtifactKind,
+  migrateEnvironmentSnapshot,
+  validateEnvironmentSnapshot,
+} from './environment_artifact_kind';
+import { rollEnvironmentSnapshot } from './environment_roll';
+import type { EnvironmentSnapshot } from './environment_snapshot';
+
+const snapshot = rollEnvironmentSnapshot('kind-seed');
+
+/** A copy of the good payload with one part replaced, for the rejection cases. */
+function broken(changes: Record<string, unknown>): unknown {
+  return { ...(snapshot as unknown as Record<string, unknown>), ...changes };
+}
+
+describe('the environment artifact kind', () => {
+  it('is registered under a stable, unqualified id', () => {
+    expect(environmentArtifactKind.kind).toEqual(ENVIRONMENT_ARTIFACT_KIND);
+    expect(ENVIRONMENT_ARTIFACT_KIND).toEqual('environment');
+  });
+
+  it('declares the payload version it writes', () => {
+    expect(environmentArtifactKind.payloadVersion).toEqual(ENVIRONMENT_PAYLOAD_VERSION);
+  });
+
+  it('names a saved environment by its biome and climate', () => {
+    expect(environmentArtifactKind.nameOf(snapshot)).toEqual(
+      `${snapshot.biome.name}, ${snapshot.climate.name}`,
+    );
+  });
+
+  it('falls back to whichever half it still has', () => {
+    expect(
+      environmentArtifactKind.nameOf({ ...snapshot, biome: { ...snapshot.biome, name: '  ' } }),
+    ).toEqual(snapshot.climate.name);
+  });
+
+  it('falls back to the kind when both have been emptied', () => {
+    expect(
+      environmentArtifactKind.nameOf({
+        ...snapshot,
+        biome: { ...snapshot.biome, name: '' },
+        climate: { ...snapshot.climate, name: '' },
+      }),
+    ).toEqual('Environment');
+  });
+
+  it('round-trips through its own codec', async () => {
+    const codec = await environmentArtifactKind.loadCodec();
+    expect(codec.toSnapshot(codec.fromSnapshot(snapshot, undefined as never))).toEqual(snapshot);
+  });
+});
+
+describe('validating a stored environment', () => {
+  it('accepts what the generator wrote', () => {
+    expect(validateEnvironmentSnapshot(snapshot).ok).toBe(true);
+  });
+
+  it('accepts one whose description a user has emptied', () => {
+    // An editing decision, not a broken artifact: 3.3 asks for a well-defined empty result.
+    expect(validateEnvironmentSnapshot(broken({ description: '' })).ok).toBe(true);
+  });
+
+  it('accepts one with no ecosystems, which is every environment this build makes', () => {
+    expect(validateEnvironmentSnapshot(broken({ ecosystems: [] })).ok).toBe(true);
+  });
+
+  it('rejects something that is not an object at all', () => {
+    expect(validateEnvironmentSnapshot('a forest')).toMatchObject({
+      ok: false,
+      reason: 'invalid-payload',
+    });
+  });
+
+  it('rejects a payload with no description', () => {
+    const { description: _description, ...rest } = snapshot as unknown as Record<string, unknown>;
+    expect(validateEnvironmentSnapshot(rest)).toMatchObject({ ok: false });
+  });
+
+  it('rejects ecosystems that are not a list', () => {
+    expect(validateEnvironmentSnapshot(broken({ ecosystems: 'lots' }))).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it('rejects an ecosystem whose flora is not a list of strings', () => {
+    expect(
+      validateEnvironmentSnapshot(
+        broken({ ecosystems: [{ name: '', description: '', flora: [3], fauna: [] }] }),
+      ),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects a biome with no name', () => {
+    expect(
+      validateEnvironmentSnapshot(broken({ biome: { ...snapshot.biome, name: 4 } })),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects a biome that does not say whether it is water', () => {
+    expect(
+      validateEnvironmentSnapshot(broken({ biome: { ...snapshot.biome, isAquatic: 'yes' } })),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects a biome whose features are not strings', () => {
+    expect(
+      validateEnvironmentSnapshot(broken({ biome: { ...snapshot.biome, features: [1, 2] } })),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects a climate with a non-numeric measurement', () => {
+    expect(
+      validateEnvironmentSnapshot(broken({ climate: { ...snapshot.climate, humidity: 'damp' } })),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects a climate whose wind is not a vector', () => {
+    expect(
+      validateEnvironmentSnapshot(broken({ climate: { ...snapshot.climate, wind: 'westerly' } })),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects a season with no name', () => {
+    const seasons = snapshot.climate.seasons.map((season, index) =>
+      index === 0 ? { ...season, name: undefined } : season,
+    );
+    expect(
+      validateEnvironmentSnapshot(broken({ climate: { ...snapshot.climate, seasons } })),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects a season whose adjustment is not a number', () => {
+    const seasons = snapshot.climate.seasons.map((season, index) =>
+      index === 0 ? { ...season, humidityAdjustment: 'wetter' } : season,
+    );
+    expect(
+      validateEnvironmentSnapshot(broken({ climate: { ...snapshot.climate, seasons } })),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects terrain with no geological makeup', () => {
+    expect(
+      validateEnvironmentSnapshot(
+        broken({ terrain: { ...snapshot.terrain, geologicalMakeup: undefined } }),
+      ),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects terrain whose slope is not a vector', () => {
+    expect(
+      validateEnvironmentSnapshot(broken({ terrain: { ...snapshot.terrain, normalVector: [] } })),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects a water system with no water type', () => {
+    expect(
+      validateEnvironmentSnapshot(
+        broken({ waterSystem: { ...snapshot.waterSystem, waterType: undefined } }),
+      ),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects a water system with a non-numeric surface level', () => {
+    expect(
+      validateEnvironmentSnapshot(
+        broken({ waterSystem: { ...snapshot.waterSystem, surfaceLevel: 'high' } }),
+      ),
+    ).toMatchObject({ ok: false });
+  });
+
+  it('rejects each of the four parts being missing outright', () => {
+    for (const part of ['biome', 'climate', 'terrain', 'waterSystem']) {
+      expect(validateEnvironmentSnapshot(broken({ [part]: undefined })), part).toMatchObject({
+        ok: false,
+      });
+    }
+  });
+});
+
+describe('migrating a stored environment (7.3)', () => {
+  it('rejects every version, because version 1 is the only shape there has been', () => {
+    // The whole of this kind's migration story today, asserted so that the day a version 2 lands
+    // this test is what has to change rather than something that silently drops a user's work.
+    const result = migrateEnvironmentSnapshot(snapshot as unknown as EnvironmentSnapshot, 0);
+    expect(result).toMatchObject({ ok: false, reason: 'unsupported-version' });
+    expect(result.ok ? '' : result.message).toContain('version 0');
+  });
+});

--- a/src/lib/environment/environment_artifact_kind.ts
+++ b/src/lib/environment/environment_artifact_kind.ts
@@ -1,0 +1,280 @@
+import cloud from '$lib/assets/icons/set3/cloud.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  isStringArray,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import type Environment from './environment.js';
+import type { EnvironmentSnapshot } from './environment_snapshot.js';
+
+/**
+ * Stable artifact kind id. Unqualified, and genre-neutral with it: an environment is a place, and
+ * a place belongs to no ruleset and no setting. Per the kind table in docs/tool-readiness.md.
+ */
+export const ENVIRONMENT_ARTIFACT_KIND = 'environment' as const;
+
+/** Version 1. The first shape an environment has been stored in. */
+export const ENVIRONMENT_PAYLOAD_VERSION = 1 as const;
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function hasNumberFields(record: Record<string, unknown>, keys: string[]): boolean {
+  return keys.every((key) => isFiniteNumber(record[key]));
+}
+
+/** A direction across the surface: a list of finite numbers, however many components. */
+function isNumberVector(value: unknown): value is number[] {
+  return Array.isArray(value) && value.length > 0 && value.every(isFiniteNumber);
+}
+
+function validateBiome(value: unknown): PayloadResult<unknown> {
+  const biome = asRecord(value);
+  if (biome === null) {
+    return rejectedPayload('invalid-payload', 'environment biome is not an object');
+  }
+  if (!hasStringFields(biome, ['name'])) {
+    return rejectedPayload('invalid-payload', 'environment biome has no name');
+  }
+  if (!hasNumberFields(biome, ['temperature', 'altitude', 'humidity'])) {
+    return rejectedPayload(
+      'invalid-payload',
+      'environment biome needs a temperature, an altitude and a humidity',
+    );
+  }
+  if (typeof biome.isAquatic !== 'boolean') {
+    return rejectedPayload('invalid-payload', 'environment biome does not say whether it is water');
+  }
+  if (!isStringArray(biome.descriptions) || !isStringArray(biome.features)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'environment biome descriptions and features are not lists of strings',
+    );
+  }
+  return acceptedPayload(biome);
+}
+
+function validateSeason(value: unknown, index: number): PayloadResult<unknown> {
+  const season = asRecord(value);
+  if (season === null) {
+    return rejectedPayload('invalid-payload', `environment season ${index} is not an object`);
+  }
+  if (!hasStringFields(season, ['name'])) {
+    return rejectedPayload('invalid-payload', `environment season ${index} has no name`);
+  }
+  if (
+    !hasNumberFields(season, ['startDay', 'endDay', 'temperatureAdjustment', 'humidityAdjustment'])
+  ) {
+    return rejectedPayload(
+      'invalid-payload',
+      `environment season ${index} has a non-numeric day or adjustment`,
+    );
+  }
+  return acceptedPayload(season);
+}
+
+function validateClimate(value: unknown): PayloadResult<unknown> {
+  const climate = asRecord(value);
+  if (climate === null) {
+    return rejectedPayload('invalid-payload', 'environment climate is not an object');
+  }
+  if (!hasStringFields(climate, ['name', 'description'])) {
+    return rejectedPayload('invalid-payload', 'environment climate needs a name and a description');
+  }
+  if (
+    !hasNumberFields(climate, [
+      'cloudCover',
+      'temperature',
+      'temperatureMin',
+      'temperatureMax',
+      'precipitationAmount',
+      'precipitationFrequency',
+      'humidity',
+    ])
+  ) {
+    return rejectedPayload('invalid-payload', 'environment climate has a non-numeric measurement');
+  }
+  if (!isNumberVector(climate.wind)) {
+    return rejectedPayload('invalid-payload', 'environment climate wind is not a vector');
+  }
+  if (!Array.isArray(climate.seasons)) {
+    return rejectedPayload('invalid-payload', 'environment climate seasons is not a list');
+  }
+  return climate.seasons.map(validateSeason).find((check) => !check.ok) ?? acceptedPayload(climate);
+}
+
+function validateTerrain(value: unknown): PayloadResult<unknown> {
+  const terrain = asRecord(value);
+  if (terrain === null) {
+    return rejectedPayload('invalid-payload', 'environment terrain is not an object');
+  }
+  if (!hasNumberFields(terrain, ['elevationMin', 'elevationMax', 'reliefEnergy'])) {
+    return rejectedPayload(
+      'invalid-payload',
+      'environment terrain needs an elevation range and a relief energy',
+    );
+  }
+  if (!isNumberVector(terrain.normalVector)) {
+    return rejectedPayload('invalid-payload', 'environment terrain slope is not a vector');
+  }
+  if (!isStringArray(terrain.landforms)) {
+    return rejectedPayload('invalid-payload', 'environment terrain landforms is not a list');
+  }
+  const makeup = asRecord(terrain.geologicalMakeup);
+  if (makeup === null) {
+    return rejectedPayload('invalid-payload', 'environment terrain has no geological makeup');
+  }
+  if (!isStringArray(makeup.soilTypes) || !isStringArray(makeup.rockTypes)) {
+    return rejectedPayload(
+      'invalid-payload',
+      'environment geological makeup soils and rocks are not lists of strings',
+    );
+  }
+  return acceptedPayload(terrain);
+}
+
+function validateWaterSystem(value: unknown): PayloadResult<unknown> {
+  const water = asRecord(value);
+  if (water === null) {
+    return rejectedPayload('invalid-payload', 'environment water system is not an object');
+  }
+  if (!hasStringFields(water, ['waterType'])) {
+    return rejectedPayload('invalid-payload', 'environment water system has no water type');
+  }
+  if (!hasNumberFields(water, ['surfaceLevel', 'temperature'])) {
+    return rejectedPayload(
+      'invalid-payload',
+      'environment water system needs a surface level and a temperature',
+    );
+  }
+  if (!isNumberVector(water.current)) {
+    return rejectedPayload('invalid-payload', 'environment water current is not a vector');
+  }
+  return acceptedPayload(water);
+}
+
+/**
+ * One ecosystem.
+ *
+ * Every field may be empty, and today every one of them is: `Ecosystems.generate` is a documented
+ * stub returning a nameless ecosystem with no flora and no fauna. Rejecting an empty ecosystem
+ * would reject every environment this build has ever made.
+ */
+function validateEcosystem(value: unknown, index: number): PayloadResult<unknown> {
+  const ecosystem = asRecord(value);
+  if (ecosystem === null) {
+    return rejectedPayload('invalid-payload', `environment ecosystem ${index} is not an object`);
+  }
+  if (!hasStringFields(ecosystem, ['name', 'description'])) {
+    return rejectedPayload(
+      'invalid-payload',
+      `environment ecosystem ${index} needs a name and a description`,
+    );
+  }
+  if (!isStringArray(ecosystem.flora) || !isStringArray(ecosystem.fauna)) {
+    return rejectedPayload(
+      'invalid-payload',
+      `environment ecosystem ${index} flora and fauna are not lists of strings`,
+    );
+  }
+  return acceptedPayload(ecosystem);
+}
+
+/**
+ * Checks the five parts an environment is made of, and its own description.
+ *
+ * An environment with no ecosystems is accepted, and reads back with the empty one the generator
+ * itself produces. A description that has been emptied is accepted too: a user who has deleted the
+ * paragraph has made an editing decision, and a payload that fails its own validator is a broken
+ * artifact rather than an edited one — 3.3 asks for a well-defined empty result, not a refusal.
+ */
+export function validateEnvironmentSnapshot(payload: unknown): PayloadResult<EnvironmentSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'environment payload is not an object');
+  }
+  if (typeof record.description !== 'string') {
+    return rejectedPayload('invalid-payload', 'environment payload needs a description');
+  }
+  if (!Array.isArray(record.ecosystems)) {
+    return rejectedPayload('invalid-payload', 'environment ecosystems is not a list');
+  }
+
+  const checks = [
+    validateBiome(record.biome),
+    validateClimate(record.climate),
+    validateTerrain(record.terrain),
+    validateWaterSystem(record.waterSystem),
+    ...record.ecosystems.map(validateEcosystem),
+  ];
+  const failed = checks.find((check) => !check.ok);
+  if (failed !== undefined) {
+    return failed as PayloadResult<EnvironmentSnapshot>;
+  }
+
+  return acceptedPayload(record as unknown as EnvironmentSnapshot);
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day the
+ * shape changes — a kind without one looks complete right up until it silently drops someone's
+ * work, and local-only means there is no server-side migration to fall back on.
+ */
+export function migrateEnvironmentSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<EnvironmentSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Environments have no migration from payload version ${from}; version ${ENVIRONMENT_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/**
+ * What to call a saved environment: its biome and climate, which is how a person refers to one.
+ *
+ * An environment has no name of its own — it is a description of a place rather than a named
+ * thing — so "temperate deciduous forest, humid subtropical" is the honest default, and the user
+ * renames the artifact on save. Either half being empty falls back to the other, and both being
+ * empty falls back to the kind.
+ */
+function environmentName(snapshot: EnvironmentSnapshot): string {
+  const parts = [snapshot.biome.name, snapshot.climate.name]
+    .map((part) => part.trim())
+    .filter((part) => part !== '');
+  return parts.length === 0 ? 'Environment' : parts.join(', ');
+}
+
+/**
+ * An environment as an artifact.
+ *
+ * The codec is a dynamic import for consistency with every other kind rather than for weight:
+ * reading an environment reaches nothing this module has not already loaded. Keeping the shape
+ * uniform is worth more than saving one indirection, because the day this payload grows a part
+ * that *is* heavy, the seam is already where it needs to be.
+ */
+export const environmentArtifactKind = defineArtifactKind<Environment, EnvironmentSnapshot>({
+  kind: ENVIRONMENT_ARTIFACT_KIND,
+  displayName: 'Environment',
+  icon: cloud,
+  payloadVersion: ENVIRONMENT_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { toEnvironmentSnapshot, environmentFromSnapshotWithRng } =
+      await import('./environment_snapshot.js');
+    return {
+      toSnapshot: toEnvironmentSnapshot,
+      fromSnapshot: environmentFromSnapshotWithRng,
+    };
+  },
+  nameOf: environmentName,
+  validate: validateEnvironmentSnapshot,
+  migrate: migrateEnvironmentSnapshot,
+});

--- a/src/lib/environment/environment_editing.test.ts
+++ b/src/lib/environment/environment_editing.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addBiomeListEntry,
+  addTerrainListEntry,
+  removeBiomeListEntry,
+  removeTerrainListEntry,
+  setBiomeAquatic,
+  setBiomeListEntry,
+  setBiomeName,
+  setBiomeNumber,
+  setClimateNumber,
+  setClimateText,
+  setClimateWindComponent,
+  setEnvironmentDescription,
+  setSeasonAdjustment,
+  setSeasonName,
+  setTerrainListEntry,
+  setTerrainNumber,
+  setTerrainSlopeComponent,
+  setWaterCurrentComponent,
+  setWaterNumber,
+  setWaterType,
+} from './environment_editing';
+import { rollEnvironmentSnapshot } from './environment_roll';
+
+const snapshot = rollEnvironmentSnapshot('editing-seed');
+
+describe('the fixture these edits are made against', () => {
+  it('has the lists and seasons the edits below address', () => {
+    // Without this the list cases pass vacuously: replacing entry zero of an empty list changes
+    // nothing, and an unchanged snapshot equals itself.
+    expect(snapshot.biome.features.length).toBeGreaterThan(0);
+    expect(snapshot.biome.descriptions.length).toBeGreaterThan(0);
+    expect(snapshot.climate.seasons.length).toBeGreaterThan(0);
+    expect(snapshot.terrain.geologicalMakeup.soilTypes.length).toBeGreaterThan(0);
+  });
+});
+
+describe('editing an environment', () => {
+  it('rewrites its description and nothing else', () => {
+    const edited = setEnvironmentDescription(snapshot, 'A cold place under a low sky.');
+    expect(edited.description).toEqual('A cold place under a low sky.');
+    expect(edited.biome).toEqual(snapshot.biome);
+    expect(edited.climate).toEqual(snapshot.climate);
+  });
+
+  it('leaves the original untouched', () => {
+    const before = snapshot.description;
+    setEnvironmentDescription(snapshot, 'somewhere else');
+    expect(snapshot.description).toEqual(before);
+  });
+});
+
+describe('editing the biome', () => {
+  it('renames it without reclassifying anything', () => {
+    // 4.2: raising a temperature must not silently pick a different biome.
+    const edited = setBiomeName(snapshot, 'blasted heath');
+    expect(edited.biome.name).toEqual('blasted heath');
+    expect(edited.biome.temperature).toEqual(snapshot.biome.temperature);
+  });
+
+  it('sets each of its measurements', () => {
+    for (const field of ['temperature', 'altitude', 'humidity'] as const) {
+      expect(setBiomeNumber(snapshot, field, 0.5).biome[field]).toEqual(0.5);
+    }
+    expect(setBiomeNumber(snapshot, 'humidity', 0.5).biome.name).toEqual(snapshot.biome.name);
+  });
+
+  it('leaves a measurement alone when the control produced nothing', () => {
+    expect(setBiomeNumber(snapshot, 'humidity', Number.NaN).biome.humidity).toEqual(
+      snapshot.biome.humidity,
+    );
+  });
+
+  it('says whether it is water', () => {
+    expect(setBiomeAquatic(snapshot, true).biome.isAquatic).toBe(true);
+    expect(setBiomeAquatic(snapshot, false).biome.isAquatic).toBe(false);
+  });
+
+  it('rewrites one sentence in a list and leaves its neighbours', () => {
+    const edited = setBiomeListEntry(snapshot, 'features', 0, 'Ash drifts against the rocks.');
+    expect(edited.biome.features[0]).toEqual('Ash drifts against the rocks.');
+    expect(edited.biome.features.slice(1)).toEqual(snapshot.biome.features.slice(1));
+    expect(edited.biome.descriptions).toEqual(snapshot.biome.descriptions);
+  });
+
+  it('removes one sentence and adds an empty one to write into', () => {
+    const removed = removeBiomeListEntry(snapshot, 'descriptions', 0);
+    expect(removed.biome.descriptions.length).toEqual(snapshot.biome.descriptions.length - 1);
+    // Empty rather than generated: adding a line is an edit, not a re-roll.
+    const added = addBiomeListEntry(snapshot, 'descriptions');
+    expect(added.biome.descriptions.at(-1)).toEqual('');
+  });
+
+  it('ignores an index that is not there', () => {
+    expect(setBiomeListEntry(snapshot, 'features', 999, 'nowhere')).toEqual(snapshot);
+    expect(removeBiomeListEntry(snapshot, 'features', -1)).toEqual(snapshot);
+  });
+});
+
+describe('editing the climate', () => {
+  it('rewrites its name and its paragraph', () => {
+    const named = setClimateText(snapshot, 'name', 'perpetual dusk');
+    expect(setClimateText(named, 'description', 'It never warms.').climate).toMatchObject({
+      name: 'perpetual dusk',
+      description: 'It never warms.',
+    });
+  });
+
+  it('sets each of its measurements', () => {
+    for (const field of [
+      'cloudCover',
+      'temperature',
+      'temperatureMin',
+      'temperatureMax',
+      'precipitationAmount',
+      'precipitationFrequency',
+      'humidity',
+    ] as const) {
+      expect(setClimateNumber(snapshot, field, 0.25).climate[field]).toEqual(0.25);
+    }
+  });
+
+  it('sets one component of the wind and leaves the others', () => {
+    const edited = setClimateWindComponent(snapshot, 0, 1.5);
+    expect(edited.climate.wind[0]).toEqual(1.5);
+    expect(edited.climate.wind.slice(1)).toEqual(snapshot.climate.wind.slice(1));
+  });
+
+  it('leaves a vector alone for a component it does not have', () => {
+    expect(setClimateWindComponent(snapshot, 9, 1).climate.wind).toEqual(snapshot.climate.wind);
+  });
+
+  it('renames one season without touching what it adjusts', () => {
+    const edited = setSeasonName(snapshot, 0, 'the long thaw');
+    expect(edited.climate.seasons[0].name).toEqual('the long thaw');
+    expect(edited.climate.seasons[0].temperatureAdjustment).toEqual(
+      snapshot.climate.seasons[0].temperatureAdjustment,
+    );
+    expect(edited.climate.seasons.slice(1)).toEqual(snapshot.climate.seasons.slice(1));
+  });
+
+  it('sets what a season adjusts', () => {
+    expect(
+      setSeasonAdjustment(snapshot, 0, 'temperatureAdjustment', -12).climate.seasons[0]
+        .temperatureAdjustment,
+    ).toEqual(-12);
+    expect(
+      setSeasonAdjustment(snapshot, 0, 'humidityAdjustment', 0.3).climate.seasons[0]
+        .humidityAdjustment,
+    ).toEqual(0.3);
+  });
+
+  it('ignores a season that is not there', () => {
+    expect(setSeasonName(snapshot, 99, 'nowhere')).toEqual(snapshot);
+    expect(setSeasonAdjustment(snapshot, 99, 'humidityAdjustment', 1)).toEqual(snapshot);
+  });
+});
+
+describe('editing the terrain', () => {
+  it('sets each of its measurements without re-eroding anything', () => {
+    for (const field of ['elevationMin', 'elevationMax', 'reliefEnergy'] as const) {
+      expect(setTerrainNumber(snapshot, field, 0.4).terrain[field]).toEqual(0.4);
+    }
+    expect(setTerrainNumber(snapshot, 'reliefEnergy', 0.4).terrain.landforms).toEqual(
+      snapshot.terrain.landforms,
+    );
+  });
+
+  it('sets one component of the slope', () => {
+    expect(setTerrainSlopeComponent(snapshot, 1, -0.3).terrain.normalVector[1]).toEqual(-0.3);
+  });
+
+  it('rewrites a landform and each of the two geology lists', () => {
+    expect(
+      setTerrainListEntry(snapshot, 'soilTypes', 0, 'black loam').terrain.geologicalMakeup
+        .soilTypes[0],
+    ).toEqual('black loam');
+    const withLandform = addTerrainListEntry(snapshot, 'landforms');
+    expect(
+      setTerrainListEntry(
+        withLandform,
+        'landforms',
+        withLandform.terrain.landforms.length - 1,
+        'esker',
+      ).terrain.landforms.at(-1),
+    ).toEqual('esker');
+  });
+
+  it('removes one entry from a geology list and leaves the other list alone', () => {
+    const edited = removeTerrainListEntry(snapshot, 'soilTypes', 0);
+    expect(edited.terrain.geologicalMakeup.soilTypes.length).toEqual(
+      snapshot.terrain.geologicalMakeup.soilTypes.length - 1,
+    );
+    expect(edited.terrain.geologicalMakeup.rockTypes).toEqual(
+      snapshot.terrain.geologicalMakeup.rockTypes,
+    );
+  });
+
+  it('ignores an index that is not there', () => {
+    expect(setTerrainListEntry(snapshot, 'rockTypes', 999, 'nowhere')).toEqual(snapshot);
+    expect(removeTerrainListEntry(snapshot, 'landforms', 999)).toEqual(snapshot);
+  });
+});
+
+describe('editing the water system', () => {
+  it('sets the water type and its measurements', () => {
+    expect(setWaterType(snapshot, 'brackish').waterSystem.waterType).toEqual('brackish');
+    for (const field of ['surfaceLevel', 'temperature'] as const) {
+      expect(setWaterNumber(snapshot, field, 3).waterSystem[field]).toEqual(3);
+    }
+  });
+
+  it('sets one component of the current', () => {
+    const edited = setWaterCurrentComponent(snapshot, 0, 0.8);
+    expect(edited.waterSystem.current[0]).toEqual(0.8);
+    expect(edited.waterSystem.current.slice(1)).toEqual(snapshot.waterSystem.current.slice(1));
+  });
+});

--- a/src/lib/environment/environment_editing.ts
+++ b/src/lib/environment/environment_editing.ts
@@ -1,0 +1,330 @@
+/**
+ * Editing a saved environment, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction — rewriting one biome feature must
+ * not disturb another, and renaming a season must not touch its adjustments — and it is what lets
+ * the editing framework compare what is on screen against what was read to decide whether anything
+ * needs saving.
+ *
+ * **What is editable is what the page shows** (4.1), which after this change is everything an
+ * environment holds: its own description, the biome, the climate and its seasons, the terrain and
+ * its geology, and the water system. The fields are grouped by the part they belong to and keyed by
+ * a field union rather than written out one function per field, which is the shape
+ * `settlement_editing.ts` already uses for a payload of this size — twenty-odd one-line functions
+ * differing only in a key is a table pretending to be code.
+ *
+ * **Nothing here recomputes anything.** Raising a biome's temperature does not reclassify it, and
+ * changing the terrain's slope does not re-erode it. Both would be regenerating over the user's
+ * edits, which is exactly what 4.2 forbids; a user who wants the arithmetic back re-rolls, and the
+ * re-roll is a button of its own (4.3).
+ *
+ * **Ecosystems are not editable, and that is honest rather than an omission.** `Ecosystems.generate`
+ * is a documented stub returning a nameless ecosystem with no flora and no fauna, so there is
+ * nothing on the page to edit — the presentation drops the section entirely. When the sub-generator
+ * is written, this is where its edits go.
+ */
+
+import type { EnvironmentSnapshot } from './environment_snapshot.js';
+
+/** The biome measurements a user can change. */
+export type BiomeNumberField = 'temperature' | 'altitude' | 'humidity';
+
+/** The biome's two lists of sentences. */
+export type BiomeListField = 'descriptions' | 'features';
+
+/** The climate's two strings. */
+export type ClimateTextField = 'name' | 'description';
+
+/** The climate measurements a user can change. */
+export type ClimateNumberField =
+  | 'cloudCover'
+  | 'temperature'
+  | 'temperatureMin'
+  | 'temperatureMax'
+  | 'precipitationAmount'
+  | 'precipitationFrequency'
+  | 'humidity';
+
+/** What a season shifts. */
+export type SeasonAdjustmentField = 'temperatureAdjustment' | 'humidityAdjustment';
+
+/** The terrain measurements a user can change. */
+export type TerrainNumberField = 'elevationMin' | 'elevationMax' | 'reliefEnergy';
+
+/** The terrain's list of landforms, and the two lists its geology is made of. */
+export type TerrainListField = 'landforms' | 'soilTypes' | 'rockTypes';
+
+/** The water measurements a user can change. */
+export type WaterNumberField = 'surfaceLevel' | 'temperature';
+
+function hasIndex(length: number, index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < length;
+}
+
+function replaceAt<T>(list: T[], index: number, value: T): T[] {
+  return list.map((entry, position) => (position === index ? value : entry));
+}
+
+function removeAt<T>(list: T[], index: number): T[] {
+  return list.filter((_entry, position) => position !== index);
+}
+
+/**
+ * One component of a direction vector, left alone when the component is not there.
+ *
+ * A vector's length is the generator's business — the climate's wind and the terrain's slope are
+ * three-component, and the page offers the two that mean something across a surface — so this
+ * addresses a component that exists rather than growing the vector to fit an index.
+ */
+function setComponent(vector: number[], index: number, value: number): number[] {
+  return hasIndex(vector.length, index) && Number.isFinite(value)
+    ? replaceAt(vector, index, value)
+    : vector;
+}
+
+/** A number a control produced, or the value as it stands when the control produced nothing. */
+function readable(value: number, current: number): number {
+  return Number.isFinite(value) ? value : current;
+}
+
+export function setEnvironmentDescription(
+  snapshot: EnvironmentSnapshot,
+  description: string,
+): EnvironmentSnapshot {
+  return { ...snapshot, description };
+}
+
+export function setBiomeName(snapshot: EnvironmentSnapshot, name: string): EnvironmentSnapshot {
+  return { ...snapshot, biome: { ...snapshot.biome, name } };
+}
+
+export function setBiomeNumber(
+  snapshot: EnvironmentSnapshot,
+  field: BiomeNumberField,
+  value: number,
+): EnvironmentSnapshot {
+  return {
+    ...snapshot,
+    biome: { ...snapshot.biome, [field]: readable(value, snapshot.biome[field]) },
+  };
+}
+
+export function setBiomeAquatic(
+  snapshot: EnvironmentSnapshot,
+  isAquatic: boolean,
+): EnvironmentSnapshot {
+  return { ...snapshot, biome: { ...snapshot.biome, isAquatic } };
+}
+
+export function setBiomeListEntry(
+  snapshot: EnvironmentSnapshot,
+  field: BiomeListField,
+  index: number,
+  value: string,
+): EnvironmentSnapshot {
+  const list = snapshot.biome[field];
+  return hasIndex(list.length, index)
+    ? { ...snapshot, biome: { ...snapshot.biome, [field]: replaceAt(list, index, value) } }
+    : snapshot;
+}
+
+export function removeBiomeListEntry(
+  snapshot: EnvironmentSnapshot,
+  field: BiomeListField,
+  index: number,
+): EnvironmentSnapshot {
+  const list = snapshot.biome[field];
+  return hasIndex(list.length, index)
+    ? { ...snapshot, biome: { ...snapshot.biome, [field]: removeAt(list, index) } }
+    : snapshot;
+}
+
+/** Add an empty sentence for the user to write into. Not a generated one: this is not a re-roll. */
+export function addBiomeListEntry(
+  snapshot: EnvironmentSnapshot,
+  field: BiomeListField,
+): EnvironmentSnapshot {
+  return { ...snapshot, biome: { ...snapshot.biome, [field]: [...snapshot.biome[field], ''] } };
+}
+
+export function setClimateText(
+  snapshot: EnvironmentSnapshot,
+  field: ClimateTextField,
+  value: string,
+): EnvironmentSnapshot {
+  return { ...snapshot, climate: { ...snapshot.climate, [field]: value } };
+}
+
+export function setClimateNumber(
+  snapshot: EnvironmentSnapshot,
+  field: ClimateNumberField,
+  value: number,
+): EnvironmentSnapshot {
+  return {
+    ...snapshot,
+    climate: { ...snapshot.climate, [field]: readable(value, snapshot.climate[field]) },
+  };
+}
+
+export function setClimateWindComponent(
+  snapshot: EnvironmentSnapshot,
+  index: number,
+  value: number,
+): EnvironmentSnapshot {
+  return {
+    ...snapshot,
+    climate: { ...snapshot.climate, wind: setComponent(snapshot.climate.wind, index, value) },
+  };
+}
+
+function editSeason(
+  snapshot: EnvironmentSnapshot,
+  index: number,
+  change: (
+    season: EnvironmentSnapshot['climate']['seasons'][number],
+  ) => EnvironmentSnapshot['climate']['seasons'][number],
+): EnvironmentSnapshot {
+  const { seasons } = snapshot.climate;
+  return hasIndex(seasons.length, index)
+    ? {
+        ...snapshot,
+        climate: {
+          ...snapshot.climate,
+          seasons: replaceAt(seasons, index, change(seasons[index])),
+        },
+      }
+    : snapshot;
+}
+
+export function setSeasonName(
+  snapshot: EnvironmentSnapshot,
+  index: number,
+  name: string,
+): EnvironmentSnapshot {
+  return editSeason(snapshot, index, (season) => ({ ...season, name }));
+}
+
+export function setSeasonAdjustment(
+  snapshot: EnvironmentSnapshot,
+  index: number,
+  field: SeasonAdjustmentField,
+  value: number,
+): EnvironmentSnapshot {
+  return editSeason(snapshot, index, (season) => ({
+    ...season,
+    [field]: readable(value, season[field]),
+  }));
+}
+
+export function setTerrainNumber(
+  snapshot: EnvironmentSnapshot,
+  field: TerrainNumberField,
+  value: number,
+): EnvironmentSnapshot {
+  return {
+    ...snapshot,
+    terrain: { ...snapshot.terrain, [field]: readable(value, snapshot.terrain[field]) },
+  };
+}
+
+export function setTerrainSlopeComponent(
+  snapshot: EnvironmentSnapshot,
+  index: number,
+  value: number,
+): EnvironmentSnapshot {
+  return {
+    ...snapshot,
+    terrain: {
+      ...snapshot.terrain,
+      normalVector: setComponent(snapshot.terrain.normalVector, index, value),
+    },
+  };
+}
+
+function terrainList(snapshot: EnvironmentSnapshot, field: TerrainListField): string[] {
+  return field === 'landforms'
+    ? snapshot.terrain.landforms
+    : snapshot.terrain.geologicalMakeup[field];
+}
+
+function withTerrainList(
+  snapshot: EnvironmentSnapshot,
+  field: TerrainListField,
+  list: string[],
+): EnvironmentSnapshot {
+  return field === 'landforms'
+    ? { ...snapshot, terrain: { ...snapshot.terrain, landforms: list } }
+    : {
+        ...snapshot,
+        terrain: {
+          ...snapshot.terrain,
+          geologicalMakeup: { ...snapshot.terrain.geologicalMakeup, [field]: list },
+        },
+      };
+}
+
+export function setTerrainListEntry(
+  snapshot: EnvironmentSnapshot,
+  field: TerrainListField,
+  index: number,
+  value: string,
+): EnvironmentSnapshot {
+  const list = terrainList(snapshot, field);
+  return hasIndex(list.length, index)
+    ? withTerrainList(snapshot, field, replaceAt(list, index, value))
+    : snapshot;
+}
+
+export function removeTerrainListEntry(
+  snapshot: EnvironmentSnapshot,
+  field: TerrainListField,
+  index: number,
+): EnvironmentSnapshot {
+  const list = terrainList(snapshot, field);
+  return hasIndex(list.length, index)
+    ? withTerrainList(snapshot, field, removeAt(list, index))
+    : snapshot;
+}
+
+export function addTerrainListEntry(
+  snapshot: EnvironmentSnapshot,
+  field: TerrainListField,
+): EnvironmentSnapshot {
+  return withTerrainList(snapshot, field, [...terrainList(snapshot, field), '']);
+}
+
+export function setWaterType(
+  snapshot: EnvironmentSnapshot,
+  waterType: string,
+): EnvironmentSnapshot {
+  return { ...snapshot, waterSystem: { ...snapshot.waterSystem, waterType } };
+}
+
+export function setWaterNumber(
+  snapshot: EnvironmentSnapshot,
+  field: WaterNumberField,
+  value: number,
+): EnvironmentSnapshot {
+  return {
+    ...snapshot,
+    waterSystem: {
+      ...snapshot.waterSystem,
+      [field]: readable(value, snapshot.waterSystem[field]),
+    },
+  };
+}
+
+export function setWaterCurrentComponent(
+  snapshot: EnvironmentSnapshot,
+  index: number,
+  value: number,
+): EnvironmentSnapshot {
+  return {
+    ...snapshot,
+    waterSystem: {
+      ...snapshot.waterSystem,
+      current: setComponent(snapshot.waterSystem.current, index, value),
+    },
+  };
+}

--- a/src/lib/environment/environment_presentation.test.ts
+++ b/src/lib/environment/environment_presentation.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addBiomeListEntry,
+  removeBiomeListEntry,
+  removeTerrainListEntry,
+  setBiomeName,
+  setClimateText,
+  setEnvironmentDescription,
+} from './environment_editing';
+import {
+  describeVector,
+  elevationToFeet,
+  environmentDisplayName,
+  environmentFileStem,
+  environmentToDocument,
+  environmentToMarkdown,
+  environmentToText,
+} from './environment_presentation';
+import { rollEnvironmentSnapshot } from './environment_roll';
+
+const snapshot = rollEnvironmentSnapshot('presentation-seed');
+
+describe('arranging an environment for reading', () => {
+  const document = environmentToDocument(snapshot);
+
+  it('is headed by the biome and the climate', () => {
+    expect(document.title).toEqual(`${snapshot.biome.name}, ${snapshot.climate.name}`);
+  });
+
+  it('opens with the paragraphs the generator wrote', () => {
+    expect(document.paragraphs).toEqual([snapshot.description, snapshot.climate.description]);
+  });
+
+  it('has a section for each of the four parts an environment is made of', () => {
+    expect(document.sections.map((section) => section.heading)).toEqual([
+      'Biome',
+      'Climate',
+      'Terrain',
+      'Water',
+    ]);
+  });
+
+  it('spells out what the page printed as raw numbers', () => {
+    const climate = document.sections.find((section) => section.heading === 'Climate');
+    // The page showed `[0.4, -0.2, 0]`; a referee needs a direction and a strength.
+    expect(climate?.lines.some((line) => line.label === 'Wind')).toBe(true);
+    expect(
+      climate?.lines.some((line) => line.label === 'Humidity' && /^\d+%$/.test(line.value)),
+    ).toBe(true);
+  });
+
+  it('lists a season under the climate', () => {
+    const climate = document.sections.find((section) => section.heading === 'Climate');
+    const season = snapshot.climate.seasons[0];
+    expect(climate?.lines.some((line) => line.label === season.name)).toBe(true);
+  });
+});
+
+describe('dropping what is empty (6.4)', () => {
+  it('prints no Ecosystem section, because every ecosystem this build makes is empty', () => {
+    // The reason 6.4 has teeth for this tool: a printed heading over nothing, on every sheet.
+    expect(
+      environmentToDocument(snapshot).sections.some((section) => section.heading === 'Ecosystem'),
+    ).toBe(false);
+  });
+
+  it('prints an ecosystem once there is something in it', () => {
+    const populated = {
+      ...snapshot,
+      ecosystems: [
+        {
+          name: 'Fen',
+          description: 'Standing water and sedge.',
+          flora: ['sedge'],
+          fauna: ['crane'],
+        },
+      ],
+    };
+    const fen = environmentToDocument(populated).sections.find(
+      (section) => section.heading === 'Fen',
+    );
+    expect(fen?.lines).toContainEqual({ label: 'Flora', value: 'sedge' });
+    expect(fen?.lines).toContainEqual({ label: 'Fauna', value: 'crane' });
+  });
+
+  it('prints no blank paragraph for a description that has been emptied', () => {
+    const blanked = setClimateText(setEnvironmentDescription(snapshot, '  '), 'description', '');
+    expect(environmentToDocument(blanked).paragraphs).toEqual([]);
+  });
+
+  it('drops a landform list once its last entry is removed', () => {
+    let stripped = snapshot;
+    for (let index = snapshot.terrain.landforms.length - 1; index >= 0; index--) {
+      stripped = removeTerrainListEntry(stripped, 'landforms', index);
+    }
+    const terrain = environmentToDocument(stripped).sections.find(
+      (section) => section.heading === 'Terrain',
+    );
+    expect(terrain?.lines.some((line) => line.label === 'Landforms')).toBe(false);
+  });
+
+  it('does not print a biome feature the user has emptied', () => {
+    const withBlank = addBiomeListEntry(snapshot, 'features');
+    const biome = environmentToDocument(withBlank).sections.find(
+      (section) => section.heading === 'Biome',
+    );
+    expect(biome?.lines.every((line) => line.value.trim() !== '')).toBe(true);
+  });
+
+  it('drops the biome type line rather than printing a bare label', () => {
+    const nameless = setBiomeName(snapshot, '   ');
+    const biome = environmentToDocument(nameless).sections.find(
+      (section) => section.heading === 'Biome',
+    );
+    expect(biome?.lines.some((line) => line.label === 'Type')).toBe(false);
+  });
+});
+
+describe('describing a direction', () => {
+  it('gives a compass word and a strength', () => {
+    expect(describeVector([1, 1])).toEqual('northwest, strength 1.41');
+  });
+
+  it('says a vector of no length is none rather than naming a direction', () => {
+    expect(describeVector([0, 0, 0])).toEqual('none');
+    expect(describeVector([])).toEqual('none');
+  });
+});
+
+describe('reading an elevation in feet', () => {
+  it('maps the -1 to 1 range onto 30,000 feet either way', () => {
+    expect(elevationToFeet(1)).toEqual(30000);
+    expect(elevationToFeet(-1)).toEqual(-30000);
+    expect(elevationToFeet(0)).toEqual(0);
+  });
+});
+
+describe('exporting an environment (6.3)', () => {
+  it('writes Markdown a referee can drop into their notes', () => {
+    const markdown = environmentToMarkdown(snapshot);
+    expect(markdown).toContain(`# ${environmentDisplayName(snapshot)}`);
+    expect(markdown).toContain('## Climate');
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('writes the same document as plain text, without repeating the title', () => {
+    const text = environmentToText(snapshot);
+    expect(text).toContain('CLIMATE');
+    expect(text.startsWith(environmentDisplayName(snapshot))).toBe(false);
+  });
+
+  it('never leaves a blank line where a part had nothing to say', () => {
+    const blanked = setClimateText(setEnvironmentDescription(snapshot, ''), 'description', '');
+    expect(environmentToMarkdown(blanked)).not.toContain('\n\n\n');
+    expect(environmentToText(blanked)).not.toContain('\n\n\n');
+  });
+
+  it('carries an edit straight into the export', () => {
+    const edited = setEnvironmentDescription(snapshot, 'A cold place under a low sky.');
+    expect(environmentToMarkdown(edited)).toContain('A cold place under a low sky.');
+  });
+});
+
+describe('naming an environment for a file', () => {
+  it('uses the biome and the climate', () => {
+    expect(environmentFileStem(snapshot)).toMatch(/^environment-[a-z0-9-]+$/);
+  });
+
+  it('falls back to the bare stem when it has no name of its own', () => {
+    const nameless = {
+      ...snapshot,
+      biome: { ...snapshot.biome, name: '' },
+      climate: { ...snapshot.climate, name: '' },
+    };
+    expect(environmentFileStem(nameless)).toEqual('environment');
+  });
+});
+
+describe('a biome description a user removed entirely', () => {
+  it('is gone from the document', () => {
+    const first = snapshot.biome.features[0];
+    const removed = removeBiomeListEntry(snapshot, 'features', 0);
+    const biome = environmentToDocument(removed).sections.find(
+      (section) => section.heading === 'Biome',
+    );
+    expect(biome?.lines).not.toContainEqual({ value: first });
+  });
+});

--- a/src/lib/environment/environment_presentation.ts
+++ b/src/lib/environment/environment_presentation.ts
@@ -1,0 +1,256 @@
+/**
+ * An environment arranged for reading, and the Markdown and PDF exports written from it.
+ *
+ * This tool had no export of any kind, which is requirement 6.3, and the page it exports from was
+ * a debugging readout: raw floats for elevation and humidity, a bare `[0.4, -0.2, 0]` for the wind.
+ * The document is what a referee would actually read at the table — the paragraph the generator
+ * already writes, then the biome, climate, terrain and water as labelled lines with their units
+ * and their compass directions spelled out.
+ *
+ * 6.4 has teeth here for one reason above all: **`Ecosystems.generate` is a stub**. Every
+ * environment on the site carries one nameless ecosystem with no flora and no fauna, so a document
+ * that printed an Ecosystem section would print an empty heading on every sheet ever exported. It
+ * is dropped when there is nothing in it, along with every other empty list and blank paragraph.
+ *
+ * Presentation works on the **stored** shape rather than the live one: the page converts for saving
+ * anyway and the editor holds a snapshot, so one model both can print is cheaper than two, and the
+ * only field the live shape adds is `dominantEcosystem`, which is `ecosystems[0]`.
+ */
+
+import { Directions } from '$lib/geometry';
+import * as Temperature from '$lib/temperature';
+
+import type { EnvironmentSnapshot } from './environment_snapshot.js';
+
+/**
+ * One line of a section: a measurement with its label, or a bare sentence.
+ *
+ * Structured rather than a pre-joined `"Label: value"` string because two readers need it in two
+ * shapes — the page draws a labelled line as a `Stat` and a bare one as a paragraph, and the
+ * exports join them — and splitting a joined string back apart in the component is how a biome
+ * feature containing a colon ends up mislabelled.
+ */
+export type EnvironmentLine = {
+  /** Absent for a sentence that is not a measurement, such as a biome feature. */
+  label?: string;
+  value: string;
+};
+
+/** A titled list of lines; dropped entirely when it has no lines. */
+export type EnvironmentSection = {
+  heading: string;
+  lines: EnvironmentLine[];
+};
+
+/** An environment arranged for reading, independent of the format it is finally written in. */
+export type EnvironmentDocument = {
+  title: string;
+  paragraphs: string[];
+  sections: EnvironmentSection[];
+};
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+/** A 0–1 measure as a percentage, which is how a person reads humidity or cloud cover. */
+function asPercentage(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+/** A −1..1 elevation in feet, the way the generator page has always shown it. */
+export function elevationToFeet(elevation: number): number {
+  return Math.floor(elevation * 30000);
+}
+
+function asElevation(value: number): string {
+  return `${value.toFixed(2)} (${elevationToFeet(value).toLocaleString('en-US')} ft)`;
+}
+
+/**
+ * A direction vector as a compass word and a magnitude.
+ *
+ * The page printed the raw array. "north-north-east, strength 0.42" is the same information in the
+ * form a referee can use, and a vector of no length reads as still rather than as a direction.
+ */
+export function describeVector(vector: number[]): string {
+  const [x = 0, y = 0] = vector;
+  const magnitude = Math.hypot(x, y);
+  if (magnitude === 0) {
+    return 'none';
+  }
+  return `${Directions.getWordForVector(vector)}, strength ${magnitude.toFixed(2)}`;
+}
+
+/** What to head the document with, and what the vault calls a saved environment. */
+export function environmentDisplayName(snapshot: EnvironmentSnapshot): string {
+  const parts = [snapshot.biome.name, snapshot.climate.name]
+    .map((part) => part.trim())
+    .filter(isPrintable);
+  return parts.length === 0 ? 'Environment' : parts.join(', ');
+}
+
+function labelled(label: string, value: string): EnvironmentLine {
+  return { label, value };
+}
+
+/** A line as one string, which is what both exports write. */
+export function environmentLineToString(line: EnvironmentLine): string {
+  return line.label === undefined ? line.value : `${line.label}: ${line.value}`;
+}
+
+function biomeSection(snapshot: EnvironmentSnapshot): EnvironmentSection {
+  const { biome } = snapshot;
+  return {
+    heading: 'Biome',
+    lines: [
+      ...(isPrintable(biome.name) ? [labelled('Type', biome.name)] : []),
+      labelled('Temperature', Temperature.getComparativeString(biome.temperature, 'celsius')),
+      labelled('Altitude', asElevation(biome.altitude)),
+      labelled('Humidity', asPercentage(biome.humidity)),
+      labelled('Water', biome.isAquatic ? 'aquatic' : 'dry land'),
+      ...biome.features.filter(isPrintable).map((feature) => ({ value: feature })),
+    ],
+  };
+}
+
+function climateSection(snapshot: EnvironmentSnapshot): EnvironmentSection {
+  const { climate } = snapshot;
+  return {
+    heading: 'Climate',
+    lines: [
+      ...(isPrintable(climate.name) ? [labelled('Type', climate.name)] : []),
+      labelled(
+        'Temperature',
+        `${Temperature.getComparativeString(climate.temperatureMin, 'celsius')} to ${Temperature.getComparativeString(climate.temperatureMax, 'celsius')}`,
+      ),
+      labelled('Humidity', asPercentage(climate.humidity)),
+      labelled('Cloud cover', asPercentage(climate.cloudCover)),
+      labelled('Wind', describeVector(climate.wind)),
+      labelled(
+        'Precipitation',
+        `${asPercentage(climate.precipitationAmount)} amount, ${asPercentage(climate.precipitationFrequency)} of the time`,
+      ),
+      ...climate.seasons
+        .filter((season) => isPrintable(season.name))
+        .map((season) =>
+          labelled(
+            season.name,
+            `${season.temperatureAdjustment >= 0 ? '+' : ''}${season.temperatureAdjustment}°C, humidity ${season.humidityAdjustment >= 0 ? '+' : ''}${season.humidityAdjustment}`,
+          ),
+        ),
+    ],
+  };
+}
+
+function terrainSection(snapshot: EnvironmentSnapshot): EnvironmentSection {
+  const { terrain } = snapshot;
+  const geology = [...terrain.geologicalMakeup.soilTypes, ...terrain.geologicalMakeup.rockTypes]
+    .filter(isPrintable)
+    .join(', ');
+  return {
+    heading: 'Terrain',
+    lines: [
+      labelled(
+        'Elevation',
+        `${asElevation(terrain.elevationMin)} to ${asElevation(terrain.elevationMax)}`,
+      ),
+      labelled('Relief', terrain.reliefEnergy.toFixed(2)),
+      labelled('Slope', describeVector(terrain.normalVector)),
+      ...(terrain.landforms.filter(isPrintable).length > 0
+        ? [labelled('Landforms', terrain.landforms.filter(isPrintable).join(', '))]
+        : []),
+      ...(isPrintable(geology) ? [labelled('Geology', geology)] : []),
+    ],
+  };
+}
+
+function waterSection(snapshot: EnvironmentSnapshot): EnvironmentSection {
+  const water = snapshot.waterSystem;
+  return {
+    heading: 'Water',
+    lines: [
+      ...(isPrintable(water.waterType) ? [labelled('Type', water.waterType)] : []),
+      labelled('Surface level', asElevation(water.surfaceLevel)),
+      labelled('Temperature', Temperature.getComparativeString(water.temperature, 'celsius')),
+      labelled('Current', describeVector(water.current)),
+    ],
+  };
+}
+
+/**
+ * The living communities, when there are any.
+ *
+ * There never are today. `Ecosystems.generate` returns a nameless ecosystem with no flora and no
+ * fauna, so this yields nothing and the section does not appear — which is 6.4 rather than a
+ * missing feature, and the section will fill itself in the day the sub-generator is written.
+ */
+function ecosystemSections(snapshot: EnvironmentSnapshot): EnvironmentSection[] {
+  return snapshot.ecosystems
+    .map((ecosystem) => ({
+      heading: isPrintable(ecosystem.name) ? ecosystem.name.trim() : 'Ecosystem',
+      lines: [
+        ...(isPrintable(ecosystem.description) ? [{ value: ecosystem.description.trim() }] : []),
+        ...(ecosystem.flora.filter(isPrintable).length > 0
+          ? [labelled('Flora', ecosystem.flora.filter(isPrintable).join(', '))]
+          : []),
+        ...(ecosystem.fauna.filter(isPrintable).length > 0
+          ? [labelled('Fauna', ecosystem.fauna.filter(isPrintable).join(', '))]
+          : []),
+      ],
+    }))
+    .filter((section) => section.lines.length > 0);
+}
+
+/** Arrange an environment for reading. */
+export function environmentToDocument(snapshot: EnvironmentSnapshot): EnvironmentDocument {
+  return {
+    title: environmentDisplayName(snapshot),
+    paragraphs: [snapshot.description, snapshot.climate.description].filter(isPrintable),
+    sections: [
+      biomeSection(snapshot),
+      climateSection(snapshot),
+      terrainSection(snapshot),
+      waterSection(snapshot),
+      ...ecosystemSections(snapshot),
+    ].filter((section) => section.lines.length > 0),
+  };
+}
+
+/** An environment as Markdown, for a referee who wants it in their own notes. */
+export function environmentToMarkdown(snapshot: EnvironmentSnapshot): string {
+  const document = environmentToDocument(snapshot);
+  const blocks = [`# ${document.title}`, ...document.paragraphs];
+
+  for (const section of document.sections) {
+    blocks.push(
+      `## ${section.heading}`,
+      section.lines.map((line) => `- ${environmentLineToString(line)}`).join('\n'),
+    );
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** The body of the PDF: the same document as plain text, without the title the PDF draws itself. */
+export function environmentToText(snapshot: EnvironmentSnapshot): string {
+  const document = environmentToDocument(snapshot);
+  const blocks = [...document.paragraphs];
+
+  for (const section of document.sections) {
+    blocks.push(
+      [section.heading.toUpperCase(), ...section.lines.map(environmentLineToString)].join('\n'),
+    );
+  }
+
+  return blocks.join('\n\n');
+}
+
+/** A filename stem for an exported environment, reduced to something a filesystem takes. */
+export function environmentFileStem(snapshot: EnvironmentSnapshot): string {
+  const stem = environmentDisplayName(snapshot)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' || stem === 'environment' ? 'environment' : `environment-${stem}`;
+}

--- a/src/lib/environment/environment_roll.test.ts
+++ b/src/lib/environment/environment_roll.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ENVIRONMENT_DEFAULT_ELEVATION,
+  ENVIRONMENT_DEFAULT_LATITUDE,
+  defaultEnvironmentGeneratorConfig,
+  randomEnvironmentGeneratorConfig,
+  readEnvironmentGeneratorConfig,
+  rollEnvironment,
+  rollEnvironmentSnapshot,
+} from './environment_roll';
+
+describe('rolling an environment', () => {
+  it('gives the same environment for the same seed and settings (2.2)', () => {
+    expect(rollEnvironment('repeatable')).toEqual(rollEnvironment('repeatable'));
+  });
+
+  it('gives the same environment twice from one config object', () => {
+    // `generate` writes derived settings back into the config it is handed, so a roll that shared
+    // one would differ from itself the second time. A fresh config per call is what stops that.
+    const config = defaultEnvironmentGeneratorConfig();
+    expect(rollEnvironment('shared-config', config)).toEqual(
+      rollEnvironment('shared-config', config),
+    );
+  });
+
+  it('gives a different environment for a different seed', () => {
+    expect(rollEnvironment('one').description).not.toEqual(rollEnvironment('two').description);
+  });
+
+  it('honours the latitude it is given', () => {
+    // A polar latitude and an equatorial one cannot produce the same climate from one seed.
+    const polar = rollEnvironment('latitude', {
+      ...defaultEnvironmentGeneratorConfig(),
+      latitude: 85,
+    });
+    const tropical = rollEnvironment('latitude', {
+      ...defaultEnvironmentGeneratorConfig(),
+      latitude: 0,
+    });
+    expect(polar.climate.name).not.toEqual(tropical.climate.name);
+  });
+
+  it('rolls a snapshot by the same path', () => {
+    expect(rollEnvironmentSnapshot('snapshotted').description).toEqual(
+      rollEnvironment('snapshotted').description,
+    );
+  });
+});
+
+describe('the parameters the randomize button produces', () => {
+  it('are the same for the same seed', () => {
+    expect(randomEnvironmentGeneratorConfig('params')).toEqual(
+      randomEnvironmentGeneratorConfig('params'),
+    );
+  });
+
+  it('are drawn from a stream of their own, so they do not move the roll', () => {
+    // The page presses Generate and Randomize independently. Sharing one stream would make what
+    // Generate produced depend on how many times Randomize had been pressed.
+    const before = rollEnvironment('independent');
+    randomEnvironmentGeneratorConfig('independent');
+    expect(rollEnvironment('independent')).toEqual(before);
+  });
+
+  it('stay inside the ranges the button has always used', () => {
+    const config = randomEnvironmentGeneratorConfig('ranges');
+    expect(Math.abs(config.latitude)).toBeLessThanOrEqual(70);
+    expect(config.elevation).toBeGreaterThanOrEqual(0.1);
+    expect(config.elevation).toBeLessThanOrEqual(0.8);
+    expect(config.terrainVector.every((n) => Math.abs(n) <= 0.5)).toBe(true);
+    expect(config.current.every((n) => Math.abs(n) <= 1)).toBe(true);
+    expect(config.waterDirection.every((n) => Math.abs(n) <= 20)).toBe(true);
+  });
+
+  it('produces two-component vectors, which is what a config records', () => {
+    expect(randomEnvironmentGeneratorConfig('shape').terrainVector).toHaveLength(2);
+  });
+});
+
+describe('reading a stored generator config', () => {
+  it('reads back what the page recorded', () => {
+    const recorded = {
+      latitude: 55,
+      elevation: 0.6,
+      erosionIterations: 5,
+      erosionStrength: 4,
+      reliefEnergy: 0.3,
+      terrainVector: [0.2, -0.1],
+      current: [0.5, 0.5],
+      waterDirection: [10, -4],
+    };
+    expect(readEnvironmentGeneratorConfig(recorded)).toEqual(recorded);
+  });
+
+  it('falls back to the library defaults for anything it does not recognise', () => {
+    const read = readEnvironmentGeneratorConfig({ latitude: 'north', elevation: null });
+    expect(read.latitude).toEqual(ENVIRONMENT_DEFAULT_LATITUDE);
+    expect(read.elevation).toEqual(ENVIRONMENT_DEFAULT_ELEVATION);
+  });
+
+  it('drops a vector of the wrong length rather than padding it', () => {
+    // Guessing the missing component would roll an environment sloping in a direction nobody chose.
+    expect(readEnvironmentGeneratorConfig({ terrainVector: [0.3] }).terrainVector).toEqual([0, 0]);
+    expect(readEnvironmentGeneratorConfig({ current: 'east' }).current).toEqual([0, 0]);
+  });
+
+  it('drops a vector whose components are not numbers', () => {
+    expect(readEnvironmentGeneratorConfig({ waterDirection: ['a', 'b'] }).waterDirection).toEqual([
+      0, 0,
+    ]);
+  });
+
+  it('reads an empty config as the defaults', () => {
+    expect(readEnvironmentGeneratorConfig({})).toEqual(defaultEnvironmentGeneratorConfig());
+  });
+});

--- a/src/lib/environment/environment_roll.ts
+++ b/src/lib/environment/environment_roll.ts
@@ -1,0 +1,165 @@
+/**
+ * The single path from a seed to an environment, and the record of how it was rolled.
+ *
+ * `EnvironmentGenerator.svelte` was closer to requirement 2.2 than most of the pass: it held one
+ * `RNG`, reseeded it from the seed box on every press, and `Environments.generate` is a pure
+ * function of the config it is handed. What it lacked was a record — eleven number fields sat in a
+ * `$state` config that nothing wrote down, so a saved environment could not say what latitude or
+ * relief energy produced it, and "the same seed" reproduced a different place under different
+ * settings. This module is that record and the roll it feeds.
+ *
+ * The eleven fields are the page's, and nothing else. The four sub-configs are not among them:
+ * `generate` overwrites every field of them it uses from the top-level settings, so recording them
+ * would be recording values that are discarded before they are read.
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import type Environment from './environment.js';
+import { generate, getDefaultConfig } from './environments.js';
+import { toEnvironmentSnapshot, type EnvironmentSnapshot } from './environment_snapshot.js';
+
+/** The page's defaults, which are the library's defaults, named once so both can read them. */
+export const ENVIRONMENT_DEFAULT_LATITUDE = 35;
+export const ENVIRONMENT_DEFAULT_ELEVATION = 0.35;
+export const ENVIRONMENT_DEFAULT_EROSION_ITERATIONS = 3;
+export const ENVIRONMENT_DEFAULT_EROSION_STRENGTH = 2;
+export const ENVIRONMENT_DEFAULT_RELIEF_ENERGY = 0.05;
+
+/**
+ * What the generator records about how it rolled, and what a re-roll reads back.
+ *
+ * Stated as a type so the two ends — what is written as provenance and what a re-roll expects to
+ * find — are in one place and drift loudly instead of quietly. The three vectors are stored as
+ * `[x, y]`: the generator's are three-component, but the third is always zero because these are
+ * directions across a surface, and recording a component no control can set would be recording the
+ * shape of a type rather than a decision.
+ */
+export type EnvironmentGeneratorConfigRecord = {
+  latitude: number;
+  elevation: number;
+  erosionIterations: number;
+  erosionStrength: number;
+  reliefEnergy: number;
+  terrainVector: number[];
+  current: number[];
+  waterDirection: number[];
+};
+
+/** The settings a roll starts from with nothing recorded: the library's own defaults. */
+export function defaultEnvironmentGeneratorConfig(): EnvironmentGeneratorConfigRecord {
+  return {
+    latitude: ENVIRONMENT_DEFAULT_LATITUDE,
+    elevation: ENVIRONMENT_DEFAULT_ELEVATION,
+    erosionIterations: ENVIRONMENT_DEFAULT_EROSION_ITERATIONS,
+    erosionStrength: ENVIRONMENT_DEFAULT_EROSION_STRENGTH,
+    reliefEnergy: ENVIRONMENT_DEFAULT_RELIEF_ENERGY,
+    terrainVector: [0, 0],
+    current: [0, 0],
+    waterDirection: [0, 0],
+  };
+}
+
+function readNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+/**
+ * A stored two-component vector, or the default.
+ *
+ * A vector of the wrong length is dropped rather than padded: a config that recorded one number
+ * where two were meant is a config this build cannot read, and guessing the missing component
+ * would roll an environment sloping in a direction nobody chose.
+ */
+function readVector(value: unknown, fallback: number[]): number[] {
+  if (!Array.isArray(value) || value.length < 2) {
+    return [...fallback];
+  }
+  const [x, y] = value;
+  return typeof x === 'number' && Number.isFinite(x) && typeof y === 'number' && Number.isFinite(y)
+    ? [x, y]
+    : [...fallback];
+}
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Anything unrecognisable falls back to the library's default for that field rather than being
+ * coerced: a config written by a build that spelled these differently should roll the default
+ * environment, not one built from a field it misread.
+ */
+export function readEnvironmentGeneratorConfig(
+  config: Record<string, unknown>,
+): EnvironmentGeneratorConfigRecord {
+  const defaults = defaultEnvironmentGeneratorConfig();
+  return {
+    latitude: readNumber(config.latitude, defaults.latitude),
+    elevation: readNumber(config.elevation, defaults.elevation),
+    erosionIterations: readNumber(config.erosionIterations, defaults.erosionIterations),
+    erosionStrength: readNumber(config.erosionStrength, defaults.erosionStrength),
+    reliefEnergy: readNumber(config.reliefEnergy, defaults.reliefEnergy),
+    terrainVector: readVector(config.terrainVector, defaults.terrainVector),
+    current: readVector(config.current, defaults.current),
+    waterDirection: readVector(config.waterDirection, defaults.waterDirection),
+  };
+}
+
+/** A recorded `[x, y]` as the three-component vector the generator works in. */
+function toGeneratorVector(vector: number[]): number[] {
+  return [vector[0], vector[1], 0];
+}
+
+/**
+ * Roll an environment from a seed and a set of settings — the one path the page and a re-roll take.
+ *
+ * A fresh config is built per call rather than shared, because `generate` writes the settings it
+ * derives back into the config it is handed: reusing one would make the second roll from the same
+ * seed differ from the first.
+ */
+export function rollEnvironment(
+  seed: string,
+  config: EnvironmentGeneratorConfigRecord = defaultEnvironmentGeneratorConfig(),
+): Environment {
+  const generatorConfig = getDefaultConfig(new RNG(seed));
+  generatorConfig.latitude = config.latitude;
+  generatorConfig.elevation = config.elevation;
+  generatorConfig.erosionIterations = config.erosionIterations;
+  generatorConfig.erosionStrength = config.erosionStrength;
+  generatorConfig.reliefEnergy = config.reliefEnergy;
+  generatorConfig.terrainVector = toGeneratorVector(config.terrainVector);
+  generatorConfig.current = toGeneratorVector(config.current);
+  generatorConfig.waterDirection = toGeneratorVector(config.waterDirection);
+
+  return generate(generatorConfig);
+}
+
+/**
+ * The settings the page's "Randomize Parameters" button produces, as a function of a seed.
+ *
+ * Drawn from a stream of its own so that randomizing the parameters and rolling the environment do
+ * not move each other: the page presses these two buttons independently, and a shared stream would
+ * make what Generate produced depend on how many times Randomize had been pressed. The ranges are
+ * the ones the button has always used.
+ */
+export function randomEnvironmentGeneratorConfig(seed: string): EnvironmentGeneratorConfigRecord {
+  const rng = new RNG(`${seed}-parameters`);
+  return {
+    ...defaultEnvironmentGeneratorConfig(),
+    latitude: rng.float(-70, 70),
+    elevation: rng.float(0.1, 0.8),
+    waterDirection: [rng.float(-20, 20), rng.float(-20, 20)],
+    current: [rng.float(-1, 1), rng.float(-1, 1)],
+    terrainVector: [rng.float(-0.5, 0.5), rng.float(-0.5, 0.5)],
+  };
+}
+
+/**
+ * Roll a fresh environment as a snapshot — the destructive half of editing (requirement 4.3), and
+ * what `ARTIFACT_EDITORS` registers as this kind's roller.
+ */
+export function rollEnvironmentSnapshot(
+  seed: string,
+  config: EnvironmentGeneratorConfigRecord = defaultEnvironmentGeneratorConfig(),
+): EnvironmentSnapshot {
+  return toEnvironmentSnapshot(rollEnvironment(seed, config));
+}

--- a/src/lib/environment/environment_snapshot.test.ts
+++ b/src/lib/environment/environment_snapshot.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { RNG } from '@ironarachne/rng';
+
+import {
+  emptyEcosystem,
+  environmentFromSnapshot,
+  environmentFromSnapshotWithRng,
+  toEnvironmentSnapshot,
+} from './environment_snapshot';
+import { rollEnvironment } from './environment_roll';
+
+/**
+ * Requirement 7.2: `fromSnapshot(toSnapshot(x))` preserves everything that matters.
+ *
+ * For an environment that is everything, because every part of one is plain data. The single field
+ * that is not stored is `dominantEcosystem`, and it comes back because it is `ecosystems[0]` — the
+ * claim the approved domain model rests on, asserted here rather than assumed.
+ */
+const environment = rollEnvironment('round-trip-seed');
+
+describe('an environment snapshot', () => {
+  const snapshot = toEnvironmentSnapshot(environment);
+  const restored = environmentFromSnapshot(snapshot);
+
+  it('comes back exactly as it went in', () => {
+    expect(restored).toEqual(environment);
+  });
+
+  it('does not store the dominant ecosystem twice', () => {
+    expect('dominantEcosystem' in snapshot).toBe(false);
+  });
+
+  it('rebuilds the dominant ecosystem from the list', () => {
+    expect(restored.dominantEcosystem).toEqual(environment.ecosystems[0]);
+  });
+
+  it('carries no functions into storage', () => {
+    expect(() => structuredClone(snapshot)).not.toThrow();
+  });
+
+  it('reads back through the codec signature without drawing from the RNG', () => {
+    // The RNG is handed over by the registry and deliberately unused: an environment is finished
+    // when it is stored, and drawing from a seed on the way back would regenerate over an edit.
+    const rng = new RNG('unused-seed');
+    expect(environmentFromSnapshotWithRng(snapshot, rng)).toEqual(restored);
+  });
+});
+
+describe('an environment stored with no ecosystems', () => {
+  it('reads back with the empty one the generator itself produces', () => {
+    const snapshot = { ...toEnvironmentSnapshot(environment), ecosystems: [] };
+    expect(environmentFromSnapshot(snapshot).dominantEcosystem).toEqual(emptyEcosystem());
+  });
+
+  it('is the shape every environment on the site has today', () => {
+    // `Ecosystems.generate` is a documented stub. If this ever fails, the sub-generator has been
+    // written and the presentation's dropped Ecosystem section is now doing real work.
+    expect(environment.dominantEcosystem).toEqual(emptyEcosystem());
+  });
+});

--- a/src/lib/environment/environment_snapshot.ts
+++ b/src/lib/environment/environment_snapshot.ts
@@ -1,0 +1,62 @@
+/**
+ * Writing an environment for storage, and reading one back.
+ *
+ * Both halves live here rather than in a `*_rehydrate.ts` beside it, and that is the rule the pass
+ * states rather than an omission: the split exists only where reading pulls a heavy dependency the
+ * writing side does not — species tables, archetype equipment, charge art. Reading an environment
+ * pulls nothing. Every part of one is a plain record of strings, numbers and number arrays, so the
+ * conversion is a copy in both directions.
+ *
+ * **`dominantEcosystem` is not stored, and is rebuilt from the list.** A live `Environment` carries
+ * both `dominantEcosystem` and `ecosystems`, and the generator sets the first to the first entry of
+ * the second — they are the same object, so storing both would write the same ecosystem twice and
+ * invite the two to drift the day something edits one of them. This is the shape the approved
+ * domain model in docs/readiness-locations.md declares. An environment stored with no ecosystems at
+ * all reads back with the empty one `Ecosystems.generate` itself returns, which is what every
+ * environment on the site has today.
+ *
+ * The final `stripFunctionValuesDeep` is a net rather than the mechanism, as it is for a settlement
+ * or an encounter: nothing in an environment is expected to carry a closure, and the strip is what
+ * keeps one grown somewhere new from turning a save into a `DataCloneError`.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+
+import { stripFunctionValuesDeep } from '$lib/persistent_save';
+
+import type Ecosystem from './ecosystems/ecosystem.js';
+import type Environment from './environment.js';
+
+/** An environment as it is stored. */
+export type EnvironmentSnapshot = Omit<Environment, 'dominantEcosystem'>;
+
+/** The ecosystem an environment falls back to: the one `Ecosystems.generate` returns today. */
+export function emptyEcosystem(): Ecosystem {
+  return { name: '', description: '', fauna: [], flora: [] };
+}
+
+export function toEnvironmentSnapshot(environment: Environment): EnvironmentSnapshot {
+  const { dominantEcosystem: _dominant, ...rest } = environment;
+  return stripFunctionValuesDeep(rest) as EnvironmentSnapshot;
+}
+
+export function environmentFromSnapshot(snapshot: EnvironmentSnapshot): Environment {
+  return {
+    ...snapshot,
+    dominantEcosystem: snapshot.ecosystems[0] ?? emptyEcosystem(),
+  };
+}
+
+/**
+ * The codec's reading half, with the signature the registry hands it.
+ *
+ * The RNG is unused, and that is the correct amount of use for it: an environment is finished when
+ * it is stored, and drawing anything from a seed on the way back would be regenerating over the
+ * user's edits.
+ */
+export function environmentFromSnapshotWithRng(
+  snapshot: EnvironmentSnapshot,
+  _rng: RNG,
+): Environment {
+  return environmentFromSnapshot(snapshot);
+}

--- a/src/lib/environment/environments.ts
+++ b/src/lib/environment/environments.ts
@@ -62,7 +62,7 @@ export function generate(config: EnvironmentGeneratorConfig): Environment {
 }
 
 export function generateForClimate(climateName: string, rng: RNG.RNG): Environment {
-  const config = getDefaultConfig();
+  const config = getDefaultConfig(rng);
   const climateType = Climates.getClimateTypeByName(climateName);
   config.latitude = rng.float(climateType.latitudeMin, climateType.latitudeMax);
   config.rng = rng;
@@ -119,10 +119,20 @@ export function describeTerrain(terrain: Terrain, rng: RNG.RNG): string {
   return description;
 }
 
-export function getDefaultConfig(): EnvironmentGeneratorConfig {
+/**
+ * The default environment settings, built around the RNG the caller is generating from.
+ *
+ * The RNG is a required parameter rather than a clock-seeded default — decision 1 of
+ * docs/tool-readiness.md, and the last of the five this library owned. Every caller already
+ * overwrote it on the next line, so the clock never actually reached a generated environment; what
+ * it did was make the helper *look* like a source of randomness a caller could safely forget
+ * about. It is handed to the four sub-configs here for the same reason, so a caller that reaches
+ * past `generate` into one of them gets a seeded config rather than a clock-seeded one.
+ */
+export function getDefaultConfig(rng: RNG.RNG): EnvironmentGeneratorConfig {
   return {
-    biomeConfig: Biomes.getDefaultConfig(),
-    climateConfig: Climates.getDefaultConfig(),
+    biomeConfig: Biomes.getDefaultConfig(rng),
+    climateConfig: Climates.getDefaultConfig(rng),
     current: [0, 0, 0],
     ecosystemConfig: EcosystemGeneration.getDefaultConfig(),
     elevation: 0.35,
@@ -131,10 +141,10 @@ export function getDefaultConfig(): EnvironmentGeneratorConfig {
     latitude: 35,
     reliefEnergy: 0.05,
     terrainVector: [0, 0, 0],
-    terrainConfig: TerrainGeneration.getDefaultConfig(),
+    terrainConfig: TerrainGeneration.getDefaultConfig(rng),
     waterDirection: [0, 0, 0], // water is present
-    waterSystemConfig: WaterSystems.getDefaultConfig(),
-    rng: new RNG.RNG(Date.now().toString()),
+    waterSystemConfig: WaterSystems.getDefaultConfig(rng),
+    rng,
   };
 }
 

--- a/src/lib/environment/index.ts
+++ b/src/lib/environment/index.ts
@@ -14,6 +14,12 @@ export * as PrecipitationTypes from './precipitationtypes';
 export * as Terrain from './terrain';
 export * as WaterSystems from './water_systems';
 
+export * from './environment_artifact_kind';
+export * from './environment_editing';
+export * from './environment_presentation';
+export * from './environment_roll';
+export * from './environment_snapshot';
+
 export * as BiomeClassifications from './biomes/biome_classifications';
 export * as Environments from './environments';
 export type * from './biomes/biome_types';

--- a/src/lib/environment/terrain/terrain.test.ts
+++ b/src/lib/environment/terrain/terrain.test.ts
@@ -6,14 +6,14 @@ import type { TerrainGeneratorConfig } from './terrain_types';
 describe('Terrain Generator', () => {
   it('should generate a terrain deterministically given a seed', () => {
     const config1: TerrainGeneratorConfig = {
-      ...getDefaultConfig(),
+      ...getDefaultConfig(new RNG('base-seed')),
       rng: new RNG('test-seed-1'),
     };
 
     const terrain1 = generate(config1);
 
     const config2: TerrainGeneratorConfig = {
-      ...getDefaultConfig(),
+      ...getDefaultConfig(new RNG('base-seed')),
       rng: new RNG('test-seed-1'),
     };
 
@@ -24,7 +24,7 @@ describe('Terrain Generator', () => {
 
   it('should assign valid geology materials to a generated terrain', () => {
     const config: TerrainGeneratorConfig = {
-      ...getDefaultConfig(),
+      ...getDefaultConfig(new RNG('base-seed')),
       rng: new RNG('geology-seed'),
     };
 

--- a/src/lib/environment/terrain/terrain.ts
+++ b/src/lib/environment/terrain/terrain.ts
@@ -47,7 +47,13 @@ export function generate(config: TerrainGeneratorConfig): Terrain {
   return result;
 }
 
-export function getDefaultConfig(): TerrainGeneratorConfig {
+/**
+ * The default terrain settings, with the RNG the caller is generating from.
+ *
+ * Required rather than clock-defaulted, per decision 1 of docs/tool-readiness.md; see
+ * `biomes.ts` for the whole of the reasoning.
+ */
+export function getDefaultConfig(rng: RNG): TerrainGeneratorConfig {
   return {
     elevationMin: 0,
     elevationMax: 1.0,
@@ -56,7 +62,7 @@ export function getDefaultConfig(): TerrainGeneratorConfig {
     normalVector: [0, 0, 0],
     erosionIterations: 3,
     erosionStrength: 2,
-    rng: new RNG(Date.now().toString()),
+    rng,
   };
 }
 

--- a/src/lib/environment/water_systems/water_systems.test.ts
+++ b/src/lib/environment/water_systems/water_systems.test.ts
@@ -30,7 +30,7 @@ describe('Water Systems Generator', () => {
 
   it('calculates temperature based on latitude', () => {
     const configEquator: WaterSystemGeneratorConfig = {
-      ...WaterSystems.getDefaultConfig(),
+      ...WaterSystems.getDefaultConfig(new RNG('base-seed')),
       latitude: 0,
       temperatureMin: 0,
       temperatureMax: 30,

--- a/src/lib/environment/water_systems/water_systems.ts
+++ b/src/lib/environment/water_systems/water_systems.ts
@@ -17,7 +17,13 @@ export function generate(config: WaterSystemGeneratorConfig): WaterSystem {
   };
 }
 
-export function getDefaultConfig(): WaterSystemGeneratorConfig {
+/**
+ * The default water-system settings, with the RNG the caller is generating from.
+ *
+ * Required rather than clock-defaulted, per decision 1 of docs/tool-readiness.md; see
+ * `biomes.ts` for the whole of the reasoning.
+ */
+export function getDefaultConfig(rng: RNG.RNG): WaterSystemGeneratorConfig {
   return {
     current: [0, 0, 0],
     latitude: 0,
@@ -26,6 +32,6 @@ export function getDefaultConfig(): WaterSystemGeneratorConfig {
     surfaceLevelMin: 0, // default to sea level
     surfaceLevelMax: 0, // default to sea level
     waterTypes: ['fresh', 'salt'],
-    rng: new RNG.RNG(Date.now().toString()),
+    rng,
   };
 }

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -100,6 +100,12 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // made-up-names package, and through the star nation roll module the whole of
   // `$lib/astronomical_bodies`. The kind module holds metadata and validation only.
   '$lib/civilizations/star_nation_artifact_kind',
+  // There is deliberately no entry for `$lib/environment`. Its kind module was written to sit here
+  // beside the other sixteen and the measurement said not to: through `$lib/environment`'s entry
+  // point the registry chunk is 136.1 KB across 17 chunks, and through the kind module it is
+  // 136.1 KB across 17 — the same, because the environment library is tables of numbers and five
+  // small sub-generators, with no generator reaching a species list or an image. It is the first
+  // kind in the readiness pass that did not need an exception, which is what this list is for.
   // The sixteenth. `$lib/dungeon`'s entry point reaches the dungeon generator, and from there the
   // encounter generator, the treasure hoard tables and the species tables. The kind module holds
   // metadata and validation only; its codec is a dynamic import, which is what keeps the

--- a/src/lib/regions/regions.ts
+++ b/src/lib/regions/regions.ts
@@ -146,8 +146,7 @@ function populateRegionInhabitants(
   latitude: number,
   nameGenSet: Names.NameGeneratorSet,
 ): void {
-  const environmentConfig = Environments.getDefaultConfig();
-  environmentConfig.rng = config.rng;
+  const environmentConfig = Environments.getDefaultConfig(config.rng);
   environmentConfig.latitude = latitude;
 
   // Here we would typically derive climate/biome mathematically from map majority

--- a/src/lib/settlements/settlement_organizations.test.ts
+++ b/src/lib/settlements/settlement_organizations.test.ts
@@ -12,8 +12,7 @@ import {
 } from './settlement_organizations';
 
 function sampleEnvironment(seed: string) {
-  const cfg = Environments.getDefaultConfig();
-  cfg.rng = new RNG(seed);
+  const cfg = Environments.getDefaultConfig(new RNG(seed));
   return Environments.generate(cfg);
 }
 

--- a/src/lib/settlements/settlement_problems.test.ts
+++ b/src/lib/settlements/settlement_problems.test.ts
@@ -7,8 +7,7 @@ import Hamlet from './categories/hamlet';
 import type { Environment } from '$lib/environment';
 
 function sampleEnv(seed: string): Environment {
-  const cfg = Environments.getDefaultConfig();
-  cfg.rng = new RNG(seed);
+  const cfg = Environments.getDefaultConfig(new RNG(seed));
   return Environments.generate(cfg);
 }
 

--- a/src/lib/settlements/settlements.test.ts
+++ b/src/lib/settlements/settlements.test.ts
@@ -9,8 +9,7 @@ import Hamlet from './categories/hamlet';
 import type { SettlementEconomicRole } from './settlement_types';
 
 function sampleEnvironment(seed: string) {
-  const cfg = Environments.getDefaultConfig();
-  cfg.rng = new RNG(seed);
+  const cfg = Environments.getDefaultConfig(new RNG(seed));
   return Environments.generate(cfg);
 }
 
@@ -84,8 +83,7 @@ describe('generate', () => {
 
   it('adds trade, problems, orgs, and notables when enrichment is set', () => {
     const rng = new RNG('enrich-seed-aa');
-    const environmentConfig = Environments.getDefaultConfig();
-    environmentConfig.rng = rng;
+    const environmentConfig = Environments.getDefaultConfig(rng);
     const environment = Environments.generate(environmentConfig);
     const simpleNameGen = { generate: (_n: number) => [rng.randomString(8)] } as NameGenerator;
     const s = Settlements.generate({

--- a/src/lib/settlements/settlements.ts
+++ b/src/lib/settlements/settlements.ts
@@ -33,8 +33,7 @@ export function generate(config: SettlementGeneratorConfig): Settlement {
 export function getDefaultConfig(
   rng: RNG.RNG = new RNG.RNG(Date.now().toString()),
 ): SettlementGeneratorConfig {
-  const environmentConfig = Environments.getDefaultConfig();
-  environmentConfig.rng = rng;
+  const environmentConfig = Environments.getDefaultConfig(rng);
 
   const environment = Environments.generate(environmentConfig);
   const genSet = Names.getFantasyNameGeneratorSet('tiefling', rng);

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -113,6 +113,7 @@ describe('TOOL_CATALOG', () => {
     const assessedHigher = [
       '/arms-manufacturer',
       '/chop-shop',
+      '/environment',
       '/fantasy/dungeon',
       '/star-nation',
       '/character',
@@ -226,6 +227,7 @@ describe('toolsWithMaturity', () => {
       '/character',
       '/chop-shop',
       '/culture',
+      '/environment',
       '/fantasy/adnd/character',
       '/fantasy/adnd/character/build',
       '/fantasy/dcc/character',

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -277,12 +277,24 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     genres: ['fantasy'],
     tags: ['map'],
   }),
+  // Assessed release-ready under #60 against docs/workshop.md, section by section. 1: catalog
+  // entry, `TOOL_PANELS`, its own route, and no genre tag because a place belongs to no setting.
+  // 2: `environment_roll.ts` is the one path from a seed, and the five `getDefault*Config` helpers
+  // this library owns now take the RNG rather than defaulting to the clock (decision 1 of
+  // docs/tool-readiness.md); the wind arrow moved off `getElementById`, which is 2.1. 3: kind
+  // `environment`, payload the type as it stands less `dominantEcosystem`, which is rebuilt from
+  // the list. 4: a bespoke editor covering every field, because the payload is nested rather than
+  // flat. 5: nothing it consumes has a kind, so 5.1 does not bind — it is a producer, and the
+  // dungeon and region generators are what it unblocks. 6: mobile widths via the page manifest,
+  // a named wind canvas over a written-out direction, Markdown and PDF exports, the empty
+  // ecosystem section dropped. 7: round-trip, migration and Playwright tests. 8: the README
+  // documents the five kind modules and still says the ecosystem sub-generator is a stub.
   defineTool({
     path: '/environment',
     label: 'Environment',
     kind: 'generator',
     domain: 'locations',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     tags: ['worldbuilding'],
   }),
   defineTool({

--- a/src/lib/workshop/artifact_editors.test.ts
+++ b/src/lib/workshop/artifact_editors.test.ts
@@ -186,6 +186,22 @@ describe('the artifact editor registry', () => {
     expect(rolled.theme.blueprint.name).toBe('Tomb');
   });
 
+  it('rolls an environment from provenance through the registered roller', async () => {
+    const roll = await artifactEditorEntry('environment')!.loadRoller!();
+    const provenance = {
+      toolPath: '/environment' as const,
+      seed: 'registry-seed',
+      config: { latitude: 82 },
+    };
+    const rolled = roll(provenance) as { climate: { name: string }; description: string };
+
+    expect(rolled.description).not.toBe('');
+    // The recorded latitude is honoured rather than redrawn, which is the whole claim provenance
+    // makes about a re-roll: a polar latitude cannot produce a tropical climate.
+    expect(rolled.climate.name).not.toBe('tropical');
+    expect(rolled).toEqual(roll(provenance));
+  });
+
   it('rolls a star nation from provenance through the registered roller', async () => {
     const roll = await artifactEditorEntry('star-nation')!.loadRoller!();
     const rolled = roll({

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -187,6 +187,16 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         rollDungeonSnapshot(provenance.seed, readDungeonGeneratorConfig(provenance.config));
     },
   },
+  environment: {
+    loadEditor: () => import('$components/locations/EnvironmentArtifactEditor.svelte'),
+    /** The page's eleven number fields, read back through the roll module's own reader. */
+    loadRoller: async () => {
+      const { readEnvironmentGeneratorConfig, rollEnvironmentSnapshot } =
+        await import('$lib/environment/environment_roll.js');
+      return (provenance) =>
+        rollEnvironmentSnapshot(provenance.seed, readEnvironmentGeneratorConfig(provenance.config));
+    },
+  },
   'arms-manufacturer': {
     loadEditor: () => import('$components/factions/ArmsManufacturerArtifactEditor.svelte'),
     /**

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -28,6 +28,7 @@ describe('artifact kind catalog', () => {
       'star-nation',
       'chop-shop',
       'dungeon',
+      'environment',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -28,6 +28,10 @@ import { encounterArtifactKind } from '$lib/encounters/encounter_artifact_kind';
 import { cultureArtifactKind } from '$lib/culture/culture_artifact_kind';
 import { dccCharacterArtifactKind } from '$lib/dcc/dcc_character_artifact_kind';
 import { dungeonArtifactKind } from '$lib/dungeon/dungeon_artifact_kind';
+// Through the entry point, unlike most of its neighbours, and measured rather than assumed: this
+// library is tables of numbers and five small sub-generators, so the registry chunk is the same
+// 136.1 KB across 17 chunks either way. See the note in `library_imports.test.ts`.
+import { environmentArtifactKind } from '$lib/environment';
 import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
 import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
 import { settlementArtifactKind } from '$lib/settlements/settlement_artifact_kind';
@@ -63,6 +67,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, starNationArtifactKind);
   registerArtifactKind(registry, chopShopArtifactKind);
   registerArtifactKind(registry, dungeonArtifactKind);
+  registerArtifactKind(registry, environmentArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Closes #60. Takes `/environment` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the design in `docs/readiness-locations.md` and the shape the pass gives every tool.

## What changed

- **`$lib/environment` grows the five kind modules**, flat at the library root beside its five sub-libraries: `environment_roll.ts`, `environment_snapshot.ts`, `environment_artifact_kind.ts`, `environment_editing.ts`, `environment_presentation.ts` — one test file each.
- **Kind `environment`**, payload the type as it stands less `dominantEcosystem`, which is `ecosystems[0]` and is rebuilt from the list rather than stored twice. Genre-neutral, so every project sees it.
- **`EnvironmentGenerator.svelte`** rolls through the library, saves with its eleven controls as provenance, and exports Markdown and PDF — the first export this tool has ever had.
- **`EnvironmentArtifactEditor.svelte`** covers every field an environment holds: its description, the biome and its two sentence lists, the climate and its seasons, the terrain and its geology, and the water system.

## Three departures from the design

Each recorded in `docs/readiness-locations.md`:

- **The editor is bespoke, not a `SnapshotFieldEditor` case.** The design said it would be one, and the payload turned out not to be flat: an environment is four nested records, two of which hold lists of strings and one of which holds a list of *season* records. [Decision 5](https://github.com/ironarachne/ironarachne/blob/main/docs/tool-readiness.md#5-flat-payloads-get-a-declared-field-editor-not-twenty-five-bespoke-components)'s descriptor language addresses `field: string` — a key on the snapshot — so it cannot reach `terrain.elevationMin`, and none of its four controls says "repeat these three fields per row". That decision's own guard is what applies. **`SnapshotFieldEditor` is still unbuilt, and this is the third tool to decline to build it** after #52 and #53, each because the payload was not as flat as the design assumed. The remaining candidates on that list are worth re-checking against their actual types before the next tool plans around it.
- **The five clock-defaulting `getDefault*Config` helpers this library owns are gone** — decision 1 reaching the library rather than the page. Every caller already overwrote the RNG on the next line, so the clock never reached a generated environment; what the default did was make the helper look like a source of randomness a caller could safely forget about. It is a required parameter in all five now, and `$lib/dungeon`, `$lib/regions`, `$lib/settlements` and `scripts/render_dungeon.ts` each lost the assignment line that followed the call. Six of the pass's fifteen are now done.
- **The kind needed no deep-import exception, and it is the first in the pass that did not.** The module was written to sit in `ALLOWED_DEEP_IMPORTS` beside the other sixteen and the measurement said not to: the registry chunk is **136.1 KB across 17 chunks either way**, because this library is tables of numbers and five small sub-generators with no generator reaching a species list or an image. The absence is commented in `library_imports.test.ts` so the next person does not add one out of habit.

## Two defects found while assessing

- **The wind arrow was fetched with `document.getElementById('windArrow')`**, which finds the first element with that id on the page. A tool must work identically in a panel and on its own route (2.1), and the workshop can mount two of anything — two of these would have drawn both arrows onto one canvas and left the other blank. It is `bind:this` now, with an accessible name and fallback content.
- **The page was a debugging readout.** Raw floats for humidity and elevation, a bare `[0.4, -0.2, 0]` for the wind, and the environment's own generated description not shown at all. It renders the presentation document now — the same one the exports write, so what a referee reads on screen and what they take away cannot drift, and an empty part is absent from both.

The page description said the tool was "mostly useful for debugging", which is not a thing a Release-ready tool says about itself. It now says what the tool is: the natural setting of a place, and the land the dungeon and region generators build on.

## 6.4 has teeth here for one reason

`Ecosystems.generate` is a documented stub returning a nameless ecosystem with no flora and no fauna. A document that printed an Ecosystem section would print an empty heading on **every sheet ever exported**, so it is dropped when empty — and the editor has no ecosystem fields for the same reason. Both are written to fill themselves in when the sub-generator is, and a test asserts the stub is still a stub so that day is noticed.

## Verification

- `npm run verify` green.
- `npm run verify:all`: 534 passed, 2 failed — both the `preview_goldens.spec.ts` WebGL cases the spec documents as expected to differ on a developer GPU. (The `dcc_character.spec.ts` flake I reported on #185 passed this run, as expected of a flake.)
- New `e2e/environment.spec.ts`: generate → save → reopen → edit → reload; editing a measurement without reclassifying around it; Markdown and PDF exports with no Ecosystem heading; same seed reproduces the environment; randomizing the parameters does not move what the seed produces. All five pass, as do the mobile-width checks for `/environment`.

## Left as found

- **`Ecosystems.generate` is still a stub.** Writing it is a generator, not a readiness task, and the README still says so.
- **Nine of the pass's fifteen clock-defaulting helpers remain** — four in `astronomical_bodies`, two in `civilizations`, and one each in `culture`, `heraldry`, `adnd` and `dice`. Each belongs to the tool whose work item covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiNEQcwu29qi81SrrYg6co
