### PR TITLE
Fix the seed-dependent DCC recalculation test

### DIFF
--- a/e2e/dcc_character.spec.ts
+++ b/e2e/dcc_character.spec.ts
@@ -122,17 +122,32 @@ test.describe('a DCC zero-level character', () => {
 
     const panel = await openInWorkshop(page, 'Bess Tanner');
     const fortitude = panel.getByRole('spinbutton', { name: 'Fortitude save' });
-    await fortitude.fill('7');
-    await expect(fortitude).toHaveValue('7');
+
+    // The rule the button applies is `fortitudeSave = baseSave + stamina modifier`, and `baseSave`
+    // is not a constant: the "saving throws" birth augur adds the luck modifier to it. So the
+    // expected value is read from the sheet rather than written down. This test used to set the
+    // save to 7 and assert it was no longer 7 afterwards, which failed on any character whose
+    // augur made `baseSave + 4` come to exactly 7 — roughly one seed in forty, and it rolls an
+    // unpinned character every run.
+    const baseSave = Number(
+      await panel.getByRole('spinbutton', { name: 'Base save', exact: true }).inputValue(),
+    );
+    // 18 is a +4 modifier: `Math.floor((18 - 10) / 2)`.
+    const expected = String(baseSave + 4);
+
+    // A sentinel no derivation can produce, so "unmoved" below means unmoved rather than coincided.
+    await fortitude.fill('99');
+    await expect(fortitude).toHaveValue('99');
 
     await panel.getByRole('spinbutton', { name: 'stamina score' }).fill('18');
     // Unmoved: changing the score did not touch the save.
-    await expect(fortitude).toHaveValue('7');
+    await expect(fortitude).toHaveValue('99');
 
     await panel
       .getByRole('button', { name: 'Recalculate modifiers and saves from the scores' })
       .click();
-    await expect(fortitude).not.toHaveValue('7');
+    // The arithmetic itself, not merely that something changed.
+    await expect(fortitude).toHaveValue(expected);
   });
 
   test('reproduces the same character from the same seed', async ({ page }) => {


### PR DESCRIPTION
`dcc_character.spec.ts` set the fortitude save to 7, pressed **Recalculate modifiers and saves from the scores**, and asserted the value was no longer 7. It rolls an unpinned character every run, so that held for most of them and failed for the rest — once in this session's `verify:all`, and it would keep failing at random on merges to `main`.

## It was arithmetic, not timing

The button applies `fortitudeSave = baseSave + stamina modifier`. The test assumed `baseSave` is zero, and it usually is — but the **"saving throws" birth augur** in `lucky_roll_data.ts` adds the luck modifier to it:

```ts
character.baseSave += this.modifier;
```

A stamina of 18 is `+4` by this library's `floor((value - 10) / 2)`. So a character whose augur rolled `+3` recalculates to `3 + 4 = 7`, and the assertion fails **on a correct result**. Roughly one seed in forty.

## The fix

The expectation is read from the sheet rather than written down:

```ts
const baseSave = Number(await panel.getByRole('spinbutton', { name: 'Base save', exact: true }).inputValue());
const expected = String(baseSave + 4);
```

That cannot collide by construction, and it asserts **the arithmetic** rather than merely that something changed — which is what the test is for, since the button exists so a judge can ask for the derivation rather than have it applied silently (4.2).

The sentinel the save is set to first is now `99`, which no derivation can produce, so "unmoved after the score changed" means unmoved rather than coincided.

## Nothing was wrong on the library side

`dcc_character_editing.test.ts` already asserts `after.fortitudeSave` equals `after.baseSave + 4` — derived, not a literal — and its comment already explains why the modifier is 4 rather than the published DCC table's +3. So the arithmetic was pinned correctly all along; only the browser test used a magic number. Nothing is added there.

## Verification

- `--repeat-each=12` on fresh characters, then the whole DCC spec (7 passed).
- `npm run verify` green.
- **Not run against the full browser suite.** This changes one spec file and no route, component or renderer, so the rule in CLAUDE.md doesn't bind — and running ten minutes of Chromium to check a test-only edit is the disproportionate thing we discussed.

This was the prerequisite for putting e2e on pull requests. With it fixed, the two flakes I hit this session are down to one — `/heraldry`'s mobile layout timed out waiting for a page title under full-suite load, which is contention rather than a bad assertion, and would be worth watching before the workflow moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiNEQcwu29qi81SrrYg6co
