### PR TITLE
Take the word generator cheat sheet to Release-ready

### DIFF
--- a/docs/readiness-utilities.md
+++ b/docs/readiness-utilities.md
@@ -153,6 +153,39 @@ terms set a minimum width, so the table scrolls on its own rather than the page 
 That is exactly the repository rule. This is a case where the issue's expectation — "6.1 and 6.2
 are the real work" — is half met already.
 
+**As assessed.** The library landed as designed: `src/lib/word_patterns` holds the element table
+and, which this section did not anticipate, the **pattern syntax** — three paragraphs of prose above
+the controls that were the only place in the repository that syntax was written down. Both are data
+now, so both reach the exports.
+
+6.1 was already handled, as predicted, and `DataTable`'s `narrow="scroll"` is the same mechanism
+with the hand-rolled wrapper removed. **6.4 is what actually failed**, in two places — the third
+tool in a row where the finding is 6.4 rather than the 6.1 the pass expected:
+
+- **The page opened with an empty pattern**, and generating from one produces empty strings. Ten
+  blank bullets, on arrival, from the button the page is built around. It opens on `cvcv` now, and
+  Generate is disabled while the pattern is blank.
+- **The clicks element set is `|`, `||`, `|!`** — the vocabulary genuinely contains the character a
+  Markdown table separates columns with. Unescaped, that one row splits into five columns and takes
+  the rest of the table's alignment with it. Only writing the export revealed it; there was no
+  export before.
+
+**6.2 was met in the letter and not in the mechanism**, which is the point decision 8 makes. The
+headers did exist — inside a string the component concatenated, where nothing could check them and
+`{@html}` was needed to render them. They are `DataTable` columns now, the one
+`svelte/no-at-html-tags` suppression on the page is gone, and both tables carry names, because two
+tables that look alike need names that do not.
+
+**A seed, which the spec does not require of a reference tool.** 2.2 and 2.3 are G/E only, and this
+tool is R — but it has a Generate button, and it built a `new WordGenerator()` with no RNG, so
+nothing it produced could be quoted, written down, or reproduced by whoever was asked what the
+pattern did. `SeedControls` costs one row and is what every other tool in the pass has. Recorded
+here as a judgment rather than a requirement.
+
+**One thing the library caught for free**: the package's own doc comment lists thirty-six symbols
+and the package ships forty-five. Reading `allElements` rather than copying it is why the sheet was
+right anyway, and the test that counts them is why it stays right.
+
 ## Domain model
 
 ```mermaid

--- a/docs/tool-readiness.md
+++ b/docs/tool-readiness.md
@@ -446,10 +446,13 @@ migration. They are days of work in total, they are independent of everything ab
 table-shaped ones (#65 and #76) are the site's most likely 6.1 failures — wide tables at 320px.
 They run in parallel with the rest of the pass rather than after it.
 
-**#65 and #75 are done, and they correct the prediction above the same way.** Both were expected to
-fail 6.1 and neither did; both failed **6.4**, and in both the reason was
-[decision 8](#8-a-reference-tool-with-no-logic-still-gets-a-library) — logic sitting in a component
-where no unit test could reach it. #76 should expect the same shape of finding.
+**All three are done, and all three correct the prediction above the same way.** Each was expected
+to fail 6.1 and none did; each failed **6.4**, and in each the reason was
+[decision 8](#8-a-reference-tool-with-no-logic-still-gets-a-library) — content or logic sitting in a
+component where no unit test could reach it. The prediction that the wide tables were the risk was
+wrong three times out of three, and it was wrong for an instructive reason: a table that overflows
+is visible to anyone who looks, and `pages.mobile.spec.ts` had been looking. What nobody was
+looking at was the text inside it.
 
 **#65 in particular.** 6.1 was already met: the price lists have
 used `DataTable` since #154, so the tables flip on a phone rather than pushing the page sideways,
@@ -466,6 +469,13 @@ could emit a category whose maximum age was below its minimum. No shipped specie
 enough to hit the second; a calculator where the user types the lifespan does. The tool's own
 failure, rows reading "2 to 1 years" from a cleared field, was that bug seen from the page.
 
+**#76 settles the spec question this pass raised**, and settles it where decision 8 already put it:
+`src/lib/word_patterns` holds the element table and the pattern syntax as data, where the component
+held them as a concatenated HTML string rendered with `{@html}`. No sentence is added to
+`docs/workshop.md` exempting a logic-free reference tool from 8.1 and 8.2, because there turned out
+to be no such tool — the "no logic" one had a Generate button, an undocumented pattern syntax, and
+two 6.4 failures, one of which (the clicks element set being made of Markdown table separators) only
+appeared once there was an export to write.
 **#75 carries a caveat the other two do not.** The species height and weight calculator returns
 confident numbers from placeholder data: #25 records that 182 of 239 species carry placeholder
 human sizes. Section 6 polish does not fix that, and this document does not pretend otherwise —

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -65,6 +65,12 @@ const SILENT_TOOL_PAGES = [
     path: '/species-stats',
     title: 'Species Height and Weight Calculator | Iron Arachne',
   },
+  {
+    // The third and last reference tool of the pass (#76), and the one that forced the question
+    // decision 8 answers: a tool with no library gets one rather than an exemption.
+    path: '/word-generator-cheat-sheet',
+    title: 'Word Generator Cheat Sheet | Iron Arachne',
+  },
   { path: '/fantasy/encounter', title: 'Encounter | Iron Arachne' },
   { path: '/fantasy/family', title: 'Fantasy Family Generator | Iron Arachne' },
   { path: '/fantasy/organization', title: 'Organization Generator | Iron Arachne' },

--- a/e2e/word_generator_cheat_sheet.spec.ts
+++ b/e2e/word_generator_cheat_sheet.spec.ts
@@ -1,0 +1,169 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * The word generator cheat sheet, as a developer meets it (#76).
+ *
+ * The last reference tool of the pass, and the one that forced the spec question decision 8
+ * answers: it has a library now, `$lib/word_patterns`, where the element table used to be an HTML
+ * string the component concatenated and injected with `{@html}`. What the unit tests cannot settle
+ * is that the sheet reaches the page as markup — headers, cells, and a scroll container of its own
+ * — and that the same component works on its own route and in a panel (2.1).
+ *
+ * 6.1 is covered by `e2e/pages.mobile.spec.ts` at every width in `MOBILE_VIEWPORTS`.
+ */
+
+const TITLE = 'Word Generator Cheat Sheet | Iron Arachne';
+
+const elementTable = (page: Page) => page.locator('.elements .data-table');
+const syntaxTable = (page: Page) => page.locator('.syntax .data-table');
+const words = (page: Page) => page.getByRole('list', { name: 'Generated words' }).locator('li');
+
+async function openSheet(page: Page): Promise<void> {
+  await visitRoute(page, '/word-generator-cheat-sheet', { title: TITLE });
+  await expect(elementTable(page)).toBeVisible();
+}
+
+test.describe('the word generator cheat sheet', () => {
+  test('renders both tables as real markup, headed', async ({ page }) => {
+    await openSheet(page);
+
+    await expect(syntaxTable(page).locator('thead th')).toHaveText([
+      'Syntax',
+      'Meaning',
+      'Example',
+    ]);
+    await expect(elementTable(page).locator('thead th')).toHaveText(['Name', 'Symbol', 'Elements']);
+    await expect(elementTable(page).locator('thead th').first()).toHaveAttribute('scope', 'col');
+
+    // Every element the package ships, rather than the thirty-six its own doc comment lists.
+    await expect(elementTable(page).locator('tbody tr')).toHaveCount(45);
+    await expect(
+      elementTable(page).locator('tbody tr', { hasText: 'consonants' }).first(),
+    ).toBeVisible();
+  });
+
+  test('scrolls the element table rather than the page', async ({ page }) => {
+    // 6.1, and the mechanism the design says was already right: unbreakable terms like
+    // "palatals/post-alveolars" set a minimum width no phone can meet, so the table gets its own
+    // scroller and carries the `data-scroll-x` that excuses it from the overflow sweep.
+    await page.setViewportSize({ width: 320, height: 800 });
+    await openSheet(page);
+
+    await expect(elementTable(page)).toHaveAttribute('data-scroll-x', '');
+
+    const overflow = await page.evaluate(() => {
+      const region = document.querySelector('main.shell__page');
+      return region === null ? 0 : region.scrollWidth - region.clientWidth;
+    });
+    expect(overflow, 'the page scrolls sideways').toBeLessThanOrEqual(0);
+  });
+
+  test('opens on a pattern that works, and never lists a blank word', async ({ page }) => {
+    // Requirement 6.4. The page opened with an empty pattern, and generating from one produces
+    // empty strings — ten blank bullets.
+    await openSheet(page);
+    await expect(page.getByRole('textbox', { name: 'Pattern' })).toHaveValue('cvcv');
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    await expect(words(page)).toHaveCount(10);
+    for (const word of await words(page).allInnerTexts()) {
+      expect(word.trim()).not.toBe('');
+    }
+
+    // And a pattern cleared by hand cannot produce them either.
+    await page.getByRole('textbox', { name: 'Pattern' }).fill('');
+    await expect(page.getByRole('button', { name: 'Generate', exact: true })).toBeDisabled();
+  });
+
+  test('reproduces the same words from the same seed', async ({ page }) => {
+    // The generator built a `WordGenerator` with no RNG, so nothing it produced could be got back.
+    // 2.2 and 2.3 do not bind on a reference tool; a button that generates something a developer
+    // may want to quote does.
+    await openSheet(page);
+    const generate = page.getByRole('button', { name: 'Generate', exact: true });
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await generate.click();
+    const first = await words(page).allInnerTexts();
+    expect(first.length).toBe(10);
+
+    await generate.click();
+    expect(await words(page).allInnerTexts()).toEqual(first);
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await generate.click();
+    expect(await words(page).allInnerTexts()).not.toEqual(first);
+  });
+
+  test('downloads the sheet a developer can keep', async ({ page }) => {
+    // Requirement 6.3, and the first export this page has ever had.
+    await openSheet(page);
+    await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    await expect(words(page)).toHaveCount(10);
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const file = await markdown;
+    expect(file.suggestedFilename()).toBe('word-generator-cheat-sheet.md');
+
+    const contents = await new Response(await file.createReadStream()).text();
+    expect(contents).toContain('# Word Generator Cheat Sheet');
+    expect(contents).toContain('## Pattern syntax');
+    expect(contents).toContain('## Elements');
+    expect(contents).toContain('Pattern `cvcv`, seed `a-fixed-seed`');
+    // The clicks set is made of the character a Markdown table separates columns with.
+    expect(contents).toContain('\\|');
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toBe('word-generator-cheat-sheet.pdf');
+  });
+
+  test('is operable by keyboard, with named controls', async ({ page }) => {
+    // Requirement 6.2.
+    await openSheet(page);
+
+    await page.getByRole('textbox', { name: 'Pattern' }).focus();
+    await page.keyboard.press('Tab');
+    await expect(page.getByLabel('Number of Words')).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(page.getByLabel('Seed', { exact: true })).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(page.getByLabel('Lock Seed')).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button', { name: 'Generate', exact: true })).toBeFocused();
+
+    // The two tables look alike enough that they need names that do not.
+    await expect(syntaxTable(page).locator('table')).toHaveAttribute(
+      'aria-label',
+      'Pattern syntax',
+    );
+    await expect(elementTable(page).locator('table')).toHaveAttribute(
+      'aria-label',
+      'Word pattern elements',
+    );
+  });
+
+  test('works the same mounted in a workshop panel', async ({ page }) => {
+    // Requirement 2.1.
+    await visitRoute(page, '/workshop', { title: 'Workshop | Iron Arachne' });
+    await page
+      .locator('section.tool-browser')
+      .getByRole('button', { name: /^Word Generator Cheat Sheet/ })
+      .click();
+
+    const panel = page.locator('section.workshop-panel');
+    await expect(panel.locator('.panel__title')).toContainText('Word Generator Cheat Sheet');
+    await expect(panel.locator('.elements .data-table tbody tr')).toHaveCount(45);
+
+    await panel.getByRole('button', { name: 'Generate', exact: true }).click();
+    await expect(panel.getByRole('list', { name: 'Generated words' }).locator('li')).toHaveCount(
+      10,
+    );
+  });
+});

--- a/src/components/utilities/WordGeneratorCheatSheet.svelte
+++ b/src/components/utilities/WordGeneratorCheatSheet.svelte
@@ -1,85 +1,164 @@
 <script lang="ts">
-  import { WordGenerator, allElements } from '@ironarachne/word-generator';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import ControlsPanel from '$components/common/ControlsPanel.svelte';
+  import DataTable, { type Column } from '$components/common/DataTable.svelte';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
   import InputGroup from '$components/common/InputGroup.svelte';
   import NumberField from '$components/common/NumberField.svelte';
-  import BaseButton from '$components/common/BaseButton.svelte';
+  import SeedControls from '$components/common/SeedControls.svelte';
+  import { downloadTextFile } from '$lib/download';
+  import { downloadTextPdf } from '$lib/pdf';
+  import {
+    DEFAULT_PATTERN,
+    MAXIMUM_WORD_COUNT,
+    MINIMUM_WORD_COUNT,
+    WORD_PATTERN_SHEET_FILE_STEM,
+    WORD_PATTERN_SHEET_TITLE,
+    generateWords,
+    isBlankPattern,
+    sheetToMarkdown,
+    sheetToText,
+    wordPatternSheet,
+  } from '$lib/word_patterns';
+  import { RNG } from '@ironarachne/rng';
 
-  const elements = allElements;
+  const TOOL_PATH = '/word-generator-cheat-sheet';
 
-  let html = $state(
-    '<table><thead><tr><th>Name</th><th>Symbol</th><th>Elements</th></tr></thead><tbody>',
-  );
+  const SYNTAX_COLUMNS: Column[] = [
+    { label: 'Syntax' },
+    { label: 'Meaning' },
+    { label: 'Example' },
+  ];
 
-  for (let i = 0; i < elements.length; i++) {
-    html +=
-      '<tr><td>' +
-      elements[i].name +
-      '</td><td>' +
-      elements[i].symbol +
-      '</td><td>' +
-      elements[i].elements.join(', ') +
-      '</td></tr>';
-  }
+  const ELEMENT_COLUMNS: Column[] = [{ label: 'Name' }, { label: 'Symbol' }, { label: 'Elements' }];
 
-  html += '</tbody></table>';
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again — the shape the rest of the pass settled
+   * on. The generator here used to build a `new WordGenerator()` with no RNG at all, so nothing it
+   * produced could be got back, written down, or shared with whoever asked what the pattern did.
+   */
+  const rng = new RNG(Date.now().toString());
 
-  let pattern = $state('');
+  let pattern = $state(DEFAULT_PATTERN);
   let numberOfWords = $state(10);
+  let seed = $state(rng.randomString(13));
+  let lockSeed = $state(false);
   let words: string[] = $state([]);
 
+  const sheet = $derived(wordPatternSheet(words.length > 0 ? { pattern, seed, words } : undefined));
+
   function generate() {
-    words = [];
-    const wordGen = new WordGenerator();
-    wordGen.patterns = [pattern];
-    for (let i = 0; i < numberOfWords; i++) {
-      words.push(wordGen.generate());
+    if (!lockSeed) {
+      seed = rng.randomString(13);
     }
+    words = generateWords(pattern, numberOfWords, seed);
+  }
+
+  function exportMarkdown() {
+    downloadTextFile(sheetToMarkdown(sheet), `${WORD_PATTERN_SHEET_FILE_STEM}.md`, 'text/markdown');
+  }
+
+  async function exportPdf() {
+    await downloadTextPdf(sheet.title, sheetToText(sheet), `${WORD_PATTERN_SHEET_FILE_STEM}.pdf`);
   }
 </script>
 
-<GeneratorPage toolPath="/word-generator-cheat-sheet" title="Word Generator Cheat Sheet">
+<GeneratorPage toolPath={TOOL_PATH} title={WORD_PATTERN_SHEET_TITLE}>
   {#snippet description()}
     <p>This is meant only for development reference.</p>
-    <p>
-      Enclosing several comma-separated patterns in parentheses will make the parser choose one of
-      those to add to the word.
-    </p>
-    <p>
-      Outside of the above, adding a + will duplicate the previous character after its processing.
-    </p>
   {/snippet}
 
-  <InputGroup id="pattern" label="Pattern">
-    <input type="text" name="pattern" bind:value={pattern} id="pattern" />
-  </InputGroup>
+  <h2>Pattern syntax</h2>
 
-  <NumberField id="number-of-words" label="Number of Words" bind:value={numberOfWords} />
+  <!-- Was three paragraphs of prose above the controls, and the only place in the repository the
+       syntax was written down at all. It is `PATTERN_SYNTAX` now, so the exports carry it too. -->
+  <!-- Wrapped, because a `{#snippet}` that is a direct child of a component is passed to *that*
+       component: left bare here, `syntaxRows` would be handed to `GeneratorPage` instead of being
+       a name this scope can pass to `DataTable`. -->
+  <div class="syntax">
+    <DataTable columns={SYNTAX_COLUMNS} rows={syntaxRows} label="Pattern syntax" />
 
-  <BaseButton onclick={generate}>Generate</BaseButton>
+    {#snippet syntaxRows()}
+      {#each sheet.syntax as rule (rule.syntax)}
+        <tr>
+          <td data-label="Syntax"><code>{rule.syntax}</code></td>
+          <td data-label="Meaning">{rule.meaning}</td>
+          <td data-label="Example"><code>{rule.example}</code></td>
+        </tr>
+      {/each}
+    {/snippet}
+  </div>
 
-  <ul>
-    {#each words as word}
-      <li>{word}</li>
-    {/each}
-  </ul>
+  <h2>Try a pattern</h2>
+
+  <ControlsPanel>
+    <InputGroup id="pattern" label="Pattern">
+      <input type="text" name="pattern" bind:value={pattern} id="pattern" />
+    </InputGroup>
+    <NumberField
+      id="number-of-words"
+      label="Number of Words"
+      bind:value={numberOfWords}
+      min={MINIMUM_WORD_COUNT}
+      max={MAXIMUM_WORD_COUNT}
+    />
+    <SeedControls bind:seed bind:lockSeed />
+  </ControlsPanel>
+
+  <div class="actions">
+    <!-- Disabled rather than generating nothing: an empty pattern produces empty words, which is
+         where the ten blank bullets came from. -->
+    <BaseButton onclick={generate} disabled={isBlankPattern(pattern)}>Generate</BaseButton>
+    <BaseButton onclick={exportMarkdown}>Download Markdown</BaseButton>
+    <BaseButton onclick={exportPdf}>Download PDF</BaseButton>
+  </div>
+
+  {#if words.length > 0}
+    <ul class="words" aria-label="Generated words">
+      {#each words as word, index (index)}
+        <li>{word}</li>
+      {/each}
+    </ul>
+  {/if}
 
   <h2>Element Reference</h2>
 
-  <!-- Scrolls sideways on purpose; see `DELIBERATE_SCROLLER` in e2e/mobile_layout.ts. -->
-  <div class="element-table-scroll" data-scroll-x>
-    <!-- Renders app-generated markup (no external or user-supplied input). -->
-    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-    {@html html}
+  <!-- `narrow="scroll"` rather than the flip: the three columns mean something only beside each
+       other, and unbreakable terms like "palatals/post-alveolars" are already wider than a 320px
+       phone allows. The table scrolls inside its own container; the page never does. This replaces
+       a hand-built HTML string injected with `{@html}` — the one `svelte/no-at-html-tags`
+       suppression on the page, for markup the component had concatenated itself. -->
+  <div class="elements">
+    <DataTable
+      columns={ELEMENT_COLUMNS}
+      rows={elementRows}
+      narrow="scroll"
+      label="Word pattern elements"
+    />
+
+    {#snippet elementRows()}
+      {#each sheet.elements as element (element.symbol)}
+        <tr>
+          <td data-label="Name">{element.name}</td>
+          <td data-label="Symbol"><code>{element.symbol}</code></td>
+          <td data-label="Elements">{element.elements.join(', ')}</td>
+        </tr>
+      {/each}
+    {/snippet}
   </div>
 </GeneratorPage>
 
 <style>
-  /* The narrowest this table can get is set by unbreakable terms like
-     "palatals/post-alveolars", which is already wider than a 320px phone allows
-     once the other two columns are beside it. Wrapping cannot fix that without
-     breaking words mid-term, so let the table scroll on its own instead. */
-  .element-table-scroll {
-    overflow-x: auto;
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+  }
+
+  .words {
+    columns: 12rem;
   }
 </style>

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -136,6 +136,7 @@ describe('TOOL_CATALOG', () => {
       '/fantasy/adnd/character',
       '/fantasy/adnd/character/build',
       '/species-stats',
+      '/word-generator-cheat-sheet',
     ];
 
     const claimingMore = TOOL_CATALOG.filter(
@@ -254,6 +255,7 @@ describe('toolsWithMaturity', () => {
       '/swn/character',
       '/unchartedworlds/character',
       '/velgarth-gifts',
+      '/word-generator-cheat-sheet',
     ]);
   });
 

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -497,12 +497,20 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     // the tool from every project that is not one (1.2).
     tags: ['species'],
   }),
+  // Release-ready, assessed section by section against docs/workshop.md and recorded in
+  // docs/readiness-utilities.md (#76). The third and last reference tool of the pass. It is the
+  // one that forced the spec question — does a tool with no library satisfy 8.1 and 8.2? — and
+  // decision 8 of docs/tool-readiness.md answered it: `src/lib/word_patterns` holds the element
+  // table and the pattern syntax as data, where the component held them as a concatenated HTML
+  // string. 6.1 was already met by the table's own scroll container. What failed was 6.4, twice:
+  // Generate on the empty pattern the page opened with produced ten blank bullets, and the clicks
+  // element set is made of the character a Markdown table separates columns with.
   defineTool({
     path: '/word-generator-cheat-sheet',
     label: 'Word Generator Cheat Sheet',
     kind: 'reference',
     domain: 'utilities',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     tags: ['naming'],
   }),
 ];

--- a/src/lib/word_patterns/README.md
+++ b/src/lib/word_patterns/README.md
@@ -1,0 +1,40 @@
+# Word patterns
+
+The **vocabulary the word generator's patterns are written in**, as data — the symbols, what each
+one can stand for, and the syntax that is not simply a symbol.
+
+The elements themselves belong to [`@ironarachne/word-generator`](https://www.npmjs.com/package/@ironarachne/word-generator)
+and are read from it rather than copied, so this library cannot describe a vocabulary the generator
+does not have. It matters: the package's own doc comment lists thirty-six symbols and the package
+ships forty-five.
+
+This library exists because of
+[decision 8 of the readiness pass](../../../docs/tool-readiness.md) — a reference tool with no logic
+still gets a library. `/word-generator-cheat-sheet` built its table as an HTML string inside the
+component and injected it with `{@html}`, which meant its headers were unverifiable, its content
+untestable, and the pattern syntax documented in three paragraphs of prose and nowhere else.
+
+## Features
+
+- **`patternElements()`** — every element the generator knows, as plain rows of
+  `{ name, symbol, elements }`. A fresh array each call, so a caller sorting it cannot reorder the
+  package's own list.
+- **`PATTERN_SYNTAX`** — the rules beyond "a symbol": `(a,b,c)` chooses one of the alternatives, and
+  `+` duplicates the previous character after processing.
+- **`generateWords(pattern, count, seed)`** — words from a pattern, reproducibly. A blank pattern
+  returns nothing rather than a list of empty strings, and empty results are dropped.
+- **`clampWordCount`** / **`isBlankPattern`** — the guards the page's number and text fields need.
+- **`wordPatternSheet`**, **`sheetToMarkdown`** and **`sheetToText`** — the sheet arranged for
+  reading, and the two exports written from it. The page renders the same sheet.
+
+## Usage
+
+```typescript
+import { generateWords, sheetToMarkdown, wordPatternSheet } from '$lib/word_patterns';
+
+const words = generateWords('cvcv', 10, 'a-seed');
+const markdown = sheetToMarkdown(wordPatternSheet({ pattern: 'cvcv', seed: 'a-seed', words }));
+```
+
+The sample section is left out of the sheet entirely when no pattern has been run, rather than
+exported as an empty heading.

--- a/src/lib/word_patterns/index.ts
+++ b/src/lib/word_patterns/index.ts
@@ -1,0 +1,2 @@
+export * from './word_patterns';
+export type * from './word_pattern_types';

--- a/src/lib/word_patterns/word_pattern_types.ts
+++ b/src/lib/word_patterns/word_pattern_types.ts
@@ -1,0 +1,38 @@
+/**
+ * The word generator's pattern vocabulary, as data.
+ *
+ * `@ironarachne/word-generator` owns the elements themselves; this library owns them as a table
+ * somebody can read, plus the pattern syntax that is documented nowhere else in the repository.
+ */
+
+/** One row of the element table: a symbol, what it is called, and what it can stand for. */
+export type WordPatternElement = {
+  name: string;
+  /** The single character written in a pattern. */
+  symbol: string;
+  /** Everything the symbol can expand to. */
+  elements: string[];
+};
+
+/** One rule of pattern syntax that is not simply "a symbol from the element table". */
+export type PatternSyntaxRule = {
+  syntax: string;
+  meaning: string;
+  example: string;
+};
+
+/** A pattern actually run, and what it produced. */
+export type WordPatternSample = {
+  pattern: string;
+  seed: string;
+  words: string[];
+};
+
+/** The cheat sheet, arranged for reading, independent of the format it is written in. */
+export type WordPatternSheet = {
+  title: string;
+  syntax: PatternSyntaxRule[];
+  elements: WordPatternElement[];
+  /** The tried-it-out box, when a pattern has actually been run. */
+  sample?: WordPatternSample;
+};

--- a/src/lib/word_patterns/word_patterns.test.ts
+++ b/src/lib/word_patterns/word_patterns.test.ts
@@ -1,0 +1,233 @@
+import { allElements } from '@ironarachne/word-generator';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_PATTERN,
+  MAXIMUM_WORD_COUNT,
+  MINIMUM_WORD_COUNT,
+  PATTERN_SYNTAX,
+  WORD_PATTERN_SHEET_TITLE,
+  clampWordCount,
+  generateWords,
+  isBlankPattern,
+  patternElements,
+  sheetToMarkdown,
+  sheetToText,
+  wordPatternSheet,
+} from './word_patterns';
+
+/** A cleared number field binds to `null`, which the type does not describe but the DOM produces. */
+const cleared = null as unknown as number;
+
+describe('patternElements', () => {
+  it('returns every element the generator knows', () => {
+    const elements = patternElements();
+
+    expect(elements.length).toBe(allElements.length);
+    expect(elements.length).toBeGreaterThan(0);
+    expect(elements.map((element) => element.symbol)).toEqual(
+      allElements.map((element) => element.symbol),
+    );
+  });
+
+  it('returns plain rows rather than the package class instances', () => {
+    for (const element of patternElements()) {
+      expect(Object.getPrototypeOf(element)).toBe(Object.prototype);
+      expect(element.name).not.toBe('');
+      expect(element.symbol.length).toBeGreaterThan(0);
+      expect(element.elements.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('hands out a fresh list, so a caller cannot reorder the package own list', () => {
+    const first = patternElements();
+    first.reverse();
+    first[0].elements.push('nonsense');
+
+    const second = patternElements();
+    expect(second[0].symbol).toBe(allElements[0].symbol);
+    expect(second[0].elements).toEqual(allElements[0].elements);
+  });
+});
+
+describe('PATTERN_SYNTAX', () => {
+  it('documents the two rules that are not a symbol', () => {
+    // This was three paragraphs of prose above the controls, and the only place in the repository
+    // the syntax appeared at all.
+    expect(PATTERN_SYNTAX.map((rule) => rule.syntax)).toEqual(['A symbol', '(a,b,c)', '+']);
+    for (const rule of PATTERN_SYNTAX) {
+      expect(rule.meaning).not.toBe('');
+      expect(rule.example).not.toBe('');
+    }
+  });
+
+  it('gives examples that actually generate something', () => {
+    for (const rule of PATTERN_SYNTAX) {
+      expect(generateWords(rule.example, 1, 'example-seed'), rule.syntax).toHaveLength(1);
+    }
+  });
+});
+
+describe('isBlankPattern', () => {
+  it('treats whitespace as no pattern at all', () => {
+    expect(isBlankPattern('')).toBe(true);
+    expect(isBlankPattern('   ')).toBe(true);
+    expect(isBlankPattern('cvc')).toBe(false);
+  });
+});
+
+describe('clampWordCount', () => {
+  it('leaves a usable count alone', () => {
+    expect(clampWordCount(10)).toBe(10);
+  });
+
+  it('floors a cleared, zero or negative count', () => {
+    expect(clampWordCount(cleared)).toBe(MINIMUM_WORD_COUNT);
+    expect(clampWordCount(NaN)).toBe(MINIMUM_WORD_COUNT);
+    expect(clampWordCount(0)).toBe(MINIMUM_WORD_COUNT);
+    expect(clampWordCount(-4)).toBe(MINIMUM_WORD_COUNT);
+  });
+
+  it('caps a count that would hang the page', () => {
+    expect(clampWordCount(1_000_000)).toBe(MAXIMUM_WORD_COUNT);
+    expect(clampWordCount(Infinity)).toBe(MINIMUM_WORD_COUNT);
+  });
+
+  it('rounds a fractional count to whole words', () => {
+    expect(clampWordCount(7.4)).toBe(7);
+  });
+});
+
+describe('generateWords', () => {
+  it('returns the same words for the same seed', () => {
+    // The page built a `new WordGenerator()` with no RNG, so nothing it produced could be got
+    // back — which is also why none of this could be tested.
+    const first = generateWords('cvcv', 5, 'a-fixed-seed');
+    const second = generateWords('cvcv', 5, 'a-fixed-seed');
+
+    expect(first).toHaveLength(5);
+    expect(second).toEqual(first);
+  });
+
+  it('returns different words for a different seed', () => {
+    expect(generateWords('cvcvcvcv', 5, 'one')).not.toEqual(generateWords('cvcvcvcv', 5, 'two'));
+  });
+
+  it('returns nothing at all for a blank pattern', () => {
+    // 6.4. Generating from an empty pattern produces empty strings, which rendered as ten blank
+    // bullets and exported as blank lines.
+    expect(generateWords('', 10, 'seed')).toEqual([]);
+    expect(generateWords('   ', 10, 'seed')).toEqual([]);
+  });
+
+  it('never returns an empty word', () => {
+    for (const pattern of ['cvc', DEFAULT_PATTERN, '(cv,vc)c', 'cv+']) {
+      for (const word of generateWords(pattern, 20, 'seed')) {
+        expect(word.trim(), pattern).not.toBe('');
+      }
+    }
+  });
+
+  it('clamps the count rather than trusting it', () => {
+    expect(generateWords('cvc', cleared, 'seed')).toHaveLength(MINIMUM_WORD_COUNT);
+    expect(generateWords('cvc', 10_000, 'seed').length).toBeLessThanOrEqual(MAXIMUM_WORD_COUNT);
+  });
+
+  it('generates from the pattern the page opens with', () => {
+    expect(generateWords(DEFAULT_PATTERN, 3, 'seed')).toHaveLength(3);
+  });
+});
+
+describe('wordPatternSheet', () => {
+  it('carries the syntax and the elements', () => {
+    const sheet = wordPatternSheet();
+
+    expect(sheet.title).toBe(WORD_PATTERN_SHEET_TITLE);
+    expect(sheet.syntax).toEqual(PATTERN_SYNTAX);
+    expect(sheet.elements.length).toBe(allElements.length);
+    expect(sheet.sample).toBeUndefined();
+  });
+
+  it('carries a sample that has words in it', () => {
+    const sheet = wordPatternSheet({ pattern: 'cvc', seed: 'seed', words: ['bod', 'gan'] });
+
+    expect(sheet.sample?.words).toEqual(['bod', 'gan']);
+  });
+
+  it('drops a sample with nothing in it rather than heading an empty list', () => {
+    expect(wordPatternSheet({ pattern: '', seed: 'seed', words: [] }).sample).toBeUndefined();
+  });
+});
+
+describe('sheetToMarkdown', () => {
+  it('writes both tables, headed', () => {
+    const markdown = sheetToMarkdown(wordPatternSheet());
+
+    expect(markdown.startsWith(`# ${WORD_PATTERN_SHEET_TITLE}\n\n`)).toBe(true);
+    expect(markdown).toContain('## Pattern syntax');
+    expect(markdown).toContain('| Syntax | Meaning | Example |');
+    expect(markdown).toContain('## Elements');
+    expect(markdown).toContain('| Name | Symbol | Elements |');
+    expect(markdown).toContain('| consonants | `c` |');
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('omits the sample section when no pattern has been run', () => {
+    expect(sheetToMarkdown(wordPatternSheet())).not.toContain('## Sample');
+  });
+
+  it('writes the sample with the seed that produced it', () => {
+    const words = generateWords('cvc', 3, 'a-fixed-seed');
+    const markdown = sheetToMarkdown(
+      wordPatternSheet({ pattern: 'cvc', seed: 'a-fixed-seed', words }),
+    );
+
+    expect(markdown).toContain('## Sample');
+    expect(markdown).toContain('Pattern `cvc`, seed `a-fixed-seed`');
+    expect(markdown).toContain(`- ${words[0]}`);
+  });
+
+  it('never leaves a blank line inside a table', () => {
+    expect(sheetToMarkdown(wordPatternSheet())).not.toContain('|\n\n|');
+  });
+
+  it('escapes the one element set that is made of table separators', () => {
+    // The clicks set is `|`, `||`, `|!`. Unescaped, that row splits into five columns and takes the
+    // rest of the table's alignment with it.
+    const clicks = sheetToMarkdown(wordPatternSheet())
+      .split('\n')
+      .find((line) => line.startsWith('| clicks '));
+
+    expect(clicks).toBeDefined();
+    expect(clicks).not.toBeUndefined();
+    expect(clicks?.split(/(?<!\\)\|/).length).toBe(5);
+  });
+});
+
+describe('sheetToText', () => {
+  it('writes the same sheet without pipes or the title the PDF draws itself', () => {
+    const text = sheetToText(wordPatternSheet());
+
+    // Not "contains no pipe": the clicks element set is `|`, `||`, `|!`, so the vocabulary itself
+    // holds the character. What must be absent is a Markdown table built out of it.
+    expect(text).not.toMatch(/^\|/m);
+    expect(text).not.toContain('| --- |');
+    expect(text).not.toContain(WORD_PATTERN_SHEET_TITLE);
+    expect(text).toContain('Pattern syntax');
+    expect(text).toContain('Elements');
+    expect(text).toContain('consonants');
+  });
+
+  it('quotes the sample without Markdown, since a PDF renders none', () => {
+    const text = sheetToText(
+      wordPatternSheet({ pattern: 'cvc', seed: 'a-fixed-seed', words: ['bod'] }),
+    );
+
+    expect(text).toContain('Pattern "cvc", seed "a-fixed-seed"');
+    expect(text).not.toContain('`');
+  });
+
+  it('has no run of blank lines anywhere in it', () => {
+    expect(sheetToText(wordPatternSheet())).not.toMatch(/\n\s*\n\s*\n/);
+  });
+});

--- a/src/lib/word_patterns/word_patterns.ts
+++ b/src/lib/word_patterns/word_patterns.ts
@@ -1,0 +1,209 @@
+/**
+ * The word generator's pattern vocabulary, and the cheat sheet written from it.
+ *
+ * `WordGeneratorCheatSheet.svelte` built the element table as an HTML string and injected it with
+ * `{@html}` — the one `svelte/no-at-html-tags` suppression on the page, for markup the component
+ * had concatenated itself. Nothing could test it, the headers in that string were unverifiable, and
+ * the page's three paragraphs of pattern syntax were the only place that syntax is written down.
+ * All of it is data here instead, which is
+ * [decision 8 of the readiness pass](../../../docs/tool-readiness.md): a reference tool with no
+ * logic still gets a library, because an exemption would be used by the next reference page too.
+ *
+ * The elements come from `@ironarachne/word-generator` rather than being copied, so the sheet
+ * cannot describe a vocabulary the generator does not have. It already had drifted: the package's
+ * own doc comment lists thirty-six symbols and ships forty-five.
+ */
+
+import { RNG } from '@ironarachne/rng';
+import { WordGenerator, allElements } from '@ironarachne/word-generator';
+
+import type {
+  PatternSyntaxRule,
+  WordPatternElement,
+  WordPatternSample,
+  WordPatternSheet,
+} from './word_pattern_types';
+
+/** The sheet's own title, shared by the page heading and the exports. */
+export const WORD_PATTERN_SHEET_TITLE = 'Word Generator Cheat Sheet';
+
+/** The filename stem for an exported sheet. */
+export const WORD_PATTERN_SHEET_FILE_STEM = 'word-generator-cheat-sheet';
+
+/** The most words one press will produce, so a mistyped count cannot hang the page. */
+export const MAXIMUM_WORD_COUNT = 200;
+
+/** The fewest, which is also what a cleared number field falls back to. */
+export const MINIMUM_WORD_COUNT = 1;
+
+/**
+ * The pattern with which the page opens.
+ *
+ * It used to open empty, and Generate on an empty pattern produces empty strings — ten blank
+ * bullets, which is requirement 6.4 exactly. A pattern that works on arrival is both the fix and
+ * the better introduction to a syntax nobody has read yet.
+ */
+export const DEFAULT_PATTERN = 'cvcv';
+
+/**
+ * The syntax that is not simply "a symbol from the element table".
+ *
+ * This lived in three paragraphs of prose above the controls, which is the only place in the
+ * repository the syntax is documented at all — so it is data now, and the exports carry it.
+ */
+export const PATTERN_SYNTAX: PatternSyntaxRule[] = [
+  {
+    syntax: 'A symbol',
+    meaning: 'Stands for one element drawn from that symbol’s set, listed in the table below.',
+    example: 'cvc',
+  },
+  {
+    syntax: '(a,b,c)',
+    meaning: 'Chooses one of the comma-separated patterns inside the parentheses.',
+    example: '(cv,vc)c',
+  },
+  {
+    syntax: '+',
+    meaning: 'Duplicates the previous character after it has been processed.',
+    example: 'cv+',
+  },
+];
+
+/**
+ * Every element the generator knows, as plain rows.
+ *
+ * `allElements` holds class instances; the sheet wants data, and a fresh array each call so a
+ * caller sorting or filtering it cannot reorder the package's own list.
+ */
+export function patternElements(): WordPatternElement[] {
+  return allElements.map((element) => ({
+    name: element.name,
+    symbol: element.symbol,
+    elements: [...element.elements],
+  }));
+}
+
+/** Whether a pattern has anything in it to generate from. */
+export function isBlankPattern(pattern: string): boolean {
+  return pattern.trim() === '';
+}
+
+/** A word count the generator can survive: whole, at least one, and not unbounded. */
+export function clampWordCount(count: number): number {
+  if (!Number.isFinite(count)) {
+    return MINIMUM_WORD_COUNT;
+  }
+  return Math.min(Math.max(Math.round(count), MINIMUM_WORD_COUNT), MAXIMUM_WORD_COUNT);
+}
+
+/**
+ * Words from a pattern, reproducibly.
+ *
+ * The page built a `new WordGenerator()` with no RNG, so nothing it produced could be got back —
+ * which is also why none of this could be tested. One `RNG` for the whole run, threaded in, is the
+ * repository's normal shape.
+ *
+ * A blank pattern returns nothing rather than a list of empty strings, and any word that comes back
+ * empty anyway is dropped: an empty `<li>` is a layout artifact (6.4), and a blank line in an
+ * export is the same fault in the other format.
+ */
+export function generateWords(pattern: string, count: number, seed: string): string[] {
+  if (isBlankPattern(pattern)) {
+    return [];
+  }
+
+  const generator = new WordGenerator(new RNG(seed));
+  generator.patterns = [pattern];
+
+  const words: string[] = [];
+  for (let i = 0; i < clampWordCount(count); i++) {
+    words.push(generator.generate());
+  }
+
+  return words.filter((word) => word.trim() !== '');
+}
+
+/** The cheat sheet, arranged for reading. */
+export function wordPatternSheet(sample?: WordPatternSample): WordPatternSheet {
+  return {
+    title: WORD_PATTERN_SHEET_TITLE,
+    syntax: PATTERN_SYNTAX,
+    elements: patternElements(),
+    // 6.4: an untried pattern leaves the section out rather than exporting an empty heading.
+    sample: sample !== undefined && sample.words.length > 0 ? sample : undefined,
+  };
+}
+
+/**
+ * A cell a Markdown table can hold.
+ *
+ * The clicks element set is `|`, `||`, `|!`, so this vocabulary genuinely contains the one
+ * character a Markdown table uses as its column separator. Unescaped, that one row silently splits
+ * into five columns and takes the rest of the table's alignment with it.
+ */
+function escapeCell(value: string): string {
+  return value.replaceAll('|', '\\|');
+}
+
+function sampleHeading(sample: WordPatternSample, quote: string): string {
+  return `Pattern ${quote}${sample.pattern}${quote}, seed ${quote}${sample.seed}${quote}`;
+}
+
+/** The sheet as Markdown, for a developer who keeps their notes in it. */
+export function sheetToMarkdown(sheet: WordPatternSheet): string {
+  const blocks = [
+    `# ${sheet.title}`,
+    '## Pattern syntax',
+    [
+      '| Syntax | Meaning | Example |',
+      '| --- | --- | --- |',
+      ...sheet.syntax.map(
+        (rule) =>
+          `| \`${escapeCell(rule.syntax)}\` | ${escapeCell(rule.meaning)} | \`${escapeCell(rule.example)}\` |`,
+      ),
+    ].join('\n'),
+    '## Elements',
+    [
+      '| Name | Symbol | Elements |',
+      '| --- | --- | --- |',
+      ...sheet.elements.map(
+        (element) =>
+          `| ${escapeCell(element.name)} | \`${escapeCell(element.symbol)}\` | ${escapeCell(element.elements.join(', '))} |`,
+      ),
+    ].join('\n'),
+  ];
+
+  if (sheet.sample !== undefined) {
+    blocks.push(
+      '## Sample',
+      sampleHeading(sheet.sample, '`'),
+      sheet.sample.words.map((word) => `- ${word}`).join('\n'),
+    );
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** The body of the PDF: the same sheet without the title the PDF draws itself. */
+export function sheetToText(sheet: WordPatternSheet): string {
+  const blocks = [
+    'Pattern syntax',
+    sheet.syntax
+      .map((rule) => `  ${rule.syntax} - ${rule.meaning} Example: ${rule.example}`)
+      .join('\n'),
+    'Elements',
+    sheet.elements
+      .map((element) => `  ${element.symbol}  ${element.name}: ${element.elements.join(', ')}`)
+      .join('\n'),
+  ];
+
+  if (sheet.sample !== undefined) {
+    blocks.push(
+      'Sample',
+      sampleHeading(sheet.sample, '"'),
+      sheet.sample.words.map((word) => `  ${word}`).join('\n'),
+    );
+  }
+
+  return blocks.join('\n\n');
+}


### PR DESCRIPTION
Closes #76. Takes `/word-generator-cheat-sheet` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the design in `docs/readiness-utilities.md`. The third and last **reference** tool of the pass.

## The spec question, settled

This is the tool that raised it — *does a tool with no library satisfy 8.1 and 8.2?* — and it is settled where [decision 8](https://github.com/ironarachne/ironarachne/blob/main/docs/tool-readiness.md) already put it: **it gets a library.** `src/lib/word_patterns` holds the element table and, which the design did not anticipate, the **pattern syntax** — three paragraphs of prose above the controls that were the only place in the repository that syntax was written down.

No sentence is added to the spec exempting a logic-free reference tool, because there turned out not to be one. This page had a Generate button, an undocumented syntax, and two 6.4 failures.

## 6.1 was already handled; 6.4 was not

6.1 landed exactly as the design predicted — `DataTable`'s `narrow="scroll"` is the same mechanism the component already had, with the hand-rolled wrapper removed. **6.4 failed twice**, and the second one is the interesting one:

- **The page opened with an empty pattern**, and generating from one produces empty strings. Ten blank bullets, on arrival, from the button the page is built around. It opens on `cvcv` now, and Generate is disabled while the pattern is blank.
- **The clicks element set is `|`, `||`, `|!`.** The vocabulary genuinely contains the character a Markdown table separates columns with, so that one row split into five columns and took the rest of the table's alignment with it. Only writing the export revealed it — there was no export before.

**6.2 was met in the letter and not in the mechanism**, which is the point decision 8 makes. The headers did exist — inside a string the component concatenated, where nothing could check them and `{@html}` was needed to render them. They are `DataTable` columns now, the one `svelte/no-at-html-tags` suppression on the page is gone, and both tables carry `aria-label`s, because two tables that look alike need names that do not.

**6.3**: Markdown and PDF, written from the same sheet the page renders. The sample section is omitted entirely when no pattern has been run, rather than exported as an empty heading.

## One judgment beyond the spec

**A seed.** 2.2 and 2.3 are generator-and-editor only and this is a reference tool — but it has a Generate button, and it built a `new WordGenerator()` with no RNG, so nothing it produced could be quoted, written down, or reproduced by whoever was asked what the pattern did. `SeedControls` costs one row and is what every other tool in the pass has. Recorded in the design document as a judgment rather than a requirement.

## Caught for free

The library reads `allElements` from `@ironarachne/word-generator` rather than copying it, which is why the sheet is right at all: **the package's own doc comment lists thirty-six symbols and it ships forty-five.** The test that counts them is what keeps it right.

## Verification

`npm run verify` is green, and `npm run verify:all` was run before opening this: 5,689 unit tests and 584 Playwright tests, including the new `e2e/word_generator_cheat_sheet.spec.ts` and the mobile pass at all five widths — now deterministic, since the page finally exposes a seed for `pinGeneratorSeed` to pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QEan2y9qHFJnvoM1dci8L
