### PR TITLE
Take the species height and weight calculator to Release-ready

### DIFF
--- a/docs/readiness-utilities.md
+++ b/docs/readiness-utilities.md
@@ -86,6 +86,47 @@ What this tool actually owes:
 - **#19 (expand the calculator for specific settings)** is the other open issue here, and it is a
   feature rather than a readiness gap. Read before scoping; not folded in.
 
+**As assessed.** 1.2 and 1.4 landed as written: the `fantasy` tag is gone, and the page, its
+`<title>` and the catalog all read **Species Height and Weight Calculator**. The prediction about
+section 6 was half right and half wrong, in the same shape #65 found.
+
+- **6.1 was never at risk and is not what needed doing.** The numbers did render as `Stat` pairs
+  rather than a wide table, and `pages.mobile.spec.ts` was already green at every width. What was
+  wrong was that they should not have been `Stat` pairs at all: a ladder of seven age categories
+  by age range, height and weight is a table, and rendering it as a stack of stat blocks inside
+  `<div style="display:flex">` is what made it two hand-built columns nothing could check. It is a
+  `DataTable` per gender now, which flips on a phone by the repository's own rule.
+- **6.2 was worse than "confirm rather than assume".** Two heading levels were skipped —
+  `<h5>` directly under `<h3>` — and four of the five fields were labelled `% of Base Height` and
+  `% of Base Weight` twice over, told apart only by an `<h3>` a screen reader user would have to
+  remember. The labels name their gender now, and the two tables carry `aria-label`s that differ.
+- **6.4 was the real failure, and it is the same failure #65 found.** A cleared number field binds
+  to `null`, `null / 100` is `0`, and an age modifier of zero drove each category's scaled
+  `maxAge` below the `minAge` chained from the row above it — so the sheet came back reading
+  "2 to 1 years". The fix is in two places: `$lib/age`'s `getVariant` never emits such a row now,
+  and `$lib/size`'s `species_stats.ts` floors the inputs.
+- **7.1 needed the arithmetic to exist somewhere testable first**, which is why the above shipped.
+  `speciesStatsDocument` holds it, and the page renders exactly what the exports write.
+- **6.3 was not skipped.** An author working out a species wants the sheet, so it exports Markdown
+  and a PDF. The filename names the proportions, because the species has no name yet — that is
+  what the tool is for.
+
+**Two findings beyond this tool**, both in `$lib/age`'s `getVariant` and both fixed here because
+6.4 depends on the first:
+
+- It **rewrote the categories it was handed** rather than returning new ones. `getHumanVariant`
+  hands it a fresh `humanStandard()` so no caller through that path noticed, but
+  `averageAgeCategories` in `species/common.ts` hands it a species' own `ageCategories` — and so
+  permanently aged that species for the rest of the session. `averageSizes`, the function
+  immediately below it, deep-clones for exactly this reason.
+- It could **emit a category ending before it begins**. No shipped species scales small enough to
+  reach it; a tool where the user types the lifespan does.
+
+**The lifespan the sheet reports is the ladder's, not the request's.** Each category scales and
+rounds up, so `100 * 0.07` being `7.000000000000001` turns a seven-year lifespan into a ladder that
+ends at eight. Reporting the request would have left the opening sentence contradicting the last
+row of the table.
+
 ## #76 — Word generator cheat sheet
 
 The smallest job in the pass. A reference tool with no artifact kind, no seed, and no logic — and

--- a/docs/tool-readiness.md
+++ b/docs/tool-readiness.md
@@ -446,13 +446,25 @@ migration. They are days of work in total, they are independent of everything ab
 table-shaped ones (#65 and #76) are the site's most likely 6.1 failures — wide tables at 320px.
 They run in parallel with the rest of the pass rather than after it.
 
-**#65 is done, and it corrects the prediction above.** 6.1 was already met: the price lists have
+**#65 and #75 are done, and they correct the prediction above the same way.** Both were expected to
+fail 6.1 and neither did; both failed **6.4**, and in both the reason was
+[decision 8](#8-a-reference-tool-with-no-logic-still-gets-a-library) — logic sitting in a component
+where no unit test could reach it. #76 should expect the same shape of finding.
+
+**#65 in particular.** 6.1 was already met: the price lists have
 used `DataTable` since #154, so the tables flip on a phone rather than pushing the page sideways,
 and `e2e/tables.spec.ts` was already holding them to it. What the pass found instead was 6.4 —
 free items printing an empty cost, and a key naming coins no price was quoted in — and the reason
 it found it late is exactly [decision 8](#8-a-reference-tool-with-no-logic-still-gets-a-library):
 the conversion lived in the component, where no unit test could reach it. The two remaining
 reference tools should expect the same shape of finding.
+
+**#75 found two bugs outside itself**, which is the other thing a reference tool's pass turns up:
+`$lib/age`'s `getVariant` rewrote the age categories it was handed rather than returning new ones —
+so `averageAgeCategories` in `species/common.ts` permanently aged a species by averaging it — and it
+could emit a category whose maximum age was below its minimum. No shipped species scales small
+enough to hit the second; a calculator where the user types the lifespan does. The tool's own
+failure, rows reading "2 to 1 years" from a cleared field, was that bug seen from the page.
 
 **#75 carries a caveat the other two do not.** The species height and weight calculator returns
 confident numbers from placeholder data: #25 records that 182 of 239 species carry placeholder

--- a/docs/visual-design.md
+++ b/docs/visual-design.md
@@ -1821,6 +1821,10 @@ the thirty already disagree with the tool catalog:
 | `/environment`   | `"default"` | none              | Agrees, but `"default"` names no stylesheet    |
 | `/language`      | `"default"` | none              | Agrees, but `"default"` names no stylesheet    |
 
+(That first row is history twice over now: `theme` is gone, and #75 dropped the `fantasy` tag as
+well, so the catalog agrees with what the page always rendered. `/species-stats` took `/workshop`'s
+place among the genre-neutral four when decision 9 took the workshop out of the catalog.)
+
 `"default"` is the tell. It is a class no stylesheet in the app defines, written in three places to
 mean "no skin" — which is what an absent class already means. A prop whose most-used value is a
 no-op is a prop nobody can read correctly, and it is duplicated data besides: **the tool catalog

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -123,8 +123,11 @@ likeliest thing that will happen here.
 
 **A tool with no genre is always listed, and so is a tool with no system.** That rule is the whole
 filter and it is load-bearing: only four tools carry no genre — `/environment`, `/language`,
-`/workshop`, and `/word-generator-cheat-sheet` — so a filter that dropped genre-neutral tools would
-take the environment generator away from a fantasy project, which is the opposite of the point. A
+`/species-stats`, and `/word-generator-cheat-sheet` — so a filter that dropped genre-neutral tools
+would take the environment generator away from a fantasy project, which is the opposite of the
+point. (`/workshop` was on that list until [decision 9](#9-the-workshop-is-a-surface-not-a-tool)
+took it out of the catalog, and `/species-stats` joined it when #75 dropped a `fantasy` tag that
+scaling a human baseline never earned.) A
 tool carrying several genres matches if any of them does: `/spooky-ship` is `scifi` and `horror`
 and belongs in both lists. `isCompatibleWithSystem` in `src/lib/tools/tool_search.ts` is already
 exactly this shape; `isCompatibleWithGenre` joins it, and the genre criterion in `searchTools`
@@ -133,14 +136,14 @@ has one caller, a checkbox that is about to go, so nothing depends on the old me
 
 **There is one way past the filter, and it is one control.** The catalog is not evenly spread:
 
-| Project setting | Tools listed, of 35     |
+| Project setting | Tools listed, of 34     |
 | --------------- | ----------------------- |
-| No genre        | 35                      |
-| `fantasy`       | 25 (21 + the 4 neutral) |
+| No genre        | 34                      |
+| `fantasy`       | 24 (20 + the 4 neutral) |
 | `scifi`         | 12 (8 + 4)              |
 | `cyberpunk`     | 6 (2 + 4)               |
 | `horror`        | 5 (1 + 4)               |
-| Any system      | 30 or 31 of 35          |
+| Any system      | 29 or 30 of 34          |
 
 A `horror` project seeing five tools is a fact about the catalog rather than a bug in the filter —
 but a panel that hides thirty tools with no way to say "show me anyway" is a wall, and the one

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -92,12 +92,24 @@ export async function expectGeneratorOutput(
       return;
     case 'stats':
       await expect(page.getByRole('heading', { name: 'Calculated Stats' })).toBeVisible();
-      // The colon went with the sentence: a stat is a `<dt>` holding "Age Range" and a `<dd>`
-      // holding the value, so the key is matched exactly rather than by the punctuation that used
-      // to separate it from what followed. docs/visual-design.md, "A stat is a pair".
-      await expect(page.getByText('Age Range', { exact: true }).first()).toBeVisible();
+      // The size ladder is a `DataTable` per gender since #75, where it was a stack of `StatBlock`s
+      // under an `<h5>` that followed an `<h3>` — a heading level skipped, and a table of four
+      // columns rendered as anything but a table.
+      //
+      // The cells rather than the column heads: this helper runs at every mobile width too, and
+      // below 640px a flipping `DataTable` hides its `<thead>` and each cell wears its key from
+      // `data-label` instead. `species_stats.spec.ts` checks the heads at desktop width, where
+      // they exist. The key is asserted here because a cell that lost it would lose it silently
+      // on exactly these screens.
+      // Located by `data-label` rather than by role and name: below 640px the flip paints the key
+      // as `::before` content, which Chromium folds into the cell's accessible name, so the adult
+      // row is named "Age categoryadult" there and "adult" here.
+      await expect(page.locator('td[data-label="Age range"]').first()).toBeVisible();
       await expect(
-        page.getByRole('heading', { name: 'adult', level: 5, exact: true }).first(),
+        page
+          .locator('td[data-label="Age category"]')
+          .filter({ hasText: /^adult$/ })
+          .first(),
       ).toBeVisible();
       return;
     case 'preview-image':

--- a/e2e/page_manifest.ts
+++ b/e2e/page_manifest.ts
@@ -274,8 +274,8 @@ export const PAGE_MANIFEST: PageEntry[] = [
   },
   {
     path: '/species-stats',
-    title: 'Species Stats Tool | Iron Arachne',
-    heading: 'Species Stats Tool',
+    title: 'Species Height and Weight Calculator | Iron Arachne',
+    heading: 'Species Height and Weight Calculator',
     kind: 'tool',
     outputCheck: 'stats',
   },

--- a/e2e/species_stats.spec.ts
+++ b/e2e/species_stats.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * The species height and weight calculator, as an author meets it (#75).
+ *
+ * A reference tool produces no artifacts, so requirement 7.4 does not bind and there is no
+ * generate/save/reopen/edit journey to cover. What is left is what the unit tests cannot settle:
+ * the page renders the same sheet the exports write, the fields recompute it, the same component
+ * works on its own route and in a panel (2.1), and the controls can be reached and used by name
+ * (6.2).
+ *
+ * 6.1 is covered by `e2e/pages.mobile.spec.ts` at every width in `MOBILE_VIEWPORTS`, and the
+ * ladder's own flip by `e2e/tables.spec.ts`.
+ */
+
+const TITLE = 'Species Height and Weight Calculator | Iron Arachne';
+
+const summary = (page: Page) => page.locator('.summary');
+const ladders = (page: Page) => page.locator('.ladder');
+
+/**
+ * One ladder's adult row.
+ *
+ * Matched on the cell rather than on the row's text: "adult" is a substring of "young adult", and
+ * the young adult row comes first.
+ */
+const adultRow = (page: Page, ladder: ReturnType<typeof ladders>) =>
+  ladder
+    .locator('tbody tr')
+    .filter({ has: page.getByRole('cell', { name: 'adult', exact: true }) });
+
+async function openCalculator(page: Page): Promise<void> {
+  await visitRoute(page, '/species-stats', { title: TITLE });
+  await expect(ladders(page)).toHaveCount(2);
+}
+
+test.describe('the species height and weight calculator', () => {
+  test('starts on the human baseline and says so', async ({ page }) => {
+    await openCalculator(page);
+
+    await expect(summary(page)).toContainText(
+      'female at 100% of human height and 100% of human weight',
+    );
+    await expect(summary(page)).toContainText('maximum lifespan of 100 years');
+
+    // The adult row of the female ladder is the human figure the whole tool is a proportion of.
+    await expect(adultRow(page, ladders(page).first())).toContainText('160');
+  });
+
+  test('recomputes both ladders as the proportions change', async ({ page }) => {
+    await openCalculator(page);
+
+    await page.getByLabel('Female % of Base Height', { exact: true }).fill('50');
+    await page.getByLabel('Male % of Base Height', { exact: true }).fill('200');
+    await expect(summary(page)).toContainText('female at 50% of human height');
+
+    await expect(adultRow(page, ladders(page).first())).toContainText('80');
+    await expect(adultRow(page, ladders(page).nth(1))).toContainText('350');
+  });
+
+  test('never shows an age range that ends before it begins', async ({ page }) => {
+    // Requirement 6.4. A cleared number field binds to `null`, `null / 100` is `0`, and an age
+    // modifier of zero used to walk the ladder into rows reading "2 to 1 years".
+    await openCalculator(page);
+    await page.getByLabel('Maximum Age (Years)', { exact: true }).fill('');
+    await page.getByLabel('Female % of Base Height', { exact: true }).fill('');
+
+    const ranges = await page.locator('.data-table tbody tr td:nth-child(2)').allInnerTexts();
+    expect(ranges.length).toBeGreaterThan(0);
+    for (const range of ranges) {
+      const [from, to] = range.replace(' years', '').split(' to ').map(Number);
+      expect(Number.isFinite(from), range).toBe(true);
+      expect(to, range).toBeGreaterThanOrEqual(from);
+    }
+
+    // And the sheet still reads as a sheet rather than as a row of blanks.
+    await expect(summary(page)).toContainText('maximum lifespan of');
+  });
+
+  test('downloads the sheet an author can take away', async ({ page }) => {
+    // Requirement 6.3, and the first export this tool has ever had.
+    await openCalculator(page);
+    await page.getByLabel('Maximum Age (Years)', { exact: true }).fill('350');
+    await page.getByLabel('Female % of Base Weight', { exact: true }).fill('85');
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const file = await markdown;
+    expect(file.suggestedFilename()).toBe('species-stats-f100x85-m100x100-age350.md');
+
+    const contents = await new Response(await file.createReadStream()).text();
+    expect(contents).toContain('# Species Height and Weight Calculator');
+    expect(contents).toContain('| Age category | Age range | Height | Weight |');
+    expect(contents).toContain('## Ingenium Second Edition heritage');
+    // What was downloaded is what is on screen.
+    expect(contents).toContain(await summary(page).innerText());
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toBe('species-stats-f100x85-m100x100-age350.pdf');
+  });
+
+  test('is operable by keyboard, with headed columns and named fields', async ({ page }) => {
+    // Requirement 6.2. The five fields used to be labelled "% of Base Height" twice over, told
+    // apart only by an `<h3>` above them, and the ladder's rows sat under an `<h5>` that followed
+    // an `<h3>` — a heading level skipped, in a page whose content is a table.
+    await openCalculator(page);
+
+    await page.getByLabel('Maximum Age (Years)', { exact: true }).focus();
+    for (const label of [
+      'Female % of Base Height',
+      'Female % of Base Weight',
+      'Male % of Base Height',
+      'Male % of Base Weight',
+    ]) {
+      await page.keyboard.press('Tab');
+      await expect(page.getByLabel(label, { exact: true })).toBeFocused();
+    }
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button', { name: 'Download Markdown' })).toBeFocused();
+
+    const headers = ladders(page).first().locator('thead th');
+    await expect(headers).toHaveText(['Age category', 'Age range', 'Height', 'Weight']);
+    await expect(headers.first()).toHaveAttribute('scope', 'col');
+
+    // Two tables that look alike need names that do not.
+    await expect(ladders(page).first().locator('table')).toHaveAttribute(
+      'aria-label',
+      'Female sizes by age',
+    );
+    await expect(ladders(page).nth(1).locator('table')).toHaveAttribute(
+      'aria-label',
+      'Male sizes by age',
+    );
+  });
+
+  test('works the same mounted in a workshop panel', async ({ page }) => {
+    // Requirement 2.1.
+    await visitRoute(page, '/workshop', { title: 'Workshop | Iron Arachne' });
+    await page
+      .locator('section.tool-browser')
+      .getByRole('button', { name: /^Species Height and Weight Calculator/ })
+      .click();
+
+    const panel = page.locator('section.workshop-panel');
+    await expect(panel.locator('.panel__title')).toContainText(
+      'Species Height and Weight Calculator',
+    );
+    await expect(panel.locator('.ladder')).toHaveCount(2);
+
+    await panel.getByLabel('Male % of Base Weight', { exact: true }).fill('250');
+    await expect(panel.locator('.summary')).toContainText('250% of human weight');
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -53,11 +53,17 @@ const SILENT_TOOL_PAGES = [
   { path: '/region', title: 'Region Generator | Iron Arachne' },
   { path: '/drug', title: 'Cyberpunk Drug Generator | Iron Arachne' },
   {
-    // The only reference tool in this list, and the reason it is worth naming: most of the spec
-    // does not apply to a tool that produces no artifacts, so it is the one entry here whose
-    // silence was earned by sections 1, 2.1, 2.5, 6, 7.1 and 8 alone (#65).
+    // The first reference tool in this list, and the reason it is worth naming: most of the spec
+    // does not apply to a tool that produces no artifacts, so its silence was earned by sections
+    // 1, 2.1, 2.5, 6, 7.1 and 8 alone (#65).
     path: '/fantasy/equipment',
     title: 'Fantasy Equipment Price Lists | Iron Arachne',
+  },
+  {
+    // The second, and the only genre-neutral tool here: #75 dropped a `fantasy` tag that scaling a
+    // human baseline never earned.
+    path: '/species-stats',
+    title: 'Species Height and Weight Calculator | Iron Arachne',
   },
   { path: '/fantasy/encounter', title: 'Encounter | Iron Arachne' },
   { path: '/fantasy/family', title: 'Fantasy Family Generator | Iron Arachne' },

--- a/src/components/utilities/SpeciesStatsCalculator.svelte
+++ b/src/components/utilities/SpeciesStatsCalculator.svelte
@@ -1,10 +1,31 @@
 <script lang="ts">
-  import Stat from '$components/common/Stat.svelte';
-  import StatBlock from '$components/common/StatBlock.svelte';
-  import { AgeCategories } from '$lib/age';
-  import { Sizes, convertMatrixToSummary } from '$lib/size';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import ControlsPanel from '$components/common/ControlsPanel.svelte';
+  import DataTable, { type Column } from '$components/common/DataTable.svelte';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
   import NumberField from '$components/common/NumberField.svelte';
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
+  import { downloadTextFile } from '$lib/download';
+  import { downloadTextPdf } from '$lib/pdf';
+  import {
+    MINIMUM_MAXIMUM_AGE,
+    MINIMUM_PERCENT,
+    SPECIES_STATS_TITLE,
+    speciesStatsDocument,
+    speciesStatsFileStem,
+    speciesStatsToMarkdown,
+    speciesStatsToText,
+  } from '$lib/size';
+
+  const TOOL_PATH = '/species-stats';
+
+  const LADDER_COLUMNS: Column[] = [
+    { label: 'Age category' },
+    { label: 'Age range' },
+    { label: 'Height' },
+    { label: 'Weight' },
+  ];
 
   let maximumAge = $state(100);
   let femaleHeightModifier = $state(100);
@@ -12,39 +33,39 @@
   let maleHeightModifier = $state(100);
   let maleWeightModifier = $state(100);
 
-  const ageCategories = $derived(AgeCategories.getHumanVariant(maximumAge / 100));
-
-  const femaleData = $derived(
-    convertMatrixToSummary(
-      Sizes.getHumanVariant(femaleWeightModifier / 100, femaleHeightModifier / 100),
-      ageCategories,
-      'female',
-    ),
+  /**
+   * The whole sheet, from `$lib/size`.
+   *
+   * Everything below the controls is read from this one value, so the page and the two exports
+   * cannot disagree. The clamping lives there too — a cleared number field binds to `null`, which
+   * used to walk the age ladder into rows reading "2 to 1 years".
+   */
+  const document_ = $derived(
+    speciesStatsDocument({
+      maximumAge,
+      female: { heightPercent: femaleHeightModifier, weightPercent: femaleWeightModifier },
+      male: { heightPercent: maleHeightModifier, weightPercent: maleWeightModifier },
+    }),
   );
 
-  const maleData = $derived(
-    convertMatrixToSummary(
-      Sizes.getHumanVariant(maleWeightModifier / 100, maleHeightModifier / 100),
-      ageCategories,
-      'male',
-    ),
-  );
+  function exportMarkdown() {
+    downloadTextFile(
+      speciesStatsToMarkdown(document_),
+      `${speciesStatsFileStem(document_)}.md`,
+      'text/markdown',
+    );
+  }
 
-  const ingenium = $derived.by(() => {
-    const femaleAdult = femaleData.find((entry) => entry.ageCategoryName === 'adult');
-    const maleAdult = maleData.find((entry) => entry.ageCategoryName === 'adult');
-
-    return {
-      adultAge: femaleAdult?.minAge ?? 0,
-      femaleHeight: femaleAdult?.heightRange ?? '',
-      maleHeight: maleAdult?.heightRange ?? '',
-      femaleWeight: femaleAdult?.weightRange ?? '',
-      maleWeight: maleAdult?.weightRange ?? '',
-    };
-  });
+  async function exportPdf() {
+    await downloadTextPdf(
+      document_.title,
+      speciesStatsToText(document_),
+      `${speciesStatsFileStem(document_)}.pdf`,
+    );
+  }
 </script>
 
-<GeneratorPage toolPath="/species-stats" title="Species Stats Tool">
+<GeneratorPage toolPath={TOOL_PATH} title={SPECIES_STATS_TITLE}>
   {#snippet description()}
     <p>
       This tool helps in the construction of non-human species. I built it to help me input standard
@@ -56,59 +77,95 @@
 
   <h2>Settings</h2>
 
-  <NumberField id="maxAge" label="Maximum Age (Years)" bind:value={maximumAge} />
+  <ControlsPanel>
+    <NumberField
+      id="maxAge"
+      label="Maximum Age (Years)"
+      bind:value={maximumAge}
+      min={MINIMUM_MAXIMUM_AGE}
+    />
+    <NumberField
+      id="female-height"
+      label="Female % of Base Height"
+      bind:value={femaleHeightModifier}
+      min={MINIMUM_PERCENT}
+    />
+    <NumberField
+      id="female-weight"
+      label="Female % of Base Weight"
+      bind:value={femaleWeightModifier}
+      min={MINIMUM_PERCENT}
+    />
+    <NumberField
+      id="male-height"
+      label="Male % of Base Height"
+      bind:value={maleHeightModifier}
+      min={MINIMUM_PERCENT}
+    />
+    <NumberField
+      id="male-weight"
+      label="Male % of Base Weight"
+      bind:value={maleWeightModifier}
+      min={MINIMUM_PERCENT}
+    />
+  </ControlsPanel>
 
-  <h3>Female</h3>
-
-  <NumberField id="female-height" label="% of Base Height" bind:value={femaleHeightModifier} />
-  <NumberField id="female-weight" label="% of Base Weight" bind:value={femaleWeightModifier} />
-
-  <h3>Male</h3>
-
-  <NumberField id="male-height" label="% of Base Height" bind:value={maleHeightModifier} />
-  <NumberField id="male-weight" label="% of Base Weight" bind:value={maleWeightModifier} />
+  <div class="actions">
+    <BaseButton onclick={exportMarkdown}>Download Markdown</BaseButton>
+    <BaseButton onclick={exportPdf}>Download PDF</BaseButton>
+  </div>
 
   <h2>Calculated Stats</h2>
 
-  <div style="display:flex">
-    <div class="half-column">
-      <h3>Female</h3>
-      {#each femaleData as entry}
-        <div>
-          <h5>{entry.ageCategoryName}</h5>
-          <StatBlock>
-            <Stat label="Age Range">{entry.minAge} to {entry.maxAge} years</Stat>
-            <Stat label="Female Height">{entry.heightRange}</Stat>
-            <Stat label="Female Weight">{entry.weightRange}</Stat>
-          </StatBlock>
-        </div>
-      {/each}
-    </div>
-    <div class="half-column">
-      <h3>Male</h3>
-      {#each maleData as entry}
-        <div>
-          <h5>{entry.ageCategoryName}</h5>
-          <StatBlock>
-            <Stat label="Age Range">{entry.minAge} to {entry.maxAge} years</Stat>
-            <Stat label="Male Height">{entry.heightRange}</Stat>
-            <Stat label="Male Weight">{entry.weightRange}</Stat>
-          </StatBlock>
-        </div>
-      {/each}
-    </div>
-  </div>
+  <!-- `role="status"` because the sheet recomputes as the fields change, and a clamped value is a
+       change the user did not ask for. The sentence is the same one both exports open with. -->
+  <p class="summary" role="status">{document_.summary}</p>
+
+  {#each document_.genders as gender (gender.name)}
+    <section class="ladder">
+      <h3>{gender.label}</h3>
+      <DataTable columns={LADDER_COLUMNS} rows={ladderRows} label="{gender.label} sizes by age" />
+
+      {#snippet ladderRows()}
+        {#each gender.rows as row (row.ageCategoryName)}
+          <tr>
+            <td data-label="Age category">{row.ageCategoryName}</td>
+            <td data-label="Age range">{row.ageRange}</td>
+            <td data-label="Height">{row.heightRange}</td>
+            <td data-label="Weight">{row.weightRange}</td>
+          </tr>
+        {/each}
+      {/snippet}
+    </section>
+  {/each}
 
   <h2>For Ingenium Second Edition</h2>
 
   <p>This is for Ingenium Second Edition heritages.</p>
 
   <StatBlock>
-    <Stat label="Female Height">{ingenium.femaleHeight}</Stat>
-    <Stat label="Male Height">{ingenium.maleHeight}</Stat>
-    <Stat label="Female Weight">{ingenium.femaleWeight}</Stat>
-    <Stat label="Male Weight">{ingenium.maleWeight}</Stat>
-    <Stat label="Adult Age">{ingenium.adultAge}</Stat>
-    <Stat label="Maximum Lifespan">{maximumAge}</Stat>
+    <Stat label="Female Height">{document_.ingenium.femaleHeight}</Stat>
+    <Stat label="Male Height">{document_.ingenium.maleHeight}</Stat>
+    <Stat label="Female Weight">{document_.ingenium.femaleWeight}</Stat>
+    <Stat label="Male Weight">{document_.ingenium.maleWeight}</Stat>
+    <Stat label="Adult Age">{document_.ingenium.adultAge}</Stat>
+    <Stat label="Maximum Lifespan">{document_.ingenium.maximumLifespan}</Stat>
   </StatBlock>
 </GeneratorPage>
+
+<style>
+  .summary {
+    color: var(--ink-faint);
+  }
+
+  .ladder {
+    margin-bottom: var(--s6);
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+  }
+</style>

--- a/src/lib/age/README.md
+++ b/src/lib/age/README.md
@@ -38,3 +38,9 @@ import { getVariant } from '$lib/age';
 
 const elfCategories = getVariant(10, humanStandard()); // ten times the human lifespan
 ```
+
+`getVariant` returns new categories rather than rewriting the ones it is handed, and it never emits
+a category whose `maxAge` is below its `minAge`. Both were fixed by #75: it used to assign straight
+into the array, which permanently aged any species that passed its own `ageCategories` in, and a
+small enough modifier drove a category's scaled `maxAge` below the `minAge` chained from the row
+above it, so the ladder came back reading "2 to 1 years".

--- a/src/lib/age/age_categories.ts
+++ b/src/lib/age/age_categories.ts
@@ -55,22 +55,45 @@ export function getMaxAge(categories: AgeCategory[]): number {
   return maxAge;
 }
 
+/**
+ * The same age ladder scaled to a different lifespan.
+ *
+ * Two things here are not obvious and both were found by taking the species height and weight
+ * calculator through the readiness spec (#75):
+ *
+ * - **It returns new categories rather than rewriting the ones it is given.** It used to assign
+ *   straight into the array, which is fine for `getHumanVariant` — that hands it a fresh
+ *   `humanStandard()` every time — and is not fine for `averageAgeCategories` in
+ *   `species/common.ts`, which hands it a species' own `ageCategories` and so permanently aged
+ *   that species for the rest of the session. `averageSizes`, immediately below it, deep-clones
+ *   for exactly this reason.
+ * - **A category never ends before it begins.** `minAge` chains from the previous category's
+ *   scaled `maxAge`, so a small enough modifier drove `maxAge` below the `minAge` that had just
+ *   been derived, and the ladder came back reading "2 to 1 years". No shipped species scales
+ *   small enough to hit it; the calculator, where a user types the lifespan, does.
+ */
 export function getVariant(ageModifier: number, categories: AgeCategory[]): AgeCategory[] {
+  const result: AgeCategory[] = [];
+
   for (let i = 0; i < categories.length; i++) {
+    const category = { ...categories[i], genderedNoun: [...categories[i].genderedNoun] };
+
     if (i > 0) {
-      categories[i].minAge = categories[i - 1].maxAge + 1;
+      category.minAge = result[i - 1].maxAge + 1;
     }
-    categories[i].maxAge = Math.ceil(categories[i].maxAge * ageModifier);
+    category.maxAge = Math.max(Math.ceil(category.maxAge * ageModifier), category.minAge);
 
     // Since "teenager" would be inappropriate if the ages aren't in the teenaged years, we'll change it to "young adult".
-    if (categories[i].name == 'teenager') {
-      categories[i].name = 'young adult';
-      categories[i].noun = 'young adult';
-      categories[i].genderedNoun = ['young woman', 'young man', 'young adult'];
+    if (category.name == 'teenager') {
+      category.name = 'young adult';
+      category.noun = 'young adult';
+      category.genderedNoun = ['young woman', 'young man', 'young adult'];
     }
+
+    result.push(category);
   }
 
-  return categories;
+  return result;
 }
 
 export function humanStandard(): AgeCategory[] {

--- a/src/lib/size/README.md
+++ b/src/lib/size/README.md
@@ -52,3 +52,24 @@ const rows = convertMatrixToSummary(
 
 Age categories come from [`$lib/age`](../age/README.md), and the two must agree: a matrix entry is
 keyed by age category **name**, so a species' matrix and its age ladder need matching names.
+
+## The species stats sheet
+
+`species_stats.ts` is the whole of what `/species-stats` renders: the calculator an author uses to
+work out a new species' figures before that species exists anywhere. It takes proportions of a
+modern human — female and male height and weight as percentages, plus a lifespan — and builds a
+size ladder per gender against a scaled age ladder, so it never reads the species list at all.
+
+- **`speciesStatsDocument(input)`** — the sheet, arranged for reading. The page renders it and both
+  exports are written from it, so what an author reads and what they download cannot drift.
+- **`clampInput` / `clampProportions`** — the floors. A cleared number field binds to `null`, and
+  `null / 100` is `0`; an age modifier of zero used to produce rows reading "2 to 1 years". A
+  lifespan may not be shorter than there are age categories, and a proportion may not be zero.
+- **`HUMAN_BASELINE_MAX_AGE`** — read from the age ladder rather than written as the literal `100`
+  the component used, which was right only for as long as that ladder happened to end at 100.
+- **`speciesStatsToMarkdown` / `speciesStatsToText` / `speciesStatsFileStem`** — the exports. The
+  stem names the proportions, because a species being authored has no name yet.
+
+The document reports the lifespan the **ladder** reaches rather than the one requested; the two
+differ by a year here and there because each category scales and rounds up, and a sheet whose
+opening sentence contradicts its own last row is worse than one that rounds visibly.

--- a/src/lib/size/index.ts
+++ b/src/lib/size/index.ts
@@ -2,5 +2,7 @@ export type { default as Size } from './size';
 export type { default as SizeGeneratorConfig } from './size_generator_config';
 export * from './size_matrix';
 export * from './sizes';
+export * from './species_stats';
+export type * from './species_stats_types';
 
 export * as Sizes from './sizes';

--- a/src/lib/size/species_stats.test.ts
+++ b/src/lib/size/species_stats.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+
+import { AgeCategories } from '$lib/age';
+
+import {
+  HUMAN_BASELINE_MAX_AGE,
+  MINIMUM_MAXIMUM_AGE,
+  MINIMUM_PERCENT,
+  SPECIES_STATS_TITLE,
+  clampInput,
+  clampProportions,
+  speciesStatsDocument,
+  speciesStatsFileStem,
+  speciesStatsSummary,
+  speciesStatsToMarkdown,
+  speciesStatsToText,
+} from './species_stats';
+import type { SpeciesStatsInput } from './species_stats_types';
+
+const HUMAN: SpeciesStatsInput = {
+  maximumAge: 100,
+  female: { heightPercent: 100, weightPercent: 100 },
+  male: { heightPercent: 100, weightPercent: 100 },
+};
+
+/** A cleared number field binds to `null`, which the type does not describe but the DOM produces. */
+const cleared = null as unknown as number;
+
+describe('HUMAN_BASELINE_MAX_AGE', () => {
+  it('is read from the age ladder rather than written as a literal', () => {
+    // The component divided by a literal 100, which is right only for as long as the standard
+    // human ladder happens to end at 100.
+    expect(HUMAN_BASELINE_MAX_AGE).toBe(AgeCategories.getMaxAge(AgeCategories.humanStandard()));
+  });
+});
+
+describe('clampProportions', () => {
+  it('leaves a usable proportion alone', () => {
+    expect(clampProportions({ heightPercent: 160, weightPercent: 220 })).toEqual({
+      heightPercent: 160,
+      weightPercent: 220,
+    });
+  });
+
+  it('floors zero, negative, and cleared fields', () => {
+    expect(clampProportions({ heightPercent: 0, weightPercent: -40 })).toEqual({
+      heightPercent: MINIMUM_PERCENT,
+      weightPercent: MINIMUM_PERCENT,
+    });
+    expect(clampProportions({ heightPercent: cleared, weightPercent: NaN })).toEqual({
+      heightPercent: MINIMUM_PERCENT,
+      weightPercent: MINIMUM_PERCENT,
+    });
+  });
+});
+
+describe('clampInput', () => {
+  it('floors a lifespan shorter than there are age categories', () => {
+    // Seven categories cannot span fewer than seven years without one ending before it begins.
+    expect(clampInput({ ...HUMAN, maximumAge: 0 }).maximumAge).toBe(MINIMUM_MAXIMUM_AGE);
+    expect(clampInput({ ...HUMAN, maximumAge: cleared }).maximumAge).toBe(MINIMUM_MAXIMUM_AGE);
+    expect(MINIMUM_MAXIMUM_AGE).toBe(AgeCategories.humanStandard().length);
+  });
+
+  it('rounds a fractional lifespan to whole years', () => {
+    expect(clampInput({ ...HUMAN, maximumAge: 87.6 }).maximumAge).toBe(88);
+  });
+});
+
+describe('speciesStatsDocument', () => {
+  it('reproduces the human baseline unchanged at 100% of everything', () => {
+    const document = speciesStatsDocument(HUMAN);
+
+    expect(document.title).toBe(SPECIES_STATS_TITLE);
+    expect(document.lifespan).toBe(100);
+    expect(document.genders.map((gender) => gender.name)).toEqual(['female', 'male']);
+
+    const femaleAdult = document.genders[0].rows.find((row) => row.ageCategoryName === 'adult');
+    expect(femaleAdult?.ageRange).toBe('20 to 60 years');
+    expect(femaleAdult?.heightRange).toContain('160');
+
+    const maleAdult = document.genders[1].rows.find((row) => row.ageCategoryName === 'adult');
+    expect(maleAdult?.heightRange).toContain('175');
+  });
+
+  it('renames the teenager row, because a long-lived species has no teens', () => {
+    const names = speciesStatsDocument(HUMAN).genders[0].rows.map((row) => row.ageCategoryName);
+
+    expect(names).toContain('young adult');
+    expect(names).not.toContain('teenager');
+  });
+
+  it('never returns a row that ends before it begins', () => {
+    // The failure the clamps and `getVariant`'s monotonic ladder exist to prevent: an age modifier
+    // small enough drove `maxAge` below the `minAge` chained from the row above, and the sheet read
+    // "2 to 1 years".
+    for (const maximumAge of [cleared, 0, -50, 1, 7, 8, 30, 100, 1000]) {
+      const document = speciesStatsDocument({ ...HUMAN, maximumAge });
+      for (const gender of document.genders) {
+        let previousMax = -1;
+        for (const row of gender.rows) {
+          expect(row.maxAge, `${maximumAge}: ${row.ageCategoryName}`).toBeGreaterThanOrEqual(
+            row.minAge,
+          );
+          expect(row.minAge, `${maximumAge}: ${row.ageCategoryName}`).toBeGreaterThan(previousMax);
+          previousMax = row.maxAge;
+        }
+      }
+    }
+  });
+
+  it('scales both genders by their own proportions', () => {
+    const document = speciesStatsDocument({
+      maximumAge: 100,
+      female: { heightPercent: 50, weightPercent: 50 },
+      male: { heightPercent: 200, weightPercent: 200 },
+    });
+
+    const female = document.genders[0].rows.find((row) => row.ageCategoryName === 'adult');
+    const male = document.genders[1].rows.find((row) => row.ageCategoryName === 'adult');
+
+    expect(female?.heightRange).toContain('80');
+    expect(male?.heightRange).toContain('350');
+  });
+
+  it('reports the lifespan the ladder reaches rather than the one requested', () => {
+    // `100 * 0.07` is `7.000000000000001`, so a seven-year lifespan rounds up to a ladder that ends
+    // at eight. The sheet says eight, because that is what its last row says.
+    const document = speciesStatsDocument({ ...HUMAN, maximumAge: 7 });
+    const lastRow = document.genders[0].rows[document.genders[0].rows.length - 1];
+
+    expect(document.lifespan).toBe(lastRow.maxAge);
+    expect(document.ingenium.maximumLifespan).toBe(document.lifespan);
+    expect(document.summary).toContain(`maximum lifespan of ${document.lifespan} years`);
+  });
+
+  it('does not age the shared human ladder by being called', () => {
+    // `getVariant` used to rewrite the categories it was handed. `getHumanVariant` hands it a fresh
+    // copy, but a species handing it its own list did not, so this is the guard for both.
+    speciesStatsDocument({ ...HUMAN, maximumAge: 900 });
+
+    expect(AgeCategories.humanStandard()[6].maxAge).toBe(100);
+    expect(AgeCategories.humanStandard()[4].name).toBe('teenager');
+  });
+
+  it('fills the Ingenium block from the adult rows', () => {
+    const document = speciesStatsDocument(HUMAN);
+    const femaleAdult = document.genders[0].rows.find((row) => row.ageCategoryName === 'adult');
+
+    expect(document.ingenium.adultAge).toBe(femaleAdult?.minAge);
+    expect(document.ingenium.femaleHeight).toBe(femaleAdult?.heightRange);
+    expect(document.ingenium.maleWeight).toBe(
+      document.genders[1].rows.find((row) => row.ageCategoryName === 'adult')?.weightRange,
+    );
+  });
+});
+
+describe('speciesStatsSummary', () => {
+  it('says what the numbers are proportions of', () => {
+    expect(
+      speciesStatsSummary(
+        {
+          maximumAge: 350,
+          female: { heightPercent: 90, weightPercent: 85 },
+          male: { heightPercent: 95, weightPercent: 92 },
+        },
+        350,
+      ),
+    ).toBe(
+      'Taken against a modern human: female at 90% of human height and 85% of human weight, male at 95% of human height and 92% of human weight, with a maximum lifespan of 350 years.',
+    );
+  });
+
+  it('writes one year in the singular', () => {
+    expect(speciesStatsSummary(HUMAN, 1)).toContain('maximum lifespan of 1 year.');
+  });
+});
+
+describe('speciesStatsToMarkdown', () => {
+  it('writes a table per gender and the Ingenium block below them', () => {
+    const markdown = speciesStatsToMarkdown(speciesStatsDocument(HUMAN));
+
+    expect(markdown.startsWith(`# ${SPECIES_STATS_TITLE}\n\n`)).toBe(true);
+    expect(markdown).toContain('## Female');
+    expect(markdown).toContain('## Male');
+    expect(markdown).toContain('| Age category | Age range | Height | Weight |');
+    expect(markdown).toContain('| adult | 20 to 60 years |');
+    expect(markdown).toContain('## Ingenium Second Edition heritage');
+    expect(markdown).toContain('- Adult age: 20');
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('never leaves a blank line inside a table', () => {
+    // 6.4: a stray blank line ends a Markdown table wherever it lands.
+    expect(speciesStatsToMarkdown(speciesStatsDocument(HUMAN))).not.toContain('|\n\n|');
+  });
+});
+
+describe('speciesStatsToText', () => {
+  it('writes the same sheet without pipes or the title the PDF draws itself', () => {
+    const text = speciesStatsToText(speciesStatsDocument(HUMAN));
+
+    expect(text).not.toContain('|');
+    expect(text).not.toContain(SPECIES_STATS_TITLE);
+    expect(text).toContain('Female');
+    expect(text).toContain('  adult - 20 to 60 years - ');
+    expect(text).toContain('Ingenium Second Edition heritage');
+    expect(text.endsWith('\n')).toBe(false);
+  });
+
+  it('has no run of blank lines anywhere in it', () => {
+    expect(speciesStatsToText(speciesStatsDocument(HUMAN))).not.toMatch(/\n\s*\n\s*\n/);
+  });
+});
+
+describe('speciesStatsFileStem', () => {
+  it('names the proportions the sheet was made from, since the species has no name yet', () => {
+    expect(
+      speciesStatsFileStem(
+        speciesStatsDocument({
+          maximumAge: 350,
+          female: { heightPercent: 90, weightPercent: 85 },
+          male: { heightPercent: 95, weightPercent: 92 },
+        }),
+      ),
+    ).toBe('species-stats-f90x85-m95x92-age350');
+  });
+
+  it('names the clamped input rather than what was typed', () => {
+    expect(speciesStatsFileStem(speciesStatsDocument({ ...HUMAN, maximumAge: cleared }))).toContain(
+      `age${MINIMUM_MAXIMUM_AGE}`,
+    );
+  });
+});

--- a/src/lib/size/species_stats.ts
+++ b/src/lib/size/species_stats.ts
@@ -1,0 +1,251 @@
+/**
+ * The species height and weight calculator, as logic rather than as a component.
+ *
+ * All of this lived in `SpeciesStatsCalculator.svelte`, where nothing could test it — and two
+ * things had gone wrong there that a test would have caught the day they were written:
+ *
+ * - **An empty or zero input produced a nonsense sheet rather than no sheet.** A number input bound
+ *   to `$state` yields `null` when the field is cleared, `null / 100` is `0`, and an age modifier
+ *   of zero walks `getVariant` into rows whose minimum age is above their maximum. The clamps here
+ *   are the fix, and they are the reason 6.4 passes: a sheet is always readable.
+ * - **The human baseline was the literal `100`**, which happens to be right because the standard
+ *   human age ladder ends at 100 and would silently stop being right the day it did not.
+ *   `HUMAN_BASELINE_MAX_AGE` reads it from the ladder.
+ *
+ * The document is what the page renders and what both exports are written from, so what an author
+ * reads on screen and what they take away cannot drift.
+ */
+
+import { AgeCategories } from '$lib/age';
+import type { AgeCategory } from '$lib/age';
+
+import * as Sizes from './sizes';
+import { convertMatrixToSummary } from './size_matrix';
+import type { SizeAgeSummary } from './size_matrix';
+import type {
+  IngeniumHeritage,
+  SpeciesProportions,
+  SpeciesStatsDocument,
+  SpeciesStatsGender,
+  SpeciesStatsInput,
+  SpeciesStatsRow,
+} from './species_stats_types';
+
+/** The document's own title, shared by the page heading and both exports. */
+export const SPECIES_STATS_TITLE = 'Species Height and Weight Calculator';
+
+/**
+ * The maximum age of the standard human ladder, which every proportion here is taken against.
+ *
+ * Read rather than written: it is 100 today, the component divided by a literal 100, and the two
+ * agreeing was luck rather than design.
+ */
+export const HUMAN_BASELINE_MAX_AGE = AgeCategories.getMaxAge(AgeCategories.humanStandard());
+
+/** The smallest proportion the calculator will work with, as a percentage. */
+export const MINIMUM_PERCENT = 1;
+
+/**
+ * The smallest lifespan the calculator will work with, in years.
+ *
+ * One year per age category, because seven categories cannot span fewer than seven years without
+ * one of them ending before it begins. `getVariant` refuses to emit such a row at all now, but a
+ * ladder of seven identical one-year rows is a sheet nobody can read, so the floor is here too.
+ */
+export const MINIMUM_MAXIMUM_AGE = AgeCategories.humanStandard().length;
+
+/** The age category the Ingenium block reads its figures from. */
+const ADULT = 'adult';
+
+/** The genders the human size matrix carries, in the order the sheet lists them. */
+const GENDERS: { name: string; label: string }[] = [
+  { name: 'female', label: 'Female' },
+  { name: 'male', label: 'Male' },
+];
+
+/**
+ * A number the arithmetic can survive, or the floor.
+ *
+ * `null` reaches here whenever a number input is cleared, and `NaN` whenever it holds something
+ * that is not a number; both coerce to values that produce a sheet full of zeroes and reversed age
+ * ranges rather than an error anyone would notice.
+ */
+function atLeast(value: number, floor: number): number {
+  if (!Number.isFinite(value) || value < floor) {
+    return floor;
+  }
+  return value;
+}
+
+/** One gender's proportions, floored so neither can be zero or absent. */
+export function clampProportions(proportions: SpeciesProportions): SpeciesProportions {
+  return {
+    heightPercent: atLeast(proportions.heightPercent, MINIMUM_PERCENT),
+    weightPercent: atLeast(proportions.weightPercent, MINIMUM_PERCENT),
+  };
+}
+
+/** The input as the calculator will actually use it. */
+export function clampInput(input: SpeciesStatsInput): SpeciesStatsInput {
+  return {
+    maximumAge: Math.round(atLeast(input.maximumAge, MINIMUM_MAXIMUM_AGE)),
+    female: clampProportions(input.female),
+    male: clampProportions(input.male),
+  };
+}
+
+function toRow(summary: SizeAgeSummary): SpeciesStatsRow {
+  return {
+    ageCategoryName: summary.ageCategoryName,
+    minAge: summary.minAge,
+    maxAge: summary.maxAge,
+    ageRange: `${summary.minAge} to ${summary.maxAge} years`,
+    heightRange: summary.heightRange,
+    weightRange: summary.weightRange,
+  };
+}
+
+function genderLadder(
+  gender: { name: string; label: string },
+  proportions: SpeciesProportions,
+  ageCategories: AgeCategory[],
+): SpeciesStatsGender {
+  const matrix = Sizes.getHumanVariant(
+    proportions.weightPercent / 100,
+    proportions.heightPercent / 100,
+  );
+
+  return {
+    name: gender.name,
+    label: gender.label,
+    rows: convertMatrixToSummary(matrix, ageCategories, gender.name).map(toRow),
+  };
+}
+
+function adultRow(gender: SpeciesStatsGender | undefined): SpeciesStatsRow | undefined {
+  return gender?.rows.find((row) => row.ageCategoryName === ADULT);
+}
+
+function ingeniumHeritage(genders: SpeciesStatsGender[], lifespan: number): IngeniumHeritage {
+  const female = adultRow(genders.find((gender) => gender.name === 'female'));
+  const male = adultRow(genders.find((gender) => gender.name === 'male'));
+
+  return {
+    adultAge: female?.minAge ?? 0,
+    maximumLifespan: lifespan,
+    femaleHeight: female?.heightRange ?? '',
+    maleHeight: male?.heightRange ?? '',
+    femaleWeight: female?.weightRange ?? '',
+    maleWeight: male?.weightRange ?? '',
+  };
+}
+
+function proportionsSentence(label: string, proportions: SpeciesProportions): string {
+  return `${label} ${proportions.heightPercent}% of human height and ${proportions.weightPercent}% of human weight`;
+}
+
+/** The sentence saying what the sheet's numbers are proportions of. */
+export function speciesStatsSummary(input: SpeciesStatsInput, lifespan: number): string {
+  const years = `a maximum lifespan of ${lifespan} ${lifespan === 1 ? 'year' : 'years'}`;
+  return `Taken against a modern human: ${proportionsSentence('female at', input.female)}, ${proportionsSentence('male at', input.male)}, with ${years}.`;
+}
+
+/** The whole sheet, arranged for reading. */
+export function speciesStatsDocument(input: SpeciesStatsInput): SpeciesStatsDocument {
+  const clamped = clampInput(input);
+
+  const ageCategories = AgeCategories.getHumanVariant(clamped.maximumAge / HUMAN_BASELINE_MAX_AGE);
+
+  // What the ladder reaches, not what was asked for. The two differ by a year here and there and
+  // the sheet has to pick one, or its last row contradicts its own opening sentence.
+  const lifespan = AgeCategories.getMaxAge(ageCategories);
+
+  const genders = GENDERS.map((gender) =>
+    genderLadder(gender, gender.name === 'female' ? clamped.female : clamped.male, ageCategories),
+  );
+
+  return {
+    title: SPECIES_STATS_TITLE,
+    input: clamped,
+    lifespan,
+    summary: speciesStatsSummary(clamped, lifespan),
+    genders,
+    ingenium: ingeniumHeritage(genders, lifespan),
+  };
+}
+
+function ingeniumLines(heritage: IngeniumHeritage): { label: string; value: string }[] {
+  return [
+    { label: 'Female height', value: heritage.femaleHeight },
+    { label: 'Male height', value: heritage.maleHeight },
+    { label: 'Female weight', value: heritage.femaleWeight },
+    { label: 'Male weight', value: heritage.maleWeight },
+    { label: 'Adult age', value: String(heritage.adultAge) },
+    { label: 'Maximum lifespan', value: String(heritage.maximumLifespan) },
+  ].filter((line) => line.value.trim() !== '');
+}
+
+/** The sheet as Markdown, for an author who keeps their species notes in it. */
+export function speciesStatsToMarkdown(document: SpeciesStatsDocument): string {
+  const blocks = [`# ${document.title}`, document.summary];
+
+  for (const gender of document.genders) {
+    blocks.push(
+      [
+        `## ${gender.label}`,
+        '| Age category | Age range | Height | Weight |',
+        '| --- | --- | --- | --- |',
+        ...gender.rows.map(
+          (row) =>
+            `| ${row.ageCategoryName} | ${row.ageRange} | ${row.heightRange} | ${row.weightRange} |`,
+        ),
+      ].join('\n'),
+    );
+  }
+
+  blocks.push(
+    [
+      '## Ingenium Second Edition heritage',
+      ...ingeniumLines(document.ingenium).map((line) => `- ${line.label}: ${line.value}`),
+    ].join('\n'),
+  );
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** The body of the PDF: the same sheet without the title the PDF draws itself. */
+export function speciesStatsToText(document: SpeciesStatsDocument): string {
+  const blocks = [document.summary];
+
+  for (const gender of document.genders) {
+    blocks.push(
+      [
+        gender.label,
+        ...gender.rows.map(
+          (row) =>
+            `  ${row.ageCategoryName} - ${row.ageRange} - ${row.heightRange} - ${row.weightRange}`,
+        ),
+      ].join('\n'),
+    );
+  }
+
+  blocks.push(
+    [
+      'Ingenium Second Edition heritage',
+      ...ingeniumLines(document.ingenium).map((line) => `  ${line.label}: ${line.value}`),
+    ].join('\n'),
+  );
+
+  return blocks.join('\n\n');
+}
+
+/**
+ * A filename stem for an exported sheet, naming the proportions it was made from.
+ *
+ * A species being authored has no name yet — that is what the tool is for — so the numbers are the
+ * only thing that tells one download from another.
+ */
+export function speciesStatsFileStem(document: SpeciesStatsDocument): string {
+  const { female, male, maximumAge } = document.input;
+  return `species-stats-f${female.heightPercent}x${female.weightPercent}-m${male.heightPercent}x${male.weightPercent}-age${maximumAge}`;
+}

--- a/src/lib/size/species_stats_types.ts
+++ b/src/lib/size/species_stats_types.ts
@@ -1,0 +1,75 @@
+/**
+ * The species height and weight calculator's own shapes.
+ *
+ * The calculator does not read the species list. It takes proportions of a modern human and
+ * derives the size and age ladders from `Sizes.getHumanVariant` and `AgeCategories.getHumanVariant`
+ * — so what it produces is an author's working sheet for a species that does not exist yet, not a
+ * lookup of one that does.
+ */
+
+/** One gender's proportions, as percentages of the human baseline. */
+export type SpeciesProportions = {
+  heightPercent: number;
+  weightPercent: number;
+};
+
+/** Everything the calculator is given. */
+export type SpeciesStatsInput = {
+  /** The species' maximum lifespan in years. */
+  maximumAge: number;
+  female: SpeciesProportions;
+  male: SpeciesProportions;
+};
+
+/** One age category's row of the sheet, for one gender. */
+export type SpeciesStatsRow = {
+  ageCategoryName: string;
+  minAge: number;
+  maxAge: number;
+  ageRange: string;
+  heightRange: string;
+  weightRange: string;
+};
+
+/** One gender's ladder, from infant to elderly. */
+export type SpeciesStatsGender = {
+  /** The gender's name as the size matrix keys it. */
+  name: string;
+  /** How it is written in a heading. */
+  label: string;
+  rows: SpeciesStatsRow[];
+};
+
+/**
+ * The adult figures, in the shape Ingenium Second Edition asks for a heritage.
+ *
+ * The one game system this tool speaks, which is why it is a named block rather than another row.
+ */
+export type IngeniumHeritage = {
+  adultAge: number;
+  maximumLifespan: number;
+  femaleHeight: string;
+  maleHeight: string;
+  femaleWeight: string;
+  maleWeight: string;
+};
+
+/** The whole sheet, arranged for reading, independent of the format it is written in. */
+export type SpeciesStatsDocument = {
+  title: string;
+  /** The input as it was actually used, after clamping. */
+  input: SpeciesStatsInput;
+  /**
+   * The lifespan the age ladder actually reaches, which is what the sheet reports.
+   *
+   * Not always the requested `input.maximumAge`: the ladder scales each category by a ratio and
+   * rounds up, so a lifespan of 7 lands on 8 through nothing worse than `100 * 0.07` being
+   * `7.000000000000001`. Reporting the ladder rather than the request is what keeps the summary
+   * and the last row of the table from disagreeing.
+   */
+  lifespan: number;
+  /** The sentence saying what the numbers are proportions of. */
+  summary: string;
+  genders: SpeciesStatsGender[];
+  ingenium: IngeniumHeritage;
+};

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -135,6 +135,7 @@ describe('TOOL_CATALOG', () => {
       '/velgarth-gifts',
       '/fantasy/adnd/character',
       '/fantasy/adnd/character/build',
+      '/species-stats',
     ];
 
     const claimingMore = TOOL_CATALOG.filter(
@@ -247,6 +248,7 @@ describe('toolsWithMaturity', () => {
       '/heraldry',
       '/planet',
       '/region',
+      '/species-stats',
       '/star-nation',
       '/star-system',
       '/swn/character',

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -479,13 +479,22 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     maturity: 'experimental',
     tags: ['naming', 'worldbuilding'],
   }),
+  // Release-ready, assessed section by section against docs/workshop.md and recorded in
+  // docs/readiness-utilities.md (#75). A reference tool, so sections 3, 4 and 5 do not apply, nor
+  // do 2.2-2.4 and 7.2-7.4. #25's placeholder species sizes are not a blocker: the calculator
+  // never reads the species list, it scales a human baseline, and #25 is a fact about data this
+  // tool is used to author. What was wrong was 6.4 — a cleared field produced age rows reading
+  // "2 to 1 years" — and 7.1, the arithmetic having lived in the component. `$lib/size`'s
+  // `species_stats.ts` holds it now, with Markdown and PDF exports for 6.3.
   defineTool({
     path: '/species-stats',
     label: 'Species Height and Weight Calculator',
     kind: 'reference',
     domain: 'utilities',
-    maturity: 'experimental',
-    genres: ['fantasy'],
+    maturity: 'release-ready',
+    // No genre. Height and weight as a proportion of a human baseline is arithmetic, and a sci-fi
+    // setting inventing a heavy-worlder does it identically; the `fantasy` tag would have hidden
+    // the tool from every project that is not one (1.2).
     tags: ['species'],
   }),
   defineTool({

--- a/src/routes/species-stats/+page.svelte
+++ b/src/routes/species-stats/+page.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <svelte:head>
-  <title>Species Stats Tool | Iron Arachne</title>
+  <title>Species Height and Weight Calculator | Iron Arachne</title>
 </svelte:head>
 
 <SpeciesStatsCalculator />


### PR DESCRIPTION
Closes #75. Takes `/species-stats` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the design in `docs/readiness-utilities.md`. The second **reference** tool of the pass: no artifacts, so sections 3, 4 and 5 do not apply, nor do 2.2–2.4 and 7.2–7.4. What was assessed is 1, 2.1, 2.5, 6, 7.1 and 8.

The design document's correction to the issue holds: **#25 does not block this.** The calculator never reads the species list — it scales a human baseline — and #25 is a fact about data this tool is used to *author*.

## Sections 1 and 6

**1.2 and 1.4 landed as designed.** The `fantasy` tag is gone (scaling a human baseline is arithmetic a sci-fi setting does identically), and the page, its `<title>` and the catalog all read **Species Height and Weight Calculator** rather than two different names.

Section 6 was half right in the design and half wrong, in the same shape #65 found:

- **6.1 was never at risk, and is not what needed doing.** The design predicted low overflow risk from `Stat` pairs and was correct. What was wrong is that they should not have been `Stat` pairs: a ladder of seven age categories by age range, height and weight is a table, and it was rendered as a stack of stat blocks inside `<div style="display:flex">` — two hand-built columns nothing could check. It is a `DataTable` per gender now, which flips on a phone by the repository's own rule.
- **6.2 was worse than "confirm rather than assume".** Two heading levels were skipped (`<h5>` directly under `<h3>`), and four of the five fields were labelled `% of Base Height` and `% of Base Weight` twice over, told apart only by an `<h3>` above them. The labels name their gender now, and the two tables carry `aria-label`s that differ.
- **6.4 was the real failure.** A cleared number field binds to `null`, `null / 100` is `0`, and an age modifier of zero drove each category's scaled `maxAge` below the `minAge` chained from the row above it — so the sheet came back reading **"2 to 1 years"**.
- **6.3 was not skipped.** The sheet exports Markdown and PDF, named for the proportions since a species being authored has no name yet.

## 7.1, and why the rest shipped

The arithmetic lived in the component, where nothing could test it — [decision 8](https://github.com/ironarachne/ironarachne/blob/main/docs/tool-readiness.md) exactly. `$lib/size/species_stats.ts` holds it now (20 unit tests), and the page renders the same document both exports are written from.

## Two findings outside the tool

Both in `$lib/age`'s `getVariant`, fixed here because 6.4 depends on the first:

- **It rewrote the categories it was handed** rather than returning new ones. `getHumanVariant` passes a fresh `humanStandard()`, so nothing through that path noticed — but `averageAgeCategories` in `src/lib/species/common.ts` passes a species' own `ageCategories`, and so permanently aged that species for the rest of the session. `averageSizes`, the function immediately below it, deep-clones for exactly this reason.
- **It could emit a category ending before it begins.** No shipped species scales small enough to reach it; a tool where the user types the lifespan does.

## Two smaller corrections

- The human baseline was the literal `100`, right only for as long as the standard age ladder happens to end at 100. It is read from the ladder now.
- The sheet reports the lifespan **the ladder reaches**, not the one requested. Each category scales and rounds up, so `100 * 0.07` being `7.000000000000001` turns a seven-year lifespan into a ladder ending at eight; an opening sentence contradicting the last row of the table is worse than rounding visibly.

## Verification

`npm run verify` is green, and `npm run verify:all` was run before opening this: 5,662 unit tests and 576 Playwright tests, including the new `e2e/species_stats.spec.ts` and the mobile pass at all five widths. `e2e/helpers.ts`'s `stats` output check was retargeted at the table and now locates cells by `data-label`, because below 640px the flip folds the key into the cell's accessible name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QEan2y9qHFJnvoM1dci8L
