### PR TITLE
Take the fantasy equipment price lists to Release-ready

### DIFF
--- a/docs/readiness-objects.md
+++ b/docs/readiness-objects.md
@@ -199,6 +199,45 @@ than a grid of cells — this tool adopts that, it does not invent anything.
 6.2 is the other half: column headers associated with their columns, and every control keyboard
 reachable.
 
+**As assessed.** 6.1 was already met, and by the repository's own mechanism: the page has used
+`DataTable` since #154, so each table flips to a stack of labelled rows below 640px and
+`e2e/tables.spec.ts` has been holding the page to it at 320px and 375px all along. This section
+expected the work to be there and it was not. What the section-by-section pass found instead was
+6.4, in three places that had nothing to do with layout and everything to do with what the page
+says:
+
+- **An item costing nothing printed an empty cell.** `valueToString(0)` is the empty string, and
+  the club, the quarterstaff and the sling stone are free. They read `Free` now.
+- **The key described coins no price was ever quoted in**, and omitted one that was. It listed
+  electrum, platinum and a crown — the first two are filtered out of the D&D display system, and
+  no currency system in `$lib/currency` has ever had a crown — while English prices came back in
+  guineas, because the guinea outranks the pound at 252 pence to 240 and `valueToString` spends
+  every denomination it is given. The farthing printed its name, `$lib/currency` giving it no
+  symbol, in a column of `cp` and `sp`.
+- **The fix is that the key is derived from the currency the prices are written in**, so the two
+  cannot drift again. Both currencies are display systems local to `$lib/equipment` rather than
+  `$lib/currency`'s own: a denomination that must never appear in a price has to be absent, not
+  merely unlikely.
+
+**7.1 needed the logic to exist somewhere testable first.** The currency conversion, the D&D
+system's filtered denominations and the copper-is-a-farthing rate lived in the component, where no
+unit test could reach them — which is why all three of the above shipped. `price_lists.ts` holds
+them now, along with the search and the exports, and `price_lists.test.ts` covers them.
+
+**6.3 applies to a reference tool and was not skipped.** A five-hundred-row price list is exactly
+the thing a referee wants on paper, so the page exports Markdown and a PDF, written from the same
+document it renders. They export what is on screen, filtered rows included.
+
+**One addition beyond the spec**, recorded because it is a judgment rather than a requirement: a
+search box. Five hundred rows in twenty-three tables is legible on a phone in the sense 6.1 means
+and unusable in the sense a reader means, and the fix is one text input over
+`filterEquipmentLists`. A category with nothing left in it is dropped rather than shown empty.
+
+**The page and the catalog now agree on the tool's name.** The heading read "Fantasy Equipment
+Lists" while the catalog entry — and therefore the panel title, the tool browser and `/tools` —
+read "Fantasy Equipment Price Lists". 1.4 is about a label reading correctly out of context, and a
+link that lands on a differently-named page is the same failure from the other end.
+
 ## Domain model
 
 ### Items, potions and hoards

--- a/docs/tool-readiness.md
+++ b/docs/tool-readiness.md
@@ -446,6 +446,14 @@ migration. They are days of work in total, they are independent of everything ab
 table-shaped ones (#65 and #76) are the site's most likely 6.1 failures — wide tables at 320px.
 They run in parallel with the rest of the pass rather than after it.
 
+**#65 is done, and it corrects the prediction above.** 6.1 was already met: the price lists have
+used `DataTable` since #154, so the tables flip on a phone rather than pushing the page sideways,
+and `e2e/tables.spec.ts` was already holding them to it. What the pass found instead was 6.4 —
+free items printing an empty cost, and a key naming coins no price was quoted in — and the reason
+it found it late is exactly [decision 8](#8-a-reference-tool-with-no-logic-still-gets-a-library):
+the conversion lived in the component, where no unit test could reach it. The two remaining
+reference tools should expect the same shape of finding.
+
 **#75 carries a caveat the other two do not.** The species height and weight calculator returns
 confident numbers from placeholder data: #25 records that 182 of 239 species carry placeholder
 human sizes. Section 6 polish does not fix that, and this document does not pretend otherwise —

--- a/e2e/equipment_price_lists.spec.ts
+++ b/e2e/equipment_price_lists.spec.ts
@@ -1,0 +1,166 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * The fantasy equipment price lists, as a reader meets them (#65).
+ *
+ * A reference tool produces no artifacts, so there is no generate/save/reopen/edit journey to
+ * cover and requirement 7.4 does not bind. What is left is the half the unit tests cannot settle:
+ * the page renders the same document the exports write, the same component works on its own route
+ * and in a panel (2.1), and the controls can be reached and used by name (6.2).
+ *
+ * 6.1 is covered where it always was — `e2e/tables.spec.ts` for the mechanism and
+ * `e2e/pages.mobile.spec.ts` for every width in `MOBILE_VIEWPORTS`.
+ */
+
+const TITLE = 'Fantasy Equipment Price Lists | Iron Arachne';
+
+const costCells = (page: Page) => page.locator('.data-table td.numeric');
+
+async function openPriceLists(page: Page): Promise<void> {
+  await visitRoute(page, '/fantasy/equipment', { title: TITLE });
+  await expect(page.locator('.equipment-list').first()).toBeVisible();
+}
+
+test.describe('the fantasy equipment price lists', () => {
+  test('quotes every price in a coin its key explains', async ({ page }) => {
+    // The failure this replaces: the key listed electrum, platinum and a crown, none of which any
+    // price was ever quoted in, while English prices came back in guineas, which it never
+    // mentioned. Both halves now come from the same currency, so the page can be read.
+    await openPriceLists(page);
+
+    const key = page.locator('.legend');
+    await expect(key).toContainText('cp');
+    await expect(key).toContainText('gp');
+    await expect(key).not.toContainText('electrum');
+    await expect(key).not.toContainText('platinum');
+
+    const dndCosts = (await costCells(page).allInnerTexts()).join('\n');
+    expect(dndCosts).not.toContain('ep');
+    expect(dndCosts).not.toContain('pp');
+
+    await page.getByLabel('Currency Type').selectOption({ label: 'English currency' });
+    await expect(key).toContainText('farthing');
+    await expect(key).toContainText('pound');
+
+    const englishCosts = (await costCells(page).allInnerTexts()).join('\n');
+    expect(englishCosts).not.toContain('guinea');
+    // The farthing has no symbol in `$lib/currency`, so it used to print its name in a column of
+    // `cp` and `sp`; the display system gives it the `f` the key has always promised.
+    expect(englishCosts).not.toContain('farthing');
+    expect(englishCosts).toMatch(/\d f\b/);
+  });
+
+  test('never leaves a cost blank', async ({ page }) => {
+    // Requirement 6.4. The club, the quarterstaff and the sling stone cost nothing, and
+    // `valueToString(0)` is the empty string, so three rows used to show an empty Cost cell.
+    await openPriceLists(page);
+
+    const costs = await costCells(page).allInnerTexts();
+    expect(costs.length).toBeGreaterThan(400);
+    for (const cost of costs) {
+      expect(cost.trim()).not.toBe('');
+    }
+    expect(costs.some((cost) => cost.trim() === 'Free')).toBe(true);
+  });
+
+  test('narrows five hundred rows to the ones a reader asked for', async ({ page }) => {
+    await openPriceLists(page);
+    const count = page.getByRole('status');
+    await expect(count).toContainText('categories');
+
+    await page.getByLabel('Search').fill('rope');
+    await expect(count).toContainText('match');
+
+    // Every row left names what was searched for, and a category with nothing left is gone
+    // rather than showing an empty table.
+    const names = await page.locator('.data-table td:not(.numeric)').allInnerTexts();
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(name.toLowerCase()).toContain('rope');
+    }
+    await expect(page.locator('.equipment-list')).toHaveCount(
+      await page.locator('.data-table').count(),
+    );
+
+    await page.getByLabel('Search').fill('');
+    await expect(count).toContainText('categories');
+  });
+
+  test('downloads the list a referee can take to the table', async ({ page }) => {
+    // Requirement 6.3, and the first export this page has ever had.
+    await openPriceLists(page);
+    await page.getByLabel('Search').fill('rope');
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const markdownFile = await markdown;
+    expect(markdownFile.suggestedFilename()).toBe('fantasy-equipment-prices-dnd.md');
+
+    // What was downloaded is what was on screen: the filtered rows, priced in the chosen currency.
+    const contents = await new Response(await markdownFile.createReadStream()).text();
+    expect(contents).toContain('# Fantasy Equipment Price Lists');
+    expect(contents).toContain('Prices in D&D currency.');
+    expect(contents).toContain('rope');
+    expect(contents).not.toContain('| longsword |');
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toBe('fantasy-equipment-prices-dnd.pdf');
+  });
+
+  test('names the currency the export is priced in', async ({ page }) => {
+    await openPriceLists(page);
+    await page.getByLabel('Currency Type').selectOption({ label: 'English currency' });
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const file = await markdown;
+    expect(file.suggestedFilename()).toBe('fantasy-equipment-prices-english.md');
+    expect(await new Response(await file.createReadStream()).text()).toContain(
+      'Prices in English currency.',
+    );
+  });
+
+  test('is reachable and operable by keyboard, with headed columns', async ({ page }) => {
+    // Requirement 6.2. The controls are found by their accessible names throughout this file;
+    // what is asserted here is that they can be reached without a pointer, and that a column of
+    // numbers announces what it is.
+    await openPriceLists(page);
+
+    await page.getByLabel('Currency Type').focus();
+    await page.keyboard.press('Tab');
+    await expect(page.getByLabel('Search')).toBeFocused();
+    await page.keyboard.type('rope');
+    await expect(page.getByRole('status')).toContainText('match');
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button', { name: 'Download Markdown' })).toBeFocused();
+
+    // `toHaveText` reads textContent, which is the name a screen reader gets; `innerText` would
+    // return what the stylesheet uppercases it to.
+    const headers = page.locator('.data-table').first().locator('thead th');
+    await expect(headers).toHaveText(['Item', 'Cost']);
+    await expect(headers.first()).toHaveAttribute('scope', 'col');
+    await expect(headers.nth(1)).toHaveAttribute('scope', 'col');
+  });
+
+  test('works the same mounted in a workshop panel', async ({ page }) => {
+    // Requirement 2.1. The panel registry points at the same component the route mounts, and this
+    // is what says the page does not quietly depend on being a page.
+    await visitRoute(page, '/workshop', { title: 'Workshop | Iron Arachne' });
+    await page
+      .locator('section.tool-browser')
+      .getByRole('button', { name: /^Fantasy Equipment Price Lists/ })
+      .click();
+
+    const panel = page.locator('section.workshop-panel');
+    await expect(panel.locator('.panel__title')).toContainText('Fantasy Equipment Price Lists');
+    await expect(panel.locator('.equipment-list').first()).toBeVisible();
+
+    await panel.getByLabel('Search').fill('rope');
+    await expect(panel.getByRole('status')).toContainText('match');
+    await expect(panel.locator('.data-table td.numeric').first()).not.toBeEmpty();
+  });
+});

--- a/e2e/page_manifest.ts
+++ b/e2e/page_manifest.ts
@@ -193,8 +193,8 @@ export const PAGE_MANIFEST: PageEntry[] = [
   },
   {
     path: '/fantasy/equipment',
-    title: 'Fantasy Equipment Lists | Iron Arachne',
-    heading: 'Fantasy Equipment Lists',
+    title: 'Fantasy Equipment Price Lists | Iron Arachne',
+    heading: 'Fantasy Equipment Price Lists',
     kind: 'static',
   },
   {

--- a/e2e/tables.spec.ts
+++ b/e2e/tables.spec.ts
@@ -16,7 +16,7 @@ test.describe('a flipped table', () => {
   test('shows one key per column it had', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 800 });
     await visitRoute(page, '/fantasy/equipment', {
-      title: 'Fantasy Equipment Lists | Iron Arachne',
+      title: 'Fantasy Equipment Price Lists | Iron Arachne',
     });
 
     const rows = page.locator('.data-table tbody tr');
@@ -42,7 +42,7 @@ test.describe('a flipped table', () => {
     // checks the mechanism itself, on the narrowest width the app supports.
     await page.setViewportSize({ width: 320, height: 800 });
     await visitRoute(page, '/fantasy/equipment', {
-      title: 'Fantasy Equipment Lists | Iron Arachne',
+      title: 'Fantasy Equipment Price Lists | Iron Arachne',
     });
 
     const overflow = await page.evaluate(() => {

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -52,6 +52,13 @@ const SILENT_TOOL_PAGES = [
   { path: '/star-system', title: 'Star System Generator | Iron Arachne', webgl: true },
   { path: '/region', title: 'Region Generator | Iron Arachne' },
   { path: '/drug', title: 'Cyberpunk Drug Generator | Iron Arachne' },
+  {
+    // The only reference tool in this list, and the reason it is worth naming: most of the spec
+    // does not apply to a tool that produces no artifacts, so it is the one entry here whose
+    // silence was earned by sections 1, 2.1, 2.5, 6, 7.1 and 8 alone (#65).
+    path: '/fantasy/equipment',
+    title: 'Fantasy Equipment Price Lists | Iron Arachne',
+  },
   { path: '/fantasy/encounter', title: 'Encounter | Iron Arachne' },
   { path: '/fantasy/family', title: 'Fantasy Family Generator | Iron Arachne' },
   { path: '/fantasy/organization', title: 'Organization Generator | Iron Arachne' },

--- a/src/components/common/DataTable.svelte
+++ b/src/components/common/DataTable.svelte
@@ -58,7 +58,10 @@
     <thead>
       <tr>
         {#each columns as column (column.label)}
-          <th class:numeric={column.numeric}>{column.label}</th>
+          <!-- `scope` is implicit for a head cell in a simple table, and stated anyway: it is what
+               a screen reader announces the column by, and requirement 6.2 asks for a name a
+               reader can actually hear rather than one a specification says they should. -->
+          <th scope="col" class:numeric={column.numeric}>{column.label}</th>
         {/each}
       </tr>
     </thead>

--- a/src/components/objects/EquipmentPriceLists.svelte
+++ b/src/components/objects/EquipmentPriceLists.svelte
@@ -1,32 +1,69 @@
 <script lang="ts">
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import ControlsPanel from '$components/common/ControlsPanel.svelte';
   import DataTable, { type Column } from '$components/common/DataTable.svelte';
-  import { valueToString, STANDARD_FANTASY, HISTORICAL_BRITISH } from '$lib/currency';
-  import { FantasyEquipmentList } from '$lib/equipment';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
+  import InputGroup from '$components/common/InputGroup.svelte';
   import SelectField from '$components/common/SelectField.svelte';
+  import { downloadTextFile } from '$lib/download';
+  import {
+    FantasyEquipmentList,
+    PRICE_CURRENCIES,
+    PRICE_LIST_TITLE,
+    countEquipmentItems,
+    filterEquipmentLists,
+    priceCurrency,
+    priceListDocument,
+    priceListFileStem,
+    priceListToMarkdown,
+    priceListToText,
+  } from '$lib/equipment';
+  import { downloadTextPdf } from '$lib/pdf';
 
-  let currency = $state('D&D currency');
+  const TOOL_PATH = '/fantasy/equipment';
+
+  /**
+   * The whole reference, read once.
+   *
+   * `all()` rebuilds the clothing list on every call, so reading it in a `$derived` would rebuild
+   * five hundred rows on every keystroke of the search box.
+   */
   const equipmentLists = FantasyEquipmentList.all();
+  const totalItems = countEquipmentItems(equipmentLists);
 
-  const DND_CURRENCY = {
-    ...STANDARD_FANTASY,
-    denominations: STANDARD_FANTASY.denominations.filter(
-      (d) => d.name !== 'electrum' && d.name !== 'platinum',
-    ),
-  };
+  const CURRENCY_OPTIONS = PRICE_CURRENCIES.map((option) => ({
+    value: option.id,
+    label: option.label,
+  }));
 
-  function convertDNDCost(cost: number) {
-    return valueToString(cost, DND_CURRENCY);
+  const PRICE_COLUMNS: Column[] = [{ label: 'Item' }, { label: 'Cost', numeric: true }];
+
+  let currencyId = $state(PRICE_CURRENCIES[0].id);
+  let search = $state('');
+
+  const currency = $derived(priceCurrency(currencyId));
+  const shownLists = $derived(filterEquipmentLists(equipmentLists, search));
+  const shownItems = $derived(countEquipmentItems(shownLists));
+  const document_ = $derived(priceListDocument(currency, shownLists));
+
+  function exportMarkdown() {
+    downloadTextFile(
+      priceListToMarkdown(document_),
+      `${priceListFileStem(currency)}.md`,
+      'text/markdown',
+    );
   }
 
-  function convertEnglishCost(cost: number) {
-    return valueToString(cost * 0.25, HISTORICAL_BRITISH);
+  async function exportPdf() {
+    await downloadTextPdf(
+      document_.title,
+      priceListToText(document_),
+      `${priceListFileStem(currency)}.pdf`,
+    );
   }
-
-  const PRICE_COLUMNS: Column[] = [{ label: 'Name' }, { label: 'Cost', numeric: true }];
 </script>
 
-<GeneratorPage toolPath="/fantasy/equipment" title="Fantasy Equipment Lists">
+<GeneratorPage toolPath={TOOL_PATH} title={PRICE_LIST_TITLE}>
   {#snippet description()}
     <p>
       This page is meant to be a comprehensive list of equipment for fantasy games. It will be
@@ -38,52 +75,78 @@
     </p>
   {/snippet}
 
-  <SelectField
-    id="currency"
-    label="Currency Type"
-    bind:value={currency}
-    options={['D&D currency', 'English currency']}
-  />
+  <ControlsPanel>
+    <SelectField
+      id="currency"
+      label="Currency Type"
+      bind:value={currencyId}
+      options={CURRENCY_OPTIONS}
+    />
+    <InputGroup id="equipment-search" label="Search">
+      <input
+        id="equipment-search"
+        type="search"
+        placeholder="rope, sword, ale…"
+        bind:value={search}
+      />
+    </InputGroup>
+  </ControlsPanel>
 
-  {#if currency === 'D&D currency'}
-    <div>
-      <ul>
-        <li>cp: copper piece</li>
-        <li>sp: silver piece (worth 10 copper pieces)</li>
-        <li>ep: electrum piece (worth 50 copper pieces, rare)</li>
-        <li>gp: gold piece (worth 10 silver pieces)</li>
-        <li>pp: platinum piece (worth 10 gold pieces, rare)</li>
-      </ul>
-    </div>
-  {:else if currency === 'English currency'}
-    <div>
-      <ul>
-        <li>f: farthing</li>
-        <li>d: pence (worth 4 farthings)</li>
-        <li>s: shilling (worth 12 pence)</li>
-        <li>c: crown (worth 5 shillings)</li>
-        <li>£: pound (worth 20 shillings)</li>
-      </ul>
-    </div>
-  {/if}
+  <!-- The key is derived from the same currency the Cost column is written in, so it cannot list a
+       coin the tables never print or omit one they do. It listed electrum, platinum and a crown
+       before #65, none of which any price was ever quoted in. -->
+  <h2>Reading the prices</h2>
+  <ul class="legend">
+    {#each currency.legend as entry (entry.symbol)}
+      <li>
+        <strong>{entry.symbol}</strong>: {entry.name}{entry.worth === '' ? '' : ` (${entry.worth})`}
+      </li>
+    {/each}
+  </ul>
 
-  {#each equipmentLists as eList}
+  <p class="count" role="status">
+    {#if search.trim() === ''}
+      {totalItems} items in {equipmentLists.length} categories.
+    {:else}
+      {shownItems} of {totalItems} items match “{search.trim()}”.
+    {/if}
+  </p>
+
+  <div class="actions">
+    <BaseButton onclick={exportMarkdown} disabled={shownItems === 0}>Download Markdown</BaseButton>
+    <BaseButton onclick={exportPdf} disabled={shownItems === 0}>Download PDF</BaseButton>
+  </div>
+
+  {#each document_.lists as list (list.title)}
     <div class="equipment-list">
-      <h2>{eList.title}</h2>
+      <h2>{list.title}</h2>
       <DataTable columns={PRICE_COLUMNS} rows={priceRows} />
 
       {#snippet priceRows()}
-        {#each eList.items as equipment}
+        {#each list.items as item (item.name)}
           <tr>
-            <td data-label="Name">{equipment.name}</td>
-            {#if currency === 'D&D currency'}
-              <td class="numeric" data-label="Cost">{convertDNDCost(equipment.cost)}</td>
-            {:else if currency === 'English currency'}
-              <td class="numeric" data-label="Cost">{convertEnglishCost(equipment.cost)}</td>
-            {/if}
+            <td data-label="Item">{item.name}</td>
+            <td class="numeric" data-label="Cost">{item.cost}</td>
           </tr>
         {/each}
       {/snippet}
     </div>
   {/each}
 </GeneratorPage>
+
+<style>
+  .legend {
+    margin-bottom: var(--s6);
+  }
+
+  .count {
+    color: var(--ink-faint);
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+  }
+</style>

--- a/src/lib/equipment/README.md
+++ b/src/lib/equipment/README.md
@@ -8,3 +8,23 @@ also don't use random generation, but can be randomly selected by generators.
 
 `index.ts` is the public API. `fantasylist/` holds the static fantasy price list, which is data
 rather than generation.
+
+## The fantasy price lists
+
+`fantasylist/` is the data: twenty-three titled lists of `{ name, cost }`, where `cost` is in
+copper pieces. `price_lists.ts` is everything done with it, and it is the whole of what
+`/fantasy/equipment` renders:
+
+- **`PRICE_CURRENCIES`** — the currencies the lists can be read in, each carrying a display
+  currency system, the copper-to-base-unit rate, and a key derived from that system. They are
+  display systems rather than `$lib/currency`'s own because `valueToString` spends every
+  denomination it is given: electrum, platinum and the guinea are absent so that no price can be
+  quoted in one, which is also why the key can be derived rather than written out and left to
+  drift. One copper piece is one farthing, which is the claim `baseUnitPerCopper` holds.
+- **`formatCost`** — one cost in one currency, and `Free` rather than the empty string for an item
+  that costs nothing. Three of them do.
+- **`filterEquipmentLists`** / **`countEquipmentItems`** — the page's search over five hundred rows,
+  dropping a list with nothing left in it rather than showing an empty table.
+- **`priceListDocument`** and **`priceListToMarkdown`** / **`priceListToText`** — the reference
+  arranged for reading, and the two exports written from it. The page renders the same document, so
+  what is on screen and what is downloaded cannot disagree.

--- a/src/lib/equipment/index.ts
+++ b/src/lib/equipment/index.ts
@@ -19,4 +19,6 @@ export * from './generation';
 
 export * as FantasyEquipmentList from './fantasylist';
 export * from './fantasylist';
+export * from './price_lists';
 export type * from './list';
+export type * from './price_list_types';

--- a/src/lib/equipment/price_list_types.ts
+++ b/src/lib/equipment/price_list_types.ts
@@ -1,0 +1,54 @@
+import type { CurrencySystem } from '$lib/currency';
+
+/** The currencies the fantasy price lists can be read in. */
+export type PriceCurrencyId = 'dnd' | 'english';
+
+/** One line of the key that tells a reader what `sp` or `£` means. */
+export type PriceLegendEntry = {
+  /** What appears in the Cost column. */
+  symbol: string;
+  /** What the symbol stands for, singular. */
+  name: string;
+  /**
+   * What it is worth in the next denomination down, or the empty string for the smallest, which
+   * is worth nothing but itself. 6.4: the empty string is dropped rather than rendered as an
+   * empty parenthetical.
+   */
+  worth: string;
+};
+
+/**
+ * A currency the lists can be priced in.
+ *
+ * The `system` is a display system rather than one of `$lib/currency`'s own: the lists quote a
+ * price in every denomination it carries, so a denomination that should never appear in a price
+ * has to be absent rather than merely unlikely. See `PRICE_CURRENCIES`.
+ */
+export type PriceCurrency = {
+  id: PriceCurrencyId;
+  /** The name of the currency, as the select offers it. */
+  label: string;
+  system: CurrencySystem;
+  /** What one copper piece of a list's stored cost is worth in this system's base unit. */
+  baseUnitPerCopper: number;
+  legend: PriceLegendEntry[];
+};
+
+/** An equipment item with its cost already rendered in a currency. */
+export type PricedItem = {
+  name: string;
+  cost: string;
+};
+
+/** One titled table of priced items. */
+export type PricedList = {
+  title: string;
+  items: PricedItem[];
+};
+
+/** The whole reference, arranged for reading, independent of the format it is written in. */
+export type PriceListDocument = {
+  title: string;
+  currency: PriceCurrency;
+  lists: PricedList[];
+};

--- a/src/lib/equipment/price_lists.test.ts
+++ b/src/lib/equipment/price_lists.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+
+import { all } from './fantasylist/index.js';
+import type { EquipmentList } from './list.js';
+import {
+  FREE_LABEL,
+  PRICE_CURRENCIES,
+  PRICE_LIST_TITLE,
+  countEquipmentItems,
+  filterEquipmentLists,
+  formatCost,
+  priceCurrency,
+  priceLegend,
+  priceListDocument,
+  priceListFileStem,
+  priceListToMarkdown,
+  priceListToText,
+  toPricedLists,
+} from './price_lists.js';
+
+const DND = priceCurrency('dnd');
+const ENGLISH = priceCurrency('english');
+
+const SAMPLE: EquipmentList[] = [
+  {
+    title: 'Rope and string',
+    items: [
+      { name: 'hemp rope, 50 ft', cost: 100 },
+      { name: 'silk rope, 50 ft', cost: 1000 },
+    ],
+  },
+  {
+    title: 'Free things',
+    items: [{ name: 'club', cost: 0 }],
+  },
+];
+
+describe('priceCurrency', () => {
+  it('returns the currency with that id', () => {
+    expect(priceCurrency('english').label).toBe('English currency');
+  });
+
+  it('falls back to the first currency rather than throwing on an unknown id', () => {
+    // The caller is a `<select>` whose value is a string, so the type does not protect this.
+    expect(priceCurrency('doubloons')).toBe(PRICE_CURRENCIES[0]);
+  });
+});
+
+describe('formatCost', () => {
+  it('writes a D&D price in the largest denominations that fit', () => {
+    expect(formatCost(100, DND)).toBe('1 gp');
+    expect(formatCost(125, DND)).toBe('1 gp 2 sp 5 cp');
+  });
+
+  it('never quotes a D&D price in electrum or platinum', () => {
+    // 60 copper is one electrum and ten copper in a system that carries electrum, which is not
+    // how any rulebook prices anything. A price over a platinum piece is the same problem.
+    expect(formatCost(60, DND)).toBe('6 sp');
+    expect(formatCost(500_000, DND)).toBe('5,000 gp');
+  });
+
+  it('treats one copper piece as one farthing in English money', () => {
+    expect(formatCost(1, ENGLISH)).toBe('1 f');
+    expect(formatCost(4, ENGLISH)).toBe('1 d');
+    expect(formatCost(48, ENGLISH)).toBe('1 s');
+    expect(formatCost(960, ENGLISH)).toBe('1 £');
+  });
+
+  it('never quotes an English price in guineas', () => {
+    // The guinea outranks the pound at 252 pence to 240, so every price above a pound used to be
+    // quoted in a coin the key never mentioned.
+    expect(formatCost(1_000_000, ENGLISH)).not.toContain('guinea');
+    expect(formatCost(1_000_000, ENGLISH)).toContain('£');
+  });
+
+  it('says an item is free rather than leaving the cost blank', () => {
+    // `valueToString(0)` is the empty string, which rendered an empty cell for the club, the
+    // quarterstaff and the sling stone — requirement 6.4.
+    expect(formatCost(0, DND)).toBe(FREE_LABEL);
+    expect(formatCost(0, ENGLISH)).toBe(FREE_LABEL);
+    expect(formatCost(-5, DND)).toBe(FREE_LABEL);
+  });
+});
+
+describe('priceLegend', () => {
+  it('describes each D&D denomination against the next one down', () => {
+    expect(DND.legend).toEqual([
+      { symbol: 'cp', name: 'copper piece', worth: '' },
+      { symbol: 'sp', name: 'silver piece', worth: 'worth 10 copper pieces' },
+      { symbol: 'gp', name: 'gold piece', worth: 'worth 10 silver pieces' },
+    ]);
+  });
+
+  it('describes each English denomination, with the plural nothing could derive', () => {
+    expect(ENGLISH.legend).toEqual([
+      { symbol: 'f', name: 'farthing', worth: '' },
+      { symbol: 'd', name: 'penny', worth: 'worth 4 farthings' },
+      { symbol: 's', name: 'shilling', worth: 'worth 12 pence' },
+      { symbol: '£', name: 'pound', worth: 'worth 20 shillings' },
+    ]);
+  });
+
+  it('names every denomination the currency can print', () => {
+    // The key is only a key while it covers what the Cost column can say. A denomination added to
+    // a display system without a name here would print its bare metal, and this is what says so.
+    for (const currency of PRICE_CURRENCIES) {
+      expect(currency.legend.length).toBe(currency.system.denominations.length);
+      for (const entry of currency.legend) {
+        expect(entry.name).not.toBe('');
+        expect(entry.symbol).not.toBe('');
+      }
+    }
+  });
+
+  it('falls back to the bare denomination name for one it has no copy for', () => {
+    const legend = priceLegend({
+      name: 'Invented',
+      description: 'A system this module has never seen.',
+      denominations: [
+        { name: 'bead', value: 1 },
+        { name: 'shell', symbol: 'sh', value: 3 },
+      ],
+    });
+
+    expect(legend).toEqual([
+      { symbol: 'bead', name: 'bead', worth: '' },
+      { symbol: 'sh', name: 'shell', worth: 'worth 3 bead' },
+    ]);
+  });
+});
+
+describe('filterEquipmentLists', () => {
+  it('returns the lists untouched for an empty query', () => {
+    expect(filterEquipmentLists(SAMPLE, '   ')).toBe(SAMPLE);
+  });
+
+  it('keeps the items whose name contains the query, whatever its case', () => {
+    const filtered = filterEquipmentLists(SAMPLE, 'ROPE');
+
+    expect(filtered.length).toBe(1);
+    expect(filtered[0].items.map((item) => item.name)).toEqual([
+      'hemp rope, 50 ft',
+      'silk rope, 50 ft',
+    ]);
+  });
+
+  it('drops a list with nothing left in it rather than showing an empty table', () => {
+    expect(filterEquipmentLists(SAMPLE, 'club')).toEqual([
+      { title: 'Free things', items: [{ name: 'club', cost: 0 }] },
+    ]);
+  });
+
+  it('returns nothing at all when nothing matches', () => {
+    expect(filterEquipmentLists(SAMPLE, 'trebuchet')).toEqual([]);
+  });
+});
+
+describe('countEquipmentItems', () => {
+  it('counts every item across every list', () => {
+    expect(countEquipmentItems(SAMPLE)).toBe(3);
+    expect(countEquipmentItems([])).toBe(0);
+  });
+});
+
+describe('toPricedLists', () => {
+  it('renders every cost in the chosen currency', () => {
+    expect(toPricedLists(SAMPLE, DND)).toEqual([
+      {
+        title: 'Rope and string',
+        items: [
+          { name: 'hemp rope, 50 ft', cost: '1 gp' },
+          { name: 'silk rope, 50 ft', cost: '10 gp' },
+        ],
+      },
+      { title: 'Free things', items: [{ name: 'club', cost: FREE_LABEL }] },
+    ]);
+  });
+
+  it('prices every item in the shipped lists in both currencies', () => {
+    // The blank cost that 6.4 catches would show up here as an empty string, on any of the five
+    // hundred rows rather than only the three that are free today.
+    for (const currency of PRICE_CURRENCIES) {
+      for (const list of toPricedLists(all(), currency)) {
+        for (const item of list.items) {
+          expect(item.cost, `${list.title}/${item.name}`).not.toBe('');
+        }
+      }
+    }
+  });
+});
+
+describe('priceListDocument', () => {
+  it('defaults to the whole shipped reference', () => {
+    const document = priceListDocument(DND);
+
+    expect(document.title).toBe(PRICE_LIST_TITLE);
+    expect(document.lists.length).toBe(all().length);
+  });
+});
+
+describe('priceListToMarkdown', () => {
+  it('writes a titled table per list, with the key above them', () => {
+    expect(priceListToMarkdown(priceListDocument(DND, SAMPLE))).toBe(
+      [
+        `# ${PRICE_LIST_TITLE}`,
+        '',
+        'Prices in D&D currency.',
+        '',
+        '- cp: copper piece',
+        '- sp: silver piece (worth 10 copper pieces)',
+        '- gp: gold piece (worth 10 silver pieces)',
+        '',
+        '## Rope and string',
+        '| Item | Cost |',
+        '| --- | ---: |',
+        '| hemp rope, 50 ft | 1 gp |',
+        '| silk rope, 50 ft | 10 gp |',
+        '',
+        '## Free things',
+        '| Item | Cost |',
+        '| --- | ---: |',
+        `| club | ${FREE_LABEL} |`,
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('writes the key and nothing else when every list has been filtered away', () => {
+    // 6.4: no stray heading, no empty table, no trailing run of blank lines.
+    const markdown = priceListToMarkdown(priceListDocument(ENGLISH, []));
+
+    expect(markdown).toBe(
+      [
+        `# ${PRICE_LIST_TITLE}`,
+        '',
+        'Prices in English currency.',
+        '',
+        '- f: farthing',
+        '- d: penny (worth 4 farthings)',
+        '- s: shilling (worth 12 pence)',
+        '- £: pound (worth 20 shillings)',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('never leaves a blank line inside a table', () => {
+    const markdown = priceListToMarkdown(priceListDocument(DND));
+
+    expect(markdown).not.toContain('|\n\n|');
+  });
+});
+
+describe('priceListToText', () => {
+  it('writes the same document without pipes or a title the PDF draws itself', () => {
+    const text = priceListToText(priceListDocument(ENGLISH, SAMPLE));
+
+    expect(text).toBe(
+      [
+        'Prices in English currency.',
+        '',
+        'f: farthing',
+        'd: penny (worth 4 farthings)',
+        's: shilling (worth 12 pence)',
+        '£: pound (worth 20 shillings)',
+        '',
+        'Rope and string',
+        '  hemp rope, 50 ft - 2 s 1 d',
+        '  silk rope, 50 ft - 1 £ 10 d',
+        '',
+        'Free things',
+        `  club - ${FREE_LABEL}`,
+      ].join('\n'),
+    );
+    expect(text).not.toContain(PRICE_LIST_TITLE);
+    expect(text).not.toContain('|');
+  });
+
+  it('ends without a trailing blank line when the lists are empty', () => {
+    expect(priceListToText(priceListDocument(DND, []))).toMatch(
+      /gold piece \(worth 10 silver pieces\)$/,
+    );
+  });
+});
+
+describe('priceListFileStem', () => {
+  it('names the currency the export is priced in', () => {
+    expect(priceListFileStem(DND)).toBe('fantasy-equipment-prices-dnd');
+    expect(priceListFileStem(ENGLISH)).toBe('fantasy-equipment-prices-english');
+  });
+});

--- a/src/lib/equipment/price_lists.ts
+++ b/src/lib/equipment/price_lists.ts
@@ -1,0 +1,249 @@
+/**
+ * The fantasy equipment price lists, priced, filtered and written out.
+ *
+ * All of this used to live in `EquipmentPriceLists.svelte`, where it could not be tested and where
+ * three things had quietly drifted apart: the key on the page listed denominations the table never
+ * printed (electrum, platinum, a crown that exists in no currency system here), the table printed
+ * one the key never mentioned (guineas, and `farthing` spelled out because the denomination
+ * carries no symbol), and an item costing nothing printed an empty cell. Requirement 6.4 is the
+ * one that catches the last of those, and the key is only honest if it is derived from the same
+ * system the prices are.
+ *
+ * The costs in `fantasylist/` are stored in copper pieces, which is also one farthing — the page
+ * has always said so, and `baseUnitPerCopper` is where that claim now lives.
+ */
+
+import { HISTORICAL_BRITISH, STANDARD_FANTASY, valueToString } from '$lib/currency';
+import type { CurrencyDenomination, CurrencySystem } from '$lib/currency';
+
+import { all } from './fantasylist/index.js';
+import type { EquipmentList } from './list.js';
+import type {
+  PriceCurrency,
+  PriceLegendEntry,
+  PriceListDocument,
+  PricedList,
+} from './price_list_types.js';
+
+/** What an item with no price shows, rather than the empty string `valueToString` returns for 0. */
+export const FREE_LABEL = 'Free';
+
+/** The document's own title, shared by the page heading and both exports. */
+export const PRICE_LIST_TITLE = 'Fantasy Equipment Price Lists';
+
+/**
+ * How each denomination is written in the key.
+ *
+ * The currency systems name a metal (`copper`) where a price list names a coin (`copper piece`),
+ * and English has one plural nothing can derive (`penny` → `pence`). Keyed by denomination name,
+ * so a system growing a denomination shows up here as a missing key rather than as silently
+ * wrong copy.
+ */
+const DENOMINATION_NAMES: Record<string, { singular: string; plural: string }> = {
+  copper: { singular: 'copper piece', plural: 'copper pieces' },
+  silver: { singular: 'silver piece', plural: 'silver pieces' },
+  gold: { singular: 'gold piece', plural: 'gold pieces' },
+  farthing: { singular: 'farthing', plural: 'farthings' },
+  penny: { singular: 'penny', plural: 'pence' },
+  shilling: { singular: 'shilling', plural: 'shillings' },
+  pound: { singular: 'pound', plural: 'pounds' },
+};
+
+/**
+ * D&D money as a price list quotes it.
+ *
+ * Electrum and platinum are dropped rather than kept and hoped against: `valueToString` spends
+ * every denomination it is given, so leaving electrum in prices a 60-copper item at "1 ep 1 cp",
+ * which no rulebook does. Both coins are rare by their own tables, which is the reason they are
+ * absent from the key too.
+ */
+const DND_SYSTEM: CurrencySystem = {
+  ...STANDARD_FANTASY,
+  denominations: STANDARD_FANTASY.denominations.filter(
+    (denomination) => denomination.name !== 'electrum' && denomination.name !== 'platinum',
+  ),
+};
+
+/**
+ * Pre-decimal English money as a price list quotes it.
+ *
+ * The guinea goes for the same reason electrum does — at 252 pence against the pound's 240 it
+ * outranks the pound, so every price over a pound was quoted in guineas. The farthing is given a
+ * symbol because it has none in `$lib/currency` and `valueToString` falls back to the
+ * denomination's name, which printed "3 farthing" in a column of `cp` and `sp`. Historically the
+ * farthing was written as a fraction of a penny; `f` is what this page's key has always called it.
+ */
+const ENGLISH_SYSTEM: CurrencySystem = {
+  ...HISTORICAL_BRITISH,
+  denominations: HISTORICAL_BRITISH.denominations
+    .filter((denomination) => denomination.name !== 'guinea')
+    .map((denomination) =>
+      denomination.name === 'farthing' ? { ...denomination, symbol: 'f' } : denomination,
+    ),
+};
+
+function denominationSymbol(denomination: CurrencyDenomination): string {
+  return denomination.symbol ?? denomination.name;
+}
+
+function denominationName(denomination: CurrencyDenomination, count: number): string {
+  const names = DENOMINATION_NAMES[denomination.name];
+  if (names === undefined) {
+    return denomination.name;
+  }
+  return count === 1 ? names.singular : names.plural;
+}
+
+/**
+ * The key, derived from the system the prices are quoted in.
+ *
+ * Each denomination is described against the next one down rather than against the base unit,
+ * because "worth 12 pence" is how a reader holds a shilling and "worth 48 farthings" is not.
+ */
+export function priceLegend(system: CurrencySystem): PriceLegendEntry[] {
+  const ascending = [...system.denominations].sort((a, b) => a.value - b.value);
+
+  return ascending.map((denomination, index) => {
+    const smaller = ascending[index - 1];
+    const count = smaller === undefined ? 0 : denomination.value / smaller.value;
+
+    return {
+      symbol: denominationSymbol(denomination),
+      name: denominationName(denomination, 1),
+      worth: smaller === undefined ? '' : `worth ${count} ${denominationName(smaller, count)}`,
+    };
+  });
+}
+
+/** Every currency the lists can be read in, in the order the select offers them. */
+export const PRICE_CURRENCIES: PriceCurrency[] = [
+  {
+    id: 'dnd',
+    label: 'D&D currency',
+    system: DND_SYSTEM,
+    baseUnitPerCopper: 1,
+    legend: priceLegend(DND_SYSTEM),
+  },
+  {
+    id: 'english',
+    label: 'English currency',
+    system: ENGLISH_SYSTEM,
+    // A copper piece is a farthing, and the historical system's base unit is the penny.
+    baseUnitPerCopper: 0.25,
+    legend: priceLegend(ENGLISH_SYSTEM),
+  },
+];
+
+/**
+ * The currency with that id, falling back to the first rather than throwing.
+ *
+ * The caller is a `<select>` whose value is a string; a value that is not a currency means the
+ * markup and this list disagree, and a reference page that shows prices in the wrong currency is
+ * a better outcome than one that shows a blank screen.
+ */
+export function priceCurrency(id: string): PriceCurrency {
+  return PRICE_CURRENCIES.find((currency) => currency.id === id) ?? PRICE_CURRENCIES[0];
+}
+
+/** One item's cost, written in a currency. */
+export function formatCost(costInCopper: number, currency: PriceCurrency): string {
+  if (costInCopper <= 0) {
+    return FREE_LABEL;
+  }
+  return valueToString(costInCopper * currency.baseUnitPerCopper, currency.system);
+}
+
+/**
+ * The lists narrowed to the items whose name matches `query`.
+ *
+ * Case- and space-insensitive substring matching, which is what a reader typing "rope" into a
+ * five-hundred-row reference means. A list with nothing left in it is dropped rather than shown
+ * empty — 6.4 for the page as much as for the exports.
+ */
+export function filterEquipmentLists(lists: EquipmentList[], query: string): EquipmentList[] {
+  const needle = query.trim().toLowerCase();
+  if (needle === '') {
+    return lists;
+  }
+
+  return lists
+    .map((list) => ({
+      ...list,
+      items: list.items.filter((item) => item.name.toLowerCase().includes(needle)),
+    }))
+    .filter((list) => list.items.length > 0);
+}
+
+/** How many items the lists hold, which is what the page counts when it filters. */
+export function countEquipmentItems(lists: EquipmentList[]): number {
+  return lists.reduce((total, list) => total + list.items.length, 0);
+}
+
+/** The lists with every cost rendered in a currency. */
+export function toPricedLists(lists: EquipmentList[], currency: PriceCurrency): PricedList[] {
+  return lists.map((list) => ({
+    title: list.title,
+    items: list.items.map((item) => ({ name: item.name, cost: formatCost(item.cost, currency) })),
+  }));
+}
+
+/** The whole reference arranged for reading. */
+export function priceListDocument(
+  currency: PriceCurrency,
+  lists: EquipmentList[] = all(),
+): PriceListDocument {
+  return {
+    title: PRICE_LIST_TITLE,
+    currency,
+    lists: toPricedLists(lists, currency),
+  };
+}
+
+function legendLine(entry: PriceLegendEntry): string {
+  return entry.worth === ''
+    ? `${entry.symbol}: ${entry.name}`
+    : `${entry.symbol}: ${entry.name} (${entry.worth})`;
+}
+
+/** The reference as Markdown, for a referee who keeps their notes in it. */
+export function priceListToMarkdown(document: PriceListDocument): string {
+  const blocks = [
+    `# ${document.title}`,
+    `Prices in ${document.currency.label}.`,
+    document.currency.legend.map((entry) => `- ${legendLine(entry)}`).join('\n'),
+  ];
+
+  for (const list of document.lists) {
+    blocks.push(
+      [
+        `## ${list.title}`,
+        '| Item | Cost |',
+        '| --- | ---: |',
+        ...list.items.map((item) => `| ${item.name} | ${item.cost} |`),
+      ].join('\n'),
+    );
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** The body of the PDF: the same document without the title the PDF draws itself. */
+export function priceListToText(document: PriceListDocument): string {
+  const blocks = [
+    `Prices in ${document.currency.label}.`,
+    document.currency.legend.map(legendLine).join('\n'),
+  ];
+
+  for (const list of document.lists) {
+    blocks.push(
+      [list.title, ...list.items.map((item) => `  ${item.name} - ${item.cost}`)].join('\n'),
+    );
+  }
+
+  return blocks.join('\n\n');
+}
+
+/** A filename stem for an exported list, which names the currency it is priced in. */
+export function priceListFileStem(currency: PriceCurrency): string {
+  return `fantasy-equipment-prices-${currency.id}`;
+}

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -122,6 +122,7 @@ describe('TOOL_CATALOG', () => {
       '/star-nation',
       '/character',
       '/fantasy/encounter',
+      '/fantasy/equipment',
       '/fantasy/family',
       '/fantasy/organization',
       '/culture',
@@ -238,6 +239,7 @@ describe('toolsWithMaturity', () => {
       '/fantasy/dcc/character',
       '/fantasy/dungeon',
       '/fantasy/encounter',
+      '/fantasy/equipment',
       '/fantasy/family',
       '/fantasy/organization',
       '/fantasy/religion',
@@ -309,6 +311,7 @@ describe('filterTools', () => {
       '/fantasy/dungeon',
       '/region',
       '/fantasy/settlement',
+      '/fantasy/equipment',
     ]);
   });
 

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -386,12 +386,19 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     maturity: 'release-ready',
     genres: ['cyberpunk'],
   }),
+  // Release-ready, assessed section by section against docs/workshop.md and recorded in
+  // docs/readiness-objects.md (#65). The first reference tool taken there, so most of the spec
+  // does not apply: it produces no artifacts, which takes out sections 3, 4 and 5 along with
+  // 2.2-2.4 and 7.2-7.4. What was assessed is 1, 2.1, 2.5, 6, 7.1 and 8. 6.1 was already met by
+  // `DataTable`'s flip and is held by e2e/tables.spec.ts; what failed was 6.4 — an item costing
+  // nothing printed an empty Cost cell, and the key named coins no price was ever quoted in. The
+  // pricing, the key and both exports live in `$lib/equipment`'s `price_lists.ts` now, under test.
   defineTool({
     path: '/fantasy/equipment',
     label: 'Fantasy Equipment Price Lists',
     kind: 'reference',
     domain: 'objects',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     genres: ['fantasy'],
     tags: ['equipment'],
   }),

--- a/src/routes/fantasy/equipment/+page.svelte
+++ b/src/routes/fantasy/equipment/+page.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <svelte:head>
-  <title>Fantasy Equipment Lists | Iron Arachne</title>
+  <title>Fantasy Equipment Price Lists | Iron Arachne</title>
 </svelte:head>
 
 <EquipmentPriceLists />


### PR DESCRIPTION
Closes #65. Takes `/fantasy/equipment` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the design in `docs/readiness-objects.md`. The first **reference** tool taken there, so most of the spec does not apply: no artifacts means sections 3, 4 and 5 go, along with 2.2–2.4 and 7.2–7.4. What was assessed is 1, 2.1, 2.5, 6, 7.1 and 8.

## 6.1 was already met; 6.4 was not

The issue and the design both call 6.1 the whole job. It was already done: the page has used `DataTable` since #154, so each table flips to a stack of labelled rows below 640px, and `e2e/tables.spec.ts` has been holding it to that at 320px all along. The section-by-section pass found 6.4 instead, in three places that have nothing to do with layout and everything to do with what the page says:

- **An item costing nothing printed an empty Cost cell.** `valueToString(0)` is the empty string, and the club, the quarterstaff and the sling stone are free. They read `Free` now.
- **The key described coins no price was ever quoted in** — electrum, platinum, and a crown that exists in no currency system in this repository — **while English prices came back in guineas**, which it never mentioned, because the guinea outranks the pound at 252 pence to 240 and `valueToString` spends every denomination it is given.
- **The farthing printed its name** in a column of `cp` and `sp`, `$lib/currency` giving it no symbol.

All three shipped for one reason, and it is the reason [decision 8](https://github.com/ironarachne/ironarachne/blob/main/docs/tool-readiness.md) gives for a reference tool getting a library at all: the conversion, the filtered D&D denominations and the copper-is-a-farthing rate lived in the component, where no unit test could reach them. `$lib/equipment/price_lists.ts` holds them now, under test, and the key is **derived from the same display system the prices are written in**, so the two cannot drift again. Both currencies are display systems local to the equipment library rather than `$lib/currency`'s own: a denomination that must never appear in a price has to be absent, not merely unlikely.

## The rest of the sections

- **6.3** applies to a reference tool and was not skipped. A five-hundred-row price list is exactly what a referee wants on paper, so the page exports Markdown and a PDF, written from the same document it renders — filtered rows included, so what is downloaded is what is on screen.
- **6.2** adds `scope="col"` to `DataTable`'s head cells and a keyboard pass over the controls.
- **7.1** is `price_lists.test.ts`; **8** is the library README section and the `index.ts` exports.
- **2.1** is covered by a new e2e test that mounts the tool in a workshop panel and drives it there.

## Two judgments beyond the letter of the spec

Both recorded in the design document as judgments rather than requirements.

- **A search box.** Five hundred rows in twenty-three tables is legible in the sense 6.1 means and unusable in the sense a reader means. One text input over `filterEquipmentLists`; a category with nothing left in it is dropped rather than shown empty.
- **The page heading now matches the catalog label.** It read "Fantasy Equipment Lists" while the panel title, the tool browser and `/tools` all read "Fantasy Equipment Price Lists" — requirement 1.4 failing from the other end.

## Verification

`npm run verify` is green, and `npm run verify:all` was run before opening this: 5,642 unit tests and 569 Playwright tests, including the new `e2e/equipment_price_lists.spec.ts` and the mobile pass at all five widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QEan2y9qHFJnvoM1dci8L
