### PR TITLE
Take the fantasy merchant generator to Release-ready

### DIFF
--- a/docs/readiness-objects.md
+++ b/docs/readiness-objects.md
@@ -134,6 +134,32 @@ quantity, note? }` — five fields, not a full `Item` — so a fifty-line invent
 - **6.3 matters here.** A shop inventory is a thing a GM wants on paper; the presentation document
   is the proprietor, the shop, the haggling advice and the stock table.
 
+**As built (#67).** The kind and the payload landed as designed, and the size worry the issue
+raises turned out to be as small as this section predicted: a `MerchantStockItem` is five fields,
+so a twelve-line inventory is under a kilobyte. Four things worth recording:
+
+- **The payload's `seed` and the provenance seed are the same value**, which is what this section
+  warned about. `merchantSeedMatchesProvenance` asserts it out loud and the roll module keeps it
+  true; a second seed would have been a shape where two answers to "what rolled this" can disagree.
+- **Re-rolling a merchant named from a culture would have crashed.** The provenance records the
+  culture's _pattern set name_, which is the treatment `character_roll.ts` settled — but
+  `getFantasyNameGeneratorSet` **throws** for a name it does not have, and a culture's set name is a
+  generated name, nothing like the twelve fantasy presets. `nameSourceForSet` falls back to the
+  default patterns instead, which is the discipline 3.3 asks of every other read path.
+- **5.1 binds twice, and the second half needed a generation change.** A culture for naming was
+  already reachable through `nameSource`. Where the shop _stands_ was not: `generateVenueDescription`
+  invents a location blurb — "on the market square", "beside the temple district" — and had never
+  known which town that square was in. `MerchantShop` gains an optional `settlementName`, the
+  location line reads "…​ In Ashford.", and the two answer different halves of the question rather
+  than one replacing the other. It is the first tool in the pass to compose two kinds.
+- **The town's name is the settlement's, not the vault entry's.** A settlement a user labelled
+  "starting town" is still called whatever the generator called it, so the reference reads the
+  payload's `name` rather than the artifact's.
+
+**The same two page-level faults #66 found were here too**, which is now three tools in a row: the
+page reseeded its own RNG from the seed field inside an `$effect`, and the payload had to move to
+`$state.raw` before IndexedDB would take it.
+
 ## #64 — Cyberpunk drug
 
 `Drug` is `{ name, description, drugType, method, effectType, effectDescription, strength, color,

--- a/docs/tool-readiness.md
+++ b/docs/tool-readiness.md
@@ -462,6 +462,13 @@ it found it late is exactly [decision 8](#8-a-reference-tool-with-no-logic-still
 the conversion lived in the component, where no unit test could reach it. The two remaining
 reference tools should expect the same shape of finding.
 
+**The generator pages share two faults, found three times running.** #66, #67 and every tool that
+follows should expect both: a page that reseeds its own RNG from the seed field inside an
+`$effect`, which makes each press's seed depend on the _text_ of the previous one and is
+requirement 2.2 failing in a form the pass had not seen when it was written; and a payload held in
+deep-reactive `$state`, which IndexedDB refuses to store because `structuredClone` will not clone a
+Proxy. `$state.raw` is the fix for the second and is what every converted page now uses.
+
 **#75 found two bugs outside itself**, which is the other thing a reference tool's pass turns up:
 `$lib/age`'s `getVariant` rewrote the age categories it was handed rather than returning new ones —
 so `averageAgeCategories` in `species/common.ts` permanently aged a species by averaging it — and it

--- a/e2e/merchant.spec.ts
+++ b/e2e/merchant.spec.ts
@@ -1,0 +1,269 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `merchant` kind: generate, save, reopen, edit (#67).
+ *
+ * This is the half no unit test can settle. The library tests prove a merchant round-trips through
+ * the codec and that each edit changes one thing; what they cannot prove is that a referee can
+ * press Generate, keep the shop, come back to it in a different page, cross a line off the
+ * inventory, and still have the shop they saved.
+ *
+ * The stock is what makes this tool different: it is a list a referee edits row by row, and the
+ * editor's rows are the only place in the pass where adding and removing are the operations rather
+ * than typing in a field.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const MERCHANT_TITLE = 'Fantasy Merchant Generator | Iron Arachne';
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+const result = (page: Page) => page.locator('.merchant-result');
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+/**
+ * Keep whatever the tool has made under the name the kind prefills.
+ *
+ * That prefill is the kind's own `nameOf`, which for a settlement is the town's name — and the
+ * town's name is what a merchant referencing it reads, not whatever the vault entry is labelled.
+ * Returns it so a caller can assert against the right string.
+ */
+async function saveUnderDefaultName(page: Page): Promise<string> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  const name = await saveArtifact(page).getByLabel('Name', { exact: true }).inputValue();
+  expect(name).not.toBe('');
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+  return name;
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+/** A pinned press, so the merchant on screen is the same one every run. */
+async function generatePinned(page: Page, seed = 'a-fixed-seed'): Promise<void> {
+  await page.getByLabel('Seed', { exact: true }).fill(seed);
+  await page.getByLabel('Lock Seed').check();
+  await page.getByRole('button', { name: 'Generate', exact: true }).click();
+  await expect(result(page)).toBeVisible();
+}
+
+test.describe('a merchant', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'The Market Road');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/fantasy/merchant', { title: MERCHANT_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a shop to keep straight away.
+    await expect(result(page)).toBeVisible();
+    await saveAs(page, 'The Copper Kettle');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'The Copper Kettle');
+
+    // Typed rather than filled: the point is that the editor's own binding carries keystrokes
+    // through to the snapshot it announces.
+    const advice = panel.getByRole('textbox', { name: 'Haggling advice' });
+    await advice.fill('');
+    await advice.pressSequentially('Will not budge a copper.');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'The Copper Kettle');
+    await expect(reopened.getByRole('textbox', { name: 'Haggling advice' })).toHaveValue(
+      'Will not budge a copper.',
+    );
+  });
+
+  test('lets a referee cross a line off the inventory and add another', async ({ page }) => {
+    // The stock is a list a referee edits, which is why the rows carry their own controls. This is
+    // requirement 4.4 as a user meets it.
+    await visitRoute(page, '/fantasy/merchant', { title: MERCHANT_TITLE });
+    await generatePinned(page);
+    await saveAs(page, 'The Salt Barrel');
+
+    const panel = await openInWorkshop(page, 'The Salt Barrel');
+    const rows = panel.locator('.merchant-editor__row');
+    // Waited for rather than counted straight away: the editor is a dynamic import, so the panel is
+    // visible a tick before its rows are, and `count()` does not retry.
+    await expect(rows.first()).toBeVisible();
+    const before = await rows.count();
+    expect(before).toBeGreaterThan(0);
+
+    const firstItem = await rows.first().getByRole('textbox', { name: 'Item' }).inputValue();
+    await rows
+      .first()
+      .getByRole('button', { name: new RegExp(`^Remove ${firstItem}$`) })
+      .click();
+    await expect(rows).toHaveCount(before - 1);
+
+    await panel.getByRole('button', { name: 'Add a stock row' }).click();
+    await expect(rows).toHaveCount(before);
+    await rows.last().getByRole('textbox', { name: 'Item' }).fill('a jar of pickled eggs');
+
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'The Salt Barrel');
+    await expect(
+      reopened.locator('.merchant-editor__row').last().getByRole('textbox', { name: 'Item' }),
+    ).toHaveValue('a jar of pickled eggs');
+  });
+
+  test('offers the repricing rather than doing it under the user', async ({ page }) => {
+    // Requirement 4.2, and the sharpest temptation in this library: every ask price is the catalog
+    // cost times the modifier, so a form that re-derived the column would undo a marked-down price.
+    await visitRoute(page, '/fantasy/merchant', { title: MERCHANT_TITLE });
+    await generatePinned(page);
+    await saveAs(page, 'The Bent Nail');
+
+    const panel = await openInWorkshop(page, 'The Bent Nail');
+    const firstRow = panel.locator('.merchant-editor__row').first();
+    const askPrice = firstRow.getByRole('spinbutton', { name: 'Ask price (cp)' });
+    await askPrice.fill('7');
+
+    // Unmoved: changing the modifier the price is derived from did not touch it.
+    await panel.getByRole('spinbutton', { name: 'Price modifier' }).fill('3');
+    await expect(askPrice).toHaveValue('7');
+
+    // And the arithmetic is there for the asking.
+    await panel.getByRole('button', { name: 'Reprice the stock from the modifier' }).click();
+    await expect(askPrice).not.toHaveValue('7');
+  });
+
+  test('downloads a shop a referee can take to the table', async ({ page }) => {
+    // Requirement 6.3, and the first exports this tool has ever had. A shop inventory is exactly
+    // the thing a referee wants on paper.
+    await visitRoute(page, '/fantasy/merchant', { title: MERCHANT_TITLE });
+    await generatePinned(page);
+    const shopName = await result(page).locator('h2').innerText();
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const file = await markdown;
+    expect(file.suggestedFilename()).toMatch(/^merchant-.*\.md$/);
+
+    const contents = await new Response(await file.createReadStream()).text();
+    expect(contents).toContain(`# ${shopName}`);
+    expect(contents).toContain('## Proprietor');
+    expect(contents).toContain('## Stock');
+    expect(contents).toContain('| Item | Qty | Catalog | Ask price | Note |');
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/^merchant-.*\.pdf$/);
+  });
+
+  test('reproduces the same merchant from the same seed', async ({ page }) => {
+    // Requirement 2.2. The page reseeded its own RNG from the seed field inside an `$effect`, so
+    // the next press depended on the text of the previous one.
+    await visitRoute(page, '/fantasy/merchant', { title: MERCHANT_TITLE });
+
+    await generatePinned(page, 'a-fixed-seed');
+    const first = await result(page).innerText();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await result(page).innerText()).toEqual(first);
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await result(page).innerText()).not.toEqual(first);
+  });
+
+  test('generates its own inputs when there is nothing to compose with', async ({ page }) => {
+    // Requirement 5.3. A project with no saved settlements has nothing to offer, so the picker
+    // renders nothing at all and the shop invents its own corner of an unnamed town, exactly as it
+    // did before.
+    await visitRoute(page, '/fantasy/merchant', { title: MERCHANT_TITLE });
+
+    await expect(page.getByLabel('Put this shop in a saved settlement')).toHaveCount(0);
+    await generatePinned(page);
+    await expect(result(page).locator('.location')).not.toContainText(' In ');
+  });
+
+  test('puts the shop in a settlement the project already holds', async ({ page }) => {
+    // Requirement 5.1: `settlement` is a registered kind, and where the shop stands is otherwise
+    // invented. The offer appears only once there is something to offer.
+    await visitRoute(page, '/fantasy/settlement', { title: 'Settlement Generator | Iron Arachne' });
+    const town = await saveUnderDefaultName(page);
+
+    await visitRoute(page, '/fantasy/merchant', { title: MERCHANT_TITLE });
+    await page.getByLabel('Put this shop in a saved settlement').check();
+    await page.getByLabel('Settlement', { exact: true }).selectOption({ label: town });
+    await generatePinned(page);
+
+    // The *town's* name, not the vault entry's: a settlement labelled "starting town" is still
+    // called whatever the generator called it.
+    await expect(result(page).locator('.location')).toContainText(`In ${town}.`);
+
+    // And it travels with the artifact, which is what a reference is for.
+    await saveAs(page, 'The Corner Stall');
+    const panel = await openInWorkshop(page, 'The Corner Stall');
+    await expect(panel.getByRole('textbox', { name: 'Settlement' })).toHaveValue(town);
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -53,6 +53,7 @@ const SILENT_TOOL_PAGES = [
   { path: '/region', title: 'Region Generator | Iron Arachne' },
   { path: '/drug', title: 'Cyberpunk Drug Generator | Iron Arachne' },
   { path: '/fantasy/equipment-generator', title: 'Equipment Generator | Iron Arachne' },
+  { path: '/fantasy/merchant', title: 'Fantasy Merchant Generator | Iron Arachne' },
   {
     // The first reference tool in this list, and the reason it is worth naming: most of the spec
     // does not apply to a tool that produces no artifacts, so its silence was earned by sections

--- a/src/components/objects/MerchantArtifactEditor.svelte
+++ b/src/components/objects/MerchantArtifactEditor.svelte
@@ -1,0 +1,338 @@
+<script lang="ts">
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import DeleteButton from '$components/common/DeleteButton.svelte';
+  import Notice from '$components/common/Notice.svelte';
+  import {
+    addStockItem,
+    merchantPriceText,
+    proprietorTraitsLine,
+    removeStockItem,
+    repricedStock,
+    setMerchantText,
+    setPriceModifier,
+    setProprietorText,
+    setProprietorTraits,
+    setShopText,
+    setStockNumber,
+    setStockText,
+    validateMerchantSnapshot,
+    type MerchantSnapshot,
+    type MerchantTextField,
+    type ProprietorTextField,
+    type ShopTextField,
+  } from '$lib/merchants';
+
+  /**
+   * The editing view for a saved merchant.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it.
+   *
+   * **The stock is the point.** A shop is a list a referee crosses things off, marks one item down
+   * on, and adds the thing a player asked for — none of which is a field, which is why the rows
+   * carry their own controls rather than being a generic list.
+   *
+   * **Nothing is recomputed.** Every ask price is the catalog cost times the price modifier, so a
+   * form that re-derived the column whenever the modifier changed would be the most natural thing
+   * to write and would undo a hand-marked price on the next keystroke — 4.2 exactly. The button at
+   * the foot offers the arithmetic to anyone who wants it.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps this editor from rendering fields over
+   * something that is not a merchant.
+   */
+  const accepted = $derived(validateMerchantSnapshot(snapshot));
+  const merchant = $derived<MerchantSnapshot | undefined>(accepted.ok ? accepted.value : undefined);
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: MerchantSnapshot) => MerchantSnapshot): void {
+    if (merchant === undefined) {
+      return;
+    }
+    onChange(change(merchant));
+  }
+
+  const SHOP_FIELDS: { field: ShopTextField; label: string }[] = [
+    { field: 'name', label: 'Shop name' },
+    { field: 'settlementName', label: 'Settlement' },
+  ];
+
+  const PROPRIETOR_FIELDS: { field: ProprietorTextField; label: string }[] = [
+    { field: 'fullName', label: 'Proprietor' },
+    { field: 'firstName', label: 'First name' },
+    { field: 'lastName', label: 'Last name' },
+  ];
+
+  const NOTE_FIELDS: { field: MerchantTextField; label: string }[] = [
+    { field: 'honestyNotes', label: 'Honesty notes' },
+    { field: 'hagglingAdvice', label: 'Haggling advice' },
+  ];
+</script>
+
+{#if merchant === undefined}
+  <Notice tone="danger">
+    These contents are stored as a merchant but do not read as one, so there is nothing safe to edit
+    here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="merchant-editor">
+    {#each SHOP_FIELDS as entry (entry.field)}
+      <div class="input-group input-group--inline">
+        <label for="{uid}-shop-{entry.field}">{entry.label}</label>
+        <input
+          id="{uid}-shop-{entry.field}"
+          type="text"
+          value={merchant.shop[entry.field] ?? ''}
+          oninput={(event) =>
+            edit((current) => setShopText(current, entry.field, event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+    {/each}
+
+    <div class="input-group">
+      <label for="{uid}-location">Where it stands</label>
+      <textarea
+        id="{uid}-location"
+        rows="2"
+        value={merchant.shop.locationBlurb}
+        oninput={(event) =>
+          edit((current) => setShopText(current, 'locationBlurb', event.currentTarget.value))}
+      ></textarea>
+    </div>
+
+    <div class="input-group">
+      <label for="{uid}-shop-description">Shop description</label>
+      <textarea
+        id="{uid}-shop-description"
+        rows="3"
+        value={merchant.shop.description}
+        oninput={(event) =>
+          edit((current) => setShopText(current, 'description', event.currentTarget.value))}
+      ></textarea>
+    </div>
+
+    {#each PROPRIETOR_FIELDS as entry (entry.field)}
+      <div class="input-group input-group--inline">
+        <label for="{uid}-prop-{entry.field}">{entry.label}</label>
+        <input
+          id="{uid}-prop-{entry.field}"
+          type="text"
+          value={merchant.proprietor[entry.field]}
+          oninput={(event) =>
+            edit((current) => setProprietorText(current, entry.field, event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+    {/each}
+
+    <div class="input-group input-group--inline">
+      <label for="{uid}-traits">Temperament</label>
+      <input
+        id="{uid}-traits"
+        type="text"
+        value={proprietorTraitsLine(merchant)}
+        oninput={(event) =>
+          edit((current) => setProprietorTraits(current, event.currentTarget.value))}
+        autocomplete="off"
+      />
+    </div>
+
+    <div class="input-group">
+      <label for="{uid}-prop-description">Proprietor description</label>
+      <textarea
+        id="{uid}-prop-description"
+        rows="3"
+        value={merchant.proprietor.description}
+        oninput={(event) =>
+          edit((current) => setProprietorText(current, 'description', event.currentTarget.value))}
+      ></textarea>
+    </div>
+
+    <div class="input-group input-group--inline">
+      <!-- A multiplier on the catalog price, so 1 is "sells at cost". -->
+      <label for="{uid}-modifier">Price modifier</label>
+      <input
+        id="{uid}-modifier"
+        type="number"
+        min="0"
+        step="0.05"
+        value={merchant.priceModifier}
+        oninput={(event) =>
+          edit((current) => setPriceModifier(current, event.currentTarget.valueAsNumber))}
+      />
+    </div>
+
+    {#each NOTE_FIELDS as entry (entry.field)}
+      <div class="input-group">
+        <label for="{uid}-{entry.field}">{entry.label}</label>
+        <textarea
+          id="{uid}-{entry.field}"
+          rows="2"
+          value={merchant[entry.field]}
+          oninput={(event) =>
+            edit((current) => setMerchantText(current, entry.field, event.currentTarget.value))}
+        ></textarea>
+      </div>
+    {/each}
+
+    <h3 class="merchant-editor__heading">Stock</h3>
+
+    {#each merchant.stock as item, index (index)}
+      <fieldset class="merchant-editor__row inset">
+        <legend>{item.name === '' ? `Row ${index + 1}` : item.name}</legend>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-stock-{index}-name">Item</label>
+          <input
+            id="{uid}-stock-{index}-name"
+            type="text"
+            value={item.name}
+            oninput={(event) =>
+              edit((current) => setStockText(current, index, 'name', event.currentTarget.value))}
+            autocomplete="off"
+          />
+        </div>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-stock-{index}-quantity">Quantity</label>
+          <input
+            id="{uid}-stock-{index}-quantity"
+            type="number"
+            min="0"
+            value={item.quantity}
+            oninput={(event) =>
+              edit((current) =>
+                setStockNumber(current, index, 'quantity', event.currentTarget.valueAsNumber),
+              )}
+          />
+        </div>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-stock-{index}-baseCost">Catalog (cp)</label>
+          <input
+            id="{uid}-stock-{index}-baseCost"
+            type="number"
+            min="0"
+            value={item.baseCost}
+            oninput={(event) =>
+              edit((current) =>
+                setStockNumber(current, index, 'baseCost', event.currentTarget.valueAsNumber),
+              )}
+          />
+        </div>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-stock-{index}-price">Ask price (cp)</label>
+          <input
+            id="{uid}-stock-{index}-price"
+            type="number"
+            min="0"
+            value={item.price}
+            oninput={(event) =>
+              edit((current) =>
+                setStockNumber(current, index, 'price', event.currentTarget.valueAsNumber),
+              )}
+          />
+          <span class="merchant-editor__price">{merchantPriceText(item.price)}</span>
+        </div>
+
+        <div class="input-group input-group--inline">
+          <label for="{uid}-stock-{index}-note">Note</label>
+          <input
+            id="{uid}-stock-{index}-note"
+            type="text"
+            value={item.note ?? ''}
+            oninput={(event) =>
+              edit((current) => setStockText(current, index, 'note', event.currentTarget.value))}
+            autocomplete="off"
+          />
+        </div>
+
+        <DeleteButton
+          label="Remove {item.name === '' ? `row ${index + 1}` : item.name}"
+          onclick={() => edit((current) => removeStockItem(current, index))}
+        />
+      </fieldset>
+    {/each}
+
+    <div class="merchant-editor__actions">
+      <BaseButton onclick={() => edit(addStockItem)}>Add a stock row</BaseButton>
+      <!-- Offered rather than done automatically, for the reason the header gives. -->
+      <BaseButton onclick={() => edit(repricedStock)}>
+        Reprice the stock from the modifier
+      </BaseButton>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .merchant-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+    align-items: flex-start;
+  }
+
+  .merchant-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .merchant-editor input,
+  .merchant-editor textarea {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+
+  .merchant-editor__heading {
+    margin: var(--s4) 0 0;
+  }
+
+  /* `inset` rather than a hand-rolled border and radius: the panel language owns those. */
+  .merchant-editor__row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    align-items: flex-start;
+    min-width: 0;
+    padding: var(--s4);
+    width: 100%;
+  }
+
+  .merchant-editor__row legend {
+    font: var(--t-micro);
+    letter-spacing: var(--t-micro-tracking);
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  /* The stored price is copper; this is the same number in coins, so a referee typing 1500 can
+     see they have written fifteen gold. */
+  .merchant-editor__price {
+    color: var(--ink-faint);
+    font: var(--t-micro);
+    white-space: nowrap;
+  }
+
+  .merchant-editor__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--s4);
+  }
+</style>

--- a/src/components/objects/MerchantGenerator.svelte
+++ b/src/components/objects/MerchantGenerator.svelte
@@ -1,25 +1,52 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+  import { RNG } from '@ironarachne/rng';
+
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import CheckboxField from '$components/common/CheckboxField.svelte';
+  import ControlsPanel from '$components/common/ControlsPanel.svelte';
   import DataTable, { type Column } from '$components/common/DataTable.svelte';
+  import GeneratorPage from '$components/layout/GeneratorPage.svelte';
+  import NumberField from '$components/common/NumberField.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
+  import SavedArtifactPicker from '$components/common/SavedArtifactPicker.svelte';
+  import SeedControls from '$components/common/SeedControls.svelte';
+  import SelectField from '$components/common/SelectField.svelte';
   import Stat from '$components/common/Stat.svelte';
   import StatBlock from '$components/common/StatBlock.svelte';
-  import { onMount } from 'svelte';
-  import { valueToString, COMMON_FANTASY } from '$lib/currency';
-  import { generateMerchant, getDefaultMerchantConfig, type Merchant } from '$lib/merchants';
+  import type { ArtifactReference } from '$lib/artifacts';
+  import { CULTURE_ARTIFACT_KIND, type Culture } from '$lib/culture';
+  import { downloadTextFile } from '$lib/download';
+  import {
+    MAXIMUM_STOCK_COUNT,
+    MERCHANT_ARTIFACT_KIND,
+    MINIMUM_STOCK_COUNT,
+    merchantFileStem,
+    merchantPriceText,
+    merchantToDocument,
+    merchantToMarkdown,
+    merchantToText,
+    rollMerchant,
+    toMerchantSnapshot,
+    type MerchantGeneratorConfigRecord,
+    type MerchantSnapshot,
+  } from '$lib/merchants';
   import { renderMerchantMarkSvg } from '$lib/merchant_marks';
-  import { RNG } from '@ironarachne/rng';
-  import GeneratorPage from '$components/layout/GeneratorPage.svelte';
-  import SeedControls from '$components/common/SeedControls.svelte';
-  import ControlsPanel from '$components/common/ControlsPanel.svelte';
-  import SelectField from '$components/common/SelectField.svelte';
-  import NumberField from '$components/common/NumberField.svelte';
-  import CheckboxField from '$components/common/CheckboxField.svelte';
-  import BaseButton from '$components/common/BaseButton.svelte';
+  import { downloadTextPdf } from '$lib/pdf';
+  import { SETTLEMENT_ARTIFACT_KIND, type Settlement } from '$lib/settlements';
 
+  const TOOL_PATH = '/fantasy/merchant';
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. It used to be reseeded from the seed
+   * field inside an `$effect`, so the next press's seed depended on the *text* of the previous
+   * one — the same requirement 2.2 failure #66 found in the equipment generator.
+   */
   const rng = new RNG(Date.now().toString());
+
   let seed = $state(rng.randomString(13));
-  $effect(() => {
-    rng.setSeed(seed);
-  });
   let lockSeed = $state(false);
 
   let shopType = $state('any');
@@ -29,33 +56,88 @@
   let stockCount = $state(12);
   let includeMerchantMark = $state(true);
 
-  let merchant: Merchant | null = $state(null);
+  /** Composition, opt-in twice over (rule 1, docs/workshop.md). */
+  let useCulture = $state(false);
+  let referencedCulture: Culture | undefined = $state();
+  let cultureReference: ArtifactReference | undefined = $state();
+  let useSettlement = $state(false);
+  let referencedSettlement: Settlement | undefined = $state();
+  let settlementReference: ArtifactReference | undefined = $state();
 
-  function buildConfig() {
-    const config = getDefaultMerchantConfig();
-    config.shopType = shopType as typeof config.shopType;
-    config.venueType = venueType as typeof config.venueType;
-    config.honesty = honesty as typeof config.honesty;
-    config.priceLevel = priceLevel as typeof config.priceLevel;
-    config.stockCount = { min: stockCount, max: stockCount };
-    config.includeMerchantMark = includeMerchantMark;
-    return config;
+  /**
+   * The rolled merchant.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every array and object in
+   * the payload in a Proxy, and `structuredClone` — what IndexedDB stores with — refuses one
+   * outright, so saving fails with `could not be cloned`. #66 hit exactly this.
+   */
+  let merchant: MerchantSnapshot | null = $state.raw(null);
+
+  /** The seed and settings the merchant on screen was rolled from, which is its provenance. */
+  let rolledSeed = $state('');
+  let rolledConfig: MerchantGeneratorConfigRecord = $state(configRecord());
+
+  const references = $derived(
+    [cultureReference, settlementReference].filter(
+      (reference): reference is ArtifactReference => reference !== undefined,
+    ),
+  );
+
+  const document_ = $derived(merchant === null ? null : merchantToDocument(merchant));
+
+  function configRecord(): MerchantGeneratorConfigRecord {
+    return {
+      shopType: shopType as MerchantGeneratorConfigRecord['shopType'],
+      venueType: venueType as MerchantGeneratorConfigRecord['venueType'],
+      honesty: honesty as MerchantGeneratorConfigRecord['honesty'],
+      priceLevel: priceLevel as MerchantGeneratorConfigRecord['priceLevel'],
+      stockCount,
+      includeMerchantMark,
+      // The culture's *pattern set name*, not its id: a re-roll cannot ask the store for an
+      // artifact it has only a reference to, and naming of the same tongue is what was chosen.
+      // The link itself is an artifact reference and lives beside the payload.
+      ...(useCulture && referencedCulture !== undefined
+        ? { nameGeneratorSet: referencedCulture.nameGenerators.name }
+        : {}),
+      ...(useSettlement && referencedSettlement !== undefined
+        ? { settlementName: referencedSettlement.name }
+        : {}),
+    };
   }
 
   function generate() {
     if (!lockSeed) {
       seed = rng.randomString(13);
     }
-    rng.setSeed(seed);
-    merchant = generateMerchant(seed, buildConfig());
+    rolledSeed = seed;
+    rolledConfig = configRecord();
+    merchant = toMerchantSnapshot(
+      rollMerchant(
+        rolledSeed,
+        rolledConfig,
+        useCulture && referencedCulture !== undefined
+          ? { kind: 'referenced_culture', culture: referencedCulture }
+          : undefined,
+      ),
+    );
   }
 
-  function formatPrice(cost: number) {
-    return valueToString(cost, COMMON_FANTASY);
+  function exportMarkdown() {
+    if (merchant === null) return;
+    downloadTextFile(
+      merchantToMarkdown(merchant),
+      `${merchantFileStem(merchant)}.md`,
+      'text/markdown',
+    );
   }
 
-  function formatModifier(modifier: number) {
-    return `${Math.round(modifier * 100)}%`;
+  async function exportPdf() {
+    if (merchant === null) return;
+    await downloadTextPdf(
+      merchant.shop.name,
+      merchantToText(merchant),
+      `${merchantFileStem(merchant)}.pdf`,
+    );
   }
 
   onMount(() => {
@@ -71,7 +153,7 @@
   ];
 </script>
 
-<GeneratorPage toolPath="/fantasy/merchant" title="Fantasy Merchant Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Fantasy Merchant Generator">
   {#snippet description()}
     <p>
       Generate a fantasy merchant with a proprietor, shop or traveling venue, merchant mark, and
@@ -141,7 +223,13 @@
       ]}
     />
 
-    <NumberField id="stockCount" label="Stock Items" bind:value={stockCount} min={4} max={30} />
+    <NumberField
+      id="stockCount"
+      label="Stock Items"
+      bind:value={stockCount}
+      min={MINIMUM_STOCK_COUNT}
+      max={MAXIMUM_STOCK_COUNT}
+    />
 
     <div class="checkbox-group">
       <CheckboxField
@@ -156,7 +244,45 @@
     <BaseButton onclick={generate}>Generate</BaseButton>
   </ControlsPanel>
 
-  {#if merchant}
+  <!-- Requirement 5.1, twice. Both are offers: the checkboxes start off, and a merchant handed
+       nothing names its proprietor from the default patterns and invents its own corner of an
+       unnamed town, exactly as it always did (5.3). -->
+  <SavedArtifactPicker
+    kind={CULTURE_ARTIFACT_KIND}
+    role="naming-culture"
+    checkboxLabel="Name the proprietor from a saved culture"
+    selectLabel="Naming culture"
+    bind:enabled={useCulture}
+    bind:value={referencedCulture}
+    bind:reference={cultureReference}
+  />
+
+  <SavedArtifactPicker
+    kind={SETTLEMENT_ARTIFACT_KIND}
+    role="settlement"
+    checkboxLabel="Put this shop in a saved settlement"
+    selectLabel="Settlement"
+    bind:enabled={useSettlement}
+    bind:value={referencedSettlement}
+    bind:reference={settlementReference}
+  />
+
+  <SaveArtifactButton
+    kind={MERCHANT_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={merchant}
+    seed={rolledSeed}
+    config={{ ...rolledConfig }}
+    defaultName={merchant?.shop.name ?? ''}
+    {references}
+  />
+
+  <div class="actions">
+    <BaseButton onclick={exportMarkdown} disabled={merchant === null}>Download Markdown</BaseButton>
+    <BaseButton onclick={exportPdf} disabled={merchant === null}>Download PDF</BaseButton>
+  </div>
+
+  {#if merchant && document_}
     <!-- A result surface is a panel, not a box with a border on it: the two layers,
          and the keyline, corner and padding are the system's. It wrote its own
          border, radius and padding until #124. -->
@@ -164,10 +290,8 @@
       <div class="panel__field">
         <header class="merchant-header">
           <div class="merchant-heading">
-            <h2>{merchant.shop.name}</h2>
-            <p class="shop-meta">
-              {merchant.shop.shopTypeLabel} · {merchant.shop.venueTypeLabel}
-            </p>
+            <h2>{document_.title}</h2>
+            <p class="shop-meta">{document_.subtitle}</p>
           </div>
           {#if merchant.mark}
             <div class="merchant-mark" aria-hidden="true">
@@ -178,53 +302,75 @@
           {/if}
         </header>
 
-        <p class="location">{merchant.shop.locationBlurb}</p>
-        <p>{merchant.shop.description}</p>
+        {#if document_.location !== ''}
+          <p class="location">{document_.location}</p>
+        {/if}
+        {#each document_.paragraphs as paragraph, index (index)}
+          <p>{paragraph}</p>
+        {/each}
 
-        <h3>Proprietor</h3>
-        <p><strong>{merchant.proprietor.fullName}</strong></p>
-        <p>{merchant.proprietor.description}</p>
-        {#if merchant.proprietor.personalityTraits.length > 0}
-          <StatBlock>
-            <Stat label="Temperament">{merchant.proprietor.personalityTraits.join(', ')}</Stat>
-          </StatBlock>
+        {#if document_.proprietor.name !== ''}
+          <h3>Proprietor</h3>
+          <p><strong>{document_.proprietor.name}</strong></p>
+          {#each document_.proprietor.paragraphs as paragraph, index (index)}
+            <p>{paragraph}</p>
+          {/each}
+          {#if document_.proprietor.lines.length > 0}
+            <StatBlock>
+              {#each document_.proprietor.lines as line (line.label)}
+                <Stat label={line.label}>{line.value}</Stat>
+              {/each}
+            </StatBlock>
+          {/if}
         {/if}
 
         <h3>Trading Character</h3>
-        <ul class="trading-notes">
-          <StatBlock>
-            <Stat label="Honesty">{merchant.honesty}</Stat>
-            <Stat label="Price level">{merchant.priceLevel}</Stat>
-            <Stat label="Price modifier"
-              >{formatModifier(merchant.priceModifier)} of catalog value</Stat
-            >
-          </StatBlock>
-          <li>{merchant.honestyNotes}</li>
-          <li>{merchant.hagglingAdvice}</li>
-        </ul>
-
-        <h3>Stock</h3>
-        <!-- Five columns, and it scrolled sideways in its own container until #154. A stock row
-             reads perfectly well as a list of pairs, which is the test: it flips. -->
-        <DataTable columns={STOCK_COLUMNS} rows={stockRows} />
-
-        {#snippet stockRows()}
-          {#each merchant?.stock ?? [] as item}
-            <tr>
-              <td data-label="Item">{item.name}</td>
-              <td class="numeric" data-label="Qty">{item.quantity}</td>
-              <td class="numeric" data-label="Catalog">{formatPrice(item.baseCost)}</td>
-              <td class="numeric" data-label="Ask Price">{formatPrice(item.price)}</td>
-              <td data-label="Note">{item.note ?? ''}</td>
-            </tr>
+        <StatBlock>
+          {#each document_.trading as line (line.label)}
+            <Stat label={line.label}>{line.value}</Stat>
           {/each}
-        {/snippet}
+        </StatBlock>
+        {#if document_.notes.length > 0}
+          <ul class="trading-notes">
+            {#each document_.notes as note, index (index)}
+              <li>{note}</li>
+            {/each}
+          </ul>
+        {/if}
+
+        <!-- 6.4: an empty shop shows no heading at all rather than a table head with nothing
+             under it. A referee can empty one from the editor. -->
+        {#if document_.stock.length > 0}
+          <h3>Stock</h3>
+          <!-- Five columns, and it scrolled sideways in its own container until #154. A stock row
+               reads perfectly well as a list of pairs, which is the test: it flips. -->
+          <DataTable columns={STOCK_COLUMNS} rows={stockRows} label="Stock" />
+
+          {#snippet stockRows()}
+            {#each document_?.stock ?? [] as item, index (index)}
+              <tr>
+                <td data-label="Item">{item.name}</td>
+                <td class="numeric" data-label="Qty">{item.quantity}</td>
+                <td class="numeric" data-label="Catalog">{merchantPriceText(item.baseCost)}</td>
+                <td class="numeric" data-label="Ask Price">{merchantPriceText(item.price)}</td>
+                <td data-label="Note">{item.note ?? ''}</td>
+              </tr>
+            {/each}
+          {/snippet}
+        {/if}
       </div>
     </article>
   {/if}
 </GeneratorPage>
 
 <style>
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+  }
+
   /* The keyline, the corner and the padding are the panel's now. What is left is where the
      result sits on the page. */
   .merchant-result {
@@ -271,7 +417,4 @@
   .trading-notes {
     padding-left: var(--s6);
   }
-
-  /* Five columns cannot compress to phone width without the item names turning
-     into one letter per line, so let the table scroll on its own instead. */
 </style>

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -112,6 +112,12 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // build: through the kind module the registry chunk and everything it statically imports is
   // 292 KB across 31 chunks, and through the entry point it is 408 KB across 35.
   '$lib/equipment/item_artifact_kind',
+  // The sharpest case since settlement: `$lib/merchants`'s entry point reaches `generate_merchant`,
+  // and from there the character generator, the species tables and — through the merchant mark —
+  // the whole charge library. Measured on the build: through the kind module the registry chunk and
+  // everything it statically imports is 296 KB across 31 chunks, and through the entry point it is
+  // 19.7 MB across 47.
+  '$lib/merchants/merchant_artifact_kind',
   // The eighteenth, the same library and the same reason: the star-system kind module holds
   // metadata and validation only, and its codec is a dynamic import.
   '$lib/astronomical_bodies/star_system_artifact_kind',

--- a/src/lib/merchants/README.md
+++ b/src/lib/merchants/README.md
@@ -51,3 +51,31 @@ have shopkeepers named after the culture of the settlement they are in rather th
 
 When `includeMerchantMark` is set, the merchant also gets a trade mark from
 [`$lib/merchant_marks`](../merchant_marks/README.md).
+
+## The `merchant` artifact kind
+
+A merchant is a durable artifact (#67). `Merchant` was already plain data — the mark had been
+stored as a charge _name_ and a fill since before the pass reached this tool — so the codec is a
+deep copy rather than a conversion.
+
+- **`merchant_snapshot.ts`** — `MerchantSnapshot` and the codec. **The stock is stored, not
+  regenerated**: a `MerchantStockItem` is five fields, so a fifty-line inventory is a few kilobytes,
+  and a referee who has crossed two things off has edited the shop.
+  `merchantSeedMatchesProvenance` says out loud that the payload's own `seed` and the artifact's
+  provenance seed are the same value, which is the trap the design named.
+- **`merchant_artifact_kind.ts`** — the kind, its version, and a validator that normalises rather
+  than refuses: an unreadable stock row is dropped, a named row with unreadable numbers keeps its
+  name, and a mark that is not a `{ chargeName, fillHex }` pair becomes no mark.
+- **`merchant_roll.ts`** — the one path from a seed. `nameSourceForSet` is the guard that matters:
+  `getFantasyNameGeneratorSet` **throws** for a name it does not have, and the recorded set name is
+  usually a _culture's_, so a re-roll would have crashed rather than falling back.
+- **`merchant_editing.ts`** — the setters, none of which recompute. Changing the price modifier does
+  not re-derive the ask column; `repricedStock` offers that as an explicit command.
+- **`merchant_presentation.ts`** — the sheet, and the Markdown and PDF written from it. A shop that
+  has sold out prints no stock heading at all.
+
+**Composition (5.1).** Both inputs are opt-in offers. A saved `culture` names the proprietor — the
+provenance records that culture's _pattern set name_ rather than its id, so a re-roll produces names
+of the same tongue without reaching for an artifact it cannot ask for — and a saved `settlement`
+supplies `shop.settlementName`, which is where a shop that would otherwise invent an unnamed town
+now stands.

--- a/src/lib/merchants/generate_merchant.ts
+++ b/src/lib/merchants/generate_merchant.ts
@@ -116,6 +116,9 @@ export function generateMerchant(seed: string, config: MerchantGeneratorConfig):
       venueTypeLabel: getVenueTypeLabel(venueType),
       description: venueDescription,
       locationBlurb,
+      ...(config.settlementName === undefined || config.settlementName === ''
+        ? {}
+        : { settlementName: config.settlementName }),
     },
     mark,
     honesty,

--- a/src/lib/merchants/index.ts
+++ b/src/lib/merchants/index.ts
@@ -1,4 +1,9 @@
 export * from './generate_merchant.js';
+export * from './merchant_artifact_kind.js';
+export * from './merchant_editing.js';
+export * from './merchant_presentation.js';
+export * from './merchant_roll.js';
+export * from './merchant_snapshot.js';
 export * from './merchant_generator_config.js';
 export * from './merchant_narrative.js';
 export type * from './merchant_types.js';

--- a/src/lib/merchants/merchant_artifact_kind.test.ts
+++ b/src/lib/merchants/merchant_artifact_kind.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MERCHANT_ARTIFACT_KIND,
+  MERCHANT_PAYLOAD_VERSION,
+  merchantArtifactKind,
+  merchantName,
+  migrateMerchantSnapshot,
+  validateMerchantSnapshot,
+} from './merchant_artifact_kind';
+import { defaultMerchantGeneratorConfigRecord, rollMerchantSnapshot } from './merchant_roll';
+
+const MERCHANT = rollMerchantSnapshot('kind-seed', defaultMerchantGeneratorConfigRecord());
+
+function accepted(payload: unknown) {
+  const result = validateMerchantSnapshot(payload);
+  if (!result.ok) {
+    throw new Error(`expected an accepted payload, got: ${result.message}`);
+  }
+  return result.value;
+}
+
+describe('merchantArtifactKind', () => {
+  it('registers the id and version the pass assigned it', () => {
+    expect(merchantArtifactKind.kind).toBe(MERCHANT_ARTIFACT_KIND);
+    expect(MERCHANT_ARTIFACT_KIND).toBe('merchant');
+    expect(merchantArtifactKind.payloadVersion).toBe(MERCHANT_PAYLOAD_VERSION);
+    expect(MERCHANT_PAYLOAD_VERSION).toBe(1);
+  });
+
+  it('loads a codec that round-trips', async () => {
+    const codec = await merchantArtifactKind.loadCodec();
+
+    expect(codec.fromSnapshot(codec.toSnapshot(MERCHANT), undefined as never)).toEqual(MERCHANT);
+  });
+});
+
+describe('validateMerchantSnapshot', () => {
+  it('accepts a rolled merchant unchanged', () => {
+    expect(accepted(MERCHANT)).toEqual(MERCHANT);
+  });
+
+  it('accepts one that has been through storage', () => {
+    expect(accepted(JSON.parse(JSON.stringify(MERCHANT)))).toEqual(MERCHANT);
+  });
+
+  it('refuses anything that is not an object', () => {
+    for (const payload of [null, undefined, 42, 'a shop', ['a shop']]) {
+      expect(validateMerchantSnapshot(payload).ok, String(payload)).toBe(false);
+    }
+  });
+
+  it('refuses a payload with no seed, proprietor, shop or stock', () => {
+    for (const field of ['seed', 'proprietor', 'shop', 'stock']) {
+      const broken: Record<string, unknown> = { ...MERCHANT };
+      delete broken[field];
+
+      expect(validateMerchantSnapshot(broken).ok, field).toBe(false);
+    }
+  });
+
+  it('accepts emptied prose, because clearing it is an editing decision', () => {
+    // 3.3 asks for a well-defined empty result rather than a refusal.
+    const emptied = accepted({ ...MERCHANT, honestyNotes: '', hagglingAdvice: '' });
+
+    expect(emptied.honestyNotes).toBe('');
+    expect(emptied.hagglingAdvice).toBe('');
+  });
+
+  it('accepts an emptied shop, which a referee can sell out of', () => {
+    expect(accepted({ ...MERCHANT, stock: [] }).stock).toEqual([]);
+  });
+
+  it('drops a stock row with no name and keeps the rest', () => {
+    const mixed = accepted({
+      ...MERCHANT,
+      stock: [{ baseCost: 1, price: 2, quantity: 3 }, MERCHANT.stock[0]],
+    });
+
+    expect(mixed.stock).toEqual([MERCHANT.stock[0]]);
+  });
+
+  it('keeps a named row whose numbers are unreadable, reading them as nothing', () => {
+    // A referee can retype a price; they cannot retype a line that vanished.
+    const row = accepted({
+      ...MERCHANT,
+      stock: [{ name: 'a bundle of arrows', baseCost: 'lots', price: null, quantity: undefined }],
+    }).stock[0];
+
+    expect(row).toEqual({ name: 'a bundle of arrows', baseCost: 0, price: 0, quantity: 0 });
+  });
+
+  it('drops a mark that is not a charge and a fill', () => {
+    expect(accepted({ ...MERCHANT, mark: { chargeName: 'barrel' } }).mark).toBeNull();
+    expect(accepted({ ...MERCHANT, mark: 'a barrel' }).mark).toBeNull();
+  });
+
+  it('keeps a settlement name and drops an empty one', () => {
+    expect(
+      accepted({ ...MERCHANT, shop: { ...MERCHANT.shop, settlementName: 'Ashford' } }).shop
+        .settlementName,
+    ).toBe('Ashford');
+    expect(
+      accepted({ ...MERCHANT, shop: { ...MERCHANT.shop, settlementName: '' } }).shop.settlementName,
+    ).toBeUndefined();
+  });
+});
+
+describe('migrateMerchantSnapshot', () => {
+  it('rejects rather than pretending there has been another shape', () => {
+    // Requirement 7.3 has one step to exercise and it is the absence of one.
+    const result = migrateMerchantSnapshot({ seed: 'x' }, 0);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? '' : result.reason).toBe('unsupported-version');
+    expect(result.ok ? '' : result.message).toContain('payload version 0');
+  });
+});
+
+describe('merchantName', () => {
+  it('prefers the shop, which is what a party remembers', () => {
+    expect(merchantName(MERCHANT)).toBe(MERCHANT.shop.name);
+  });
+
+  it('falls back to the proprietor, then to the kind', () => {
+    const unnamed = { ...MERCHANT, shop: { ...MERCHANT.shop, name: '  ' } };
+
+    expect(merchantName(unnamed)).toBe(MERCHANT.proprietor.fullName);
+    expect(merchantName({ ...unnamed, proprietor: { ...unnamed.proprietor, fullName: '' } })).toBe(
+      'Merchant',
+    );
+  });
+});

--- a/src/lib/merchants/merchant_artifact_kind.ts
+++ b/src/lib/merchants/merchant_artifact_kind.ts
@@ -1,0 +1,192 @@
+import market from '$lib/assets/icons/set1/market.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  isStringArray,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import type { MerchantSnapshot } from './merchant_snapshot';
+import type {
+  MerchantStockItem,
+  ResolvedHonestyLevel,
+  ResolvedPriceLevel,
+  ResolvedShopType,
+  ResolvedVenueType,
+} from './merchant_types';
+
+/**
+ * Stable artifact kind id. Unqualified: a shopkeeper is neither a game system's nor a setting's,
+ * per the kind table in docs/tool-readiness.md.
+ *
+ * Its own kind rather than a share of anything: a merchant is a person, a venue and an inventory,
+ * and no other tool produces that shape.
+ */
+export const MERCHANT_ARTIFACT_KIND = 'merchant' as const;
+
+/** Version 1. The first shape a merchant has been stored in. */
+export const MERCHANT_PAYLOAD_VERSION = 1 as const;
+
+function readNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+/**
+ * One stock row, normalised.
+ *
+ * A row missing its name is dropped rather than printed as `undefined` in a shop list; a row with
+ * an unreadable price keeps its name and reads as costing nothing, because a referee can retype a
+ * number and cannot retype a line that vanished.
+ */
+function readStockItem(value: unknown): MerchantStockItem | undefined {
+  const record = asRecord(value);
+  if (record === null || typeof record.name !== 'string') {
+    return undefined;
+  }
+  return {
+    name: record.name,
+    baseCost: readNumber(record.baseCost, 0),
+    price: readNumber(record.price, 0),
+    quantity: readNumber(record.quantity, 0),
+    ...(typeof record.note === 'string' && record.note !== '' ? { note: record.note } : {}),
+  };
+}
+
+/**
+ * Reads a stored merchant, normalising rather than refusing wherever it honestly can.
+ *
+ * What is checked is what every reader depends on: the proprietor and the shop have to be objects
+ * with the strings the sheet prints, and the stock has to be a list. Everything else degrades —
+ * an unreadable stock row is dropped, a missing number reads as zero, and a mark that is not a
+ * `{ chargeName, fillHex }` pair becomes no mark rather than a broken drawing.
+ *
+ * Empty strings are accepted throughout: a referee who has cleared the haggling advice on the way
+ * to writing their own has made an editing decision, and 3.3 asks for a well-defined empty result
+ * rather than a refusal.
+ */
+export function validateMerchantSnapshot(payload: unknown): PayloadResult<MerchantSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'Merchant payload is not an object');
+  }
+  if (typeof record.seed !== 'string') {
+    return rejectedPayload('invalid-payload', 'Merchant payload has no usable seed');
+  }
+
+  const proprietor = asRecord(record.proprietor);
+  if (proprietor === null || !hasStringFields(proprietor, ['firstName', 'lastName', 'fullName'])) {
+    return rejectedPayload('invalid-payload', 'Merchant payload has no usable proprietor');
+  }
+
+  const shop = asRecord(record.shop);
+  if (shop === null || !hasStringFields(shop, ['name'])) {
+    return rejectedPayload('invalid-payload', 'Merchant payload has no usable shop');
+  }
+
+  if (!Array.isArray(record.stock)) {
+    return rejectedPayload('invalid-payload', 'Merchant payload has no usable stock list');
+  }
+
+  const mark = asRecord(record.mark);
+  const usableMark =
+    mark !== null && hasStringFields(mark, ['chargeName', 'fillHex'])
+      ? { chargeName: mark.chargeName as string, fillHex: mark.fillHex as string }
+      : null;
+
+  return acceptedPayload({
+    seed: record.seed,
+    proprietor: {
+      firstName: proprietor.firstName as string,
+      lastName: proprietor.lastName as string,
+      fullName: proprietor.fullName as string,
+      description: typeof proprietor.description === 'string' ? proprietor.description : '',
+      personalityTraits: isStringArray(proprietor.personalityTraits)
+        ? proprietor.personalityTraits
+        : [],
+    },
+    shop: {
+      name: shop.name as string,
+      shopType: (typeof shop.shopType === 'string' ? shop.shopType : 'general') as ResolvedShopType,
+      shopTypeLabel: typeof shop.shopTypeLabel === 'string' ? shop.shopTypeLabel : '',
+      venueType: (typeof shop.venueType === 'string'
+        ? shop.venueType
+        : 'shop') as ResolvedVenueType,
+      venueTypeLabel: typeof shop.venueTypeLabel === 'string' ? shop.venueTypeLabel : '',
+      description: typeof shop.description === 'string' ? shop.description : '',
+      locationBlurb: typeof shop.locationBlurb === 'string' ? shop.locationBlurb : '',
+      ...(typeof shop.settlementName === 'string' && shop.settlementName !== ''
+        ? { settlementName: shop.settlementName }
+        : {}),
+    },
+    mark: usableMark,
+    honesty: (typeof record.honesty === 'string' ? record.honesty : 'fair') as ResolvedHonestyLevel,
+    priceLevel: (typeof record.priceLevel === 'string'
+      ? record.priceLevel
+      : 'standard') as ResolvedPriceLevel,
+    priceModifier: readNumber(record.priceModifier, 1),
+    honestyNotes: typeof record.honestyNotes === 'string' ? record.honestyNotes : '',
+    hagglingAdvice: typeof record.hagglingAdvice === 'string' ? record.hagglingAdvice : '',
+    stock: record.stock
+      .map(readStockItem)
+      .filter((item): item is MerchantStockItem => item !== undefined),
+  });
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day
+ * the shape changes — a kind without one looks complete right up until it silently drops someone's
+ * work, and local-only means there is no server-side migration to fall back on.
+ */
+export function migrateMerchantSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<MerchantSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Merchants have no migration from payload version ${from}; version ${MERCHANT_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/**
+ * What to call a saved merchant: the shop, which is what a referee looks for in a vault listing.
+ *
+ * The proprietor's name is the fallback rather than the first choice — a party remembers "the
+ * Copper Kettle" and argues about what the shopkeeper was called.
+ */
+export function merchantName(snapshot: MerchantSnapshot): string {
+  const shop = snapshot.shop.name.trim();
+  if (shop !== '') {
+    return shop;
+  }
+  const proprietor = snapshot.proprietor.fullName.trim();
+  return proprietor === '' ? 'Merchant' : proprietor;
+}
+
+/**
+ * A merchant as an artifact.
+ *
+ * The codec is a dynamic import for consistency with every other kind rather than for weight:
+ * reading a merchant resolves nothing, because a stored one already holds everything it is.
+ */
+export const merchantArtifactKind = defineArtifactKind<MerchantSnapshot, MerchantSnapshot>({
+  kind: MERCHANT_ARTIFACT_KIND,
+  displayName: 'Merchant',
+  icon: market,
+  payloadVersion: MERCHANT_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { toMerchantSnapshot, merchantFromSnapshotWithRng } =
+      await import('./merchant_snapshot.js');
+    return {
+      toSnapshot: toMerchantSnapshot,
+      fromSnapshot: merchantFromSnapshotWithRng,
+    };
+  },
+  nameOf: merchantName,
+  validate: validateMerchantSnapshot,
+  migrate: migrateMerchantSnapshot,
+});

--- a/src/lib/merchants/merchant_editing.test.ts
+++ b/src/lib/merchants/merchant_editing.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addStockItem,
+  proprietorTraitsLine,
+  removeStockItem,
+  repricedStock,
+  setMerchantText,
+  setPriceModifier,
+  setProprietorText,
+  setProprietorTraits,
+  setShopText,
+  setStockNumber,
+  setStockText,
+} from './merchant_editing';
+import { defaultMerchantGeneratorConfigRecord, rollMerchantSnapshot } from './merchant_roll';
+
+const MERCHANT = rollMerchantSnapshot('editing-seed', {
+  ...defaultMerchantGeneratorConfigRecord(),
+  settlementName: 'Ashford',
+});
+
+describe('setShopText and setProprietorText', () => {
+  it('change one field and nothing else', () => {
+    const renamed = setShopText(MERCHANT, 'name', 'The Copper Kettle');
+
+    expect(renamed.shop.name).toBe('The Copper Kettle');
+    expect(renamed.proprietor).toEqual(MERCHANT.proprietor);
+    expect(MERCHANT.shop.name).not.toBe('The Copper Kettle');
+  });
+
+  it('removes an emptied settlement rather than storing it blank', () => {
+    expect('settlementName' in setShopText(MERCHANT, 'settlementName', '  ').shop).toBe(false);
+    expect(setShopText(MERCHANT, 'settlementName', 'Grimwold').shop.settlementName).toBe(
+      'Grimwold',
+    );
+  });
+
+  it('leaves the full name alone when a half changes, and the halves alone when it does', () => {
+    // The payload keeps all three because the generator wrote all three, and a shopkeeper called
+    // "Old Maren" has a full name no split of a first and a last would produce.
+    const edited = setProprietorText(MERCHANT, 'firstName', 'Maren');
+
+    expect(edited.proprietor.firstName).toBe('Maren');
+    expect(edited.proprietor.fullName).toBe(MERCHANT.proprietor.fullName);
+
+    const renamed = setProprietorText(MERCHANT, 'fullName', 'Old Maren');
+    expect(renamed.proprietor.firstName).toBe(MERCHANT.proprietor.firstName);
+  });
+});
+
+describe('setMerchantText', () => {
+  it('rewrites the trading prose', () => {
+    expect(setMerchantText(MERCHANT, 'hagglingAdvice', 'Will not budge.').hagglingAdvice).toBe(
+      'Will not budge.',
+    );
+  });
+});
+
+describe('setProprietorTraits', () => {
+  it('reads a comma-separated line, dropping the blanks', () => {
+    expect(
+      setProprietorTraits(MERCHANT, 'gruff, watchful ,, generous,').proprietor.personalityTraits,
+    ).toEqual(['gruff', 'watchful', 'generous']);
+  });
+
+  it('round-trips through the line the editor shows', () => {
+    const edited = setProprietorTraits(MERCHANT, 'gruff, watchful');
+
+    expect(proprietorTraitsLine(edited)).toBe('gruff, watchful');
+  });
+});
+
+describe('setPriceModifier', () => {
+  it('takes the number given, and floors a cleared or negative one', () => {
+    expect(setPriceModifier(MERCHANT, 1.4).priceModifier).toBe(1.4);
+    expect(setPriceModifier(MERCHANT, Number.NaN).priceModifier).toBe(0);
+    expect(setPriceModifier(MERCHANT, -1).priceModifier).toBe(0);
+  });
+
+  it('does not reprice the stock', () => {
+    // Requirement 4.2, and the sharpest temptation in this library: a form that re-derived the ask
+    // column whenever the modifier moved would undo a hand-marked price on the next keystroke.
+    expect(setPriceModifier(MERCHANT, 4).stock).toEqual(MERCHANT.stock);
+  });
+});
+
+describe('the stock rows', () => {
+  it('rewrites one row without touching its neighbours', () => {
+    const edited = setStockText(MERCHANT, 1, 'name', 'a very fine hat');
+
+    expect(edited.stock[1].name).toBe('a very fine hat');
+    expect(edited.stock[0]).toEqual(MERCHANT.stock[0]);
+    expect(edited.stock).toHaveLength(MERCHANT.stock.length);
+  });
+
+  it('removes an emptied note rather than storing it blank', () => {
+    const noted = setStockText(MERCHANT, 0, 'note', 'the last one');
+
+    expect(noted.stock[0].note).toBe('the last one');
+    expect('note' in setStockText(noted, 0, 'note', '   ').stock[0]).toBe(false);
+  });
+
+  it('floors a cleared or negative number at zero', () => {
+    expect(setStockNumber(MERCHANT, 0, 'price', Number.NaN).stock[0].price).toBe(0);
+    expect(setStockNumber(MERCHANT, 0, 'quantity', -2).stock[0].quantity).toBe(0);
+    expect(setStockNumber(MERCHANT, 0, 'baseCost', 55).stock[0].baseCost).toBe(55);
+  });
+
+  it('does nothing for a row that is not there', () => {
+    expect(setStockText(MERCHANT, 99, 'name', 'nowhere')).toBe(MERCHANT);
+    expect(setStockNumber(MERCHANT, -1, 'price', 5)).toBe(MERCHANT);
+    expect(removeStockItem(MERCHANT, 99)).toBe(MERCHANT);
+  });
+
+  it('adds a row a referee can fill in', () => {
+    const added = addStockItem(MERCHANT);
+
+    expect(added.stock).toHaveLength(MERCHANT.stock.length + 1);
+    expect(added.stock[added.stock.length - 1]).toEqual({
+      name: 'New item',
+      baseCost: 0,
+      price: 0,
+      quantity: 1,
+    });
+  });
+
+  it('crosses one off', () => {
+    const removed = removeStockItem(MERCHANT, 0);
+
+    expect(removed.stock).toHaveLength(MERCHANT.stock.length - 1);
+    expect(removed.stock[0]).toEqual(MERCHANT.stock[1]);
+  });
+
+  it('empties completely, which is a shop that has sold out', () => {
+    let emptied = MERCHANT;
+    while (emptied.stock.length > 0) {
+      emptied = removeStockItem(emptied, 0);
+    }
+
+    expect(emptied.stock).toEqual([]);
+  });
+});
+
+describe('repricedStock', () => {
+  it('sets every ask price from the catalog cost and the modifier', () => {
+    const marked = setStockNumber(setPriceModifier(MERCHANT, 2), 0, 'price', 1);
+    const repriced = repricedStock(marked);
+
+    for (const [index, item] of repriced.stock.entries()) {
+      expect(item.price, item.name).toBe(Math.max(1, Math.round(item.baseCost * 2)));
+      expect(item.name).toBe(marked.stock[index].name);
+    }
+  });
+
+  it('never prices anything at nothing', () => {
+    // A free item in a shop reads as a bug rather than as generosity.
+    const free = repricedStock(setPriceModifier(MERCHANT, 0));
+
+    for (const item of free.stock) {
+      expect(item.price).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('is the only thing that touches the ask column', () => {
+    expect(repricedStock(MERCHANT).stock).not.toBe(MERCHANT.stock);
+    expect(setStockText(MERCHANT, 0, 'name', 'renamed').stock[0].price).toBe(
+      MERCHANT.stock[0].price,
+    );
+  });
+});

--- a/src/lib/merchants/merchant_editing.ts
+++ b/src/lib/merchants/merchant_editing.ts
@@ -1,0 +1,169 @@
+/**
+ * Editing a saved merchant, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction, and it is what lets the editing
+ * framework compare what is on screen against what was read to decide whether anything needs
+ * saving.
+ *
+ * **Nothing here recomputes anything**, and the temptation is sharper than usual: every ask price
+ * in the stock is the catalog cost times the price modifier, so a form that re-derived the column
+ * whenever the modifier changed would be the most natural thing to write. It is also requirement
+ * 4.2's exact prohibition — a referee who has marked one sword down to clear it has priced that
+ * sword, and the next keystroke elsewhere must not undo that. `repricedStock` is offered as a
+ * command instead, the shape the drug editor and the DCC sheet both use.
+ *
+ * **The stock is a list a referee crosses things off.** Adding, removing and reordering are what an
+ * inventory is edited by, and none of them can be expressed as a field, so they are functions
+ * rather than a generic list control.
+ */
+
+import type { MerchantSnapshot } from './merchant_snapshot.js';
+import type { MerchantStockItem } from './merchant_types.js';
+
+/** The merchant's own text fields, all of which a referee may rewrite. */
+export type MerchantTextField = 'honestyNotes' | 'hagglingAdvice';
+
+/** The proprietor's text fields. */
+export type ProprietorTextField = 'firstName' | 'lastName' | 'fullName' | 'description';
+
+/** The shop's text fields. */
+export type ShopTextField = 'name' | 'description' | 'locationBlurb' | 'settlementName';
+
+export function setMerchantText(
+  snapshot: MerchantSnapshot,
+  field: MerchantTextField,
+  value: string,
+): MerchantSnapshot {
+  return { ...snapshot, [field]: value };
+}
+
+/**
+ * A proprietor's field.
+ *
+ * `fullName` is not recomputed from the two halves and the two halves are not parsed out of it:
+ * the payload keeps all three because the generator wrote all three, and a shopkeeper called
+ * "Old Maren" has a full name that no split of a first and a last would produce.
+ */
+export function setProprietorText(
+  snapshot: MerchantSnapshot,
+  field: ProprietorTextField,
+  value: string,
+): MerchantSnapshot {
+  return { ...snapshot, proprietor: { ...snapshot.proprietor, [field]: value } };
+}
+
+export function setShopText(
+  snapshot: MerchantSnapshot,
+  field: ShopTextField,
+  value: string,
+): MerchantSnapshot {
+  if (field === 'settlementName' && value.trim() === '') {
+    const shop = { ...snapshot.shop };
+    delete shop.settlementName;
+    return { ...snapshot, shop };
+  }
+  return { ...snapshot, shop: { ...snapshot.shop, [field]: value } };
+}
+
+/** The proprietor's temperament, as one comma-separated line. Blank entries are dropped. */
+export function setProprietorTraits(snapshot: MerchantSnapshot, line: string): MerchantSnapshot {
+  return {
+    ...snapshot,
+    proprietor: {
+      ...snapshot.proprietor,
+      personalityTraits: line
+        .split(',')
+        .map((trait) => trait.trim())
+        .filter((trait) => trait !== ''),
+    },
+  };
+}
+
+/** The temperament as the line the editor shows. */
+export function proprietorTraitsLine(snapshot: MerchantSnapshot): string {
+  return snapshot.proprietor.personalityTraits.join(', ');
+}
+
+/** The price modifier, floored at zero — a shop cannot charge less than nothing. */
+export function setPriceModifier(snapshot: MerchantSnapshot, modifier: number): MerchantSnapshot {
+  return {
+    ...snapshot,
+    priceModifier: Number.isFinite(modifier) && modifier > 0 ? modifier : 0,
+  };
+}
+
+/** One stock row's name or note. */
+export function setStockText(
+  snapshot: MerchantSnapshot,
+  index: number,
+  field: 'name' | 'note',
+  value: string,
+): MerchantSnapshot {
+  return updateStock(snapshot, index, (item) =>
+    field === 'note' && value.trim() === '' ? stripNote(item) : { ...item, [field]: value },
+  );
+}
+
+/** One stock row's number, floored at zero. */
+export function setStockNumber(
+  snapshot: MerchantSnapshot,
+  index: number,
+  field: 'baseCost' | 'price' | 'quantity',
+  value: number,
+): MerchantSnapshot {
+  const usable = Number.isFinite(value) && value > 0 ? value : 0;
+  return updateStock(snapshot, index, (item) => ({ ...item, [field]: usable }));
+}
+
+function stripNote(item: MerchantStockItem): MerchantStockItem {
+  const next = { ...item };
+  delete next.note;
+  return next;
+}
+
+function updateStock(
+  snapshot: MerchantSnapshot,
+  index: number,
+  change: (item: MerchantStockItem) => MerchantStockItem,
+): MerchantSnapshot {
+  if (index < 0 || index >= snapshot.stock.length) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    stock: snapshot.stock.map((item, at) => (at === index ? change(item) : item)),
+  };
+}
+
+/** A blank row for a referee adding something the generator did not think of. */
+export function addStockItem(snapshot: MerchantSnapshot): MerchantSnapshot {
+  return {
+    ...snapshot,
+    stock: [...snapshot.stock, { name: 'New item', baseCost: 0, price: 0, quantity: 1 }],
+  };
+}
+
+/** Cross a line off the list. */
+export function removeStockItem(snapshot: MerchantSnapshot, index: number): MerchantSnapshot {
+  if (index < 0 || index >= snapshot.stock.length) {
+    return snapshot;
+  }
+  return { ...snapshot, stock: snapshot.stock.filter((_item, at) => at !== index) };
+}
+
+/**
+ * Every ask price set back to the catalog cost times the current modifier.
+ *
+ * Offered rather than done automatically, for the reason the header gives. Rounded to whole copper,
+ * which is what the generator does and what a price the site can print has to be.
+ */
+export function repricedStock(snapshot: MerchantSnapshot): MerchantSnapshot {
+  return {
+    ...snapshot,
+    stock: snapshot.stock.map((item) => ({
+      ...item,
+      price: Math.max(1, Math.round(item.baseCost * snapshot.priceModifier)),
+    })),
+  };
+}

--- a/src/lib/merchants/merchant_generator_config.ts
+++ b/src/lib/merchants/merchant_generator_config.ts
@@ -9,6 +9,8 @@ export type MerchantGeneratorConfig = {
   stockCount: { min: number; max: number };
   includeMerchantMark: boolean;
   nameSource: CharacterNameSource;
+  /** The settlement the shop stands in, when the caller supplied one (requirement 5.1). */
+  settlementName?: string;
 };
 
 export function getDefaultMerchantConfig(): MerchantGeneratorConfig {

--- a/src/lib/merchants/merchant_presentation.test.ts
+++ b/src/lib/merchants/merchant_presentation.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import { removeStockItem, setMerchantText, setShopText } from './merchant_editing';
+import {
+  merchantDisplayName,
+  merchantFileStem,
+  merchantLocationText,
+  merchantPriceText,
+  merchantToDocument,
+  merchantToMarkdown,
+  merchantToText,
+  priceModifierText,
+} from './merchant_presentation';
+import { defaultMerchantGeneratorConfigRecord, rollMerchantSnapshot } from './merchant_roll';
+
+const CONFIG = defaultMerchantGeneratorConfigRecord();
+const MERCHANT = rollMerchantSnapshot('presentation-seed', CONFIG);
+const PLACED = rollMerchantSnapshot('placed-seed', { ...CONFIG, settlementName: 'Ashford' });
+
+/** Every row of the stock list crossed off, which a referee can do. */
+function soldOut(snapshot: typeof MERCHANT) {
+  let emptied = snapshot;
+  while (emptied.stock.length > 0) {
+    emptied = removeStockItem(emptied, 0);
+  }
+  return emptied;
+}
+
+describe('merchantDisplayName', () => {
+  it('prefers the shop and falls back twice', () => {
+    expect(merchantDisplayName(MERCHANT)).toBe(MERCHANT.shop.name);
+    expect(merchantDisplayName({ ...MERCHANT, shop: { ...MERCHANT.shop, name: ' ' } })).toBe(
+      MERCHANT.proprietor.fullName,
+    );
+    expect(
+      merchantDisplayName({
+        ...MERCHANT,
+        shop: { ...MERCHANT.shop, name: '' },
+        proprietor: { ...MERCHANT.proprietor, fullName: '' },
+      }),
+    ).toBe('Merchant');
+  });
+});
+
+describe('merchantLocationText', () => {
+  it('names the settlement beside the corner the shop stands on', () => {
+    // The two answer different halves of the question, so a referee who linked a settlement does
+    // not lose the blurb.
+    expect(merchantLocationText(PLACED)).toBe(`${PLACED.shop.locationBlurb} In Ashford.`);
+  });
+
+  it('is the blurb alone when nothing was referenced', () => {
+    expect(merchantLocationText(MERCHANT)).toBe(MERCHANT.shop.locationBlurb);
+  });
+
+  it('is the settlement alone when the blurb has been cleared', () => {
+    expect(merchantLocationText(setShopText(PLACED, 'locationBlurb', ''))).toBe('In Ashford.');
+  });
+
+  it('is empty when there is neither', () => {
+    expect(merchantLocationText(setShopText(MERCHANT, 'locationBlurb', ''))).toBe('');
+  });
+});
+
+describe('merchantPriceText and priceModifierText', () => {
+  it('quote a price in coins and a modifier as a percentage', () => {
+    expect(merchantPriceText(100)).toBe('1 gp');
+    expect(priceModifierText(1.25)).toBe('125% of catalog value');
+  });
+
+  it('write out a price of nothing rather than leaving it blank', () => {
+    // The fault #65 found in the price lists: `valueToString(0)` is the empty string.
+    expect(merchantPriceText(0)).toBe('0 cp');
+  });
+});
+
+describe('merchantToDocument', () => {
+  it('arranges the shop, the person and the stock', () => {
+    const document = merchantToDocument(MERCHANT);
+
+    expect(document.title).toBe(MERCHANT.shop.name);
+    expect(document.subtitle).toContain(MERCHANT.shop.shopTypeLabel);
+    expect(document.proprietor.name).toBe(MERCHANT.proprietor.fullName);
+    expect(document.trading.map((line) => line.label)).toEqual([
+      'Honesty',
+      'Price level',
+      'Price modifier',
+    ]);
+    expect(document.stock).toHaveLength(MERCHANT.stock.length);
+  });
+
+  it('drops every part whose field is empty', () => {
+    // 6.4. A merchant edited down to nothing must not print headings over blanks.
+    const stripped = soldOut(
+      setMerchantText(
+        setMerchantText(setShopText(MERCHANT, 'description', ''), 'honestyNotes', ''),
+        'hagglingAdvice',
+        '',
+      ),
+    );
+    const document = merchantToDocument(stripped);
+
+    expect(document.paragraphs).toEqual([]);
+    expect(document.notes).toEqual([]);
+    expect(document.stock).toEqual([]);
+  });
+});
+
+describe('merchantToMarkdown', () => {
+  it('writes the shop, the proprietor, the trading notes and the stock table', () => {
+    const markdown = merchantToMarkdown(MERCHANT);
+
+    expect(markdown.startsWith(`# ${MERCHANT.shop.name}\n\n`)).toBe(true);
+    expect(markdown).toContain('## Proprietor');
+    expect(markdown).toContain('## Trading');
+    expect(markdown).toContain('## Stock');
+    expect(markdown).toContain('| Item | Qty | Catalog | Ask price | Note |');
+    expect(markdown).toContain(`| ${MERCHANT.stock[0].name} |`);
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('names the settlement when one was referenced', () => {
+    expect(merchantToMarkdown(PLACED)).toContain('In Ashford.');
+  });
+
+  it('prints no stock heading for a shop that has sold out', () => {
+    // 6.4 with teeth: a table head over nothing is the artifact this drops.
+    const markdown = merchantToMarkdown(soldOut(MERCHANT));
+
+    expect(markdown).not.toContain('## Stock');
+    expect(markdown).not.toContain('| Item |');
+  });
+
+  it('never leaves a blank line inside the table', () => {
+    expect(merchantToMarkdown(MERCHANT)).not.toContain('|\n\n|');
+  });
+
+  it('has no run of blank lines anywhere in it', () => {
+    expect(merchantToMarkdown(MERCHANT)).not.toMatch(/\n\s*\n\s*\n/);
+  });
+});
+
+describe('merchantToText', () => {
+  it('writes the same sheet without pipes or the title the PDF draws itself', () => {
+    const text = merchantToText(MERCHANT);
+
+    expect(text).not.toContain('|');
+    expect(text).not.toContain(`# ${MERCHANT.shop.name}`);
+    expect(text).toContain('Proprietor: ');
+    expect(text).toContain('Stock');
+    expect(text.endsWith('\n')).toBe(false);
+  });
+
+  it('prints no stock section for a shop that has sold out', () => {
+    expect(merchantToText(soldOut(MERCHANT))).not.toContain('Stock');
+  });
+
+  it('has no run of blank lines anywhere in it', () => {
+    expect(merchantToText(MERCHANT)).not.toMatch(/\n\s*\n\s*\n/);
+  });
+});
+
+describe('merchantFileStem', () => {
+  it('reduces the shop name to something a filesystem takes', () => {
+    expect(
+      merchantFileStem({ ...MERCHANT, shop: { ...MERCHANT.shop, name: "Halgrim's Fine Wares" } }),
+    ).toBe('merchant-halgrim-s-fine-wares');
+  });
+
+  it('falls back for a name that reduces to nothing', () => {
+    expect(
+      merchantFileStem({
+        ...MERCHANT,
+        shop: { ...MERCHANT.shop, name: '???' },
+        proprietor: { ...MERCHANT.proprietor, fullName: '' },
+      }),
+    ).toBe('merchant');
+  });
+});

--- a/src/lib/merchants/merchant_presentation.ts
+++ b/src/lib/merchants/merchant_presentation.ts
@@ -1,0 +1,210 @@
+/**
+ * A merchant arranged for reading, and the Markdown and PDF exports written from it.
+ *
+ * 6.3 matters more here than for most tools in the pass: a shop inventory is exactly the thing a
+ * referee wants on paper beside them, and this tool had no export at all.
+ *
+ * 6.4 has teeth for the same reason a hoard's does. A merchant with no mark must not print a mark
+ * heading, one whose haggling advice has been cleared must not print a blank line where it was, and
+ * an empty shop must not print a table head with nothing under it. Every section is dropped by
+ * construction when the field behind it is empty.
+ */
+
+import { COMMON_FANTASY, valueToString } from '$lib/currency';
+
+import type { MerchantSnapshot } from './merchant_snapshot';
+import type { MerchantStockItem } from './merchant_types';
+
+/** One line of the sheet: a label and what it says. */
+export type MerchantLine = {
+  label: string;
+  value: string;
+};
+
+/** A merchant arranged for reading, independent of the format it is finally written in. */
+export type MerchantDocument = {
+  title: string;
+  /** The shop type and venue, as the page's subheading reads them. */
+  subtitle: string;
+  /** The location blurb, and the settlement when one was referenced. */
+  location: string;
+  paragraphs: string[];
+  proprietor: { name: string; lines: MerchantLine[]; paragraphs: string[] };
+  trading: MerchantLine[];
+  /** The trading notes, which are sentences rather than labelled values. */
+  notes: string[];
+  stock: MerchantStockItem[];
+};
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+/** A price, in the currency the rest of the site quotes prices in. */
+export function merchantPriceText(cost: number): string {
+  return cost <= 0 ? '0 cp' : valueToString(cost, COMMON_FANTASY);
+}
+
+/** The price modifier as the page and the exports read it. */
+export function priceModifierText(modifier: number): string {
+  return `${Math.round(modifier * 100)}% of catalog value`;
+}
+
+/** What to head the document with: the shop, falling back to the proprietor. */
+export function merchantDisplayName(snapshot: MerchantSnapshot): string {
+  const shop = snapshot.shop.name.trim();
+  if (shop !== '') {
+    return shop;
+  }
+  const proprietor = snapshot.proprietor.fullName.trim();
+  return proprietor === '' ? 'Merchant' : proprietor;
+}
+
+/**
+ * Where the shop stands, in one line.
+ *
+ * The settlement is appended rather than replacing the blurb: "on the market square" and "in
+ * Ashford" answer different halves of the question, and a referee who linked a settlement did not
+ * ask to lose the corner it stands on.
+ */
+export function merchantLocationText(snapshot: MerchantSnapshot): string {
+  const blurb = snapshot.shop.locationBlurb.trim();
+  const settlement = (snapshot.shop.settlementName ?? '').trim();
+  if (settlement === '') {
+    return blurb;
+  }
+  return blurb === '' ? `In ${settlement}.` : `${blurb} In ${settlement}.`;
+}
+
+/** Arrange a merchant for reading. */
+export function merchantToDocument(snapshot: MerchantSnapshot): MerchantDocument {
+  const subtitleParts = [snapshot.shop.shopTypeLabel, snapshot.shop.venueTypeLabel].filter(
+    isPrintable,
+  );
+
+  return {
+    title: merchantDisplayName(snapshot),
+    subtitle: subtitleParts.join(' · '),
+    location: merchantLocationText(snapshot),
+    paragraphs: [snapshot.shop.description].filter(isPrintable),
+    proprietor: {
+      name: snapshot.proprietor.fullName.trim(),
+      lines: [
+        {
+          label: 'Temperament',
+          value: snapshot.proprietor.personalityTraits.filter(isPrintable).join(', '),
+        },
+      ].filter((line) => isPrintable(line.value)),
+      paragraphs: [snapshot.proprietor.description].filter(isPrintable),
+    },
+    trading: [
+      { label: 'Honesty', value: snapshot.honesty },
+      { label: 'Price level', value: snapshot.priceLevel },
+      { label: 'Price modifier', value: priceModifierText(snapshot.priceModifier) },
+    ].filter((line) => isPrintable(line.value)),
+    notes: [snapshot.honestyNotes, snapshot.hagglingAdvice].filter(isPrintable),
+    stock: snapshot.stock,
+  };
+}
+
+function stockRows(stock: MerchantStockItem[]): string[] {
+  return stock.map(
+    (item) =>
+      `| ${item.name} | ${item.quantity} | ${merchantPriceText(item.baseCost)} | ${merchantPriceText(item.price)} | ${item.note ?? ''} |`,
+  );
+}
+
+/** A merchant as Markdown, for a referee who keeps their shops in their own notes. */
+export function merchantToMarkdown(snapshot: MerchantSnapshot): string {
+  const document = merchantToDocument(snapshot);
+  const blocks = [`# ${document.title}`];
+
+  if (isPrintable(document.subtitle)) {
+    blocks.push(`*${document.subtitle}*`);
+  }
+  if (isPrintable(document.location)) {
+    blocks.push(document.location);
+  }
+  blocks.push(...document.paragraphs);
+
+  if (document.proprietor.name !== '') {
+    const entry = [`## Proprietor`, `**${document.proprietor.name}**`];
+    entry.push(...document.proprietor.paragraphs);
+    entry.push(...document.proprietor.lines.map((line) => `- ${line.label}: ${line.value}`));
+    blocks.push(entry.join('\n\n'));
+  }
+
+  if (document.trading.length > 0 || document.notes.length > 0) {
+    const entry = ['## Trading'];
+    if (document.trading.length > 0) {
+      entry.push(document.trading.map((line) => `- ${line.label}: ${line.value}`).join('\n'));
+    }
+    entry.push(...document.notes);
+    blocks.push(entry.join('\n\n'));
+  }
+
+  // 6.4: an empty shop prints no heading at all rather than a table head with nothing under it.
+  if (document.stock.length > 0) {
+    blocks.push(
+      [
+        '## Stock',
+        '| Item | Qty | Catalog | Ask price | Note |',
+        '| --- | ---: | ---: | ---: | --- |',
+        ...stockRows(document.stock),
+      ].join('\n'),
+    );
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** The body of the PDF: the same document without the title the PDF draws itself. */
+export function merchantToText(snapshot: MerchantSnapshot): string {
+  const document = merchantToDocument(snapshot);
+  const blocks: string[] = [];
+
+  if (isPrintable(document.subtitle)) {
+    blocks.push(document.subtitle);
+  }
+  if (isPrintable(document.location)) {
+    blocks.push(document.location);
+  }
+  blocks.push(...document.paragraphs);
+
+  if (document.proprietor.name !== '') {
+    const entry = [`Proprietor: ${document.proprietor.name}`];
+    entry.push(...document.proprietor.paragraphs);
+    entry.push(...document.proprietor.lines.map((line) => `${line.label}: ${line.value}`));
+    blocks.push(entry.join('\n'));
+  }
+
+  if (document.trading.length > 0 || document.notes.length > 0) {
+    const entry = ['Trading'];
+    entry.push(...document.trading.map((line) => `  ${line.label}: ${line.value}`));
+    entry.push(...document.notes.map((note) => `  ${note}`));
+    blocks.push(entry.join('\n'));
+  }
+
+  if (document.stock.length > 0) {
+    blocks.push(
+      [
+        'Stock',
+        ...document.stock.map(
+          (item) =>
+            `  ${item.quantity} x ${item.name} - ${merchantPriceText(item.price)}${item.note === undefined ? '' : ` (${item.note})`}`,
+        ),
+      ].join('\n'),
+    );
+  }
+
+  return blocks.join('\n\n');
+}
+
+/** A filename stem for an exported merchant, reduced to something a filesystem takes. */
+export function merchantFileStem(snapshot: MerchantSnapshot): string {
+  const stem = merchantDisplayName(snapshot)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' || stem === 'merchant' ? 'merchant' : `merchant-${stem}`;
+}

--- a/src/lib/merchants/merchant_roll.test.ts
+++ b/src/lib/merchants/merchant_roll.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAXIMUM_STOCK_COUNT,
+  MINIMUM_STOCK_COUNT,
+  clampStockCount,
+  defaultMerchantGeneratorConfigRecord,
+  nameSourceForSet,
+  readMerchantGeneratorConfig,
+  rollMerchant,
+  rollMerchantSnapshot,
+  toMerchantGeneratorConfig,
+} from './merchant_roll';
+import { toMerchantSnapshot } from './merchant_snapshot';
+
+const CONFIG = defaultMerchantGeneratorConfigRecord();
+
+describe('rollMerchant', () => {
+  it('gives the same merchant for the same seed and settings', () => {
+    // Requirement 2.2. `generateMerchant` was already pure; the page around it was not.
+    expect(toMerchantSnapshot(rollMerchant('fixed', CONFIG))).toEqual(
+      toMerchantSnapshot(rollMerchant('fixed', CONFIG)),
+    );
+  });
+
+  it('gives a different merchant for a different seed', () => {
+    expect(toMerchantSnapshot(rollMerchant('one', CONFIG))).not.toEqual(
+      toMerchantSnapshot(rollMerchant('two', CONFIG)),
+    );
+  });
+
+  it('records the seed it was rolled from', () => {
+    expect(rollMerchant('the-seed', CONFIG).seed).toBe('the-seed');
+  });
+
+  it('honours the settings that fix a choice', () => {
+    const merchant = rollMerchant('fixed-choices', {
+      ...CONFIG,
+      shopType: 'jeweler',
+      venueType: 'wagon',
+      honesty: 'swindler',
+      priceLevel: 'extortionate',
+    });
+
+    expect(merchant.shop.shopType).toBe('jeweler');
+    expect(merchant.shop.venueType).toBe('wagon');
+    expect(merchant.honesty).toBe('swindler');
+    expect(merchant.priceLevel).toBe('extortionate');
+  });
+
+  it('rolls the stock count asked for', () => {
+    expect(rollMerchant('counted', { ...CONFIG, stockCount: 7 }).stock).toHaveLength(7);
+  });
+
+  it('puts the shop in a settlement when one was supplied', () => {
+    // Requirement 5.1: `settlement` is a registered kind, and where the shop stands is otherwise
+    // invented.
+    const merchant = rollMerchant('placed', { ...CONFIG, settlementName: 'Ashford' });
+
+    expect(merchant.shop.settlementName).toBe('Ashford');
+  });
+
+  it('leaves the settlement out when none was supplied', () => {
+    // 5.3: composition is opt-in, and a merchant handed nothing generates its own inputs.
+    expect('settlementName' in rollMerchant('unplaced', CONFIG).shop).toBe(false);
+  });
+
+  it('names from a pattern set when the record holds one', () => {
+    // What makes a re-roll possible without the culture artifact: the set's *name* is what the
+    // provenance records, and naming of the same tongue is what the user chose.
+    const named = rollMerchant('named', { ...CONFIG, nameGeneratorSet: 'dwarf' });
+    const plain = rollMerchant('named', CONFIG);
+
+    expect(named.proprietor.fullName).not.toBe(plain.proprietor.fullName);
+    expect(rollMerchant('named', { ...CONFIG, nameGeneratorSet: 'dwarf' })).toEqual(named);
+  });
+});
+
+describe('nameSourceForSet', () => {
+  it('names from a set this build has', () => {
+    expect(nameSourceForSet('dwarf')).toEqual({ kind: 'preset', setName: 'dwarf' });
+  });
+
+  it('falls back rather than throwing on a set this build does not have', () => {
+    // `getFantasyNameGeneratorSet` throws for an unknown name, and the name recorded here is
+    // usually a *culture's* — a generated name, nothing like the twelve fantasy presets. Without
+    // this, re-rolling a merchant named from a saved culture crashed.
+    expect(nameSourceForSet('Tuvaari')).toEqual({ kind: 'default' });
+    expect(nameSourceForSet(undefined)).toEqual({ kind: 'default' });
+  });
+
+  it('lets such a merchant re-roll rather than refusing', () => {
+    expect(() =>
+      rollMerchant('culture-named', { ...CONFIG, nameGeneratorSet: 'Tuvaari' }),
+    ).not.toThrow();
+  });
+});
+
+describe('clampStockCount', () => {
+  it('leaves a usable count alone', () => {
+    expect(clampStockCount(12)).toBe(12);
+  });
+
+  it('clamps a cleared, negative or oversized count into the page bounds', () => {
+    expect(clampStockCount(Number.NaN)).toBe(MINIMUM_STOCK_COUNT);
+    expect(clampStockCount(0)).toBe(MINIMUM_STOCK_COUNT);
+    expect(clampStockCount(9000)).toBe(MAXIMUM_STOCK_COUNT);
+    expect(clampStockCount(7.4)).toBe(7);
+  });
+});
+
+describe('readMerchantGeneratorConfig', () => {
+  it('reads back what the page wrote', () => {
+    const written = {
+      shopType: 'tavern',
+      venueType: 'tent',
+      honesty: 'shifty',
+      priceLevel: 'bargain',
+      stockCount: 9,
+      includeMerchantMark: false,
+      nameGeneratorSet: 'dwarf',
+      settlementName: 'Ashford',
+    };
+
+    expect(readMerchantGeneratorConfig(written)).toEqual(written);
+  });
+
+  it('falls back to the defaults for anything it does not recognise', () => {
+    // A config written by a build that spelled these differently should re-roll the ordinary way
+    // rather than from a field it misread.
+    expect(readMerchantGeneratorConfig({})).toEqual(CONFIG);
+    expect(readMerchantGeneratorConfig({ shopType: 'fishmonger' }).shopType).toBe('any');
+    expect(readMerchantGeneratorConfig({ includeMerchantMark: 'yes' }).includeMerchantMark).toBe(
+      true,
+    );
+  });
+
+  it('keeps "any", which is a setting rather than a missing one', () => {
+    expect(readMerchantGeneratorConfig({ honesty: 'any' }).honesty).toBe('any');
+  });
+
+  it('clamps a stock count rather than dropping it', () => {
+    expect(readMerchantGeneratorConfig({ stockCount: 900 }).stockCount).toBe(MAXIMUM_STOCK_COUNT);
+  });
+
+  it('drops an empty optional rather than storing it blank', () => {
+    expect(readMerchantGeneratorConfig({ settlementName: '' }).settlementName).toBeUndefined();
+    expect(readMerchantGeneratorConfig({ nameGeneratorSet: '' }).nameGeneratorSet).toBeUndefined();
+  });
+});
+
+describe('toMerchantGeneratorConfig', () => {
+  it('carries the settings onto the library config', () => {
+    const full = toMerchantGeneratorConfig({ ...CONFIG, stockCount: 6, shopType: 'scribe' });
+
+    expect(full.shopType).toBe('scribe');
+    expect(full.stockCount).toEqual({ min: 6, max: 6 });
+  });
+
+  it('names from the recorded pattern set when no live culture is handed in', () => {
+    expect(toMerchantGeneratorConfig({ ...CONFIG, nameGeneratorSet: 'dwarf' }).nameSource).toEqual({
+      kind: 'preset',
+      setName: 'dwarf',
+    });
+  });
+
+  it('prefers a live culture, which is what the page has', () => {
+    const source = { kind: 'preset' as const, setName: 'elvish' };
+
+    expect(
+      toMerchantGeneratorConfig({ ...CONFIG, nameGeneratorSet: 'dwarf' }, source).nameSource,
+    ).toEqual(source);
+  });
+
+  it('names from the default patterns when the record has nothing', () => {
+    expect(toMerchantGeneratorConfig(CONFIG).nameSource).toEqual({ kind: 'default' });
+  });
+});
+
+describe('rollMerchantSnapshot', () => {
+  it('is the roller a re-roll takes, and matches the page', () => {
+    expect(rollMerchantSnapshot('seed', CONFIG)).toEqual(
+      toMerchantSnapshot(rollMerchant('seed', CONFIG)),
+    );
+  });
+});

--- a/src/lib/merchants/merchant_roll.ts
+++ b/src/lib/merchants/merchant_roll.ts
@@ -1,0 +1,188 @@
+/**
+ * The single path from a seed to a merchant, and the record of how it was rolled.
+ *
+ * `generateMerchant` was already a pure function of seed and config. What was not was the page:
+ * `MerchantGenerator.svelte` reseeded its own RNG from the seed field inside an `$effect`, so the
+ * seed of the next press depended on the *text* of the previous one — the same fault #66 found in
+ * the equipment generator, and requirement 2.2's usual failure in this repository's newer form.
+ * Pressing Generate draws a fresh seed from the page's RNG now, and the roll is this function.
+ *
+ * `getDefaultMerchantConfig` does not read the clock, contrary to the blanket note in
+ * `docs/tool-readiness.md` about fifteen `getDefault*Config` helpers. It returns six literals and
+ * takes no RNG at all.
+ */
+
+import type { CharacterNameSource } from '$lib/characters';
+import { getFantasyNameGeneratorSetNames } from '$lib/names';
+
+import { generateMerchant } from './generate_merchant.js';
+import { getDefaultMerchantConfig } from './merchant_generator_config.js';
+import type { MerchantGeneratorConfig } from './merchant_generator_config.js';
+import { toMerchantSnapshot, type MerchantSnapshot } from './merchant_snapshot.js';
+import type { HonestyLevel, Merchant, PriceLevel, ShopType, VenueType } from './merchant_types.js';
+import { RESOLVED_SHOP_TYPES } from './shop_catalog.js';
+import {
+  RESOLVED_HONESTY_LEVELS,
+  RESOLVED_PRICE_LEVELS,
+  RESOLVED_VENUE_TYPES,
+} from './merchant_narrative.js';
+
+/** The fewest and most stock rows the page's control allows. */
+export const MINIMUM_STOCK_COUNT = 4;
+export const MAXIMUM_STOCK_COUNT = 30;
+
+/**
+ * What the generator records about how it rolled, and what a re-roll reads back.
+ *
+ * Stated as a type so the two ends — what is written as provenance and what a re-roll expects to
+ * find — are in one place and drift loudly instead of quietly. It is the page's six controls, plus
+ * the two things composition supplies.
+ */
+export type MerchantGeneratorConfigRecord = {
+  shopType: ShopType;
+  venueType: VenueType;
+  honesty: HonestyLevel;
+  priceLevel: PriceLevel;
+  stockCount: number;
+  includeMerchantMark: boolean;
+  /**
+   * The name pattern set the proprietor was named from.
+   *
+   * A merchant named from a referenced culture records that culture's own pattern set here rather
+   * than the culture's id, so a re-roll produces names of the same tongue without reaching back
+   * into the store for an artifact it has no way to ask for. The link to the culture is an
+   * artifact reference and lives beside the payload, not in this record. That is the treatment
+   * `character_roll.ts` settled.
+   */
+  nameGeneratorSet?: string;
+  /** The settlement the shop stands in, when one was referenced. */
+  settlementName?: string;
+};
+
+/** The settings a page opens on, and what an unreadable provenance record falls back to. */
+export function defaultMerchantGeneratorConfigRecord(): MerchantGeneratorConfigRecord {
+  return {
+    shopType: 'any',
+    venueType: 'any',
+    honesty: 'any',
+    priceLevel: 'any',
+    stockCount: 12,
+    includeMerchantMark: true,
+  };
+}
+
+function readChoice<T extends string>(value: unknown, resolved: readonly string[], fallback: T): T {
+  if (value === 'any') {
+    return 'any' as T;
+  }
+  return typeof value === 'string' && resolved.includes(value) ? (value as T) : fallback;
+}
+
+function readText(value: unknown, key: string): Record<string, string> {
+  return typeof value === 'string' && value !== '' ? { [key]: value } : {};
+}
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Anything unrecognisable falls back to the default rather than being coerced: a config written by
+ * a build that spelled these differently should re-roll the ordinary way, not from a field it
+ * misread. The stock count is clamped rather than dropped, because a count outside the page's own
+ * bounds is still a number a roll can honour.
+ */
+export function readMerchantGeneratorConfig(
+  config: Record<string, unknown>,
+): MerchantGeneratorConfigRecord {
+  const defaults = defaultMerchantGeneratorConfigRecord();
+
+  return {
+    shopType: readChoice(config.shopType, RESOLVED_SHOP_TYPES, defaults.shopType),
+    venueType: readChoice(config.venueType, RESOLVED_VENUE_TYPES, defaults.venueType),
+    honesty: readChoice(config.honesty, RESOLVED_HONESTY_LEVELS, defaults.honesty),
+    priceLevel: readChoice(config.priceLevel, RESOLVED_PRICE_LEVELS, defaults.priceLevel),
+    stockCount: clampStockCount(
+      typeof config.stockCount === 'number' ? config.stockCount : defaults.stockCount,
+    ),
+    includeMerchantMark:
+      typeof config.includeMerchantMark === 'boolean'
+        ? config.includeMerchantMark
+        : defaults.includeMerchantMark,
+    ...readText(config.nameGeneratorSet, 'nameGeneratorSet'),
+    ...readText(config.settlementName, 'settlementName'),
+  };
+}
+
+/** A stock count the shop generator can survive: whole, and inside the page's own bounds. */
+export function clampStockCount(count: number): number {
+  if (!Number.isFinite(count)) {
+    return MINIMUM_STOCK_COUNT;
+  }
+  return Math.min(Math.max(Math.round(count), MINIMUM_STOCK_COUNT), MAXIMUM_STOCK_COUNT);
+}
+
+/**
+ * The settings as the whole generator config the library's own roller takes.
+ *
+ * `nameSource` is a parameter rather than part of the record because the two callers hold
+ * different things: the page has a live `Culture` it just loaded from the vault, and a re-roll has
+ * only the pattern set's name. Naming from the name is what makes a re-roll possible at all
+ * without the artifact.
+ */
+export function toMerchantGeneratorConfig(
+  config: MerchantGeneratorConfigRecord,
+  nameSource?: CharacterNameSource,
+): MerchantGeneratorConfig {
+  const full = getDefaultMerchantConfig();
+  full.shopType = config.shopType;
+  full.venueType = config.venueType;
+  full.honesty = config.honesty;
+  full.priceLevel = config.priceLevel;
+  const count = clampStockCount(config.stockCount);
+  full.stockCount = { min: count, max: count };
+  full.includeMerchantMark = config.includeMerchantMark;
+  full.nameSource = nameSource ?? nameSourceForSet(config.nameGeneratorSet);
+  if (config.settlementName !== undefined) {
+    full.settlementName = config.settlementName;
+  }
+  return full;
+}
+
+/**
+ * The naming a recorded pattern set asks for, or the default when this build has no such set.
+ *
+ * `getFantasyNameGeneratorSet` **throws** for a name it does not have, and the name recorded here
+ * is usually a *culture's* — which is a generated name and is nothing like the twelve fantasy
+ * presets. So a re-roll of a merchant named from a saved culture would have crashed rather than
+ * fallen back, which is the opposite of what 3.3's discipline asks of every other read path.
+ *
+ * The fallback is the default patterns, and it is silent: a proprietor named from a tongue this
+ * build cannot rebuild is still a proprietor, and the alternative is a re-roll that cannot happen
+ * at all.
+ */
+export function nameSourceForSet(setName: string | undefined): CharacterNameSource {
+  if (setName === undefined || !getFantasyNameGeneratorSetNames().includes(setName)) {
+    return { kind: 'default' };
+  }
+  return { kind: 'preset', setName };
+}
+
+/** Roll a merchant — the one path the generator page and a re-roll both take. */
+export function rollMerchant(
+  seed: string,
+  config: MerchantGeneratorConfigRecord,
+  nameSource?: CharacterNameSource,
+): Merchant {
+  return generateMerchant(seed, toMerchantGeneratorConfig(config, nameSource));
+}
+
+/**
+ * Roll a fresh merchant as a snapshot — the destructive half of editing (requirement 4.3), and
+ * what `ARTIFACT_EDITORS` registers as this kind's roller.
+ */
+export function rollMerchantSnapshot(
+  seed: string,
+  config: MerchantGeneratorConfigRecord,
+  nameSource?: CharacterNameSource,
+): MerchantSnapshot {
+  return toMerchantSnapshot(rollMerchant(seed, config, nameSource));
+}

--- a/src/lib/merchants/merchant_snapshot.test.ts
+++ b/src/lib/merchants/merchant_snapshot.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultMerchantGeneratorConfigRecord,
+  rollMerchant,
+  rollMerchantSnapshot,
+} from './merchant_roll';
+import {
+  merchantFromSnapshot,
+  merchantSeedMatchesProvenance,
+  toMerchantSnapshot,
+} from './merchant_snapshot';
+
+const CONFIG = defaultMerchantGeneratorConfigRecord();
+const MERCHANT = toMerchantSnapshot(rollMerchant('snapshot-seed', CONFIG));
+
+describe('toMerchantSnapshot', () => {
+  it('keeps the person, the shop and the stock', () => {
+    expect(MERCHANT.proprietor.fullName).not.toBe('');
+    expect(MERCHANT.shop.name).not.toBe('');
+    expect(MERCHANT.stock.length).toBeGreaterThan(0);
+    expect(MERCHANT.stock[0].name).toBeTypeOf('string');
+  });
+
+  it('keeps the mark as a charge name and a fill, not a drawing', () => {
+    // Decision 5 of docs/readiness-factions.md, and it was already done before the pass got here.
+    expect(MERCHANT.mark).not.toBeNull();
+    expect(Object.keys(MERCHANT.mark ?? {}).sort()).toEqual(['chargeName', 'fillHex']);
+  });
+
+  it('keeps no mark when the generator was told not to make one', () => {
+    expect(
+      toMerchantSnapshot(rollMerchant('no-mark', { ...CONFIG, includeMerchantMark: false })).mark,
+    ).toBeNull();
+  });
+});
+
+describe('merchantFromSnapshot', () => {
+  it('round-trips everything that matters', () => {
+    // Requirement 7.2.
+    expect(merchantFromSnapshot(MERCHANT)).toEqual(MERCHANT);
+    expect(merchantFromSnapshot(merchantFromSnapshot(MERCHANT))).toEqual(MERCHANT);
+  });
+
+  it('survives a trip through JSON, which is what storage is', () => {
+    expect(merchantFromSnapshot(JSON.parse(JSON.stringify(MERCHANT)))).toEqual(MERCHANT);
+  });
+
+  it('copies deeply enough that an editor cannot reach the stored record', () => {
+    const read = merchantFromSnapshot(MERCHANT);
+
+    read.stock.push({ name: 'tampered', baseCost: 0, price: 0, quantity: 1 });
+    read.stock[0].name = 'tampered';
+    read.proprietor.personalityTraits.push('tampered');
+
+    expect(MERCHANT.stock.map((item) => item.name)).not.toContain('tampered');
+    expect(MERCHANT.proprietor.personalityTraits).not.toContain('tampered');
+  });
+
+  it('recomputes nothing on read', () => {
+    // Requirement 4.2: a price a referee marked down by hand is the shop's price, not an input to
+    // a multiplication that runs again every time the artifact is opened.
+    const edited = {
+      ...MERCHANT,
+      stock: MERCHANT.stock.map((item, index) => (index === 0 ? { ...item, price: 1 } : item)),
+    };
+
+    expect(merchantFromSnapshot(edited).stock[0].price).toBe(1);
+  });
+});
+
+describe('merchantSeedMatchesProvenance', () => {
+  it('holds for a merchant the roll module produced', () => {
+    // The trap the design names: `Merchant` carries its own `seed`, and a payload whose seed
+    // disagrees with its provenance is a shape where two answers to "what rolled this" exist.
+    const snapshot = rollMerchantSnapshot('provenance-seed', CONFIG);
+
+    expect(snapshot.seed).toBe('provenance-seed');
+    expect(merchantSeedMatchesProvenance(snapshot, 'provenance-seed')).toBe(true);
+    expect(merchantSeedMatchesProvenance(snapshot, 'something-else')).toBe(false);
+  });
+});

--- a/src/lib/merchants/merchant_snapshot.ts
+++ b/src/lib/merchants/merchant_snapshot.ts
@@ -1,0 +1,65 @@
+/**
+ * Writing a merchant for storage, and reading one back.
+ *
+ * `Merchant` is already plain — strings, numbers, two string lists, a `{ chargeName, fillHex }`
+ * mark and a list of five-field stock rows — so the codec is a deep copy rather than a conversion.
+ * That is not an accident: `MerchantMark` was already stored as the *name* of its charge and a
+ * fill, which is the treatment
+ * [decision 5 of the factions document](../../../docs/readiness-factions.md) asks of generated
+ * imagery, done before this pass reached the tool.
+ *
+ * **The stock is stored, not regenerated.** #67 worries that duplicated item records would make a
+ * merchant the largest object in the vault, and it would be right about `Item`: a
+ * `MerchantStockItem` is five fields, so a fifty-line inventory is a few kilobytes. Storing it is
+ * also the only honest option — a referee who has crossed two things off the list has edited the
+ * shop, and 4.2 says the payload remembers that.
+ *
+ * **The payload's `seed` and the artifact's provenance seed are the same value.** `Merchant`
+ * carries its own `seed` field, which pre-dates this pass, and a second one would be a shape where
+ * two answers to "what rolled this" can disagree. `merchantSeedMatchesProvenance` is what says so
+ * out loud, and the roll module is what keeps it true.
+ */
+
+import type { Merchant } from './merchant_types.js';
+
+/** A merchant as it is stored: the type as it stands. */
+export type MerchantSnapshot = Merchant;
+
+export function toMerchantSnapshot(merchant: Merchant): MerchantSnapshot {
+  return {
+    seed: merchant.seed,
+    proprietor: {
+      ...merchant.proprietor,
+      personalityTraits: [...merchant.proprietor.personalityTraits],
+    },
+    shop: { ...merchant.shop },
+    mark: merchant.mark === null ? null : { ...merchant.mark },
+    honesty: merchant.honesty,
+    priceLevel: merchant.priceLevel,
+    priceModifier: merchant.priceModifier,
+    honestyNotes: merchant.honestyNotes,
+    hagglingAdvice: merchant.hagglingAdvice,
+    stock: merchant.stock.map((item) => ({ ...item })),
+  };
+}
+
+/**
+ * Nothing is recomputed on read.
+ *
+ * A stored merchant is finished. Re-deriving the ask prices from the price modifier would
+ * overwrite whatever a referee changed by hand — requirement 4.2 exactly — and re-drawing the
+ * haggling advice would replace a line they may have rewritten.
+ */
+export function merchantFromSnapshot(snapshot: MerchantSnapshot): Merchant {
+  return toMerchantSnapshot(snapshot);
+}
+
+/** The codec's reading half, with the signature the registry hands it. The RNG is unused. */
+export function merchantFromSnapshotWithRng(snapshot: MerchantSnapshot, _rng: unknown): Merchant {
+  return merchantFromSnapshot(snapshot);
+}
+
+/** Whether a stored merchant agrees with the provenance recorded beside it. */
+export function merchantSeedMatchesProvenance(snapshot: MerchantSnapshot, seed: string): boolean {
+  return snapshot.seed === seed;
+}

--- a/src/lib/merchants/merchant_types.ts
+++ b/src/lib/merchants/merchant_types.ts
@@ -51,6 +51,15 @@ export type MerchantShop = {
   venueTypeLabel: string;
   description: string;
   locationBlurb: string;
+  /**
+   * The settlement the shop stands in, when one was supplied.
+   *
+   * Absent by default: the generator invents a location blurb — "on the market square", "beside
+   * the temple district" — and has never known which town that square is in. Requirement 5.1 is
+   * what puts it here: `settlement` is a registered kind, so a merchant that would otherwise
+   * invent its setting must be able to take one by reference.
+   */
+  settlementName?: string;
 };
 
 export type Merchant = {

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -125,6 +125,7 @@ describe('TOOL_CATALOG', () => {
       '/fantasy/equipment',
       '/fantasy/equipment-generator',
       '/fantasy/family',
+      '/fantasy/merchant',
       '/fantasy/organization',
       '/culture',
       '/fantasy/dcc/character',
@@ -139,6 +140,7 @@ describe('TOOL_CATALOG', () => {
       '/species-stats',
       '/word-generator-cheat-sheet',
       '/fantasy/equipment-generator',
+      '/fantasy/merchant',
     ];
 
     const claimingMore = TOOL_CATALOG.filter(
@@ -246,6 +248,7 @@ describe('toolsWithMaturity', () => {
       '/fantasy/equipment',
       '/fantasy/equipment-generator',
       '/fantasy/family',
+      '/fantasy/merchant',
       '/fantasy/organization',
       '/fantasy/religion',
       '/fantasy/settlement',
@@ -320,6 +323,7 @@ describe('filterTools', () => {
       '/fantasy/settlement',
       '/fantasy/equipment',
       '/fantasy/equipment-generator',
+      '/fantasy/merchant',
     ]);
   });
 

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -418,12 +418,20 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     genres: ['fantasy'],
     tags: ['equipment'],
   }),
+  // Release-ready, assessed section by section against docs/workshop.md and recorded in
+  // docs/readiness-objects.md (#67). It saves as `merchant` — the person, the venue and the
+  // inventory, with the stock stored rather than regenerated because a referee who crosses two
+  // things off has edited the shop — has an editor in `ARTIFACT_EDITORS`, and exports Markdown and
+  // PDF, the first exports it has ever had. Its roll is deterministic from the seed via
+  // `merchant_roll.ts`, and the payload's own `seed` is the provenance seed rather than a second
+  // answer to the same question. It is the first tool in the pass to compose two kinds: a culture
+  // for naming and a settlement for where the shop stands (5.1).
   defineTool({
     path: '/fantasy/merchant',
     label: 'Fantasy Merchant',
     kind: 'generator',
     domain: 'objects',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     genres: ['fantasy'],
     tags: ['equipment'],
   }),

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -252,6 +252,23 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         rollItemSnapshot(provenance.seed, readEquipmentGeneratorConfig(provenance.config));
     },
   },
+  merchant: {
+    loadEditor: () => import('$components/objects/MerchantArtifactEditor.svelte'),
+    /**
+     * The page's six controls, read back through the roll module's own reader.
+     *
+     * No name source is passed, so a merchant named from a referenced culture re-rolls from that
+     * culture's *pattern set name* rather than from the artifact — which is what the record stores
+     * and why. A re-roll cannot ask the store for an artifact it has only a reference to, and
+     * naming of the same tongue is what the user was actually choosing.
+     */
+    loadRoller: async () => {
+      const { readMerchantGeneratorConfig, rollMerchantSnapshot } =
+        await import('$lib/merchants/merchant_roll.js');
+      return (provenance) =>
+        rollMerchantSnapshot(provenance.seed, readMerchantGeneratorConfig(provenance.config));
+    },
+  },
   'arms-manufacturer': {
     loadEditor: () => import('$components/factions/ArmsManufacturerArtifactEditor.svelte'),
     /**

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -34,6 +34,7 @@ describe('artifact kind catalog', () => {
       'region',
       'drug',
       'item',
+      'merchant',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -45,6 +45,12 @@ import { drugArtifactKind } from '$lib/drug';
 // chunks; through the entry point it is 408 KB across 35. Every page that lists what a project
 // contains pays that difference.
 import { itemArtifactKind } from '$lib/equipment/item_artifact_kind';
+// Deep, and the sharpest of the lot: `$lib/merchants`'s entry point reaches `generate_merchant`,
+// and from there the character generator, the species tables and — through the merchant mark —
+// the whole charge library. Measured on the build: through the kind module the registry chunk and
+// everything it statically imports is 296 KB across 31 chunks; through the entry point it is
+// 19.7 MB across 47.
+import { merchantArtifactKind } from '$lib/merchants/merchant_artifact_kind';
 import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
 import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
 import { settlementArtifactKind } from '$lib/settlements/settlement_artifact_kind';
@@ -86,6 +92,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, regionArtifactKind);
   registerArtifactKind(registry, drugArtifactKind);
   registerArtifactKind(registry, itemArtifactKind);
+  registerArtifactKind(registry, merchantArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Closes #67. Takes `/fantasy/merchant` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the design in `docs/readiness-objects.md`.

Kind `merchant`: the person, the venue and the inventory. `$lib/merchants` grows the five kind modules the pass prescribes — roll, snapshot, artifact kind, editing and presentation.

**The size worry in the issue is as small as the design predicted.** A `MerchantStockItem` is five fields, not a full `Item`, so a twelve-line inventory is under a kilobyte. Storing it is also the only honest option — a referee who has crossed two things off has edited the shop.

## Four things worth recording

- **The payload's `seed` and the provenance seed are the same value**, which is the trap the design named. `merchantSeedMatchesProvenance` asserts it out loud and the roll module keeps it true; a second seed would be a shape where two answers to "what rolled this" can disagree.
- **Re-rolling a merchant named from a culture would have crashed.** The provenance records the culture's *pattern set name*, which is the treatment `character_roll.ts` settled — but `getFantasyNameGeneratorSet` **throws** for a name it does not have, and a culture's set name is a generated name, nothing like the twelve fantasy presets. `nameSourceForSet` falls back to the default patterns instead, which is the discipline 3.3 asks of every other read path.
- **5.1 binds twice, and the second half needed a generation change.** A culture for naming was already reachable through `nameSource`. Where the shop *stands* was not: `generateVenueDescription` invents a location blurb — "on the market square", "beside the temple district" — and had never known which town that square was in. `MerchantShop` gains an optional `settlementName`, and the location line reads "… In Ashford." The two answer different halves of the question rather than one replacing the other. **It is the first tool in the pass to compose two kinds.**
- **The town's name is the settlement's, not the vault entry's.** A settlement a user labelled "starting town" is still called whatever the generator called it, so the reference reads the payload's `name`.

## The same two page faults, three tools running

Both of the faults #66 found were here too, and `docs/tool-readiness.md` records the pattern now so the remaining tools expect them:

- The page **reseeded its own RNG from the seed field** inside an `$effect`, so each press's seed depended on the *text* of the previous one.
- The payload had to move to **`$state.raw`** before IndexedDB would take it — `structuredClone` will not clone a Proxy.

## The rest of the sections

- **6.3** — Markdown and PDF, the first exports this tool has ever had. A shop inventory is exactly the thing a referee wants on paper.
- **6.4** has teeth here: a shop that has sold out prints no stock heading at all rather than a table head over nothing, and a cleared note or blurb leaves no blank line behind.
- **4** — an editor in `ARTIFACT_EDITORS` covering the shop, the proprietor, the trading prose and the stock. The rows carry their own add and remove controls, because that is how an inventory is edited. Nothing recomputes: changing the price modifier does not re-derive the ask column, and `repricedStock` offers that as an explicit command.
- **7.2–7.4** — round-trip, migration and a full generate/save/reopen/edit journey in `e2e/merchant.spec.ts`, including crossing a line off the inventory and getting it back after a reload.

## Measurement

The deep import of the kind module is measured as the allowlist rule requires, and it is the sharpest case since settlement: through the kind module the registry chunk and everything it statically imports is **296 KB across 31 chunks**; through `$lib/merchants`' entry point it is **19.7 MB across 47** — the merchant mark reaches the whole charge library.

## Verification

`npm run verify` is green, and `npm run verify:all` was run before opening this: 5,848 unit tests and 600 Playwright tests, including the new `e2e/merchant.spec.ts` and the mobile pass at all five widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QEan2y9qHFJnvoM1dci8L
