### PR TITLE
Take the cyberpunk drug generator to Release-ready

### DIFF
--- a/docs/readiness-objects.md
+++ b/docs/readiness-objects.md
@@ -117,6 +117,41 @@ The issue calls this a good tool to run the whole spec against early, to find th
 of the process rather than of the tool. [Wave 1](tool-readiness.md#the-order-of-the-work) agrees,
 and pairs it with the arms manufacturer for exactly that purpose.
 
+**As built.** The kind and the payload landed as designed. Three corrections, and the first is to
+this document.
+
+- **`EffectType` carries no closure.** This section says it does — "`EffectType` carries a
+  `generate` closure in the effect tables (`src/lib/drug/drugs.ts`)" — and that is the reason it
+  gives for storing the effect by name. The type is `{ name, effects: string[] }`, entirely plain.
+  The only closures in the library are the three `generate` functions inside `randomName`'s local
+  `nameType` list, which never leave that function. So nothing in a `Drug` was ever at risk of
+  reaching storage as a function, and `stripFunctionValuesDeep` is not needed here.
+- **`DrugType` is stored by name too**, where this section says it "travels whole". The reason the
+  document gives for naming the effect turns out not to apply to either, but a better reason
+  applies to both: each is a row of a table, of which the payload uses the name and one drawn
+  entry — the method, or the effect sentence — and both of those are already fields of their own.
+  Storing a row whole copies every _other_ method into the payload, to go stale the day the table
+  changes. That is the treatment the pass gives species, archetypes and realm types.
+- **The page showed one paragraph.** `drug.description` was the whole of the output, with the ten
+  fields behind it invisible — which would also have left the editor with fields answering to
+  nothing on screen. The page renders the presentation document now, as the other tools in the pass
+  do.
+
+**The description is offered rather than recomputed**, which is the one genuinely interesting
+corner in a tool the issue rightly calls easy. `describe()` builds the paragraph from the other ten
+fields, so an editor that re-ran it on every field change would be the most natural thing to write
+and would throw away a hand-written description on the next keystroke — requirement 4.2 exactly. It
+is a button instead, the shape the DCC sheet uses for its derived saves.
+
+**On the editor.** This section calls it "the simplest `SnapshotFieldEditor` case in the pass", and
+once the two table rows reduce to names the payload really is eleven strings — the first and only
+payload in the pass that would have fitted the descriptor language, including its `select` control
+for the two named rows. It arrives one merge after
+[decision 5a](tool-readiness.md#5a-the-re-derive-none-of-the-twelve-was-a-customer) retired that
+component for want of customers, and the retirement still holds: one customer does not pay for a
+declarative layer, and this editor is shorter than the descriptor list that would have configured
+it. The re-derive's own reasoning about _this_ tool was wrong, though, and is corrected there.
+
 ## #71 — Spooky starship
 
 Like the chop shop, `src/lib/spooky_ship/index.ts` is a single file whose `generate(rng)` returns

--- a/docs/tool-readiness.md
+++ b/docs/tool-readiness.md
@@ -338,30 +338,38 @@ this list. The result is that **the list was wrong when it was written**, and th
 decision asks for ("should check that it is, since two 'flat' payloads have now turned out to carry
 a list of records") should have been run before the list existed.
 
-| Tool              | Payload                                                                     | Flat?  |
-| ----------------- | --------------------------------------------------------------------------- | ------ |
-| Chop shop         | `{ text }`                                                                  | Yes    |
-| Spooky ship       | `{ text }` — `generate(rng)` returns a string, same as the chop shop        | Yes    |
-| Drug              | 9 strings, plus `drugType` and `effectType` records                         | Nearly |
-| Arms manufacturer | a list of `Weapon` records                                                  | No     |
-| Star nation       | three records, `regionsOfControl[]`, an embedded star system                | No     |
-| Environment       | four nested records, two string lists, a list of `Season` records           | No     |
-| Planet            | a body, `moons: AstronomicalBody[]`, a nested civilization                  | No     |
-| Star system       | two lists of `AstronomicalBody`                                             | No     |
-| Potion            | `container`, `liquid`, `sensory`, `effect` records, `modifications[]`       | No     |
-| Item              | ~18 fields with nested material, enchantment, decoration and combat profile | No     |
-| Treasure hoard    | `Item[]` — a list of the above                                              | No     |
-| Merchant          | `proprietor`, `shop`, `mark` records, `stock[]`                             | No     |
+| Tool              | Payload                                                                     | Flat?   |
+| ----------------- | --------------------------------------------------------------------------- | ------- |
+| Chop shop         | `{ text }`                                                                  | Yes     |
+| Spooky ship       | `{ text }` — `generate(rng)` returns a string, same as the chop shop        | Yes     |
+| Drug              | 11 strings — both table rows stored by name (#64)                           | **Yes** |
+| Arms manufacturer | a list of `Weapon` records                                                  | No      |
+| Star nation       | three records, `regionsOfControl[]`, an embedded star system                | No      |
+| Environment       | four nested records, two string lists, a list of `Season` records           | No      |
+| Planet            | a body, `moons: AstronomicalBody[]`, a nested civilization                  | No      |
+| Star system       | two lists of `AstronomicalBody`                                             | No      |
+| Potion            | `container`, `liquid`, `sensory`, `effect` records, `modifications[]`       | No      |
+| Item              | ~18 fields with nested material, enchantment, decoration and combat profile | No      |
+| Treasure hoard    | `Item[]` — a list of the above                                              | No      |
+| Merchant          | `proprietor`, `shop`, `mark` records, `stock[]`                             | No      |
 
-Nine of the twelve are structures. Two are flat and are the _same_ case — the prose payload
+Nine of the twelve are structures. Two of the other three are the _same_ case — the prose payload
 [decision 4](#4-prose-generators-get-a-kind-and-it-holds-the-prose) describes, whose editing view is
 one textarea and which needs no descriptor framework to produce one. The chop shop's is fourteen
 lines.
 
-Drug is the only borderline entry, and it fails on this decision's own guard: `drugType` and
-`effectType` are rows of a table, so editing them means a `select` that maps a name back to a
-record, and the descriptor language addresses `field: string` — a key holding a value, not a key
-holding a name that resolves to one. That is the fifth control the guard refuses.
+Drug was recorded here as the only borderline entry, failing the guard because `drugType` and
+`effectType` are table rows. **That was wrong, and #64 proved it by building the tool.** The
+judgement was made against the _live_ `Drug` type rather than against the payload, and the payload
+stores both rows by name — so it is eleven strings, and the two named rows are exactly the `select`
+with `options` that the control union already has. Drug is the one tool on this list the descriptor
+language would have served.
+
+It changes the recommendation not at all. One customer does not pay for a declarative layer: the
+bespoke editor #64 shipped is shorter than the descriptor list that would have configured it, and
+the eleven other entries above still need components of their own. But the row is corrected here
+rather than left standing, because a reader checking this table against the code would find it
+does not match.
 
 **So `SnapshotFieldEditor` has no customers, and the recommendation is to retire it from this
 document rather than defer it again.** Six tools have been asked to write it and none could use it;

--- a/e2e/drug.spec.ts
+++ b/e2e/drug.spec.ts
@@ -1,0 +1,177 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `drug` kind: generate, save, reopen, edit.
+ *
+ * This is the half no unit test can settle. The library tests prove a drug round-trips through the
+ * codec and that each field edit changes one thing; what they cannot prove is that a referee can
+ * press Generate, keep the result, come back to it in a different page, change something, and still
+ * have the drug they saved. Every step of that crosses a boundary the unit tests stub out — the
+ * artifact store, IndexedDB, the editor registry, and a page reload.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+
+const DRUG_TITLE = 'Cyberpunk Drug Generator | Iron Arachne';
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool on this page has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+test.describe('a drug', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'Night Market');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/drug', { title: DRUG_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a drug to keep straight away.
+    await expect(page.locator('.drug')).toBeVisible();
+    await saveAs(page, 'Blue Jack');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'Blue Jack');
+
+    // Typed rather than filled: the point is that the editor's own binding carries keystrokes
+    // through to the snapshot it announces. The value is one no roll produces.
+    const colour = panel.getByRole('textbox', { name: 'Colour' });
+    await colour.fill('');
+    await colour.pressSequentially('matte black');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'Blue Jack');
+    await expect(reopened.getByRole('textbox', { name: 'Colour' })).toHaveValue('matte black');
+  });
+
+  test('offers the description rather than rewriting it under the user', async ({ page }) => {
+    // Requirement 4.2. The description is built from the other ten fields, so a form that
+    // regenerated it on every keystroke would throw away a hand-written one.
+    await visitRoute(page, '/drug', { title: DRUG_TITLE });
+    await saveAs(page, 'Star Wonder');
+
+    const panel = await openInWorkshop(page, 'Star Wonder');
+    const description = panel.getByRole('textbox', { name: 'Drug description' });
+    await description.fill('A judge wrote this by hand.');
+
+    // Unmoved: changing a field the description is built from did not touch it.
+    await panel.getByRole('textbox', { name: 'Strength' }).fill('catastrophically potent');
+    await expect(description).toHaveValue('A judge wrote this by hand.');
+
+    // And the generated wording is there for the asking.
+    await panel.getByRole('button', { name: 'Rewrite the description from the fields' }).click();
+    // `toHaveValue`, not `toContainText`: a textarea's edited value is not its text content.
+    await expect(description).toHaveValue(/catastrophically potent/);
+  });
+
+  test('downloads a drug a referee can take to the table', async ({ page }) => {
+    // Requirement 6.3, and the first exports this tool has ever had.
+    await visitRoute(page, '/drug', { title: DRUG_TITLE });
+    const heading = await page.locator('.drug h2').innerText();
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const markdownFile = await markdown;
+    expect(markdownFile.suggestedFilename()).toMatch(/\.md$/);
+    const contents = await new Response(await markdownFile.createReadStream()).text();
+    expect(contents).toContain(`# ${heading}`);
+    expect(contents).toContain('- Form: ');
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/\.pdf$/);
+  });
+
+  test('shows the fields it used to hide behind the description', async ({ page }) => {
+    // The page rendered `drug.description` alone, so the ten fields behind it were invisible and
+    // the editor had fields answering to nothing on screen.
+    await visitRoute(page, '/drug', { title: DRUG_TITLE });
+    const drug = page.locator('.drug');
+    for (const label of ['Form', 'Taken', 'Effect', 'Strength', 'Colour', 'Duration']) {
+      await expect(drug.getByText(label, { exact: true })).toBeVisible();
+    }
+  });
+
+  test('reproduces the same drug from the same seed', async ({ page }) => {
+    // Requirement 2.2: the seed control worked and the seed itself came from the clock.
+    await visitRoute(page, '/drug', { title: DRUG_TITLE });
+    const drug = page.locator('.drug');
+
+    await page.getByLabel('Random Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const first = await drug.innerText();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await drug.innerText()).toEqual(first);
+
+    await page.getByLabel('Random Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await drug.innerText()).not.toEqual(first);
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -19,9 +19,10 @@ import { visitRoute } from './helpers';
 const maturityBadge = (page: Page) => page.locator('.maturity__level');
 
 const TOOL_PAGES = [
-  // Was `/planet` until #61 took it to Release-ready. Any Experimental tool serves here; the drug
-  // generator is one with a stable title and no renderer to wait for.
-  { path: '/drug', title: 'Cyberpunk Drug Generator | Iron Arachne', level: 'Experimental' },
+  // Was `/planet` until #61 and `/drug` until #64, both of which reached Release-ready. Any
+  // Experimental tool serves here; the spooky starship is one with a stable title and no renderer
+  // to wait for.
+  { path: '/spooky-ship', title: 'Spooky Ship Generator | Iron Arachne', level: 'Experimental' },
 ] as const;
 
 /** The release-ready tools, which must say nothing at all. */
@@ -50,6 +51,7 @@ const SILENT_TOOL_PAGES = [
   { path: '/planet', title: 'Planet Generator | Iron Arachne', webgl: true },
   { path: '/star-system', title: 'Star System Generator | Iron Arachne', webgl: true },
   { path: '/region', title: 'Region Generator | Iron Arachne' },
+  { path: '/drug', title: 'Cyberpunk Drug Generator | Iron Arachne' },
   { path: '/fantasy/encounter', title: 'Encounter | Iron Arachne' },
   { path: '/fantasy/family', title: 'Fantasy Family Generator | Iron Arachne' },
   { path: '/fantasy/organization', title: 'Organization Generator | Iron Arachne' },
@@ -86,7 +88,7 @@ for (const entry of SILENT_TOOL_PAGES) {
 }
 
 test('maturity: a tool page says what its level promises', async ({ page }) => {
-  await visitRoute(page, '/drug', { title: 'Cyberpunk Drug Generator | Iron Arachne' });
+  await visitRoute(page, '/spooky-ship', { title: 'Spooky Ship Generator | Iron Arachne' });
 
   // The sentence, not just the pill: "Experimental" means nothing to a visitor who has not read
   // the design document, and the point is that they can decide before they invest work.
@@ -162,7 +164,8 @@ test('maturity: the tool browser marks every tool that has something to warn abo
   // Planet was the still-marked case until #61 took it to Release-ready. The drug generator is
   // Experimental and mountable, so it holds that end of the assertion now.
   await expect(browser.getByRole('button', { name: /^Planet/ })).not.toContainText('Experimental');
-  await expect(browser.getByRole('button', { name: /^Cyberpunk Drug/ })).toContainText(
+  await expect(browser.getByRole('button', { name: /^Cyberpunk Drug/ })).not.toContainText(
     'Experimental',
   );
+  await expect(browser.getByRole('button', { name: /^Spooky Ship/ })).toContainText('Experimental');
 });

--- a/src/components/objects/DrugArtifactEditor.svelte
+++ b/src/components/objects/DrugArtifactEditor.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import {
+    describeDrug,
+    drugTypes,
+    effectTypes,
+    setDrugText,
+    validateDrugSnapshot,
+    type DrugSnapshot,
+    type DrugTextField,
+  } from '$lib/drug';
+
+  /**
+   * The editing view for a saved drug.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it.
+   *
+   * **This is the flattest payload in the pass — eleven strings — and it still gets a bespoke
+   * editor.** `docs/tool-readiness.md` retired `SnapshotFieldEditor` after six tools declined it;
+   * this one would genuinely have fitted, and one customer does not make a framework worth the
+   * indirection. What is here is shorter than the descriptor list that would have configured it.
+   *
+   * **Nothing recomputes the description.** It is the field a user is most likely to have rewritten
+   * by hand, and a form that regenerated it whenever another field changed would throw that away on
+   * the next keystroke — which is what 4.2 forbids. The button below offers the generated wording
+   * to anyone who wants it back, which is the same shape the DCC sheet uses for its saves.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps this editor from rendering fields over
+   * something that is not a drug.
+   */
+  const accepted = $derived(validateDrugSnapshot(snapshot));
+  const drug = $derived<DrugSnapshot | undefined>(accepted.ok ? accepted.value : undefined);
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: DrugSnapshot) => DrugSnapshot): void {
+    if (drug === undefined) {
+      return;
+    }
+    onChange(change(drug));
+  }
+
+  function set(field: DrugTextField, value: string): void {
+    edit((current) => setDrugText(current, field, value));
+  }
+
+  /**
+   * The two fields backed by a table, offered as a select over the names that table has.
+   *
+   * A stored drug may name a form or an effect this build has dropped, so the current value is
+   * added to the list when it is not in it — otherwise opening such a drug would silently move it
+   * to whichever option happened to be first.
+   */
+  const formOptions = $derived(
+    drug === undefined
+      ? []
+      : [...new Set([...drugTypes.all().map((type) => type.name), drug.drugTypeName])].filter(
+          (name) => name !== '',
+        ),
+  );
+
+  const effectOptions = $derived(
+    drug === undefined
+      ? []
+      : [...new Set([...effectTypes.all().map((type) => type.name), drug.effectTypeName])].filter(
+          (name) => name !== '',
+        ),
+  );
+
+  /** The plain text fields, in the order the sheet reads them. */
+  const TEXT_FIELDS: { field: DrugTextField; label: string }[] = [
+    { field: 'name', label: 'Street name' },
+    { field: 'method', label: 'How it is taken' },
+    { field: 'strength', label: 'Strength' },
+    { field: 'color', label: 'Colour' },
+    { field: 'duration', label: 'Duration' },
+    { field: 'sideEffect', label: 'Side effects' },
+    { field: 'commonality', label: 'Availability' },
+  ];
+</script>
+
+{#if drug === undefined}
+  <Notice tone="danger">
+    These contents are stored as a drug but do not read as one, so there is nothing safe to edit
+    here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="drug-editor">
+    {#each TEXT_FIELDS as entry (entry.field)}
+      <div class="input-group input-group--inline">
+        <label for="{uid}-{entry.field}">{entry.label}</label>
+        <input
+          id="{uid}-{entry.field}"
+          type="text"
+          value={drug[entry.field]}
+          oninput={(event) => set(entry.field, event.currentTarget.value)}
+          autocomplete="off"
+        />
+      </div>
+    {/each}
+
+    <div class="input-group input-group--inline">
+      <label for="{uid}-form">Form</label>
+      <select
+        id="{uid}-form"
+        value={drug.drugTypeName}
+        onchange={(event) => set('drugTypeName', event.currentTarget.value)}
+      >
+        {#each formOptions as name (name)}
+          <option value={name}>{name}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="input-group input-group--inline">
+      <label for="{uid}-effect">Effect</label>
+      <select
+        id="{uid}-effect"
+        value={drug.effectTypeName}
+        onchange={(event) => set('effectTypeName', event.currentTarget.value)}
+      >
+        {#each effectOptions as name (name)}
+          <option value={name}>{name}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="input-group">
+      <label for="{uid}-effectDescription">What it does</label>
+      <textarea
+        id="{uid}-effectDescription"
+        rows="2"
+        value={drug.effectDescription}
+        oninput={(event) => set('effectDescription', event.currentTarget.value)}
+      ></textarea>
+    </div>
+
+    <div class="input-group">
+      <!-- Qualified as "Drug description": the panel above has a field labelled "Name" that renames
+           the artifact, and "What it does" sits right beside this one. -->
+      <label for="{uid}-description">Drug description</label>
+      <textarea
+        id="{uid}-description"
+        rows="4"
+        value={drug.description}
+        oninput={(event) => set('description', event.currentTarget.value)}
+      ></textarea>
+    </div>
+
+    <!-- Offered rather than done automatically, for the reason the header gives. -->
+    <BaseButton
+      onclick={() => edit((current) => setDrugText(current, 'description', describeDrug(current)))}
+    >
+      Rewrite the description from the fields
+    </BaseButton>
+  </div>
+{/if}
+
+<style>
+  .drug-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+    align-items: flex-start;
+  }
+
+  .drug-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .drug-editor input[type='text'],
+  .drug-editor textarea,
+  .drug-editor select {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+</style>

--- a/src/components/objects/DrugGenerator.svelte
+++ b/src/components/objects/DrugGenerator.svelte
@@ -1,24 +1,62 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { Drug } from '$lib/drug';
-  import { Drugs } from '$lib/drug';
   import { RNG } from '@ironarachne/rng';
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
   import SeedControls from '$components/common/SeedControls.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
+  import * as Drug from '$lib/drug';
+  import { downloadTextFile } from '$lib/download';
+  import { downloadTextPdf } from '$lib/pdf';
 
-  const initialSeed = new RNG(Date.now().toString()).randomString(13);
-  let seed = $state(initialSeed);
-  const config = Drugs.getDefaultConfig();
-  let drug: Drug | null = $state(null);
+  const TOOL_PATH = '/drug';
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. It used to build a whole new `RNG` from
+   * `Date.now()` twice — once at module load for the initial seed and once per press — which is the
+   * requirement 2.2 failure the readiness pass finds most often: a seed control that works,
+   * over a seed nobody can reproduce.
+   */
+  const rng = new RNG(Date.now().toString());
+  let seed = $state(rng.randomString(13));
   let lockSeed = $state(false);
+
+  /**
+   * The rolled drug, as it is stored.
+   *
+   * The snapshot rather than the live value, because everything the page shows is in it and the
+   * live type adds only two table rows the page does not read. `$state.raw` for the usual reason:
+   * deep-reactive `$state` wraps values in a Proxy and `structuredClone` refuses one, so saving
+   * would fail with `could not be cloned`.
+   */
+  let drug = $state.raw<Drug.DrugSnapshot | null>(null);
+
+  const document_ = $derived(drug === null ? null : Drug.drugToDocument(drug));
+  const defaultArtifactName = $derived(drug === null ? '' : Drug.drugDisplayName(drug));
 
   function generate() {
     if (!lockSeed) {
-      seed = new RNG(Date.now().toString()).randomString(13);
+      seed = rng.randomString(13);
     }
-    const rng = new RNG(seed);
-    drug = Drugs.generate(config, rng);
+    drug = Drug.rollDrugSnapshot(seed);
+  }
+
+  function exportMarkdown() {
+    if (drug === null) return;
+    downloadTextFile(Drug.drugToMarkdown(drug), `${Drug.drugFileStem(drug)}.md`, 'text/markdown');
+  }
+
+  async function exportPdf() {
+    if (drug === null) return;
+    await downloadTextPdf(
+      Drug.drugDisplayName(drug),
+      Drug.drugToText(drug),
+      `${Drug.drugFileStem(drug)}.pdf`,
+    );
   }
 
   onMount(() => {
@@ -26,16 +64,53 @@
   });
 </script>
 
-<GeneratorPage toolPath="/drug" title="Drug Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Drug Generator">
   {#snippet description()}
     <p>I suppose you could also use this for any sci-fi setting, really.</p>
   {/snippet}
 
   <SeedControls bind:seed bind:lockSeed label="Random Seed" />
 
-  <BaseButton onclick={generate}>Generate</BaseButton>
+  <div class="actions">
+    <BaseButton onclick={generate}>Generate</BaseButton>
+    <BaseButton onclick={exportMarkdown} disabled={!drug}>Download Markdown</BaseButton>
+    <BaseButton onclick={exportPdf} disabled={!drug}>Download PDF</BaseButton>
+  </div>
 
-  {#if drug}
-    <p>{drug.description}</p>
+  <SaveArtifactButton
+    kind={Drug.DRUG_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={drug}
+    {seed}
+    defaultName={defaultArtifactName}
+  />
+
+  {#if document_}
+    <!-- The page renders the same document the exports do, so what a referee reads on screen and
+         what they take away cannot drift. It used to show the description alone, with the ten
+         fields behind it invisible — which also meant the editor had fields answering to nothing
+         on the page. -->
+    <div class="drug">
+      <h2>{document_.title}</h2>
+
+      {#each document_.paragraphs as paragraph, index (index)}
+        <p>{paragraph}</p>
+      {/each}
+
+      <StatBlock>
+        {#each document_.lines as line (line.label)}
+          <Stat label={line.label}>{line.value}</Stat>
+        {/each}
+      </StatBlock>
+    </div>
   {/if}
 </GeneratorPage>
+
+<style>
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+  }
+</style>

--- a/src/lib/drug/README.md
+++ b/src/lib/drug/README.md
@@ -37,4 +37,34 @@ const stimulant = generate(config, rng);
 ```
 
 The generator takes an existing `RNG` rather than a seed, because it is normally called as part of a
-larger run that already owns one.
+larger run that already owns one. `rollDrug(seed)` is the entry point for a caller that has a seed
+instead — it is the one path the generator page and a re-roll from provenance both take.
+
+## The artifact kind
+
+The five modules the readiness pass gives every Release-ready tool
+([docs/tool-readiness.md](../../../docs/tool-readiness.md)):
+
+- **`drug_roll.ts`** — a seed in, a drug out. There is no config record: this tool has one control
+  besides the seed, and it is the seed.
+- **`drug_snapshot.ts`** — writing a drug for storage and reading it back, both halves in one file
+  because reading pulls nothing. **The two table rows are stored by name**: a live `Drug` carries a
+  whole `DrugType` and `EffectType`, and what the generator used from each is the name plus the one
+  method and the one effect sentence it drew — both already fields of their own. Storing the rows
+  whole would copy every _other_ method and effect into the payload, to go stale the day the table
+  changes. An unknown name reads back as an inert row rather than a refusal.
+- **`drug_artifact_kind.ts`** — kind `drug`, payload version 1. Eleven strings, each of which may
+  be empty, because clearing a field is an edit rather than a broken payload.
+- **`drug_editing.ts`** — one setter over a field union, since every field is a string.
+- **`drug_presentation.ts`** — the drug as a document of paragraphs and labelled lines, empty ones
+  dropped, written once as Markdown and once as plain text for the PDF. It is also what the
+  generator page renders, so what a referee reads on screen and what they take away cannot drift.
+
+### The description is offered, never recomputed
+
+`describe()` builds the paragraph from the other ten fields during generation. The editor does
+**not** re-run it when a field changes: the description is the field a user is most likely to have
+rewritten by hand, and a form that regenerated it on the next keystroke elsewhere would throw that
+away — which is what requirement 4.2 forbids. `describeDrug` in `drug_presentation.ts` produces the
+generated wording from the fields as they now stand, and a button offers it. That is the same shape
+the DCC character sheet uses for its derived saves.

--- a/src/lib/drug/drug_artifact_kind.test.ts
+++ b/src/lib/drug/drug_artifact_kind.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DRUG_ARTIFACT_KIND,
+  DRUG_PAYLOAD_VERSION,
+  drugArtifactKind,
+  migrateDrugSnapshot,
+  validateDrugSnapshot,
+} from './drug_artifact_kind';
+import { rollDrugSnapshot } from './drug_roll';
+
+const snapshot = rollDrugSnapshot('kind-seed');
+
+/** A copy of the good payload with one part replaced, for the rejection cases. */
+function broken(changes: Record<string, unknown>): unknown {
+  return { ...(snapshot as unknown as Record<string, unknown>), ...changes };
+}
+
+describe('the drug artifact kind', () => {
+  it('is registered under a stable, unqualified id', () => {
+    expect(drugArtifactKind.kind).toEqual(DRUG_ARTIFACT_KIND);
+    expect(DRUG_ARTIFACT_KIND).toEqual('drug');
+  });
+
+  it('is its own kind rather than a share of `item`', () => {
+    // Decision 1 of docs/readiness-objects.md gives `item` to the tools that produce the same
+    // payload shape. A drug has no material, rarity, weight or combat profile, and an item has no
+    // method of ingestion.
+    expect(DRUG_ARTIFACT_KIND).not.toEqual('item');
+  });
+
+  it('declares the payload version it writes', () => {
+    expect(drugArtifactKind.payloadVersion).toEqual(DRUG_PAYLOAD_VERSION);
+  });
+
+  it('names a saved drug by its street name', () => {
+    expect(drugArtifactKind.nameOf(snapshot)).toEqual(snapshot.name);
+  });
+
+  it('falls back to the kind when the name has been emptied', () => {
+    expect(drugArtifactKind.nameOf({ ...snapshot, name: '  ' })).toEqual('Drug');
+  });
+
+  it('round-trips through its own codec', async () => {
+    const codec = await drugArtifactKind.loadCodec();
+    expect(codec.toSnapshot(codec.fromSnapshot(snapshot, undefined as never))).toEqual(snapshot);
+  });
+});
+
+describe('validating a stored drug', () => {
+  it('accepts what the generator wrote', () => {
+    expect(validateDrugSnapshot(snapshot).ok).toBe(true);
+  });
+
+  it('accepts one a user has emptied field by field', () => {
+    // Every one of the eleven may be empty: clearing the side effects of a drug is an editing
+    // decision, and 3.3 asks for a well-defined empty result rather than a refusal.
+    const emptied = Object.fromEntries(Object.keys(snapshot).map((key) => [key, '']));
+    expect(validateDrugSnapshot(emptied).ok).toBe(true);
+  });
+
+  it('rejects something that is not an object at all', () => {
+    expect(validateDrugSnapshot('a drug')).toMatchObject({
+      ok: false,
+      reason: 'invalid-payload',
+    });
+  });
+
+  it('rejects a payload missing any one of the eleven fields', () => {
+    for (const field of Object.keys(snapshot)) {
+      const { [field]: _dropped, ...rest } = snapshot as unknown as Record<string, unknown>;
+      expect(validateDrugSnapshot(rest), field).toMatchObject({ ok: false });
+    }
+  });
+
+  it('rejects a field that is not a string', () => {
+    // `undefined` would print as the word once the presentation joined the fields.
+    expect(validateDrugSnapshot(broken({ strength: 7 }))).toMatchObject({ ok: false });
+    expect(validateDrugSnapshot(broken({ sideEffect: null }))).toMatchObject({ ok: false });
+  });
+
+  it('says which field it rejected', () => {
+    const result = validateDrugSnapshot(broken({ color: 12 }));
+    expect(result.ok ? '' : result.message).toContain('color');
+  });
+});
+
+describe('migrating a stored drug (7.3)', () => {
+  it('rejects every version, because version 1 is the only shape there has been', () => {
+    // The whole of this kind's migration story today, asserted so that the day a version 2 lands
+    // this test is what has to change rather than something that silently drops a user's work.
+    const result = migrateDrugSnapshot(snapshot, 0);
+    expect(result).toMatchObject({ ok: false, reason: 'unsupported-version' });
+    expect(result.ok ? '' : result.message).toContain('version 0');
+  });
+});

--- a/src/lib/drug/drug_artifact_kind.ts
+++ b/src/lib/drug/drug_artifact_kind.ts
@@ -1,0 +1,109 @@
+// A pill. `potion-*.svg` is left for #68, which is the tool that actually makes potions.
+import pill from '$lib/assets/icons/set2/pill.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import type Drug from './drug.js';
+import type { DrugSnapshot } from './drug_snapshot.js';
+
+/**
+ * Stable artifact kind id. Unqualified: a drug is neither a game system's nor a setting's, per the
+ * kind table in docs/tool-readiness.md.
+ *
+ * Its own kind rather than a share of `item`, which decision 1 of docs/readiness-objects.md gives
+ * to the equipment and weapon generators. The test that decision sets is whether two tools produce
+ * the same payload shape; a drug and a sword do not — a drug has no material, no rarity, no weight
+ * and no combat profile, and an `Item` has no method of ingestion.
+ */
+export const DRUG_ARTIFACT_KIND = 'drug' as const;
+
+/** Version 1. The first shape a drug has been stored in. */
+export const DRUG_PAYLOAD_VERSION = 1 as const;
+
+/** Every field of a stored drug. All eleven are strings; none of them is optional. */
+const DRUG_FIELDS = [
+  'name',
+  'description',
+  'drugTypeName',
+  'method',
+  'effectTypeName',
+  'effectDescription',
+  'strength',
+  'color',
+  'duration',
+  'sideEffect',
+  'commonality',
+] as const;
+
+/**
+ * Checks that all eleven fields are strings.
+ *
+ * Every one may be *empty*, and that is deliberate: a user who has cleared the side effects of a
+ * drug has made an editing decision, and a payload that failed its own validator would be a broken
+ * artifact rather than an edited one — 3.3 asks for a well-defined empty result, not a refusal.
+ * What is checked is that each field is present and is a string, because the presentation joins
+ * them and `undefined` would print as the word.
+ */
+export function validateDrugSnapshot(payload: unknown): PayloadResult<DrugSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'drug payload is not an object');
+  }
+
+  const missing = DRUG_FIELDS.find((field) => typeof record[field] !== 'string');
+  if (missing !== undefined) {
+    return rejectedPayload('invalid-payload', `drug payload has no usable ${missing}`);
+  }
+
+  return acceptedPayload(record as unknown as DrugSnapshot);
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day the
+ * shape changes — a kind without one looks complete right up until it silently drops someone's
+ * work, and local-only means there is no server-side migration to fall back on.
+ */
+export function migrateDrugSnapshot(_payload: unknown, from: number): PayloadResult<DrugSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Drugs have no migration from payload version ${from}; version ${DRUG_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/** What to call a saved drug: its street name, or the kind when the name has been emptied. */
+function drugName(snapshot: DrugSnapshot): string {
+  const name = snapshot.name.trim();
+  return name === '' ? 'Drug' : name;
+}
+
+/**
+ * A drug as an artifact.
+ *
+ * The codec is a dynamic import for consistency with every other kind rather than for weight:
+ * reading a drug reaches only this library's two tables. Keeping the shape uniform is worth more
+ * than saving one indirection, because the day this payload grows a part that *is* heavy, the seam
+ * is already where it needs to be.
+ */
+export const drugArtifactKind = defineArtifactKind<Drug, DrugSnapshot>({
+  kind: DRUG_ARTIFACT_KIND,
+  displayName: 'Drug',
+  icon: pill,
+  payloadVersion: DRUG_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { toDrugSnapshot, drugFromSnapshotWithRng } = await import('./drug_snapshot.js');
+    return {
+      toSnapshot: toDrugSnapshot,
+      fromSnapshot: drugFromSnapshotWithRng,
+    };
+  },
+  nameOf: drugName,
+  validate: validateDrugSnapshot,
+  migrate: migrateDrugSnapshot,
+});

--- a/src/lib/drug/drug_editing.test.ts
+++ b/src/lib/drug/drug_editing.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { setDrugText } from './drug_editing';
+import { rollDrugSnapshot } from './drug_roll';
+
+const snapshot = rollDrugSnapshot('editing-seed');
+
+describe('editing a drug', () => {
+  it('sets each of the eleven fields', () => {
+    for (const field of Object.keys(snapshot) as (keyof typeof snapshot)[]) {
+      expect(setDrugText(snapshot, field, 'changed')[field]).toEqual('changed');
+    }
+  });
+
+  it('changes one field and nothing else (4.4)', () => {
+    const edited = setDrugText(snapshot, 'color', 'matte black');
+    expect(edited.color).toEqual('matte black');
+    expect({ ...edited, color: snapshot.color }).toEqual(snapshot);
+  });
+
+  it('leaves the original untouched', () => {
+    const before = snapshot.name;
+    setDrugText(snapshot, 'name', 'something else');
+    expect(snapshot.name).toEqual(before);
+  });
+
+  it('does not recompute the description when another field changes', () => {
+    // 4.2, and the trap this tool sets: `describe()` builds the paragraph from the other ten
+    // fields, so a form that re-ran it on every keystroke would throw away a hand-written one.
+    const edited = setDrugText(snapshot, 'strength', 'catastrophically potent');
+    expect(edited.description).toEqual(snapshot.description);
+  });
+
+  it('does not change the method when the form changes', () => {
+    // The two are related in the generator and independent in the payload: picking a new form
+    // cannot know which of its methods the user meant.
+    const edited = setDrugText(snapshot, 'drugTypeName', 'gas');
+    expect(edited.method).toEqual(snapshot.method);
+  });
+
+  it('accepts an empty value, because clearing a field is an edit', () => {
+    expect(setDrugText(snapshot, 'sideEffect', '').sideEffect).toEqual('');
+  });
+});

--- a/src/lib/drug/drug_editing.ts
+++ b/src/lib/drug/drug_editing.ts
@@ -1,0 +1,33 @@
+/**
+ * Editing a saved drug, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction, and it is what lets the editing
+ * framework compare what is on screen against what was read to decide whether anything needs
+ * saving.
+ *
+ * **Nothing here recomputes the description.** `describe()` in `drugs.ts` builds the paragraph from
+ * the other ten fields, and it is tempting to re-run it whenever one of them changes. That is
+ * exactly what 4.2 forbids: the paragraph is the field a user is most likely to have rewritten by
+ * hand, and a form that silently regenerated it would throw that away on the next keystroke
+ * elsewhere. The description is edited directly, like everything else. `describeDrug` in
+ * `drug_presentation.ts` is there for a user who wants the generated wording back.
+ *
+ * **Changing the drug type does not change the method.** A gas is inhaled and a pill is swallowed,
+ * so the two are related — but the method is a sentence the generator drew from the old type's
+ * list, and picking a new type cannot know which of the new list's methods the user wanted. It is
+ * a field of its own and it stays as it was until the user says otherwise.
+ */
+
+import type { DrugSnapshot } from './drug_snapshot.js';
+
+/** Every field of a stored drug, all of which are strings the user may rewrite. */
+export type DrugTextField = keyof DrugSnapshot;
+
+export function setDrugText(
+  snapshot: DrugSnapshot,
+  field: DrugTextField,
+  value: string,
+): DrugSnapshot {
+  return { ...snapshot, [field]: value };
+}

--- a/src/lib/drug/drug_presentation.test.ts
+++ b/src/lib/drug/drug_presentation.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import { setDrugText } from './drug_editing';
+import {
+  describeDrug,
+  drugDisplayName,
+  drugFileStem,
+  drugToDocument,
+  drugToMarkdown,
+  drugToText,
+} from './drug_presentation';
+import { rollDrugSnapshot } from './drug_roll';
+
+const snapshot = rollDrugSnapshot('presentation-seed');
+
+describe('arranging a drug for reading', () => {
+  const document = drugToDocument(snapshot);
+
+  it('is headed by the street name and opens with the paragraphs', () => {
+    expect(document.title).toEqual(snapshot.name);
+    expect(document.paragraphs).toEqual([snapshot.description, snapshot.effectDescription]);
+  });
+
+  it('lists the eight fields the page used to hide behind the description', () => {
+    expect(document.lines.map((line) => line.label)).toEqual([
+      'Form',
+      'Taken',
+      'Effect',
+      'Strength',
+      'Colour',
+      'Duration',
+      'Side effects',
+      'Availability',
+    ]);
+  });
+});
+
+describe('dropping what is empty (6.4)', () => {
+  it('drops a line whose field has been cleared', () => {
+    const cleared = setDrugText(snapshot, 'sideEffect', '  ');
+    expect(drugToDocument(cleared).lines.some((line) => line.label === 'Side effects')).toBe(false);
+  });
+
+  it('drops a paragraph that has been emptied', () => {
+    const blanked = setDrugText(setDrugText(snapshot, 'description', ''), 'effectDescription', ' ');
+    expect(drugToDocument(blanked).paragraphs).toEqual([]);
+  });
+
+  it('exports a drug emptied of everything as its title alone', () => {
+    let bare = snapshot;
+    for (const field of Object.keys(snapshot) as (keyof typeof snapshot)[]) {
+      if (field !== 'name') {
+        bare = setDrugText(bare, field, '');
+      }
+    }
+    expect(drugToMarkdown(bare)).toEqual(`# ${snapshot.name}\n`);
+  });
+
+  it('never leaves a blank line where a field had nothing to say', () => {
+    const bare = setDrugText(snapshot, 'description', '');
+    expect(drugToMarkdown(bare)).not.toContain('\n\n\n');
+    expect(drugToText(bare)).not.toContain('\n\n\n');
+  });
+});
+
+describe('rewriting the description from the fields', () => {
+  it('reads as the generator words it', () => {
+    // The counterpart to the editor never recomputing it: this is offered, not applied.
+    const described = describeDrug(snapshot);
+    expect(described).toContain(snapshot.name);
+    expect(described).toContain(snapshot.strength);
+    expect(described).toContain(snapshot.commonality);
+  });
+
+  it('drops the clauses whose fields are empty rather than printing gaps', () => {
+    const cleared = setDrugText(setDrugText(snapshot, 'sideEffect', ''), 'duration', '');
+    const described = describeDrug(cleared);
+    expect(described).not.toContain('Side effects can include');
+    expect(described).not.toContain('  ');
+  });
+
+  it('picks the article from the colour', () => {
+    expect(describeDrug(setDrugText(snapshot, 'color', 'amber'))).toContain("It's an amber");
+    expect(describeDrug(setDrugText(snapshot, 'color', 'crimson'))).toContain("It's a crimson");
+  });
+});
+
+describe('exporting a drug (6.3)', () => {
+  it('writes Markdown a referee can drop into their notes', () => {
+    const markdown = drugToMarkdown(snapshot);
+    expect(markdown).toContain(`# ${snapshot.name}`);
+    expect(markdown).toContain(`- Form: ${snapshot.drugTypeName}`);
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('writes the same document as plain text, without repeating the title', () => {
+    const text = drugToText(snapshot);
+    expect(text).toContain(`Form: ${snapshot.drugTypeName}`);
+    // The title is not repeated as a line of its own — the PDF draws it as a heading. The body
+    // does begin with the drug's name, because the generated description opens with it.
+    expect(text.split('\n')[0]).not.toEqual(snapshot.name);
+    expect(text.split('\n')[0]).toEqual(snapshot.description);
+  });
+
+  it('carries an edit straight into the export', () => {
+    expect(drugToMarkdown(setDrugText(snapshot, 'name', 'Blue Jack'))).toContain('# Blue Jack');
+  });
+});
+
+describe('naming a drug for a file', () => {
+  it('uses the street name', () => {
+    expect(drugDisplayName(snapshot)).toEqual(snapshot.name);
+    expect(drugFileStem({ name: 'Star Wonder' })).toEqual('drug-star-wonder');
+  });
+
+  it('falls back to the bare stem for one with no name', () => {
+    expect(drugDisplayName({ name: '  ' })).toEqual('Drug');
+    expect(drugFileStem({ name: '' })).toEqual('drug');
+  });
+
+  it('reduces punctuation a filesystem would not take', () => {
+    expect(drugFileStem({ name: 'Synth-9!!' })).toEqual('drug-synth-9');
+  });
+});

--- a/src/lib/drug/drug_presentation.ts
+++ b/src/lib/drug/drug_presentation.ts
@@ -1,0 +1,115 @@
+/**
+ * A drug arranged for reading, and the Markdown and PDF exports written from it.
+ *
+ * This tool had no export, and the page showed one paragraph — the generated description — while
+ * the ten fields behind it stayed invisible. Both halves are fixed by the same document: the page
+ * renders it and the exports write it, so what a referee reads on screen and what they take away
+ * cannot drift.
+ *
+ * 6.4 applies field by field rather than section by section here, because there are no sections.
+ * Every line is dropped when its field is empty, which an edited drug can be in any of eleven
+ * places, and a drug emptied of everything exports its name alone.
+ */
+
+import type { DrugSnapshot } from './drug_snapshot.js';
+
+/** One line of the sheet: a label and what it says. */
+export type DrugLine = {
+  label: string;
+  value: string;
+};
+
+/** A drug arranged for reading, independent of the format it is finally written in. */
+export type DrugDocument = {
+  title: string;
+  paragraphs: string[];
+  lines: DrugLine[];
+};
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+/** What to head the document with: the drug's street name, or the kind when it has none. */
+export function drugDisplayName(drug: { name: string }): string {
+  const name = drug.name.trim();
+  return name === '' ? 'Drug' : name.trim();
+}
+
+/**
+ * The description as the generator words it, from the fields as they stand now.
+ *
+ * The same sentence `describe()` builds during generation, exposed so a user who has edited the
+ * fields can ask for the paragraph to match — the counterpart to the editor never recomputing it
+ * (4.2). Nothing calls this automatically.
+ */
+export function describeDrug(snapshot: DrugSnapshot): string {
+  const article = /^[aeiou]/i.test(snapshot.color.trim()) ? 'an' : 'a';
+  const parts = [
+    isPrintable(snapshot.strength) || isPrintable(snapshot.effectTypeName)
+      ? `${drugDisplayName(snapshot)} is a ${[snapshot.strength, snapshot.effectTypeName].filter(isPrintable).join(' ')}.`
+      : '',
+    isPrintable(snapshot.color) || isPrintable(snapshot.drugTypeName)
+      ? `It's ${article} ${[snapshot.color, snapshot.drugTypeName].filter(isPrintable).join(' ')}${isPrintable(snapshot.method) ? ` that is ${snapshot.method}` : ''}.`
+      : '',
+    snapshot.effectDescription,
+    snapshot.duration,
+    isPrintable(snapshot.sideEffect) ? `Side effects can include ${snapshot.sideEffect}.` : '',
+    snapshot.commonality,
+  ];
+
+  return parts.filter(isPrintable).join(' ');
+}
+
+/** Arrange a drug for reading. */
+export function drugToDocument(snapshot: DrugSnapshot): DrugDocument {
+  const lines: DrugLine[] = [
+    { label: 'Form', value: snapshot.drugTypeName },
+    { label: 'Taken', value: snapshot.method },
+    { label: 'Effect', value: snapshot.effectTypeName },
+    { label: 'Strength', value: snapshot.strength },
+    { label: 'Colour', value: snapshot.color },
+    { label: 'Duration', value: snapshot.duration },
+    { label: 'Side effects', value: snapshot.sideEffect },
+    { label: 'Availability', value: snapshot.commonality },
+  ];
+
+  return {
+    title: drugDisplayName(snapshot),
+    paragraphs: [snapshot.description, snapshot.effectDescription].filter(isPrintable),
+    lines: lines.filter((line) => isPrintable(line.value)),
+  };
+}
+
+/** A drug as Markdown, for a referee who wants it in their own notes. */
+export function drugToMarkdown(snapshot: DrugSnapshot): string {
+  const document = drugToDocument(snapshot);
+  const blocks = [`# ${document.title}`, ...document.paragraphs];
+
+  if (document.lines.length > 0) {
+    blocks.push(document.lines.map((line) => `- ${line.label}: ${line.value}`).join('\n'));
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** The body of the PDF: the same document as plain text, without the title the PDF draws itself. */
+export function drugToText(snapshot: DrugSnapshot): string {
+  const document = drugToDocument(snapshot);
+  const blocks = [...document.paragraphs];
+
+  if (document.lines.length > 0) {
+    blocks.push(document.lines.map((line) => `${line.label}: ${line.value}`).join('\n'));
+  }
+
+  return blocks.join('\n\n');
+}
+
+/** A filename stem for an exported drug, reduced to something a filesystem takes. */
+export function drugFileStem(drug: { name: string }): string {
+  const stem = drugDisplayName(drug)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' || stem === 'drug' ? 'drug' : `drug-${stem}`;
+}

--- a/src/lib/drug/drug_roll.test.ts
+++ b/src/lib/drug/drug_roll.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollDrug, rollDrugSnapshot } from './drug_roll';
+
+describe('rolling a drug', () => {
+  it('gives the same drug for the same seed (2.2)', () => {
+    // The page drew its seed from `new RNG(Date.now())` twice — at module load and on every press
+    // — so the control was honoured and the seed itself was the clock's.
+    expect(rollDrug('repeatable')).toEqual(rollDrug('repeatable'));
+  });
+
+  it('gives a different drug for a different seed', () => {
+    expect(rollDrug('one').name).not.toEqual(rollDrug('two').name);
+  });
+
+  it('fills every field', () => {
+    const drug = rollDrug('complete');
+    for (const value of Object.values(toStrings(drug))) {
+      expect(value).not.toEqual('');
+    }
+  });
+
+  it('takes the method from the form it rolled', () => {
+    // The two are related in the generator and independent in the payload; this is the roll's half.
+    const drug = rollDrug('method-seed');
+    expect(drug.drugType.methods).toContain(drug.method);
+  });
+
+  it('takes the effect sentence from the effect type it rolled', () => {
+    const drug = rollDrug('effect-seed');
+    expect(drug.effectType.effects).toContain(drug.effectDescription);
+  });
+
+  it('rolls a snapshot by the same path', () => {
+    expect(rollDrugSnapshot('snapshotted').name).toEqual(rollDrug('snapshotted').name);
+  });
+});
+
+/** The drug's string fields, for the "nothing is blank" check above. */
+function toStrings(drug: ReturnType<typeof rollDrug>): Record<string, string> {
+  return {
+    name: drug.name,
+    description: drug.description,
+    method: drug.method,
+    effectDescription: drug.effectDescription,
+    strength: drug.strength,
+    color: drug.color,
+    duration: drug.duration,
+    sideEffect: drug.sideEffect,
+    commonality: drug.commonality,
+  };
+}

--- a/src/lib/drug/drug_roll.ts
+++ b/src/lib/drug/drug_roll.ts
@@ -1,0 +1,31 @@
+/**
+ * The single path from a seed to a drug, and the record of how it was rolled.
+ *
+ * `DrugGenerator.svelte` drew a fresh seed from `new RNG(Date.now())` twice — once at module load
+ * for the initial value and once per press — which is requirement 2.2's usual failure: the seed
+ * control was there and honoured, but the seed itself came from the clock rather than from a
+ * stream anybody could reproduce. The roll is a pure function of the seed now.
+ *
+ * There is no config record. The page has one control besides the seed, and it is the seed; the
+ * drug and effect tables are the library's, not the user's. Recording anything else would describe
+ * controls this tool does not have.
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import type Drug from './drug.js';
+import { generate, getDefaultConfig } from './drugs.js';
+import { toDrugSnapshot, type DrugSnapshot } from './drug_snapshot.js';
+
+/** Roll a drug from a seed — the one path the generator page and a re-roll both take. */
+export function rollDrug(seed: string): Drug {
+  return generate(getDefaultConfig(), new RNG(seed));
+}
+
+/**
+ * Roll a fresh drug as a snapshot — the destructive half of editing (requirement 4.3), and what
+ * `ARTIFACT_EDITORS` registers as this kind's roller.
+ */
+export function rollDrugSnapshot(seed: string): DrugSnapshot {
+  return toDrugSnapshot(rollDrug(seed));
+}

--- a/src/lib/drug/drug_snapshot.test.ts
+++ b/src/lib/drug/drug_snapshot.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import * as DrugTypes from './drug_types';
+import * as EffectTypes from './effect_types';
+import { rollDrug } from './drug_roll';
+import {
+  drugFromSnapshot,
+  drugFromSnapshotWithRng,
+  drugTypeFromStoredName,
+  effectTypeFromStoredName,
+  toDrugSnapshot,
+} from './drug_snapshot';
+
+/**
+ * Requirement 7.2: `fromSnapshot(toSnapshot(x))` preserves everything that matters.
+ *
+ * Everything a drug is asked about is a string, and all eleven survive. What is rebuilt rather than
+ * copied is the pair of table rows — the drug's form and its effect — which are resolved by name,
+ * so those are checked by name rather than by identity.
+ */
+const drug = rollDrug('round-trip-seed');
+
+describe('a drug snapshot', () => {
+  const snapshot = toDrugSnapshot(drug);
+  const restored = drugFromSnapshot(snapshot);
+
+  it('comes back exactly as it went in', () => {
+    expect(restored).toEqual(drug);
+  });
+
+  it('stores the two table rows by name rather than whole', () => {
+    expect(snapshot.drugTypeName).toEqual(drug.drugType.name);
+    expect(snapshot.effectTypeName).toEqual(drug.effectType.name);
+    expect('drugType' in snapshot).toBe(false);
+    expect('effectType' in snapshot).toBe(false);
+  });
+
+  it('is eleven strings and nothing else', () => {
+    // The claim the kind's validator rests on, and the reason this payload needs no conversion.
+    expect(Object.values(snapshot).every((value) => typeof value === 'string')).toBe(true);
+    expect(Object.keys(snapshot)).toHaveLength(11);
+  });
+
+  it('carries no functions into storage', () => {
+    expect(() => structuredClone(snapshot)).not.toThrow();
+  });
+
+  it('reads back through the codec signature without drawing from the RNG', () => {
+    // A drug is finished when it is stored; drawing from a seed on the way back would regenerate
+    // over an edit.
+    expect(drugFromSnapshotWithRng(snapshot, undefined)).toEqual(restored);
+  });
+});
+
+describe('resolving a stored table row', () => {
+  it('finds one this build has', () => {
+    const known = DrugTypes.all()[0];
+    expect(drugTypeFromStoredName(known.name)).toEqual(known);
+    const effect = EffectTypes.all()[0];
+    expect(effectTypeFromStoredName(effect.name)).toEqual(effect);
+  });
+
+  it('gives an inert row for one it does not, rather than refusing', () => {
+    // The same rule an unknown species gets: the method a drug is taken by is a field of its own
+    // and survives regardless, so losing the row costs the label alone.
+    expect(drugTypeFromStoredName('nanite paste')).toEqual({ name: 'nanite paste', methods: [] });
+    expect(effectTypeFromStoredName('empathogen')).toEqual({ name: 'empathogen', effects: [] });
+  });
+
+  it('round-trips a drug whose form this build has dropped', () => {
+    const snapshot = { ...toDrugSnapshot(drug), drugTypeName: 'nanite paste' };
+    expect(drugFromSnapshot(snapshot).drugType.name).toEqual('nanite paste');
+  });
+});

--- a/src/lib/drug/drug_snapshot.ts
+++ b/src/lib/drug/drug_snapshot.ts
@@ -1,0 +1,103 @@
+/**
+ * Writing a drug for storage, and reading one back.
+ *
+ * Both halves live here rather than in a `*_rehydrate.ts` beside it: reading a drug pulls nothing,
+ * because everything a stored one holds is a string.
+ *
+ * **The two table rows are stored by name.** A live `Drug` carries a whole `DrugType` and a whole
+ * `EffectType`, and each is a row of a table in this library — `{ name, methods }` and
+ * `{ name, effects }`. What the generator used from each is the name, plus the one method and the
+ * one effect sentence it drew, and both of those are already fields of their own. Storing the rows
+ * whole would copy every *other* method and effect into the payload, where they would go stale the
+ * day the table changes. This is the treatment the pass gives species, archetypes and realm types,
+ * for the same reason.
+ *
+ * `docs/readiness-objects.md` asks for that treatment for `EffectType` and says `DrugType`
+ * "travels whole". They get the same treatment here: the argument the document makes for one
+ * applies exactly to the other, and a payload where one table row is a name and the other is a
+ * record is a shape a reader has to remember rather than derive.
+ *
+ * The result is eleven strings and nothing else, which makes `fromSnapshot` a copy: the live type
+ * is rebuilt by resolving the two names against their tables, and a name this build no longer has
+ * becomes an inert row rather than a refusal.
+ */
+
+import * as DrugTypes from './drug_types.js';
+import * as EffectTypes from './effect_types.js';
+import type Drug from './drug.js';
+import type DrugType from './drug_type.js';
+import type EffectType from './effect_type.js';
+
+/** A drug as it is stored: eleven strings. */
+export type DrugSnapshot = {
+  name: string;
+  description: string;
+  drugTypeName: string;
+  method: string;
+  effectTypeName: string;
+  effectDescription: string;
+  strength: string;
+  color: string;
+  duration: string;
+  sideEffect: string;
+  commonality: string;
+};
+
+export function toDrugSnapshot(drug: Drug): DrugSnapshot {
+  return {
+    name: drug.name,
+    description: drug.description,
+    drugTypeName: drug.drugType.name,
+    method: drug.method,
+    effectTypeName: drug.effectType.name,
+    effectDescription: drug.effectDescription,
+    strength: drug.strength,
+    color: drug.color,
+    duration: drug.duration,
+    sideEffect: drug.sideEffect,
+    commonality: drug.commonality,
+  };
+}
+
+/**
+ * The drug type a stored name refers to, or an inert row when this build no longer has it.
+ *
+ * A placeholder rather than a refusal, matching how an unknown species is handled: a drug saved
+ * against a build that had a type this one dropped is still a drug, and the method it was taken by
+ * is a field of its own that survives regardless.
+ */
+export function drugTypeFromStoredName(name: string): DrugType {
+  return DrugTypes.all().find((type) => type.name === name) ?? { name, methods: [] };
+}
+
+/** The effect type a stored name refers to, or an inert row. See {@link drugTypeFromStoredName}. */
+export function effectTypeFromStoredName(name: string): EffectType {
+  return EffectTypes.all().find((type) => type.name === name) ?? { name, effects: [] };
+}
+
+export function drugFromSnapshot(snapshot: DrugSnapshot): Drug {
+  return {
+    name: snapshot.name,
+    description: snapshot.description,
+    drugType: drugTypeFromStoredName(snapshot.drugTypeName),
+    method: snapshot.method,
+    effectType: effectTypeFromStoredName(snapshot.effectTypeName),
+    effectDescription: snapshot.effectDescription,
+    strength: snapshot.strength,
+    color: snapshot.color,
+    duration: snapshot.duration,
+    sideEffect: snapshot.sideEffect,
+    commonality: snapshot.commonality,
+  };
+}
+
+/**
+ * The codec's reading half, with the signature the registry hands it.
+ *
+ * The RNG is unused, and that is the correct amount of use for it: a drug is finished when it is
+ * stored, and drawing anything from a seed on the way back would be regenerating over the user's
+ * edits.
+ */
+export function drugFromSnapshotWithRng(snapshot: DrugSnapshot, _rng: unknown): Drug {
+  return drugFromSnapshot(snapshot);
+}

--- a/src/lib/drug/index.ts
+++ b/src/lib/drug/index.ts
@@ -8,3 +8,9 @@ export * as drugTypes from './drug_types';
 export * as effectTypes from './effect_types';
 
 export * as Drugs from './drugs';
+
+export * from './drug_artifact_kind';
+export * from './drug_editing';
+export * from './drug_presentation';
+export * from './drug_roll';
+export * from './drug_snapshot';

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -113,6 +113,7 @@ describe('TOOL_CATALOG', () => {
     const assessedHigher = [
       '/arms-manufacturer',
       '/chop-shop',
+      '/drug',
       '/environment',
       '/planet',
       '/star-system',
@@ -230,6 +231,7 @@ describe('toolsWithMaturity', () => {
       '/character',
       '/chop-shop',
       '/culture',
+      '/drug',
       '/environment',
       '/fantasy/adnd/character',
       '/fantasy/adnd/character/build',

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -369,12 +369,21 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
   }),
 
   // Objects & Items
+  // Assessed release-ready under #64 against docs/workshop.md, section by section. 1: catalog
+  // entry, `TOOL_PANELS`, its own route. 2: `drug_roll.ts` is the one path from a seed; the page
+  // drew its seed from the clock twice, at module load and on every press. 3: kind `drug`, its own
+  // rather than a share of `item` — a drug has no material, rarity or weight and an item has no
+  // method of ingestion — payload eleven strings, the two table rows stored by name. 4: a bespoke
+  // editor over all eleven, with the description offered rather than recomputed. 5: nothing it
+  // consumes has a kind, so 5.1 does not bind. 6: mobile widths via the page manifest, the ten
+  // fields shown at last, Markdown and PDF exports, empty lines dropped. 7: round-trip, migration
+  // and Playwright tests. 8: the README documents the five kind modules.
   defineTool({
     path: '/drug',
     label: 'Cyberpunk Drug',
     kind: 'generator',
     domain: 'objects',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     genres: ['cyberpunk'],
   }),
   defineTool({

--- a/src/lib/workshop/artifact_editors.test.ts
+++ b/src/lib/workshop/artifact_editors.test.ts
@@ -257,6 +257,16 @@ describe('the artifact editor registry', () => {
     expect(rolled).toEqual(roll(provenance));
   });
 
+  it('rolls a drug from provenance through the registered roller', async () => {
+    const roll = await artifactEditorEntry('drug')!.loadRoller!();
+    const provenance = { toolPath: '/drug' as const, seed: 'registry-seed', config: {} };
+    const rolled = roll(provenance) as { name: string; drugTypeName: string };
+
+    expect(rolled.name).not.toBe('');
+    expect(rolled.drugTypeName).not.toBe('');
+    expect(rolled).toEqual(roll(provenance));
+  });
+
   it('rolls a star nation from provenance through the registered roller', async () => {
     const roll = await artifactEditorEntry('star-nation')!.loadRoller!();
     const rolled = roll({

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -227,6 +227,14 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         rollRegionSnapshot(provenance.seed, readRegionGeneratorConfig(provenance.config));
     },
   },
+  drug: {
+    loadEditor: () => import('$components/objects/DrugArtifactEditor.svelte'),
+    /** The seed and nothing else: this tool has one control, and the tables are the library's. */
+    loadRoller: async () => {
+      const { rollDrugSnapshot } = await import('$lib/drug/drug_roll.js');
+      return (provenance) => rollDrugSnapshot(provenance.seed);
+    },
+  },
   'arms-manufacturer': {
     loadEditor: () => import('$components/factions/ArmsManufacturerArtifactEditor.svelte'),
     /**

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -32,6 +32,7 @@ describe('artifact kind catalog', () => {
       'planet',
       'star-system',
       'region',
+      'drug',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -35,6 +35,9 @@ import { environmentArtifactKind } from '$lib/environment';
 import { planetArtifactKind } from '$lib/astronomical_bodies/planet_artifact_kind';
 import { starSystemArtifactKind } from '$lib/astronomical_bodies/star_system_artifact_kind';
 import { regionArtifactKind } from '$lib/regions/region_artifact_kind';
+// Through the entry point: `$lib/drug` is two phrase tables and a generator, with no species list
+// or image behind it. Measured the way the entries in `library_imports.test.ts` were.
+import { drugArtifactKind } from '$lib/drug';
 import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
 import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
 import { settlementArtifactKind } from '$lib/settlements/settlement_artifact_kind';
@@ -74,6 +77,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, planetArtifactKind);
   registerArtifactKind(registry, starSystemArtifactKind);
   registerArtifactKind(registry, regionArtifactKind);
+  registerArtifactKind(registry, drugArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Closes #64. Takes `/drug` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the design in `docs/readiness-objects.md`. **The first tool of the objects domain.**

## What changed

- **Five kind modules** in `$lib/drug`: `drug_roll.ts`, `drug_snapshot.ts`, `drug_artifact_kind.ts`, `drug_editing.ts`, `drug_presentation.ts`, one test file each.
- **Kind `drug`**, its own rather than a share of `item`. Decision 1 of the objects document gives `item` to tools producing the same payload shape; a drug has no material, rarity, weight or combat profile, and an `Item` has no method of ingestion.
- **`DrugGenerator.svelte`** rolls from a seed, saves with provenance, exports Markdown and PDF, and shows the ten fields it used to hide.
- **`DrugArtifactEditor.svelte`** covers all eleven fields, with the two table-backed ones as selects.

## Three corrections, the first to the design document

- **`EffectType` carries no closure.** `docs/readiness-objects.md` says it does — "carries a `generate` closure in the effect tables" — and gives that as the reason for storing the effect by name. The type is `{ name, effects: string[] }`, entirely plain. The only closures in the library are the three `generate` functions inside `randomName`'s local `nameType` list, which never leave that function. Nothing in a `Drug` was ever at risk of reaching storage as a function.
- **`DrugType` is stored by name too**, where the document says it "travels whole". The reason the document gives applies to neither, but a better one applies to both: each is a row of a table, of which the payload uses the name and one drawn entry — the method, or the effect sentence — and both are already fields of their own. Storing a row whole copies every *other* method into the payload, to go stale the day the table changes. That is the treatment the pass gives species, archetypes and realm types.
- **The page showed one paragraph.** `drug.description` was the whole output, with the ten fields behind it invisible — which would also have left the editor with fields answering to nothing on screen.

## The one interesting corner

The issue calls this an easy tool and it is, with one exception worth the note it gets in the code. `describe()` builds the description from the other ten fields, so **an editor that re-ran it whenever a field changed is the most natural thing to write, and it would throw away a hand-written description on the next keystroke elsewhere** — requirement 4.2 exactly. It is a button instead ("Rewrite the description from the fields"), which is the shape the DCC character sheet already uses for its derived saves. There is an e2e test for both halves: edited by hand, unmoved when the strength changes; regenerated on request.

## A correction to my own audit

PR #190 recorded drug as decision 5's only borderline entry, failing the guard because `drugType` and `effectType` are table rows needing a select. **That was wrong, and building the tool proved it.** The judgement was made against the *live* `Drug` type rather than against the payload — stored by name it is eleven strings, and the two named rows are exactly the `select` with `options` the control union already has. Drug is the one tool on that list `SnapshotFieldEditor` would have served.

The recommendation is unchanged: one customer does not pay for a declarative layer, the editor here is shorter than the descriptor list that would have configured it, and the eleven other entries still need components of their own. But the table said something untrue about the code, so it now says the right thing.

## Verification

- `npm run verify` green.
- `npm run verify:all`: **561 passed, 0 failed** — the first fully green run of this session, now that the golden baselines are current and the DCC seed flake is fixed.
- New `e2e/drug.spec.ts`: generate → save → reopen → edit → reload; the description offered rather than rewritten; Markdown and PDF; the fields visible on the page; same seed reproduces the drug.

## Test-suite housekeeping

`/drug` was `tool_maturity.spec.ts`'s example of a tool that *does* show a maturity badge — it took that role from `/planet` in #61. It has now outgrown it too, so `/spooky-ship` holds it. That is the third tool to pass the baton, which is what a readiness pass looks like from the test suite's side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiNEQcwu29qi81SrrYg6co
