### PR TITLE
Take the fantasy equipment generator to Release-ready

### DIFF
--- a/docs/readiness-objects.md
+++ b/docs/readiness-objects.md
@@ -45,6 +45,39 @@ here for the same reason.
 - **Provenance tells the two tools apart.** `toolPath` is `/fantasy/equipment-generator` or
   `/fantasy/weapon`, which is what the roller reads to know which config shape it is holding.
 
+**As built (#66).** The kind and the payload landed as designed, and the composition is stored as
+the records the document asks for. Four things this section did not anticipate:
+
+- **A press is a list; an artifact is one item.** The generator rolls ten at once, and the kind is
+  `item` — so each card carries its own save button, and the seed it records is
+  `itemSeed(pageSeed, index)` rather than the page's. Deriving it keeps the whole list a pure
+  function of the one seed the user sees while still letting the third sword re-roll to the third
+  sword. Nothing else in the pass has this shape.
+- **The card showed less than it had rolled.** The material, refinement, enchantment and decoration
+  were folded into one sentence and never named: a user could read that a blade was _"finely
+  balanced"_ and not that the refinement was called "balanced". The card and both exports render
+  the presentation document now, which names all four — which is the visible half of what storing
+  the records buys, the editable half being the other.
+- **`weaponType` and `armorType` are not stored**, though `Weapon` and `Armor` carry them.
+  Everything the page shows from either is already a field of its own: `itemMinorType` is the
+  type's name, the armour's defence is in the combat profile, and the weapon's attacks are in
+  `actions`, which the snapshot does keep. Keeping the row whole would copy a table into every
+  sword.
+- **The description cannot be recomputed from a stored item.** `generateItem` writes the composed
+  paragraph back over the base type's own description, the field the composer builds _from_, so
+  re-running it on a saved item would nest the paragraph inside itself. `itemBaseDescription`
+  resolves the base sentence from the type table instead — which is the one place the store-by-name
+  treatment does apply here.
+
+**Two bugs found on the way**, both invisible until the tool was taken seriously:
+
+- **The page reseeded its own RNG from the seed field**, inside an `$effect`, so the next press's
+  seed depended on the text of the previous one. Requirement 2.2's usual failure in a form the pass
+  had not seen before: the generator was pure and the page was not.
+- **A `$state` list of payloads cannot be saved.** Svelte's deep proxy wraps every array in the
+  payload, and IndexedDB's structured clone refuses one — `[object Array] could not be cloned`. The
+  list is `$state.raw`, which is what a payload the page only ever replaces wholesale wants anyway.
+
 **#69's genre question answers itself.** The issue asks whether the tool should carry a sci-fi tag
 because `src/lib/weapons` has a `scifi.ts`. `WeaponGenerator.svelte` does not import
 `$lib/weapons` at all — the only importer anywhere is `$lib/arms_manufacturer`, which is #53 and is
@@ -379,10 +412,14 @@ a haunted freighter. They are the pass's cheapest complete tools and go first fo
 
 ## Still open
 
-- **Whether `item` should carry the generator's config in provenance in enough detail to re-roll a
-  _similar_ item rather than the same one.** Re-roll means "the same seed and config again", which
-  for an item is the identical item — arguably useless. The alternative reading, "roll me another
-  like this", is a different feature and this document does not smuggle it in.
+- ~~**Whether `item` should carry the generator's config in provenance in enough detail to re-roll a
+  _similar_ item rather than the same one.**~~ **Settled by building it (#66).** Re-roll does mean
+  "the same seed and config again", and for an item that is the identical item — which turns out
+  not to be useless at all, because that is exactly what requirement 4.3 describes: the destructive
+  command that throws away a user's edits and puts the rolled item back. "Roll me another like
+  this" is a different feature and is still not smuggled in; what the provenance carries is the
+  page's four controls, and the display system is not among them because it changes how the same
+  item reads rather than what was rolled.
 - **Whether the price lists should offer a downloadable table (6.3).** It is a SHOULD for a
   reference tool and the tables are already data; a CSV or Markdown download is a small addition
   that #65 may take or leave.

--- a/e2e/equipment.spec.ts
+++ b/e2e/equipment.spec.ts
@@ -1,0 +1,245 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `item` kind: generate, save, reopen, edit (#66).
+ *
+ * This is the half no unit test can settle. The library tests prove an item round-trips through the
+ * codec and that each edit changes one thing; what they cannot prove is that a user can press
+ * Generate, keep *one* of the ten items on screen, come back to it in a different page, change what
+ * it is made of, and still have the item they saved.
+ *
+ * The list is what makes this tool different from every other generator in the pass: one press
+ * produces ten items and each card saves on its own, so the seed a card records has to be the one
+ * that rolls *that* item.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const EQUIPMENT_TITLE = 'Equipment Generator | Iron Arachne';
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const cards = (page: Page) => page.locator('.item-card');
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep one card's item, under a name of its own.
+ *
+ * Scoped to the card rather than the page: there are ten save buttons, which is the shape this
+ * tool has and no other in the pass does.
+ */
+async function saveCard(page: Page, index: number, name: string): Promise<void> {
+  const card = cards(page).nth(index);
+  const saveArtifact = card.locator('.save-artifact');
+  await saveArtifact.getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact.getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact.getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+/** A pinned press, so the items on screen are the same ones every run. */
+async function generatePinned(page: Page, seed = 'a-fixed-seed'): Promise<void> {
+  await page.getByLabel('Seed', { exact: true }).fill(seed);
+  await page.getByLabel('Lock Seed').check();
+  await page.getByRole('button', { name: 'Generate', exact: true }).click();
+  await expect(cards(page).first()).toBeVisible();
+}
+
+test.describe('an item', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'The Armoury');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/fantasy/equipment-generator', { title: EQUIPMENT_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a list to keep from straight away.
+    await expect(cards(page)).toHaveCount(10);
+    await saveCard(page, 2, 'The Third Sword');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'The Third Sword');
+
+    // Typed rather than filled: the point is that the editor's own binding carries keystrokes
+    // through to the snapshot it announces.
+    const unique = panel.getByRole('textbox', { name: 'Unique name' });
+    await unique.fill('');
+    await unique.pressSequentially('Bitterlight');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'The Third Sword');
+    await expect(reopened.getByRole('textbox', { name: 'Unique name' })).toHaveValue('Bitterlight');
+  });
+
+  test('saves the card that was pressed, not the one beside it', async ({ page }) => {
+    // A list of ten and one kind of artifact: the third card's save has to record the third item.
+    await visitRoute(page, '/fantasy/equipment-generator', { title: EQUIPMENT_TITLE });
+    await generatePinned(page);
+
+    const fourthHeading = await cards(page).nth(3).locator('h3').innerText();
+    await saveCard(page, 3, 'The Fourth Thing');
+
+    const panel = await openInWorkshop(page, 'The Fourth Thing');
+    // The unique name is empty unless the generator drew one, so the item name is what identifies
+    // it — and it is what the card's heading showed.
+    const name = await panel.getByRole('textbox', { name: 'Item name' }).inputValue();
+    const unique = await panel.getByRole('textbox', { name: 'Unique name' }).inputValue();
+    expect([name, unique]).toContain(fourthHeading);
+  });
+
+  test('lets a user change what an item is made of, not just what it says', async ({ page }) => {
+    // The requirement #66 states outright, and the reason the composition is stored rather than
+    // only the rendered paragraph.
+    await visitRoute(page, '/fantasy/equipment-generator', { title: EQUIPMENT_TITLE });
+    await generatePinned(page);
+    await saveCard(page, 0, 'The First Thing');
+
+    const panel = await openInWorkshop(page, 'The First Thing');
+    const material = panel.getByRole('group', { name: 'Material' });
+    await expect(material).toBeVisible();
+
+    const materialName = material.getByRole('textbox', { name: 'Name' });
+    await materialName.fill('meteoric iron');
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'The First Thing');
+    await expect(
+      reopened.getByRole('group', { name: 'Material' }).getByRole('textbox', { name: 'Name' }),
+    ).toHaveValue('meteoric iron');
+  });
+
+  test('offers the description rather than rewriting it under the user', async ({ page }) => {
+    // Requirement 4.2. The paragraph is composed from the parts, so a form that regenerated it on
+    // every keystroke would throw away a hand-written one.
+    await visitRoute(page, '/fantasy/equipment-generator', { title: EQUIPMENT_TITLE });
+    await generatePinned(page);
+    await saveCard(page, 0, 'The Written Thing');
+
+    const panel = await openInWorkshop(page, 'The Written Thing');
+    const description = panel.getByRole('textbox', { name: 'Item description' });
+    await description.fill('A judge wrote this by hand.');
+
+    // Unmoved: changing a part the description is built from did not touch it.
+    await panel
+      .getByRole('group', { name: 'Material' })
+      .getByRole('textbox', { name: 'Name' })
+      .fill('bronze');
+    await expect(description).toHaveValue('A judge wrote this by hand.');
+
+    // And the generated wording is there for the asking.
+    await panel.getByRole('button', { name: 'Rewrite the description from the parts' }).click();
+    // `toHaveValue`, not `toContainText`: a textarea's edited value is not its text content.
+    await expect(description).not.toHaveValue('A judge wrote this by hand.');
+  });
+
+  test('downloads the list and one item from it', async ({ page }) => {
+    // Requirement 6.3, and the first exports this tool has ever had.
+    await visitRoute(page, '/fantasy/equipment-generator', { title: EQUIPMENT_TITLE });
+    await generatePinned(page);
+    const firstHeading = await cards(page).first().locator('h3').innerText();
+
+    const listDownload = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown', exact: true }).click();
+    const listFile = await listDownload;
+    expect(listFile.suggestedFilename()).toBe('equipment.md');
+    const list = await new Response(await listFile.createReadStream()).text();
+    expect(list).toContain('# Equipment');
+    expect(list).toContain(`## ${firstHeading}`);
+    // The composition, named rather than only described — which storing the records is what buys.
+    expect(list).toContain('- Material: ');
+
+    const oneDownload = page.waitForEvent('download');
+    await cards(page)
+      .first()
+      .getByRole('button', { name: `Download ${firstHeading} as Markdown` })
+      .click();
+    const oneFile = await oneDownload;
+    expect(oneFile.suggestedFilename()).toMatch(/^item-.*\.md$/);
+    expect(await new Response(await oneFile.createReadStream()).text()).toContain(
+      `# ${firstHeading}`,
+    );
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toBe('equipment.pdf');
+  });
+
+  test('reproduces the same list from the same seed', async ({ page }) => {
+    // Requirement 2.2. The generator was already pure; the page reseeded its own RNG from the seed
+    // field inside an `$effect`, so the next press depended on the text of the previous one.
+    await visitRoute(page, '/fantasy/equipment-generator', { title: EQUIPMENT_TITLE });
+    const results = page.locator('.results');
+
+    await generatePinned(page, 'a-fixed-seed');
+    const first = await results.innerText();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await results.innerText()).toEqual(first);
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await results.innerText()).not.toEqual(first);
+  });
+
+  test('names the composition on the card it used only to describe', async ({ page }) => {
+    await visitRoute(page, '/fantasy/equipment-generator', { title: EQUIPMENT_TITLE });
+    await generatePinned(page);
+
+    const results = page.locator('.results');
+    await expect(results).toContainText('Material:');
+    await expect(results).toContainText('Value:');
+    await expect(results).toContainText('Rarity:');
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -52,6 +52,7 @@ const SILENT_TOOL_PAGES = [
   { path: '/star-system', title: 'Star System Generator | Iron Arachne', webgl: true },
   { path: '/region', title: 'Region Generator | Iron Arachne' },
   { path: '/drug', title: 'Cyberpunk Drug Generator | Iron Arachne' },
+  { path: '/fantasy/equipment-generator', title: 'Equipment Generator | Iron Arachne' },
   {
     // The first reference tool in this list, and the reason it is worth naming: most of the spec
     // does not apply to a tool that produces no artifacts, so its silence was earned by sections

--- a/src/components/objects/EquipmentGenerator.svelte
+++ b/src/components/objects/EquipmentGenerator.svelte
@@ -1,58 +1,93 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import * as RNG from '@ironarachne/rng';
-  import {
-    type Item,
-    type Weapon,
-    type Armor,
-    generateItem,
-    getDefaultGenerationConfig,
-  } from '$lib/equipment';
-  import { kgToPounds } from '$lib/measurements';
-  import { valueToString, COMMON_FANTASY } from '$lib/currency';
-  import { convertPowerToDice, convertToDnDArmorClass } from '$lib/combat_system';
-  import GeneratorPage from '$components/layout/GeneratorPage.svelte';
-  import SeedControls from '$components/common/SeedControls.svelte';
-  import ControlsPanel from '$components/common/ControlsPanel.svelte';
-  import SelectField from '$components/common/SelectField.svelte';
-  import NumberField from '$components/common/NumberField.svelte';
-  import CheckboxField from '$components/common/CheckboxField.svelte';
+  import { RNG } from '@ironarachne/rng';
+
   import Badge from '$components/common/Badge.svelte';
   import BaseButton from '$components/common/BaseButton.svelte';
+  import CheckboxField from '$components/common/CheckboxField.svelte';
+  import ControlsPanel from '$components/common/ControlsPanel.svelte';
+  import GeneratorPage from '$components/layout/GeneratorPage.svelte';
+  import NumberField from '$components/common/NumberField.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
+  import SeedControls from '$components/common/SeedControls.svelte';
+  import SelectField from '$components/common/SelectField.svelte';
+  import { downloadTextFile } from '$lib/download';
+  import {
+    ITEM_ARTIFACT_KIND,
+    itemDisplayName,
+    itemFileStem,
+    itemListToMarkdown,
+    itemListToText,
+    itemToMarkdown,
+    itemSeed,
+    itemToDocument,
+    rollItems,
+    toItemSnapshot,
+    defaultEquipmentGeneratorConfig,
+    type EquipmentGeneratorConfigRecord,
+    type ItemDisplaySystem,
+    type ItemMajorTypeChoice,
+    type ItemSnapshot,
+  } from '$lib/equipment';
+  import { downloadTextPdf } from '$lib/pdf';
 
-  const rng = new RNG.RNG(Date.now().toString());
+  const TOOL_PATH = '/fantasy/equipment-generator';
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. It used to be reseeded from the seed
+   * field inside an `$effect`, which made the next press's seed depend on the text of the previous
+   * one — a seed control that worked and a stream nobody could reproduce, which is requirement
+   * 2.2's usual failure in a form this pass had not seen before.
+   */
+  const rng = new RNG(Date.now().toString());
+
   let seed = $state(rng.randomString(13));
-  $effect(() => {
-    rng.setSeed(seed);
-  });
   let lockSeed = $state(false);
 
-  let itemType = $state('any');
+  let itemType: ItemMajorTypeChoice = $state('any');
   let itemCount = $state(10);
   let useRefine = $state(true);
   let useEnchant = $state(true);
   let useDecorate = $state(true);
-  let displaySystem = $state('dnd5e');
+  let displaySystem: ItemDisplaySystem = $state('dnd5e');
 
-  let generatedItems: Item[] = $state([]);
+  /**
+   * The seed and settings the items on screen were rolled from, which is what their provenance
+   * records. Empty until the first press, which `onMount` makes immediately.
+   */
+  let rolledSeed = $state('');
+  let rolledConfig: EquipmentGeneratorConfigRecord = $state(defaultEquipmentGeneratorConfig());
+  /**
+   * `$state.raw`, not `$state`: a deep `$state` wraps every array in the payload — `properties`,
+   * `actions`, `bonusDamage` — in a reactive Proxy, and IndexedDB's structured clone refuses one
+   * with "[object Array] could not be cloned". The page only ever replaces this list wholesale, so
+   * the deep proxy buys nothing and costs every save.
+   */
+  let items: ItemSnapshot[] = $state.raw([]);
+
+  function rollConfig(): EquipmentGeneratorConfigRecord {
+    return { itemMajorType: itemType, useRefine, useEnchant, useDecorate };
+  }
 
   function generate() {
     if (!lockSeed) {
       seed = rng.randomString(13);
     }
-    rng.setSeed(seed);
+    rolledSeed = seed;
+    rolledConfig = rollConfig();
+    // Stored as snapshots straight away: the page renders the same shape a saved item is read
+    // back in, so a card and a reopened artifact cannot show different things.
+    items = rollItems(rolledSeed, itemCount, rolledConfig).map(toItemSnapshot);
+  }
 
-    const config = getDefaultGenerationConfig();
-    config.itemMajorType = itemType as 'any' | 'weapon' | 'armor';
-    config.useRefine = useRefine;
-    config.useEnchant = useEnchant;
-    config.useDecorate = useDecorate;
+  function exportMarkdown() {
+    downloadTextFile(itemListToMarkdown(items, displaySystem), 'equipment.md', 'text/markdown');
+  }
 
-    const items: Item[] = [];
-    for (let i = 0; i < itemCount; i++) {
-      items.push(generateItem(`${seed}-item-${i}`, config));
-    }
-    generatedItems = items;
+  async function exportPdf() {
+    await downloadTextPdf('Equipment', itemListToText(items, displaySystem), 'equipment.pdf');
   }
 
   onMount(() => {
@@ -60,7 +95,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/equipment-generator" title="Equipment Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Equipment Generator">
   {#snippet description()}
     <p>Generate random weapons and armor.</p>
     <p>"Refine" adds quality modifications to the items.</p>
@@ -80,6 +115,8 @@
       ]}
     />
 
+    <!-- Not part of the roll, and so not part of the provenance: it chooses between D&D dice and
+         this site's own numbers for the *same* rolled item. -->
     <SelectField
       id="displaySystem"
       label="System"
@@ -103,56 +140,63 @@
     <BaseButton onclick={generate}>Generate</BaseButton>
   </ControlsPanel>
 
+  <div class="actions">
+    <BaseButton onclick={exportMarkdown} disabled={items.length === 0}>
+      Download Markdown
+    </BaseButton>
+    <BaseButton onclick={exportPdf} disabled={items.length === 0}>Download PDF</BaseButton>
+  </div>
+
   <div class="results">
-    {#each generatedItems as item}
+    {#each items as item, index (item.id)}
+      {@const document_ = itemToDocument(item, displaySystem)}
       <!-- A card is a panel: the two layers, with the `li` painting the keyline across its box
            and the field covering all but a pixel of it. See docs/visual-design.md, "Cards are
            panels". This card wrote its own border, radius, fill and padding until #124. -->
       <div class="item-card panel">
         <div class="panel__field">
-          <h3>{item.name}</h3>
-          <p class="description">{item.description}</p>
+          <h3>{document_.title}</h3>
+          <p class="description">{document_.description}</p>
           <div class="stats">
             <Badge>{item.itemMajorType}</Badge>
-            {#if item.itemMajorType === 'weapon'}
-              {@const weapon = item as Weapon}
-              {#if displaySystem === 'dnd5e' && weapon.actions && weapon.actions.length > 0}
-                <Badge
-                  >Damage: {convertPowerToDice(weapon.actions[0].baseDamage || 0)} ({weapon
-                    .actions[0].damageType})</Badge
-                >
-                {#if weapon.actions[0].bonusDamage && weapon.actions[0].bonusDamage.length > 0}
-                  {#each weapon.actions[0].bonusDamage as bonus}
-                    <Badge>+ {convertPowerToDice(bonus.power)} ({bonus.type})</Badge>
-                  {/each}
-                {/if}
-              {:else}
-                <Badge
-                  >Damage: {weapon.actions[0].baseDamage || 0} ({weapon.actions[0]
-                    .damageType})</Badge
-                >
-              {/if}
-            {/if}
-            {#if item.itemMajorType === 'armor'}
-              {@const armor = item as Armor}
-              {#if displaySystem === 'dnd5e'}
-                <Badge>AC: {convertToDnDArmorClass(armor.combatProfile.defense)}</Badge>
-              {:else}
-                <Badge>Defense: {armor.combatProfile.defense}</Badge>
-              {/if}
-            {/if}
-            <Badge>Value: {valueToString(item.value, COMMON_FANTASY)}</Badge>
-            <Badge>Weight: {kgToPounds(item.weight).toFixed(1)} lbs</Badge>
+            {#each document_.lines as line (line.label)}
+              <Badge>{line.label}: {line.value}</Badge>
+            {/each}
           </div>
-          {#if item.properties && item.properties.length > 0}
+          {#if document_.properties.length > 0}
             <div class="tags">
-              {#each item.properties as tag}
+              {#each document_.properties as tag (tag)}
                 <!-- `plain` because a card can carry a dozen of these: bordered pills stop
                      annotating the item and start shouting over it. -->
                 <Badge plain>{tag}</Badge>
               {/each}
             </div>
           {/if}
+
+          <div class="card-actions">
+            <!-- One save per card, because the kind is `item` and an artifact is one item. Each
+                 card's seed is the one that rolls *that* item, so a saved sword re-rolls to a
+                 sword rather than to the list it arrived in. -->
+            <SaveArtifactButton
+              kind={ITEM_ARTIFACT_KIND}
+              toolPath={TOOL_PATH}
+              snapshot={item}
+              seed={itemSeed(rolledSeed, index)}
+              config={{ ...rolledConfig }}
+              defaultName={itemDisplayName(item)}
+            />
+            <BaseButton
+              onclick={() =>
+                downloadTextFile(
+                  itemToMarkdown(item, displaySystem),
+                  `${itemFileStem(item)}.md`,
+                  'text/markdown',
+                )}
+              aria-label="Download {document_.title} as Markdown"
+            >
+              Markdown
+            </BaseButton>
+          </div>
         </div>
       </div>
     {/each}
@@ -160,6 +204,13 @@
 </GeneratorPage>
 
 <style>
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+  }
+
   .results {
     display: grid;
     gap: var(--s6);
@@ -187,5 +238,12 @@
     flex-wrap: wrap;
     gap: var(--s3);
     margin-top: var(--s4);
+  }
+
+  .item-card .card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--s4);
+    margin-top: var(--s5);
   }
 </style>

--- a/src/components/objects/ItemArtifactEditor.svelte
+++ b/src/components/objects/ItemArtifactEditor.svelte
@@ -1,0 +1,284 @@
+<script lang="ts">
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import Notice from '$components/common/Notice.svelte';
+  import {
+    ITEM_COMPOSITION_PARTS,
+    ITEM_DENSITY_CATEGORIES,
+    ITEM_RARITIES,
+    describeItem,
+    itemPartDescription,
+    itemPartName,
+    itemPropertiesLine,
+    removeItemPart,
+    setItemDensity,
+    setItemNumber,
+    setItemPartField,
+    setItemProperties,
+    setItemRarity,
+    setItemText,
+    validateItemSnapshot,
+    type DensityCategory,
+    type ItemCompositionPart,
+    type ItemSnapshot,
+    type ItemTextField,
+    type Rarity,
+  } from '$lib/equipment';
+
+  /**
+   * The editing view for a saved item.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it.
+   *
+   * **The composition is here, which is the whole reason it is stored.** #66 asks for the records
+   * rather than the rendered prose so that an editor can reach them, and these four rows are what
+   * that buys: a user can rename the enchantment on a sword, rewrite what the refinement did, or
+   * take the decoration off entirely. An item's parts are only editable because the payload kept
+   * them.
+   *
+   * **Nothing is recomputed.** Changing the material does not re-multiply the value, and changing a
+   * part does not rewrite the description — 4.2 forbids exactly that, and `$lib/equipment`'s
+   * `item_editing.ts` says why at length. The button at the foot offers the generated wording back
+   * to anyone who wants it.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps this editor from rendering fields over
+   * something that is not an item.
+   */
+  const accepted = $derived(validateItemSnapshot(snapshot));
+  const item = $derived<ItemSnapshot | undefined>(accepted.ok ? accepted.value : undefined);
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: ItemSnapshot) => ItemSnapshot): void {
+    if (item === undefined) {
+      return;
+    }
+    onChange(change(item));
+  }
+
+  const TEXT_FIELDS: { field: ItemTextField; label: string }[] = [
+    { field: 'name', label: 'Item name' },
+    { field: 'uniqueName', label: 'Unique name' },
+    { field: 'itemMinorType', label: 'Type' },
+  ];
+
+  const PART_LABELS: Record<ItemCompositionPart, string> = {
+    material: 'Material',
+    refinement: 'Refinement',
+    enchantment: 'Enchantment',
+    decoration: 'Decoration',
+  };
+
+  /** The parts this item actually has. A part it does not have has nothing to edit. */
+  const presentParts = $derived(
+    item === undefined ? [] : ITEM_COMPOSITION_PARTS.filter((part) => item[part] !== undefined),
+  );
+</script>
+
+{#if item === undefined}
+  <Notice tone="danger">
+    These contents are stored as an item but do not read as one, so there is nothing safe to edit
+    here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="item-editor">
+    {#each TEXT_FIELDS as entry (entry.field)}
+      <div class="input-group input-group--inline">
+        <label for="{uid}-{entry.field}">{entry.label}</label>
+        <input
+          id="{uid}-{entry.field}"
+          type="text"
+          value={item[entry.field] ?? ''}
+          oninput={(event) =>
+            edit((current) => setItemText(current, entry.field, event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+    {/each}
+
+    <div class="input-group input-group--inline">
+      <label for="{uid}-rarity">Rarity</label>
+      <select
+        id="{uid}-rarity"
+        value={item.rarity}
+        onchange={(event) =>
+          edit((current) => setItemRarity(current, event.currentTarget.value as Rarity))}
+      >
+        {#each ITEM_RARITIES as rarity (rarity)}
+          <option value={rarity}>{rarity}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="input-group input-group--inline">
+      <label for="{uid}-density">Density</label>
+      <select
+        id="{uid}-density"
+        value={item.densityCategory}
+        onchange={(event) =>
+          edit((current) => setItemDensity(current, event.currentTarget.value as DensityCategory))}
+      >
+        {#each ITEM_DENSITY_CATEGORIES as density (density)}
+          <option value={density}>{density}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="input-group input-group--inline">
+      <!-- In copper, which is the unit the value is stored in and the one the price lists quote. -->
+      <label for="{uid}-value">Value (cp)</label>
+      <input
+        id="{uid}-value"
+        type="number"
+        min="0"
+        value={item.value}
+        oninput={(event) =>
+          edit((current) => setItemNumber(current, 'value', event.currentTarget.valueAsNumber))}
+      />
+    </div>
+
+    <div class="input-group input-group--inline">
+      <label for="{uid}-weight">Weight (kg)</label>
+      <input
+        id="{uid}-weight"
+        type="number"
+        min="0"
+        step="0.1"
+        value={item.weight}
+        oninput={(event) =>
+          edit((current) => setItemNumber(current, 'weight', event.currentTarget.valueAsNumber))}
+      />
+    </div>
+
+    <div class="input-group">
+      <label for="{uid}-properties">Properties</label>
+      <input
+        id="{uid}-properties"
+        type="text"
+        value={itemPropertiesLine(item)}
+        oninput={(event) =>
+          edit((current) => setItemProperties(current, event.currentTarget.value))}
+        autocomplete="off"
+      />
+    </div>
+
+    <div class="input-group">
+      <!-- Qualified as "Item description": the panel above has a field labelled "Name" that
+           renames the artifact, and three other descriptions sit below this one. -->
+      <label for="{uid}-description">Item description</label>
+      <textarea
+        id="{uid}-description"
+        rows="4"
+        value={item.description}
+        oninput={(event) =>
+          edit((current) => setItemText(current, 'description', event.currentTarget.value))}
+      ></textarea>
+    </div>
+
+    {#if presentParts.length > 0}
+      <h3 class="item-editor__heading">Composition</h3>
+      {#each presentParts as part (part)}
+        <fieldset class="item-editor__part inset">
+          <legend>{PART_LABELS[part]}</legend>
+          <div class="input-group input-group--inline">
+            <label for="{uid}-{part}-name">Name</label>
+            <input
+              id="{uid}-{part}-name"
+              type="text"
+              value={itemPartName(item, part)}
+              oninput={(event) =>
+                edit((current) =>
+                  setItemPartField(current, part, 'name', event.currentTarget.value),
+                )}
+              autocomplete="off"
+            />
+          </div>
+          <!-- A material carries no description; the other three do. -->
+          {#if part !== 'material'}
+            <div class="input-group">
+              <label for="{uid}-{part}-description">What it does</label>
+              <textarea
+                id="{uid}-{part}-description"
+                rows="2"
+                value={itemPartDescription(item, part)}
+                oninput={(event) =>
+                  edit((current) =>
+                    setItemPartField(current, part, 'description', event.currentTarget.value),
+                  )}
+              ></textarea>
+            </div>
+          {/if}
+          <BaseButton onclick={() => edit((current) => removeItemPart(current, part))}>
+            Remove {PART_LABELS[part].toLowerCase()}
+          </BaseButton>
+        </fieldset>
+      {/each}
+    {/if}
+
+    <!-- Offered rather than done automatically, for the reason the header gives. -->
+    <BaseButton
+      onclick={() => edit((current) => setItemText(current, 'description', describeItem(current)))}
+    >
+      Rewrite the description from the parts
+    </BaseButton>
+  </div>
+{/if}
+
+<style>
+  .item-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+    align-items: flex-start;
+  }
+
+  .item-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .item-editor input,
+  .item-editor textarea,
+  .item-editor select {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+
+  .item-editor__heading {
+    margin: var(--s4) 0 0;
+  }
+
+  /* `inset` rather than a hand-rolled border and radius: the panel language owns those, and a
+     nineteenth copy of `1px solid var(--tan)` is exactly what it replaced. */
+  .item-editor__part {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    align-items: flex-start;
+    min-width: 0;
+    padding: var(--s4);
+    width: 100%;
+  }
+
+  .item-editor__part legend {
+    font: var(--t-micro);
+    letter-spacing: var(--t-micro-tracking);
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+</style>

--- a/src/lib/equipment/README.md
+++ b/src/lib/equipment/README.md
@@ -9,6 +9,29 @@ also don't use random generation, but can be randomly selected by generators.
 `index.ts` is the public API. `fantasylist/` holds the static fantasy price list, which is data
 rather than generation.
 
+## The `item` artifact kind
+
+An item is a durable artifact, and `/fantasy/equipment-generator` and `/fantasy/weapon` share the
+one kind — decision 1 of [docs/readiness-objects.md](../../../docs/readiness-objects.md), because
+two kinds for one payload shape would split a user's gear across two vault entries, each openable
+by only one of the two tools that made it. The provenance's tool path says which rolled it.
+
+- **`item_snapshot.ts`** — `ItemSnapshot` and the codec. The **composition is stored**: `material`,
+  `refinement`, `enchantment` and `decoration` are kept as the records they are, not folded into the
+  description, or an editor could only rewrite prose. What is dropped is what generation _used_ —
+  `allowedMaterialTypes`, `weaponType`, `armorType` — and what belongs to something else,
+  `containerId`.
+- **`item_artifact_kind.ts`** — the kind, its version, and a validator that normalises rather than
+  refuses: an unrecognised rarity or density becomes the default, and a composition part that is
+  not a record is dropped, but an item with no name or a non-numeric value is rejected.
+- **`item_roll.ts`** — the one path from a seed. `itemSeed(seed, index)` is how one press's list
+  gives each card a seed that re-rolls _that_ item.
+- **`item_editing.ts`** — the setters, none of which recompute anything. Changing the material does
+  not re-multiply the value, and no setter rewrites the description; `describeItem` offers the
+  generated wording as an explicit command.
+- **`item_presentation.ts`** — the sheet, and the Markdown and PDF written from it, for one item or
+  for a whole press.
+
 ## The fantasy price lists
 
 `fantasylist/` is the data: twenty-three titled lists of `{ name, cost }`, where `cost` is in

--- a/src/lib/equipment/index.ts
+++ b/src/lib/equipment/index.ts
@@ -19,6 +19,11 @@ export * from './generation';
 
 export * as FantasyEquipmentList from './fantasylist';
 export * from './fantasylist';
+export * from './item_artifact_kind';
+export * from './item_editing';
+export * from './item_presentation';
+export * from './item_roll';
+export * from './item_snapshot';
 export * from './price_lists';
 export type * from './list';
 export type * from './price_list_types';

--- a/src/lib/equipment/item_artifact_kind.test.ts
+++ b/src/lib/equipment/item_artifact_kind.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ITEM_ARTIFACT_KIND,
+  ITEM_PAYLOAD_VERSION,
+  itemArtifactKind,
+  itemName,
+  migrateItemSnapshot,
+  validateItemSnapshot,
+} from './item_artifact_kind';
+import { rollItem } from './item_roll';
+import { DEFAULT_ITEM_DENSITY, DEFAULT_ITEM_RARITY, toItemSnapshot } from './item_snapshot';
+
+const CONFIG = {
+  itemMajorType: 'any' as const,
+  useRefine: true,
+  useEnchant: true,
+  useDecorate: true,
+};
+
+const ITEM = toItemSnapshot(rollItem('kind-seed', CONFIG));
+
+function accepted(payload: unknown) {
+  const result = validateItemSnapshot(payload);
+  if (!result.ok) {
+    throw new Error(`expected an accepted payload, got: ${result.message}`);
+  }
+  return result.value;
+}
+
+describe('itemArtifactKind', () => {
+  it('registers the id and version the pass assigned it', () => {
+    expect(itemArtifactKind.kind).toBe(ITEM_ARTIFACT_KIND);
+    expect(ITEM_ARTIFACT_KIND).toBe('item');
+    expect(itemArtifactKind.payloadVersion).toBe(ITEM_PAYLOAD_VERSION);
+    expect(ITEM_PAYLOAD_VERSION).toBe(1);
+  });
+
+  it('loads a codec that round-trips', async () => {
+    const codec = await itemArtifactKind.loadCodec();
+
+    expect(codec.fromSnapshot(codec.toSnapshot(ITEM), undefined as never)).toEqual(ITEM);
+  });
+});
+
+describe('validateItemSnapshot', () => {
+  it('accepts a rolled item unchanged', () => {
+    expect(accepted(ITEM)).toEqual(ITEM);
+  });
+
+  it('accepts one that has been through storage', () => {
+    expect(accepted(JSON.parse(JSON.stringify(ITEM)))).toEqual(ITEM);
+  });
+
+  it('refuses anything that is not an object', () => {
+    for (const payload of [null, undefined, 42, 'sword', ['sword']]) {
+      expect(validateItemSnapshot(payload).ok, String(payload)).toBe(false);
+    }
+  });
+
+  it('refuses a payload missing a field every reader depends on', () => {
+    for (const field of ['id', 'name', 'itemMajorType', 'description', 'value', 'weight']) {
+      const broken: Record<string, unknown> = { ...ITEM };
+      delete broken[field];
+      const result = validateItemSnapshot(broken);
+
+      expect(result.ok, field).toBe(false);
+      expect(result.ok ? '' : result.message).toContain(field);
+    }
+  });
+
+  it('refuses a value or weight that is not a finite number', () => {
+    expect(validateItemSnapshot({ ...ITEM, value: 'a lot' }).ok).toBe(false);
+    expect(validateItemSnapshot({ ...ITEM, weight: Number.NaN }).ok).toBe(false);
+  });
+
+  it('accepts an emptied name, because clearing one is an editing decision', () => {
+    // 3.3 asks for a well-defined empty result rather than a refusal.
+    expect(accepted({ ...ITEM, name: '' }).name).toBe('');
+  });
+
+  it('falls back rather than refusing on a rarity or density it does not know', () => {
+    // The discipline docs/workshop.md asks of a project's genre: a payload from a build with a
+    // sixth rarity loses the field, not the item.
+    expect(accepted({ ...ITEM, rarity: 'mythic' }).rarity).toBe(DEFAULT_ITEM_RARITY);
+    expect(accepted({ ...ITEM, densityCategory: 'squishy' }).densityCategory).toBe(
+      DEFAULT_ITEM_DENSITY,
+    );
+  });
+
+  it('empties properties that are not a list of strings', () => {
+    expect(accepted({ ...ITEM, properties: 'sharp' }).properties).toEqual([]);
+    expect(accepted({ ...ITEM, properties: [1, 2] }).properties).toEqual([]);
+  });
+
+  it('drops a composition part that is not a record, and keeps one that is', () => {
+    expect(accepted({ ...ITEM, material: 'iron' }).material).toBeUndefined();
+    expect(accepted({ ...ITEM, material: { name: 'iron' } }).material).toEqual({ name: 'iron' });
+  });
+
+  it('drops an empty optional name rather than storing it blank', () => {
+    expect(accepted({ ...ITEM, uniqueName: '' }).uniqueName).toBeUndefined();
+    expect(accepted({ ...ITEM, itemMinorType: '' }).itemMinorType).toBeUndefined();
+  });
+});
+
+describe('migrateItemSnapshot', () => {
+  it('rejects rather than pretending there has been another shape', () => {
+    // Requirement 7.3 has one step to exercise and it is the absence of one: version 1 is the only
+    // shape there has been, and a migration that quietly accepted anything would be worse than none.
+    const result = migrateItemSnapshot({ name: 'sword' }, 0);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? '' : result.reason).toBe('unsupported-version');
+    expect(result.ok ? '' : result.message).toContain('payload version 0');
+  });
+});
+
+describe('itemName', () => {
+  it('prefers the unique name, which is what a magic item is called', () => {
+    // 3.5 carries unusual weight here: an unnamed item in a list of forty is unusable.
+    expect(itemName({ ...ITEM, name: 'longsword', uniqueName: 'Bitterlight' })).toBe('Bitterlight');
+  });
+
+  it('falls back to the plain name, then to the kind', () => {
+    expect(itemName({ ...ITEM, name: 'longsword', uniqueName: '  ' })).toBe('longsword');
+    expect(itemName({ ...ITEM, name: '  ', uniqueName: undefined })).toBe('Item');
+  });
+});

--- a/src/lib/equipment/item_artifact_kind.ts
+++ b/src/lib/equipment/item_artifact_kind.ts
@@ -1,0 +1,174 @@
+import sword from '$lib/assets/icons/set2/sword-1.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  isStringArray,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import {
+  DEFAULT_ITEM_DENSITY,
+  DEFAULT_ITEM_RARITY,
+  ITEM_DENSITY_CATEGORIES,
+  ITEM_RARITIES,
+  type ItemSnapshot,
+} from './item_snapshot';
+import type { DensityCategory, Rarity } from './equipment_types';
+
+/**
+ * Stable artifact kind id. Unqualified: an item is neither a game system's nor a setting's, per
+ * the kind table in docs/tool-readiness.md.
+ *
+ * **One kind, two tools.** `/fantasy/equipment-generator` and `/fantasy/weapon` both produce an
+ * `Item` from this library, and decision 1 of docs/readiness-objects.md gives them one kind: two
+ * kinds for one payload shape would split a user's gear across two vault entries, each openable by
+ * only one of the two tools that made it. The provenance's tool path is what says which rolled it.
+ * That is the argument the AD&D builder and generator settled, applied again.
+ */
+export const ITEM_ARTIFACT_KIND = 'item' as const;
+
+/** Version 1. The first shape an item has been stored in. */
+export const ITEM_PAYLOAD_VERSION = 1 as const;
+
+function isRarity(value: unknown): value is Rarity {
+  return typeof value === 'string' && (ITEM_RARITIES as string[]).includes(value);
+}
+
+function isDensityCategory(value: unknown): value is DensityCategory {
+  return typeof value === 'string' && (ITEM_DENSITY_CATEGORIES as string[]).includes(value);
+}
+
+function optionalRecord<T>(value: unknown): { present: false } | { present: true; value: T } {
+  const record = asRecord(value);
+  return record === null ? { present: false } : { present: true, value: record as T };
+}
+
+function optionalText(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+/**
+ * Reads a stored item, normalising rather than refusing wherever it honestly can.
+ *
+ * Four fields are load-bearing and are checked as such — an item with no `name`, no
+ * `itemMajorType`, no `description` or a non-numeric `value` is not an item, and every reader here
+ * would print `undefined` at it. Everything else degrades:
+ *
+ * - **An unrecognised rarity or density becomes the default.** This is the discipline
+ *   `docs/workshop.md` asks of a project's genre for the same reason: a payload written by a build
+ *   with a sixth rarity should lose the field, not the item.
+ * - **`properties` that is not a list of strings becomes an empty list.** A badge row is not worth
+ *   an artifact for.
+ * - **The four composition records are kept if they are objects and dropped if they are not.**
+ *   Their own fields are not policed: they are what was applied at generation time, the editor
+ *   writes them back verbatim, and a stricter check here would reject an item over a multiplier
+ *   nothing reads.
+ *
+ * An empty `name` is accepted, because a user who has cleared it on the way to writing their own
+ * has made an editing decision — 3.3 asks for a well-defined empty result, not a refusal.
+ */
+export function validateItemSnapshot(payload: unknown): PayloadResult<ItemSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'Item payload is not an object');
+  }
+
+  for (const field of ['id', 'name', 'itemMajorType', 'description'] as const) {
+    if (typeof record[field] !== 'string') {
+      return rejectedPayload('invalid-payload', `Item payload has no usable ${field}`);
+    }
+  }
+  for (const field of ['value', 'weight'] as const) {
+    if (typeof record[field] !== 'number' || !Number.isFinite(record[field])) {
+      return rejectedPayload('invalid-payload', `Item payload has no usable ${field}`);
+    }
+  }
+
+  const material = optionalRecord<ItemSnapshot['material']>(record.material);
+  const refinement = optionalRecord<ItemSnapshot['refinement']>(record.refinement);
+  const enchantment = optionalRecord<ItemSnapshot['enchantment']>(record.enchantment);
+  const decoration = optionalRecord<ItemSnapshot['decoration']>(record.decoration);
+  const combatProfile = optionalRecord<ItemSnapshot['combatProfile']>(record.combatProfile);
+  const uniqueName = optionalText(record.uniqueName);
+  const itemMinorType = optionalText(record.itemMinorType);
+
+  return acceptedPayload({
+    id: record.id as string,
+    name: record.name as string,
+    ...(uniqueName === undefined ? {} : { uniqueName }),
+    itemMajorType: record.itemMajorType as string,
+    ...(itemMinorType === undefined ? {} : { itemMinorType }),
+    description: record.description as string,
+    value: record.value as number,
+    rarity: isRarity(record.rarity) ? record.rarity : DEFAULT_ITEM_RARITY,
+    densityCategory: isDensityCategory(record.densityCategory)
+      ? record.densityCategory
+      : DEFAULT_ITEM_DENSITY,
+    weight: record.weight as number,
+    properties: isStringArray(record.properties) ? record.properties : [],
+    ...(combatProfile.present ? { combatProfile: combatProfile.value } : {}),
+    ...(Array.isArray(record.actions)
+      ? { actions: record.actions as ItemSnapshot['actions'] }
+      : {}),
+    ...(material.present ? { material: material.value } : {}),
+    ...(refinement.present ? { refinement: refinement.value } : {}),
+    ...(enchantment.present ? { enchantment: enchantment.value } : {}),
+    ...(decoration.present ? { decoration: decoration.value } : {}),
+  } as ItemSnapshot);
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day
+ * the shape changes — a kind without one looks complete right up until it silently drops someone's
+ * work, and local-only means there is no server-side migration to fall back on.
+ */
+export function migrateItemSnapshot(_payload: unknown, from: number): PayloadResult<ItemSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Items have no migration from payload version ${from}; version ${ITEM_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/**
+ * What to call a saved item: its unique name if it has one, else its name.
+ *
+ * 3.5 carries unusual weight for this kind, and `docs/readiness-objects.md` says why: users
+ * accumulate many small artifacts of it, and an unnamed item in a list of forty is unusable. The
+ * save dialog prefills from here, so an enchanted sword arrives in the vault already called
+ * whatever the generator named it.
+ */
+export function itemName(snapshot: ItemSnapshot): string {
+  const unique = (snapshot.uniqueName ?? '').trim();
+  if (unique !== '') {
+    return unique;
+  }
+  const name = snapshot.name.trim();
+  return name === '' ? 'Item' : name;
+}
+
+/**
+ * An item as an artifact.
+ *
+ * The codec is a dynamic import for consistency with every other kind rather than for weight:
+ * reading an item resolves nothing, because a stored one already holds everything it is.
+ */
+export const itemArtifactKind = defineArtifactKind<ItemSnapshot, ItemSnapshot>({
+  kind: ITEM_ARTIFACT_KIND,
+  displayName: 'Item',
+  icon: sword,
+  payloadVersion: ITEM_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { toItemSnapshot, itemFromSnapshotWithRng } = await import('./item_snapshot.js');
+    return {
+      toSnapshot: toItemSnapshot,
+      fromSnapshot: itemFromSnapshotWithRng,
+    };
+  },
+  nameOf: itemName,
+  validate: validateItemSnapshot,
+  migrate: migrateItemSnapshot,
+});

--- a/src/lib/equipment/item_editing.test.ts
+++ b/src/lib/equipment/item_editing.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ITEM_COMPOSITION_PARTS,
+  describeItem,
+  itemBaseDescription,
+  itemPartDescription,
+  itemPartName,
+  itemPropertiesLine,
+  removeItemPart,
+  setItemDensity,
+  setItemNumber,
+  setItemPartField,
+  setItemProperties,
+  setItemRarity,
+  setItemText,
+} from './item_editing';
+import { defaultEquipmentGeneratorConfig, rollItem } from './item_roll';
+import { toItemSnapshot, type ItemSnapshot } from './item_snapshot';
+
+const CONFIG = defaultEquipmentGeneratorConfig();
+
+/** A rolled item carrying all four composition parts. */
+function composed(): ItemSnapshot {
+  for (let attempt = 0; attempt < 400; attempt++) {
+    const item = toItemSnapshot(rollItem(`compose-${attempt}`, CONFIG));
+    if (ITEM_COMPOSITION_PARTS.every((part) => item[part] !== undefined)) {
+      return item;
+    }
+  }
+  throw new Error('no seed in 400 produced an item with all four parts');
+}
+
+const ITEM = composed();
+
+describe('setItemText', () => {
+  it('changes one field and nothing else', () => {
+    const edited = setItemText(ITEM, 'name', 'Sting');
+
+    expect(edited.name).toBe('Sting');
+    expect(edited.value).toBe(ITEM.value);
+    expect(ITEM.name).not.toBe('Sting');
+  });
+
+  it('removes an optional name rather than storing it blank', () => {
+    // A cleared unique name reverts the item to being called what it is, not to being called
+    // nothing — which is also what `itemName` and the save dialog read.
+    const named = setItemText(ITEM, 'uniqueName', 'Bitterlight');
+    expect(named.uniqueName).toBe('Bitterlight');
+    expect('uniqueName' in setItemText(named, 'uniqueName', '   ')).toBe(false);
+    expect('itemMinorType' in setItemText(ITEM, 'itemMinorType', '')).toBe(false);
+  });
+});
+
+describe('setItemNumber', () => {
+  it('takes the number given', () => {
+    expect(setItemNumber(ITEM, 'value', 1234).value).toBe(1234);
+    expect(setItemNumber(ITEM, 'weight', 2.5).weight).toBe(2.5);
+  });
+
+  it('floors a cleared, negative or non-finite field at zero', () => {
+    // A number input binds to `NaN` when it is cleared.
+    expect(setItemNumber(ITEM, 'value', Number.NaN).value).toBe(0);
+    expect(setItemNumber(ITEM, 'weight', -3).weight).toBe(0);
+  });
+});
+
+describe('setItemRarity and setItemDensity', () => {
+  it('set the field they name', () => {
+    expect(setItemRarity(ITEM, 'legendary').rarity).toBe('legendary');
+    expect(setItemDensity(ITEM, 'airy').densityCategory).toBe('airy');
+  });
+});
+
+describe('setItemProperties', () => {
+  it('reads a comma-separated line, dropping the blanks', () => {
+    expect(setItemProperties(ITEM, 'sharp, heavy ,, two-handed,').properties).toEqual([
+      'sharp',
+      'heavy',
+      'two-handed',
+    ]);
+  });
+
+  it('round-trips through the line the editor shows', () => {
+    const edited = setItemProperties(ITEM, 'sharp, heavy');
+
+    expect(itemPropertiesLine(edited)).toBe('sharp, heavy');
+    expect(setItemProperties(edited, itemPropertiesLine(edited)).properties).toEqual(
+      edited.properties,
+    );
+  });
+
+  it('empties cleanly', () => {
+    expect(setItemProperties(ITEM, '   ').properties).toEqual([]);
+  });
+});
+
+describe('the composition parts', () => {
+  it('reads a part name and description', () => {
+    expect(itemPartName(ITEM, 'material')).toBe(ITEM.material?.name);
+    expect(itemPartDescription(ITEM, 'enchantment')).toBe(ITEM.enchantment?.description);
+  });
+
+  it('reads nothing for a part the item does not have', () => {
+    const stripped = removeItemPart(ITEM, 'decoration');
+
+    expect(itemPartName(stripped, 'decoration')).toBe('');
+    expect(itemPartDescription(stripped, 'decoration')).toBe('');
+  });
+
+  it('reads no description from a material, which has none', () => {
+    expect(itemPartDescription(ITEM, 'material')).toBe('');
+  });
+
+  it('rewrites one field of one part', () => {
+    // The whole reason the records are stored rather than only the paragraph.
+    const edited = setItemPartField(ITEM, 'enchantment', 'name', 'Ashbite');
+
+    expect(edited.enchantment?.name).toBe('Ashbite');
+    expect(edited.enchantment?.magnitude).toBe(ITEM.enchantment?.magnitude);
+    expect(edited.material).toEqual(ITEM.material);
+  });
+
+  it('does nothing to a part the item does not have', () => {
+    const stripped = removeItemPart(ITEM, 'refinement');
+
+    expect(setItemPartField(stripped, 'refinement', 'name', 'invented')).toBe(stripped);
+  });
+
+  it('does not give a material a description it has no field for', () => {
+    expect(setItemPartField(ITEM, 'material', 'description', 'shiny')).toBe(ITEM);
+  });
+
+  it('removes a part, leaving the numbers it contributed where they are', () => {
+    // 4.2: the value is the item's now, and removing a decoration is not a request to reprice it.
+    const stripped = removeItemPart(ITEM, 'decoration');
+
+    expect('decoration' in stripped).toBe(false);
+    expect(stripped.value).toBe(ITEM.value);
+    expect(stripped.weight).toBe(ITEM.weight);
+  });
+
+  it('returns the same object when there is nothing to remove', () => {
+    const stripped = removeItemPart(ITEM, 'decoration');
+
+    expect(removeItemPart(stripped, 'decoration')).toBe(stripped);
+  });
+});
+
+describe('itemBaseDescription', () => {
+  it('recovers the type sentence the composition was written over', () => {
+    const base = itemBaseDescription(ITEM);
+
+    expect(base).not.toBe('');
+    expect(ITEM.description).toContain(base);
+  });
+
+  it('yields nothing for a type this build does not have', () => {
+    expect(itemBaseDescription({ ...ITEM, itemMinorType: 'plasma glaive' })).toBe('');
+    expect(itemBaseDescription({ ...ITEM, itemMinorType: undefined })).toBe('');
+  });
+});
+
+describe('describeItem', () => {
+  it('rebuilds the generated wording rather than nesting the stored paragraph', () => {
+    // `generateItem` writes the composed paragraph back over the field it composed *from*, so
+    // re-running the composer on a stored item would embed the whole paragraph inside itself.
+    const rewritten = describeItem(ITEM);
+
+    expect(rewritten).toBe(ITEM.description);
+    expect(describeItem({ ...ITEM, description: rewritten })).toBe(rewritten);
+  });
+
+  it('follows an edited part, which is what makes the button worth having', () => {
+    const edited = setItemPartField(ITEM, 'enchantment', 'description', 'It hums in the cold.');
+
+    expect(describeItem(edited)).toContain('It hums in the cold.');
+  });
+
+  it('is never applied on its own', () => {
+    // The guard 4.2 asks for: every setter here leaves the description alone.
+    const edited = setItemPartField(ITEM, 'refinement', 'name', 'master-forged');
+
+    expect(edited.description).toBe(ITEM.description);
+  });
+});

--- a/src/lib/equipment/item_editing.ts
+++ b/src/lib/equipment/item_editing.ts
@@ -1,0 +1,183 @@
+/**
+ * Editing a saved item, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction, and it is what lets the editing
+ * framework compare what is on screen against what was read to decide whether anything needs
+ * saving.
+ *
+ * **Nothing here recomputes anything.** Two temptations, both refused for the reason 4.2 gives:
+ *
+ * - `generateDescription` in `descriptor.ts` builds the paragraph out of the name, the refinement,
+ *   the decoration and the enchantment, so a form that re-ran it on every change would throw away
+ *   a hand-written description on the next keystroke elsewhere. It is offered as a button instead,
+ *   the shape the drug editor and the DCC sheet both use.
+ * - **Changing the material does not recompute the value or the weight.** `applyMaterial`
+ *   multiplies both, and re-running it here would be arithmetic on numbers the user may have set
+ *   deliberately — a legendary blade priced by hand is not a bug to correct. The three are fields
+ *   of their own and each is edited directly.
+ *
+ * **A composition part is edited, not re-picked.** Dropping a whole `Refinement` in from the table
+ * would overwrite the description a user rewrote and the multipliers already baked into the item.
+ * What the editor changes is the part's name and description, which are the two fields the sheet
+ * shows; removing the part entirely is the other operation, and it is explicit.
+ */
+
+import { armorTypes } from './armor.js';
+import { generateDescription } from './descriptor.js';
+import type { ItemSnapshot } from './item_snapshot.js';
+import type { DensityCategory, Rarity } from './equipment_types';
+import { weaponTypes } from './weapons.js';
+
+/** The item's own text fields, all of which a user may rewrite. */
+export type ItemTextField = 'name' | 'uniqueName' | 'itemMinorType' | 'description';
+
+/** The item's own numeric fields. */
+export type ItemNumberField = 'value' | 'weight';
+
+/** The four parts of an item's composition, each optional and each removable. */
+export const ITEM_COMPOSITION_PARTS = [
+  'material',
+  'refinement',
+  'enchantment',
+  'decoration',
+] as const;
+
+export type ItemCompositionPart = (typeof ITEM_COMPOSITION_PARTS)[number];
+
+export function setItemText(
+  snapshot: ItemSnapshot,
+  field: ItemTextField,
+  value: string,
+): ItemSnapshot {
+  // The two optional names are removed rather than stored empty, so a cleared unique name reverts
+  // the item to being called what it is rather than being called nothing.
+  if ((field === 'uniqueName' || field === 'itemMinorType') && value.trim() === '') {
+    const next = { ...snapshot };
+    delete next[field];
+    return next;
+  }
+  return { ...snapshot, [field]: value };
+}
+
+/** A numeric field, floored at zero: an item cannot weigh or be worth less than nothing. */
+export function setItemNumber(
+  snapshot: ItemSnapshot,
+  field: ItemNumberField,
+  value: number,
+): ItemSnapshot {
+  const usable = Number.isFinite(value) && value > 0 ? value : 0;
+  return { ...snapshot, [field]: usable };
+}
+
+export function setItemRarity(snapshot: ItemSnapshot, rarity: Rarity): ItemSnapshot {
+  return { ...snapshot, rarity };
+}
+
+export function setItemDensity(
+  snapshot: ItemSnapshot,
+  densityCategory: DensityCategory,
+): ItemSnapshot {
+  return { ...snapshot, densityCategory };
+}
+
+/**
+ * The properties, as one comma-separated line.
+ *
+ * A list control for a row of short tags is more machinery than the thing it edits; the line is
+ * how a user reads them on the card, so it is how they are edited. Blank entries are dropped, which
+ * is what makes a trailing comma harmless.
+ */
+export function setItemProperties(snapshot: ItemSnapshot, line: string): ItemSnapshot {
+  return {
+    ...snapshot,
+    properties: line
+      .split(',')
+      .map((property) => property.trim())
+      .filter((property) => property !== ''),
+  };
+}
+
+/** The properties as the line the editor shows. */
+export function itemPropertiesLine(snapshot: ItemSnapshot): string {
+  return snapshot.properties.join(', ');
+}
+
+/** One part's name, or the empty string when the item has no such part. */
+export function itemPartName(snapshot: ItemSnapshot, part: ItemCompositionPart): string {
+  return snapshot[part]?.name ?? '';
+}
+
+/** One part's description, or the empty string when the item has no such part. */
+export function itemPartDescription(snapshot: ItemSnapshot, part: ItemCompositionPart): string {
+  const value = snapshot[part];
+  // A `Material` carries no description; the other three do. Reading it structurally rather than
+  // per-part keeps the editor's four rows identical.
+  return value !== undefined && 'description' in value ? (value.description ?? '') : '';
+}
+
+/**
+ * Rewrite one field of one composition part.
+ *
+ * Does nothing when the item has no such part: a form cannot name the enchantment of an unenchanted
+ * sword, and inventing an empty record here would give it one whose multipliers were never applied.
+ */
+export function setItemPartField(
+  snapshot: ItemSnapshot,
+  part: ItemCompositionPart,
+  field: 'name' | 'description',
+  value: string,
+): ItemSnapshot {
+  const current = snapshot[part];
+  if (current === undefined) {
+    return snapshot;
+  }
+  if (field === 'description' && !('description' in current)) {
+    return snapshot;
+  }
+  return { ...snapshot, [part]: { ...current, [field]: value } };
+}
+
+/**
+ * Remove a part entirely.
+ *
+ * The value and weight it contributed stay where they are, for the reason the header gives: they
+ * are the item's numbers now, and a user removing a decoration has not asked for the price to
+ * change.
+ */
+export function removeItemPart(snapshot: ItemSnapshot, part: ItemCompositionPart): ItemSnapshot {
+  if (snapshot[part] === undefined) {
+    return snapshot;
+  }
+  const next = { ...snapshot };
+  delete next[part];
+  return next;
+}
+
+/**
+ * The base type's own description, resolved from the stored type name.
+ *
+ * `generateDescription` opens with the *base* item's description and appends the composition's
+ * three sentences to it — and `generateItem` then writes the result back over that same field. So a
+ * stored item's `description` is the composed paragraph, and re-running the composer on it would
+ * nest the whole paragraph inside itself. The base sentence is recovered from the table instead,
+ * which is what `itemMinorType` is: the type's name. A type this build no longer has yields
+ * nothing, and the rewrite is the composition without its opening line rather than a refusal.
+ */
+export function itemBaseDescription(snapshot: ItemSnapshot): string {
+  const name = snapshot.itemMinorType;
+  if (name === undefined) {
+    return '';
+  }
+  const table = snapshot.itemMajorType === 'armor' ? armorTypes : weaponTypes;
+  return table.find((type) => type.name === name)?.description ?? '';
+}
+
+/**
+ * The description the generator would write for this item as it now stands.
+ *
+ * Offered rather than applied, and never called automatically. See the header.
+ */
+export function describeItem(snapshot: ItemSnapshot): string {
+  return generateDescription({ ...snapshot, description: itemBaseDescription(snapshot) });
+}

--- a/src/lib/equipment/item_presentation.test.ts
+++ b/src/lib/equipment/item_presentation.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+
+import { removeItemPart, setItemProperties, setItemText } from './item_editing';
+import {
+  itemDisplayName,
+  itemFileStem,
+  itemListToMarkdown,
+  itemListToText,
+  itemToDocument,
+  itemToMarkdown,
+  itemToText,
+} from './item_presentation';
+import { defaultEquipmentGeneratorConfig, rollItem, rollItems } from './item_roll';
+import { toItemSnapshot, type ItemSnapshot } from './item_snapshot';
+
+const CONFIG = defaultEquipmentGeneratorConfig();
+
+const WEAPON = toItemSnapshot(rollItem('weapon-seed', { ...CONFIG, itemMajorType: 'weapon' }));
+const ARMOR = toItemSnapshot(rollItem('armor-seed', { ...CONFIG, itemMajorType: 'armor' }));
+
+function labels(item: ItemSnapshot, system: 'dnd5e' | 'ironarachne' = 'dnd5e'): string[] {
+  return itemToDocument(item, system).lines.map((line) => line.label);
+}
+
+describe('itemDisplayName', () => {
+  it('prefers the unique name and falls back twice', () => {
+    expect(itemDisplayName({ name: 'longsword', uniqueName: 'Bitterlight' })).toBe('Bitterlight');
+    expect(itemDisplayName({ name: 'longsword', uniqueName: '  ' })).toBe('longsword');
+    expect(itemDisplayName({ name: '', uniqueName: undefined })).toBe('Item');
+  });
+});
+
+describe('itemToDocument', () => {
+  it('names the composition rather than only describing it', () => {
+    // The card showed a sentence saying a blade was finely balanced and never said the refinement
+    // was called anything. Storing the records is what makes these lines possible.
+    const composed = itemToDocument({
+      ...WEAPON,
+      material: { ...(WEAPON.material ?? ({} as never)), name: 'meteoric iron' },
+      refinement: { name: 'master-forged', description: 'It is beautifully made.' },
+    });
+
+    expect(composed.lines).toContainEqual({ label: 'Material', value: 'meteoric iron' });
+    expect(composed.lines).toContainEqual({ label: 'Refinement', value: 'master-forged' });
+  });
+
+  it('quotes a weapon damage and an armour class', () => {
+    expect(labels(WEAPON)).toContain('Damage');
+    expect(labels(ARMOR)).toContain('Armour class');
+  });
+
+  it('changes only how the numbers read when the display system changes', () => {
+    // The reason the display system is not part of the roll: both describe the same item.
+    expect(labels(ARMOR, 'ironarachne')).toContain('Defence');
+    expect(labels(ARMOR, 'ironarachne')).not.toContain('Armour class');
+    expect(itemToDocument(ARMOR, 'dnd5e').title).toBe(itemToDocument(ARMOR, 'ironarachne').title);
+  });
+
+  it('drops every line whose field is empty', () => {
+    // 6.4, line by line: an edited item can be empty in a dozen places.
+    const stripped = ['material', 'refinement', 'enchantment', 'decoration'].reduce(
+      (item, part) => removeItemPart(item, part as 'material'),
+      WEAPON,
+    );
+
+    expect(labels(stripped)).not.toContain('Material');
+    expect(labels(stripped)).not.toContain('Enchantment');
+    expect(labels(stripped)).toContain('Value');
+  });
+
+  it('drops empty properties', () => {
+    expect(itemToDocument(setItemProperties(WEAPON, '  ,  ')).properties).toEqual([]);
+  });
+});
+
+describe('itemToMarkdown', () => {
+  it('heads the sheet with the item name and lists what it is', () => {
+    const markdown = itemToMarkdown(WEAPON);
+
+    expect(markdown.startsWith(`# ${itemDisplayName(WEAPON)}\n\n`)).toBe(true);
+    expect(markdown).toContain('- Value: ');
+    expect(markdown).toContain('- Damage: ');
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('exports an item emptied of everything as its name and the three facts left', () => {
+    // 6.4. What survives is what is always true of an item — what it is, how rare, how heavy — and
+    // a value written out rather than dropped, which is the fault #65 found in the price lists.
+    const bare: ItemSnapshot = {
+      id: 'x',
+      name: 'thing',
+      itemMajorType: 'misc',
+      description: '',
+      value: 0,
+      rarity: 'common',
+      densityCategory: 'standard',
+      weight: 0,
+      properties: [],
+    };
+
+    expect(itemToMarkdown(bare)).toBe(
+      '# thing\n\n- Type: misc\n- Rarity: common\n- Value: 0 cp\n- Weight: 0.0 lbs\n',
+    );
+  });
+
+  it('has no run of blank lines anywhere in it', () => {
+    expect(itemToMarkdown(WEAPON)).not.toMatch(/\n\s*\n\s*\n/);
+  });
+});
+
+describe('itemToText', () => {
+  it('writes the same sheet without the title the PDF draws itself', () => {
+    const text = itemToText(WEAPON);
+
+    expect(text).not.toContain(`# ${itemDisplayName(WEAPON)}`);
+    expect(text).toContain('Value: ');
+    expect(text.endsWith('\n')).toBe(false);
+  });
+
+  it('is empty for an item with nothing left to say', () => {
+    const bare = setItemProperties(setItemText({ ...WEAPON, value: 0 }, 'description', ''), '');
+
+    // The lines survive — a value and a weight are always printable — so this checks the shape
+    // rather than emptiness.
+    expect(itemToText(bare)).not.toMatch(/^\n/);
+  });
+});
+
+describe('itemListToMarkdown', () => {
+  it('writes one section per item under one heading', () => {
+    const items = rollItems('press', 3, CONFIG).map(toItemSnapshot);
+    const markdown = itemListToMarkdown(items);
+
+    expect(markdown.startsWith('# Equipment\n\n')).toBe(true);
+    for (const item of items) {
+      expect(markdown).toContain(`## ${itemDisplayName(item)}`);
+    }
+    expect(markdown).not.toMatch(/\n\s*\n\s*\n/);
+  });
+
+  it('writes the heading and nothing else for an empty press', () => {
+    expect(itemListToMarkdown([])).toBe('# Equipment\n');
+  });
+});
+
+describe('itemListToText', () => {
+  it('names each item above its own lines', () => {
+    const items = [WEAPON, ARMOR];
+    const text = itemListToText(items);
+
+    expect(text).toContain(itemDisplayName(WEAPON));
+    expect(text).toContain(itemDisplayName(ARMOR));
+    expect(text).not.toContain('# ');
+  });
+
+  it('is empty for an empty press', () => {
+    expect(itemListToText([])).toBe('');
+  });
+});
+
+describe('itemFileStem', () => {
+  it('reduces a name to something a filesystem takes', () => {
+    expect(itemFileStem({ name: 'longsword', uniqueName: "Bitterlight, the Wolf's Woe" })).toBe(
+      'item-bitterlight-the-wolf-s-woe',
+    );
+    expect(itemFileStem({ name: 'plate armor' })).toBe('item-plate-armor');
+  });
+
+  it('falls back for a name that reduces to nothing', () => {
+    expect(itemFileStem({ name: '???' })).toBe('item');
+    expect(itemFileStem({ name: 'Item' })).toBe('item');
+  });
+});

--- a/src/lib/equipment/item_presentation.ts
+++ b/src/lib/equipment/item_presentation.ts
@@ -1,0 +1,221 @@
+/**
+ * An item arranged for reading, and the Markdown and PDF exports written from it.
+ *
+ * This tool had no export at all, and the page showed a card that dropped half of what it had
+ * rolled: the material, refinement, enchantment and decoration were folded into one sentence and
+ * never named, so a user could see that a sword was *"finely balanced"* and not that the refinement
+ * applied was called "master-forged".
+ *
+ * 6.4 applies line by line here rather than section by section: every line is dropped when the
+ * field behind it is empty, which an edited item can be in a dozen places. What never drops is the
+ * four facts always true of an item — what it is, how rare, what it is worth and what it weighs —
+ * and a value of zero is written out rather than left blank, which is the fault #65 found in the
+ * price lists seen from the other side.
+ */
+
+import { COMMON_FANTASY, valueToString } from '$lib/currency';
+import { convertPowerToDice, convertToDnDArmorClass } from '$lib/combat_system';
+import { kgToPounds } from '$lib/measurements';
+
+import type { ItemSnapshot } from './item_snapshot';
+
+/** Which numbers the page and the exports quote. */
+export type ItemDisplaySystem = 'dnd5e' | 'ironarachne';
+
+/** One line of the sheet: a label and what it says. */
+export type ItemLine = {
+  label: string;
+  value: string;
+};
+
+/** An item arranged for reading, independent of the format it is finally written in. */
+export type ItemDocument = {
+  title: string;
+  /** The generated paragraph, or nothing when it has been emptied. */
+  description: string;
+  lines: ItemLine[];
+  /** The item's own tags, as the card shows them. */
+  properties: string[];
+};
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+/** What to head the document with: the item's unique name, else its name, else the kind. */
+export function itemDisplayName(item: Pick<ItemSnapshot, 'name' | 'uniqueName'>): string {
+  const unique = (item.uniqueName ?? '').trim();
+  if (unique !== '') {
+    return unique;
+  }
+  const name = item.name.trim();
+  return name === '' ? 'Item' : name;
+}
+
+/**
+ * An item's value, in the currency the rest of the site quotes prices in.
+ *
+ * Zero is written out rather than left to `valueToString`, which returns the empty string for it —
+ * the same 6.4 fault #65 found in the price lists, where three free items printed an empty cost. An
+ * item a user has priced at nothing has been priced; a dropped line reads as unknown.
+ */
+export function itemValueText(item: ItemSnapshot): string {
+  return item.value <= 0 ? '0 cp' : valueToString(item.value, COMMON_FANTASY);
+}
+
+/** An item's weight, in pounds, to one decimal. */
+export function itemWeightText(item: ItemSnapshot): string {
+  return `${kgToPounds(item.weight).toFixed(1)} lbs`;
+}
+
+/**
+ * The line naming an item's damage or its armour class.
+ *
+ * The one place the display system reaches: D&D quotes damage as dice and armour as a class, and
+ * this site's own numbers are the raw power and defence the combat profile carries. Both describe
+ * the same rolled item, which is why the choice is not part of the roll.
+ */
+export function itemCombatLines(item: ItemSnapshot, system: ItemDisplaySystem): ItemLine[] {
+  const lines: ItemLine[] = [];
+  const attack = item.actions?.[0];
+
+  if (attack !== undefined) {
+    const base = attack.baseDamage ?? 0;
+    const damage =
+      system === 'dnd5e'
+        ? `${convertPowerToDice(base)} (${attack.damageType})`
+        : `${base} (${attack.damageType})`;
+    lines.push({ label: 'Damage', value: damage });
+
+    for (const bonus of attack.bonusDamage ?? []) {
+      const value =
+        system === 'dnd5e'
+          ? `${convertPowerToDice(bonus.power)} (${bonus.type})`
+          : `${bonus.power} (${bonus.type})`;
+      lines.push({ label: 'Bonus damage', value });
+    }
+  }
+
+  if (item.itemMajorType === 'armor' && item.combatProfile !== undefined) {
+    lines.push(
+      system === 'dnd5e'
+        ? {
+            label: 'Armour class',
+            value: String(convertToDnDArmorClass(item.combatProfile.defense)),
+          }
+        : { label: 'Defence', value: String(item.combatProfile.defense) },
+    );
+  }
+
+  return lines;
+}
+
+/** Arrange an item for reading. */
+export function itemToDocument(
+  item: ItemSnapshot,
+  system: ItemDisplaySystem = 'dnd5e',
+): ItemDocument {
+  const lines: ItemLine[] = [
+    { label: 'Type', value: item.itemMinorType ?? item.itemMajorType },
+    { label: 'Rarity', value: item.rarity },
+    { label: 'Value', value: itemValueText(item) },
+    { label: 'Weight', value: itemWeightText(item) },
+    ...itemCombatLines(item, system),
+    // The composition, named rather than only described. This is what storing the records buys
+    // that storing the paragraph would not.
+    { label: 'Material', value: item.material?.name ?? '' },
+    { label: 'Refinement', value: item.refinement?.name ?? '' },
+    { label: 'Enchantment', value: item.enchantment?.name ?? '' },
+    { label: 'Decoration', value: item.decoration?.name ?? '' },
+  ];
+
+  return {
+    title: itemDisplayName(item),
+    description: item.description.trim(),
+    lines: lines.filter((line) => isPrintable(line.value)),
+    properties: item.properties.filter(isPrintable),
+  };
+}
+
+/** An item as Markdown, for a player who keeps their gear in their own notes. */
+export function itemToMarkdown(item: ItemSnapshot, system: ItemDisplaySystem = 'dnd5e'): string {
+  const document = itemToDocument(item, system);
+  const blocks = [`# ${document.title}`];
+
+  if (isPrintable(document.description)) {
+    blocks.push(document.description);
+  }
+  if (document.lines.length > 0) {
+    blocks.push(document.lines.map((line) => `- ${line.label}: ${line.value}`).join('\n'));
+  }
+  if (document.properties.length > 0) {
+    blocks.push(`Properties: ${document.properties.join(', ')}`);
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** The body of the PDF: the same document without the title the PDF draws itself. */
+export function itemToText(item: ItemSnapshot, system: ItemDisplaySystem = 'dnd5e'): string {
+  const document = itemToDocument(item, system);
+  const blocks: string[] = [];
+
+  if (isPrintable(document.description)) {
+    blocks.push(document.description);
+  }
+  if (document.lines.length > 0) {
+    blocks.push(document.lines.map((line) => `${line.label}: ${line.value}`).join('\n'));
+  }
+  if (document.properties.length > 0) {
+    blocks.push(`Properties: ${document.properties.join(', ')}`);
+  }
+
+  return blocks.join('\n\n');
+}
+
+/**
+ * A whole press as Markdown — the list on screen, which is what a referee stocking a table wants.
+ *
+ * Beside `itemToMarkdown` rather than instead of it: the page offers both, because a user wants
+ * either the ten items they just rolled or the one they are about to give a player.
+ */
+export function itemListToMarkdown(
+  items: ItemSnapshot[],
+  system: ItemDisplaySystem = 'dnd5e',
+): string {
+  const blocks = ['# Equipment'];
+
+  for (const item of items) {
+    const document = itemToDocument(item, system);
+    const entry = [`## ${document.title}`];
+    if (isPrintable(document.description)) {
+      entry.push(document.description);
+    }
+    if (document.lines.length > 0) {
+      entry.push(document.lines.map((line) => `- ${line.label}: ${line.value}`).join('\n'));
+    }
+    blocks.push(entry.join('\n\n'));
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** The same list as plain text, for the PDF. */
+export function itemListToText(items: ItemSnapshot[], system: ItemDisplaySystem = 'dnd5e'): string {
+  return items
+    .map((item) => {
+      const document = itemToDocument(item, system);
+      const body = itemToText(item, system);
+      return isPrintable(body) ? `${document.title}\n\n${body}` : document.title;
+    })
+    .join('\n\n');
+}
+
+/** A filename stem for an exported item, reduced to something a filesystem takes. */
+export function itemFileStem(item: Pick<ItemSnapshot, 'name' | 'uniqueName'>): string {
+  const stem = itemDisplayName(item)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' || stem === 'item' ? 'item' : `item-${stem}`;
+}

--- a/src/lib/equipment/item_roll.test.ts
+++ b/src/lib/equipment/item_roll.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ITEM_MAJOR_TYPE_CHOICES,
+  defaultEquipmentGeneratorConfig,
+  itemSeed,
+  readEquipmentGeneratorConfig,
+  rollItem,
+  rollItemSnapshot,
+  rollItems,
+  toEquipmentGenerationConfig,
+} from './item_roll';
+import { toItemSnapshot } from './item_snapshot';
+
+const CONFIG = defaultEquipmentGeneratorConfig();
+
+describe('rollItem', () => {
+  it('gives the same item for the same seed and settings', () => {
+    // Requirement 2.2. `generateItem` was already pure; what was not was the page around it.
+    expect(toItemSnapshot(rollItem('fixed', CONFIG))).toEqual(
+      toItemSnapshot(rollItem('fixed', CONFIG)),
+    );
+  });
+
+  it('gives a different item for a different seed', () => {
+    expect(toItemSnapshot(rollItem('one', CONFIG))).not.toEqual(
+      toItemSnapshot(rollItem('two', CONFIG)),
+    );
+  });
+
+  it('honours the major type', () => {
+    for (const majorType of ['weapon', 'armor'] as const) {
+      expect(rollItem('typed', { ...CONFIG, itemMajorType: majorType }).itemMajorType).toBe(
+        majorType,
+      );
+    }
+  });
+
+  it('adds no parts the settings switched off', () => {
+    const plain = rollItem('plain-seed', {
+      itemMajorType: 'any',
+      useRefine: false,
+      useEnchant: false,
+      useDecorate: false,
+    });
+
+    expect(plain.refinement).toBeUndefined();
+    expect(plain.enchantment).toBeUndefined();
+    expect(plain.decoration).toBeUndefined();
+    // The foundry always runs, so a material is not optional in practice.
+    expect(plain.material).toBeDefined();
+  });
+});
+
+describe('itemSeed', () => {
+  it('gives each item of a press its own seed', () => {
+    expect(itemSeed('press', 0)).not.toBe(itemSeed('press', 1));
+    expect(itemSeed('press', 3)).toBe('press-item-3');
+  });
+
+  it('is what a saved card re-rolls from', () => {
+    // The whole point of deriving rather than drawing: saving the third sword records a seed that
+    // rolls the third sword, not the list it arrived in.
+    const items = rollItems('press', 5, CONFIG);
+
+    for (const [index, item] of items.entries()) {
+      expect(toItemSnapshot(rollItem(itemSeed('press', index), CONFIG))).toEqual(
+        toItemSnapshot(item),
+      );
+    }
+  });
+});
+
+describe('rollItems', () => {
+  it('rolls the count asked for, from one seed', () => {
+    expect(rollItems('press', 7, CONFIG)).toHaveLength(7);
+    expect(rollItems('press', 0, CONFIG)).toEqual([]);
+  });
+
+  it('gives the same list twice for the same seed', () => {
+    expect(rollItems('press', 4, CONFIG).map(toItemSnapshot)).toEqual(
+      rollItems('press', 4, CONFIG).map(toItemSnapshot),
+    );
+  });
+});
+
+describe('rollItemSnapshot', () => {
+  it('is the roller a re-roll takes, and matches the page', () => {
+    expect(rollItemSnapshot('seed', CONFIG)).toEqual(toItemSnapshot(rollItem('seed', CONFIG)));
+  });
+});
+
+describe('readEquipmentGeneratorConfig', () => {
+  it('reads back what the page wrote', () => {
+    const written = {
+      itemMajorType: 'armor',
+      useRefine: false,
+      useEnchant: true,
+      useDecorate: false,
+    };
+
+    expect(readEquipmentGeneratorConfig(written)).toEqual(written);
+  });
+
+  it('falls back to the defaults for anything it does not recognise', () => {
+    // A config written by a build that spelled these differently should re-roll the ordinary way
+    // rather than from a field it misread.
+    expect(readEquipmentGeneratorConfig({})).toEqual(CONFIG);
+    expect(readEquipmentGeneratorConfig({ itemMajorType: 'trebuchet' }).itemMajorType).toBe('any');
+    expect(readEquipmentGeneratorConfig({ useRefine: 'yes' }).useRefine).toBe(true);
+  });
+
+  it('accepts every major type the page offers', () => {
+    for (const itemMajorType of ITEM_MAJOR_TYPE_CHOICES) {
+      expect(readEquipmentGeneratorConfig({ itemMajorType }).itemMajorType).toBe(itemMajorType);
+    }
+  });
+});
+
+describe('toEquipmentGenerationConfig', () => {
+  it('carries the four settings onto the library config', () => {
+    const full = toEquipmentGenerationConfig({
+      itemMajorType: 'weapon',
+      useRefine: false,
+      useEnchant: false,
+      useDecorate: true,
+    });
+
+    expect(full.itemMajorType).toBe('weapon');
+    expect(full.useRefine).toBe(false);
+    expect(full.useEnchant).toBe(false);
+    expect(full.useDecorate).toBe(true);
+    // The tables come from the library, not from the page.
+    expect(full.materials.length).toBeGreaterThan(0);
+    expect(full.enchantments.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/equipment/item_roll.ts
+++ b/src/lib/equipment/item_roll.ts
@@ -1,0 +1,130 @@
+/**
+ * The single path from a seed to an item, and the record of how it was rolled.
+ *
+ * `generateItem` was already a pure function of seed and config — this library is the rare one in
+ * the pass where requirement 2.2 was met by the generator and broken only by the page around it.
+ * `EquipmentGenerator.svelte` drew each new seed from `new RNG(Date.now())` and, worse, called
+ * `rng.setSeed(seed)` inside an `$effect`, so typing in the seed field reseeded the page's own
+ * stream: the next press produced a seed that depended on the previous one's text. Pressing
+ * Generate draws a fresh seed from the page's RNG now, and the roll is this function.
+ *
+ * **A page press rolls a list; an artifact is one item.** The kind is `item` and each card is
+ * saved on its own, so each needs a seed that reproduces *that* item rather than the list it came
+ * in. `itemSeed` is the derivation, and it is public because the page and a re-roll both need to
+ * agree on it.
+ *
+ * `getDefaultGenerationConfig` does not read the clock, contrary to the blanket note in
+ * `docs/tool-readiness.md` about fifteen `getDefault*Config` helpers. It builds four tables from
+ * module constants and takes no RNG at all.
+ */
+
+import { generateItem, getDefaultGenerationConfig } from './generation.js';
+import type { EquipmentGenerationConfig } from './generation.js';
+import { toItemSnapshot, type ItemSnapshot, type RolledItem } from './item_snapshot.js';
+
+/** What the item generator's major-type control offers. */
+export const ITEM_MAJOR_TYPE_CHOICES = ['any', 'weapon', 'armor'] as const;
+
+export type ItemMajorTypeChoice = (typeof ITEM_MAJOR_TYPE_CHOICES)[number];
+
+/**
+ * What the generator records about how it rolled, and what a re-roll reads back.
+ *
+ * Stated as a type so the two ends — what is written as provenance and what a re-roll expects to
+ * find — are in one place and drift loudly instead of quietly. It is the page's four controls
+ * that change the item, and not the fifth: the display system chooses between D&D dice and this
+ * site's own numbers for the *same* rolled item, so it is a reading preference rather than part of
+ * the roll.
+ */
+export type EquipmentGeneratorConfigRecord = {
+  itemMajorType: ItemMajorTypeChoice;
+  useRefine: boolean;
+  useEnchant: boolean;
+  useDecorate: boolean;
+};
+
+/** The settings a page opens on, and what an unreadable provenance record falls back to. */
+export function defaultEquipmentGeneratorConfig(): EquipmentGeneratorConfigRecord {
+  return { itemMajorType: 'any', useRefine: true, useEnchant: true, useDecorate: true };
+}
+
+function isMajorTypeChoice(value: unknown): value is ItemMajorTypeChoice {
+  return (
+    typeof value === 'string' && (ITEM_MAJOR_TYPE_CHOICES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Anything unrecognisable falls back to the default rather than being coerced: a config written by
+ * a build that spelled these differently should re-roll the ordinary way, not from a field it
+ * misread.
+ */
+export function readEquipmentGeneratorConfig(
+  config: Record<string, unknown>,
+): EquipmentGeneratorConfigRecord {
+  const defaults = defaultEquipmentGeneratorConfig();
+  return {
+    itemMajorType: isMajorTypeChoice(config.itemMajorType)
+      ? config.itemMajorType
+      : defaults.itemMajorType,
+    useRefine: typeof config.useRefine === 'boolean' ? config.useRefine : defaults.useRefine,
+    useEnchant: typeof config.useEnchant === 'boolean' ? config.useEnchant : defaults.useEnchant,
+    useDecorate:
+      typeof config.useDecorate === 'boolean' ? config.useDecorate : defaults.useDecorate,
+  };
+}
+
+/** The settings as the whole generation config the library's own roller takes. */
+export function toEquipmentGenerationConfig(
+  config: EquipmentGeneratorConfigRecord,
+): EquipmentGenerationConfig {
+  const full = getDefaultGenerationConfig();
+  full.itemMajorType = config.itemMajorType;
+  full.useRefine = config.useRefine;
+  full.useEnchant = config.useEnchant;
+  full.useDecorate = config.useDecorate;
+  return full;
+}
+
+/**
+ * The seed of the nth item of a press.
+ *
+ * One press produces a list from one seed, and each item needs its own so that saving the third
+ * sword records a seed that rolls the third sword. Derived rather than drawn, so the whole list is
+ * still a pure function of the one seed the user sees.
+ */
+export function itemSeed(seed: string, index: number): string {
+  return `${seed}-item-${index}`;
+}
+
+/** Roll one item — the one path the generator page and a re-roll both take. */
+export function rollItem(seed: string, config: EquipmentGeneratorConfigRecord): RolledItem {
+  return generateItem(seed, toEquipmentGenerationConfig(config));
+}
+
+/**
+ * Roll a fresh item as a snapshot — the destructive half of editing (requirement 4.3), and what
+ * `ARTIFACT_EDITORS` registers as this kind's roller.
+ */
+export function rollItemSnapshot(
+  seed: string,
+  config: EquipmentGeneratorConfigRecord,
+): ItemSnapshot {
+  return toItemSnapshot(rollItem(seed, config));
+}
+
+/** One press: `count` items, each from its own derived seed. */
+export function rollItems(
+  seed: string,
+  count: number,
+  config: EquipmentGeneratorConfigRecord,
+): RolledItem[] {
+  const generationConfig = toEquipmentGenerationConfig(config);
+  const items: RolledItem[] = [];
+  for (let index = 0; index < count; index++) {
+    items.push(generateItem(itemSeed(seed, index), generationConfig));
+  }
+  return items;
+}

--- a/src/lib/equipment/item_snapshot.test.ts
+++ b/src/lib/equipment/item_snapshot.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollItem } from './item_roll';
+import { itemFromSnapshot, toItemSnapshot, type ItemSnapshot } from './item_snapshot';
+
+const CONFIG = {
+  itemMajorType: 'any' as const,
+  useRefine: true,
+  useEnchant: true,
+  useDecorate: true,
+};
+
+/** A seed that rolls an item carrying all four composition parts, found by trying seeds. */
+function rollComposed(): ItemSnapshot {
+  for (let attempt = 0; attempt < 400; attempt++) {
+    const item = toItemSnapshot(rollItem(`compose-${attempt}`, CONFIG));
+    if (
+      item.material !== undefined &&
+      item.refinement !== undefined &&
+      item.enchantment !== undefined &&
+      item.decoration !== undefined
+    ) {
+      return item;
+    }
+  }
+  throw new Error('no seed in 400 produced an item with all four parts');
+}
+
+describe('toItemSnapshot', () => {
+  it('keeps the composition rather than only the description', () => {
+    // The requirement #66 states outright: an item's parts are composed at generation time, and
+    // storing only the rendered paragraph would leave an editor able to rewrite prose and nothing
+    // else.
+    const item = rollComposed();
+
+    expect(item.material?.name).toBeTypeOf('string');
+    expect(item.refinement?.name).toBeTypeOf('string');
+    expect(item.enchantment?.name).toBeTypeOf('string');
+    expect(item.decoration?.name).toBeTypeOf('string');
+  });
+
+  it('keeps a weapon attack list, which lives on the weapon rather than on the item', () => {
+    const weapon = toItemSnapshot(rollItem('weapon-seed', { ...CONFIG, itemMajorType: 'weapon' }));
+
+    expect(weapon.itemMajorType).toBe('weapon');
+    expect(weapon.actions?.length).toBeGreaterThan(0);
+    expect(weapon.actions?.[0].damageType).toBeTypeOf('string');
+  });
+
+  it('keeps the combat profile armour carries', () => {
+    const armor = toItemSnapshot(rollItem('armor-seed', { ...CONFIG, itemMajorType: 'armor' }));
+
+    expect(armor.itemMajorType).toBe('armor');
+    expect(armor.combatProfile?.defense).toBeTypeOf('number');
+  });
+
+  it('drops what generation used and the item is not', () => {
+    // `allowedMaterialTypes` is the base type's list of what the generator could draw from, and it
+    // is on every rolled weapon. It is an input, not a fact about the sword.
+    const rolled = rollItem('weapon-seed', { ...CONFIG, itemMajorType: 'weapon' });
+    expect(rolled.allowedMaterialTypes).toBeDefined();
+
+    expect('allowedMaterialTypes' in toItemSnapshot(rolled)).toBe(false);
+    expect('weaponType' in toItemSnapshot(rolled)).toBe(false);
+  });
+
+  it('omits an absent optional rather than storing it undefined', () => {
+    // A key holding `undefined` survives a structured clone as a key holding `undefined`, which
+    // then reads back as a present-but-empty part.
+    const plain = toItemSnapshot(rollItem('plain', { ...CONFIG, useEnchant: false }));
+
+    if (plain.enchantment === undefined) {
+      expect('enchantment' in plain).toBe(false);
+    }
+  });
+});
+
+describe('itemFromSnapshot', () => {
+  it('round-trips everything that matters', () => {
+    // Requirement 7.2.
+    const item = rollComposed();
+
+    expect(itemFromSnapshot(item)).toEqual(item);
+    expect(itemFromSnapshot(itemFromSnapshot(item))).toEqual(item);
+  });
+
+  it('round-trips a weapon and armour, attacks and profile included', () => {
+    for (const majorType of ['weapon', 'armor'] as const) {
+      const item = toItemSnapshot(
+        rollItem(`round-${majorType}`, { ...CONFIG, itemMajorType: majorType }),
+      );
+      expect(itemFromSnapshot(item), majorType).toEqual(item);
+    }
+  });
+
+  it('survives a trip through JSON, which is what storage is', () => {
+    const item = rollComposed();
+
+    expect(itemFromSnapshot(JSON.parse(JSON.stringify(item)))).toEqual(item);
+  });
+
+  it('copies deeply enough that an editor cannot reach the stored record', () => {
+    const item = rollComposed();
+    const read = itemFromSnapshot(item);
+
+    read.properties.push('tampered');
+    if (read.material !== undefined) {
+      (read.material as { name: string }).name = 'tampered';
+    }
+
+    expect(item.properties).not.toContain('tampered');
+    expect(item.material?.name).not.toBe('tampered');
+  });
+
+  it('recomputes nothing on read', () => {
+    // Requirement 4.2: a value the user set by hand is the item's value, not an input to a
+    // multiplication that runs again every time the artifact is opened.
+    const edited: ItemSnapshot = { ...rollComposed(), value: 1, weight: 0.5 };
+
+    expect(itemFromSnapshot(edited).value).toBe(1);
+    expect(itemFromSnapshot(edited).weight).toBe(0.5);
+  });
+});

--- a/src/lib/equipment/item_snapshot.ts
+++ b/src/lib/equipment/item_snapshot.ts
@@ -1,0 +1,142 @@
+/**
+ * Writing an item for storage, and reading one back.
+ *
+ * **The composition is stored, not just the prose.** #66 asks for this explicitly and
+ * `docs/readiness-objects.md` settles it: an item's material, refinement, enchantment and
+ * decoration are composed at generation time, and `generateDescription` folds all four into one
+ * paragraph. Storing only the paragraph would leave an editor able to rewrite prose and nothing
+ * else — a user could not change what an item is made of, only what it says it is made of.
+ *
+ * That is a departure from the treatment the pass gives species, archetypes and drug types, which
+ * are stored by name and resolved on read. The reason it is right here and wrong there: those are
+ * table rows a payload *refers* to, where an item's four parts have already been **applied** — the
+ * material's multipliers are baked into the weight and the value, the enchantment's bonus damage
+ * into the combat profile. The record is what was applied, which a name could not tell you after
+ * the table changed, and it is a decision the user may edit.
+ *
+ * **What is not stored, and why.** `allowedMaterialTypes` is the base type's list of materials the
+ * generator was allowed to draw from, `manualVolume` is unset by every path that makes an item, and
+ * `containerId` belongs to a container that is not part of this artifact. All three are inputs to
+ * generation or to something else's bookkeeping rather than facts about the item a user keeps.
+ *
+ * **`weaponType` and `armorType` are not stored either**, and this is the one place the name
+ * treatment does apply: everything the page shows from them is already a field of its own —
+ * `itemMinorType` is the type's name, the armour's defence is in the combat profile, and the
+ * weapon's attacks are in `actions`. Keeping the row whole would copy a table into every sword.
+ */
+
+import type {
+  CombatAction,
+  CombatProfile,
+  DamageType as CombatDamageType,
+} from '$lib/combat_system';
+
+import type {
+  DensityCategory,
+  Decoration,
+  Enchantment,
+  Item,
+  Material,
+  Rarity,
+  Refinement,
+} from './equipment_types';
+
+/**
+ * An item as the generator hands it over.
+ *
+ * `generateItem` returns an `Item`, a `Weapon` or an `Armor`, and only the weapon carries
+ * `actions`. Naming that here is what lets `toItemSnapshot` read the attacks without a cast at
+ * every call site.
+ */
+export type RolledItem = Item & { actions?: CombatAction[] };
+
+/**
+ * An item as it is stored.
+ *
+ * The live shape minus what generation used to build it. It is also the shape the editor and the
+ * presentation both work in, so a saved item and a rolled one are read by the same code.
+ */
+export type ItemSnapshot = {
+  id: string;
+  name: string;
+  uniqueName?: string;
+  itemMajorType: string;
+  itemMinorType?: string;
+  description: string;
+  value: number;
+  rarity: Rarity;
+  densityCategory: DensityCategory;
+  weight: number;
+  properties: string[];
+  combatProfile?: CombatProfile;
+  /** A weapon's attacks. Absent on armour and on anything else. */
+  actions?: CombatAction[];
+  material?: Material;
+  refinement?: Refinement;
+  enchantment?: Enchantment;
+  decoration?: Decoration;
+};
+
+/** Every rarity, in ascending order, for a validator and for an editor's select. */
+export const ITEM_RARITIES: Rarity[] = ['common', 'uncommon', 'rare', 'epic', 'legendary'];
+
+/** Every density category, for the same two readers. */
+export const ITEM_DENSITY_CATEGORIES: DensityCategory[] = ['dense', 'standard', 'bulky', 'airy'];
+
+/** What an item with no rarity is read as. */
+export const DEFAULT_ITEM_RARITY: Rarity = 'common';
+
+/** What an item with no density is read as. */
+export const DEFAULT_ITEM_DENSITY: DensityCategory = 'standard';
+
+export function toItemSnapshot(item: RolledItem): ItemSnapshot {
+  return {
+    id: item.id,
+    name: item.name,
+    ...(item.uniqueName === undefined ? {} : { uniqueName: item.uniqueName }),
+    itemMajorType: item.itemMajorType,
+    ...(item.itemMinorType === undefined ? {} : { itemMinorType: item.itemMinorType }),
+    description: item.description,
+    value: item.value,
+    rarity: item.rarity,
+    densityCategory: item.densityCategory,
+    weight: item.weight,
+    properties: [...item.properties],
+    ...(item.combatProfile === undefined ? {} : { combatProfile: { ...item.combatProfile } }),
+    ...(item.actions === undefined ? {} : { actions: item.actions.map(copyAction) }),
+    ...(item.material === undefined ? {} : { material: { ...item.material } }),
+    ...(item.refinement === undefined ? {} : { refinement: { ...item.refinement } }),
+    ...(item.enchantment === undefined ? {} : { enchantment: { ...item.enchantment } }),
+    ...(item.decoration === undefined ? {} : { decoration: { ...item.decoration } }),
+  };
+}
+
+function copyAction(action: CombatAction): CombatAction {
+  return {
+    ...action,
+    ...(action.bonusDamage === undefined
+      ? {}
+      : {
+          bonusDamage: action.bonusDamage.map((damage) => ({
+            power: damage.power,
+            type: damage.type as CombatDamageType,
+          })),
+        }),
+  };
+}
+
+/**
+ * Nothing is recomputed on read.
+ *
+ * A stored item is finished, and rebuilding its value from the material's multiplier would
+ * overwrite whatever the user changed — requirement 4.2 exactly. The copy is deep enough that an
+ * editor mutating what it was handed cannot reach back into the store's own record.
+ */
+export function itemFromSnapshot(snapshot: ItemSnapshot): ItemSnapshot {
+  return toItemSnapshot(snapshot);
+}
+
+/** The codec's reading half, with the signature the registry hands it. The RNG is unused. */
+export function itemFromSnapshotWithRng(snapshot: ItemSnapshot, _rng: unknown): ItemSnapshot {
+  return itemFromSnapshot(snapshot);
+}

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -105,6 +105,13 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // the build: through the kind module the registry chunk and everything it statically imports is
   // 140.7 KB across 16 chunks, and through the entry point it is 214.8 KB across 24.
   '$lib/astronomical_bodies/planet_artifact_kind',
+  // Shared by `/fantasy/equipment-generator` and `/fantasy/weapon`, which is one kind by decision 1
+  // of docs/readiness-objects.md. `$lib/equipment`'s entry point reaches the generator and from
+  // there the weapon, armour, material, refinement, enchantment and decoration tables, the
+  // made-up-names package, and the whole twenty-three-list fantasy price list. Measured on the
+  // build: through the kind module the registry chunk and everything it statically imports is
+  // 292 KB across 31 chunks, and through the entry point it is 408 KB across 35.
+  '$lib/equipment/item_artifact_kind',
   // The eighteenth, the same library and the same reason: the star-system kind module holds
   // metadata and validation only, and its codec is a dynamic import.
   '$lib/astronomical_bodies/star_system_artifact_kind',

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -123,6 +123,7 @@ describe('TOOL_CATALOG', () => {
       '/character',
       '/fantasy/encounter',
       '/fantasy/equipment',
+      '/fantasy/equipment-generator',
       '/fantasy/family',
       '/fantasy/organization',
       '/culture',
@@ -137,6 +138,7 @@ describe('TOOL_CATALOG', () => {
       '/fantasy/adnd/character/build',
       '/species-stats',
       '/word-generator-cheat-sheet',
+      '/fantasy/equipment-generator',
     ];
 
     const claimingMore = TOOL_CATALOG.filter(
@@ -242,6 +244,7 @@ describe('toolsWithMaturity', () => {
       '/fantasy/dungeon',
       '/fantasy/encounter',
       '/fantasy/equipment',
+      '/fantasy/equipment-generator',
       '/fantasy/family',
       '/fantasy/organization',
       '/fantasy/religion',
@@ -316,6 +319,7 @@ describe('filterTools', () => {
       '/region',
       '/fantasy/settlement',
       '/fantasy/equipment',
+      '/fantasy/equipment-generator',
     ]);
   });
 

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -402,12 +402,19 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     genres: ['fantasy'],
     tags: ['equipment'],
   }),
+  // Release-ready, assessed section by section against docs/workshop.md and recorded in
+  // docs/readiness-objects.md (#66). It saves as `item` — the kind decision 1 of that document
+  // gives it and `/fantasy/weapon` to share, because two kinds for one payload shape would split a
+  // user's gear across two vault entries — has an editor in `ARTIFACT_EDITORS`, and exports
+  // Markdown and PDF, the first exports it has ever had. Its roll is deterministic from the seed
+  // via `item_roll.ts`. Nothing it takes as input has an artifact kind, so requirement 5.1 does
+  // not bind; 5.3 is met, as it always was.
   defineTool({
     path: '/fantasy/equipment-generator',
     label: 'Fantasy Equipment',
     kind: 'generator',
     domain: 'objects',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     genres: ['fantasy'],
     tags: ['equipment'],
   }),

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -235,6 +235,23 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
       return (provenance) => rollDrugSnapshot(provenance.seed);
     },
   },
+  item: {
+    loadEditor: () => import('$components/objects/ItemArtifactEditor.svelte'),
+    /**
+     * The page's four controls, read back through the roll module's own reader.
+     *
+     * One kind, two tools, and unlike the AD&D pair they re-roll the same way: `/fantasy/weapon`
+     * is this generator with the major type fixed, so its provenance is a config this reader
+     * already understands. The tool path is what tells a vault listing which made an item, not
+     * what tells a re-roll how.
+     */
+    loadRoller: async () => {
+      const { readEquipmentGeneratorConfig, rollItemSnapshot } =
+        await import('$lib/equipment/item_roll.js');
+      return (provenance) =>
+        rollItemSnapshot(provenance.seed, readEquipmentGeneratorConfig(provenance.config));
+    },
+  },
   'arms-manufacturer': {
     loadEditor: () => import('$components/factions/ArmsManufacturerArtifactEditor.svelte'),
     /**

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -33,6 +33,7 @@ describe('artifact kind catalog', () => {
       'star-system',
       'region',
       'drug',
+      'item',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -38,6 +38,13 @@ import { regionArtifactKind } from '$lib/regions/region_artifact_kind';
 // Through the entry point: `$lib/drug` is two phrase tables and a generator, with no species list
 // or image behind it. Measured the way the entries in `library_imports.test.ts` were.
 import { drugArtifactKind } from '$lib/drug';
+// Deep, and measured the way its neighbours were: `$lib/equipment`'s entry point reaches the
+// generator and from there the weapon, armour, material, refinement, enchantment and decoration
+// tables, the made-up-names package, and the whole twenty-three-list fantasy price list. Through
+// the kind module the registry chunk and everything it statically imports is 292 KB across 31
+// chunks; through the entry point it is 408 KB across 35. Every page that lists what a project
+// contains pays that difference.
+import { itemArtifactKind } from '$lib/equipment/item_artifact_kind';
 import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
 import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
 import { settlementArtifactKind } from '$lib/settlements/settlement_artifact_kind';
@@ -78,6 +85,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, starSystemArtifactKind);
   registerArtifactKind(registry, regionArtifactKind);
   registerArtifactKind(registry, drugArtifactKind);
+  registerArtifactKind(registry, itemArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Closes #66. Takes `/fantasy/equipment-generator` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the design in `docs/readiness-objects.md`. The first **generator** of the objects domain, and the tool the issue asked to settle the item-kind question for the whole domain.

## Kind `item`, shared with #69

Decision 1 of the objects document. Two kinds for one payload shape would split a user's gear across two vault entries, each openable by only one of the two tools that made it; the provenance's tool path says which rolled it. `$lib/equipment` grows the five kind modules the pass prescribes — roll, snapshot, artifact kind, editing, presentation — and #69 consumes the decision unchanged.

**The composition is stored**, which is what #66 asks for and what everything else rests on: `material`, `refinement`, `enchantment` and `decoration` are kept as the records they are rather than folded into the description, so the editor can change *what an item is made of* and not merely what it says it is made of.

## Four things the design did not anticipate

- **A press is a list; an artifact is one item.** The generator rolls ten at once, so each card carries its own save button and the seed it records is `itemSeed(pageSeed, index)`. Deriving it keeps the whole list a pure function of the one seed the user sees while still letting the third sword re-roll to the third sword. Nothing else in the pass has this shape.
- **The card showed less than it had rolled.** All four parts were folded into one sentence and never named — a user could read that a blade was *"finely balanced"* and not that the refinement was called "balanced". The card and both exports render the presentation document now.
- **`weaponType` and `armorType` are not stored**, though `Weapon` and `Armor` carry them. Everything the page shows from either is already a field of its own: `itemMinorType` is the type's name, the armour's defence is in the combat profile, and the weapon's attacks are in `actions`, which the snapshot does keep. Keeping the row whole would copy a table into every sword.
- **The description cannot be recomputed from a stored item.** `generateItem` writes the composed paragraph back over the base type's description — the field the composer builds *from* — so re-running it would nest the paragraph inside itself. `itemBaseDescription` resolves the base sentence from the type table instead, which is the one place the store-by-name treatment does apply here.

## Two bugs found on the way

Both invisible until the tool was taken seriously:

- **The page reseeded its own RNG from the seed field**, inside an `$effect`, so the next press's seed depended on the *text* of the previous one. Requirement 2.2's usual failure in a form the pass had not seen before: the generator was pure and the page was not.
- **A `$state` list of payloads cannot be saved.** Svelte's deep proxy wraps every array in the payload and IndexedDB's structured clone refuses one — `[object Array] could not be cloned`. Found by the e2e save test; the list is `$state.raw` now.

## The rest of the sections

- **6.3** — Markdown and PDF for the press, Markdown for one item. The first exports this tool has ever had.
- **6.4** — every line whose field is empty is dropped, and a value of zero is written out rather than left blank, which is the fault #65 found in the price lists seen from the other side.
- **4** — an editor in `ARTIFACT_EDITORS` covering every field the card shows plus the four composition parts, each renamable, rewritable and removable. Nothing recomputes: changing the material does not re-multiply the value, and the generated wording is an explicit button.
- **7.2–7.4** — round-trip, migration and a full generate/save/reopen/edit journey in `e2e/equipment.spec.ts`.
- **5.1** does not bind: nothing this tool takes as input has an artifact kind.

## Measurement

The deep import of the kind module is measured, as the allowlist rule requires: through it the registry chunk and everything it statically imports is **292 KB across 31 chunks**; through `$lib/equipment`'s entry point it is **408 KB across 35**. Every page that lists what a project contains pays that difference.

## Also closed

The objects document's open question about re-rolling a *similar* item. Re-roll is the same seed and config again, which for an item is the identical item — and that turns out to be exactly what requirement 4.3 describes: the command that throws away a user's edits and puts the rolled item back.

## Verification

`npm run verify` is green, and `npm run verify:all` was run before opening this: 5,765 unit tests and 592 Playwright tests, including the new `e2e/equipment.spec.ts` and the mobile pass at all five widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QEan2y9qHFJnvoM1dci8L
