### PR TITLE
Take the fantasy potion generator to Release-ready

### DIFF
--- a/docs/readiness-objects.md
+++ b/docs/readiness-objects.md
@@ -98,6 +98,31 @@ canonicalName?, sensory, effect, modifications }` — a richer shape with its ow
 - **1.4 is already satisfied.** The issue says the label reads "Fantasy Potion Generator"; the
   catalog reads `Fantasy Potion`. Nothing is owed.
 
+**As built (#68).** Decision 2 held: the kind is `potion`, not a share of `item`, and the editor's
+sensory and effect fields are what that decision buys — an item editor has no place for a duration
+or a flavour. **1.4 needed nothing**, as this section said: the catalog has always read
+`Fantasy Potion`, whatever the issue claimed.
+
+Three things this section did not anticipate:
+
+- **The payload stored the same thing twice.** `generatePotion` writes the effect, the sensory
+  profile and the display name into the liquid _and_ onto the potion beside it —
+  `liquid.effect === effect`, `liquid.sensory === sensory`, `liquid.name === displayName`. Two
+  copies of one fact is a shape where an editor changes one and the other goes stale, which is 4.2's
+  failure mode dressed as a data model. The snapshot keeps the potion's copy and rebuilds the
+  liquid's on read, so there is one place to edit an effect and one answer to what it is.
+- **The page decided the potion's form by sniffing its properties**, three levels of nested ternary
+  deep, where nothing could test it. `potionForm` owns that now — the same shape of finding the
+  reference tools kept producing, in a generator.
+- **The sensory profile was a `<ul>` wrapped around a `<dl>`.** A list whose only child is a
+  definition list is invalid markup and announces a one-item list around four pairs. It is a
+  `StatBlock` alone now (6.2).
+
+**The seed came from the clock inside every press**, which is requirement 2.2's oldest failure in
+the pass rather than the newer `$effect` form #66 and #67 had — this page built a whole
+`new RNG(Date.now().toString())` per press to draw the next seed. The `$state.raw` trap was here
+too, making it three tools in a row.
+
 ## #70 — Fantasy treasure hoard
 
 `generateRandomTreasureHoard(seed, config)` returns `Item[]` — coins packed into piles, gems, art

--- a/e2e/potion.spec.ts
+++ b/e2e/potion.spec.ts
@@ -1,0 +1,221 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `potion` kind: generate, save, reopen, edit (#68).
+ *
+ * This is the half no unit test can settle. The library tests prove a potion round-trips through
+ * the codec and that each edit changes one thing; what they cannot prove is that a referee can
+ * press Generate, keep the potion, come back to it in a different page, rewrite what it tastes of,
+ * and still have the potion they saved.
+ *
+ * The kind is its own rather than a share of `item` — decision 2 of docs/readiness-objects.md, and
+ * a correction to what this issue assumed. The editor's sensory and effect fields are what that
+ * decision buys, so they are what these tests drive.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const POTION_TITLE = 'Potion Generator | Iron Arachne';
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+const result = (page: Page) => page.locator('.potion-result');
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+/** A pinned press, so the potion on screen is the same one every run. */
+async function generatePinned(page: Page, seed = 'a-fixed-seed'): Promise<void> {
+  await page.getByLabel('Seed', { exact: true }).fill(seed);
+  await page.getByLabel('Lock Seed').check();
+  await page.getByRole('button', { name: 'Generate', exact: true }).click();
+  await expect(result(page)).toBeVisible();
+}
+
+test.describe('a potion', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'The Alchemist');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/fantasy/potion-generator', { title: POTION_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a potion to keep straight away.
+    await expect(result(page)).toBeVisible();
+    await saveAs(page, 'The Green Vial');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'The Green Vial');
+
+    // Typed rather than filled: the point is that the editor's own binding carries keystrokes
+    // through to the snapshot it announces.
+    const flavor = panel.getByRole('textbox', { name: 'Flavor' });
+    await flavor.fill('');
+    await flavor.pressSequentially('like cold iron');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'The Green Vial');
+    await expect(reopened.getByRole('textbox', { name: 'Flavor' })).toHaveValue('like cold iron');
+  });
+
+  test('reaches the fields an item editor has no place for', async ({ page }) => {
+    // Decision 2 of docs/readiness-objects.md as a user meets it: the sensory profile and the
+    // effect are why a potion is its own kind rather than a share of `item`.
+    await visitRoute(page, '/fantasy/potion-generator', { title: POTION_TITLE });
+    await generatePinned(page);
+    await saveAs(page, 'The Blue Flask');
+
+    const panel = await openInWorkshop(page, 'The Blue Flask');
+    for (const label of ['Appearance', 'Viscosity', 'Flavor', 'Scent', 'Effect name']) {
+      await expect(panel.getByRole('textbox', { name: label })).toBeVisible();
+    }
+    await expect(panel.getByRole('spinbutton', { name: 'Magnitude' })).toBeVisible();
+
+    await panel.getByRole('textbox', { name: 'Effect name' }).fill('Reconsideration');
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'The Blue Flask');
+    await expect(reopened.getByRole('textbox', { name: 'Effect name' })).toHaveValue(
+      'Reconsideration',
+    );
+  });
+
+  test('offers the description rather than rewriting it under the user', async ({ page }) => {
+    // Requirement 4.2. The prose is composed from the name, the senses and the effect, so a form
+    // that regenerated it on every keystroke would throw away a hand-written one.
+    await visitRoute(page, '/fantasy/potion-generator', { title: POTION_TITLE });
+    await generatePinned(page);
+    await saveAs(page, 'The Written Draught');
+
+    const panel = await openInWorkshop(page, 'The Written Draught');
+    const description = panel.getByRole('textbox', { name: 'Potion description' });
+    await description.fill('A judge wrote this by hand.');
+
+    // Unmoved: changing a field the description is built from did not touch it.
+    await panel.getByRole('textbox', { name: 'Scent' }).fill('of wet slate');
+    await expect(description).toHaveValue('A judge wrote this by hand.');
+
+    // And the generated wording is there for the asking.
+    await panel.getByRole('button', { name: 'Rewrite the description from the fields' }).click();
+    // `toHaveValue`, not `toContainText`: a textarea's edited value is not its text content.
+    await expect(description).toHaveValue(/wet slate/);
+  });
+
+  test('does not reprice the potion when the magnitude changes', async ({ page }) => {
+    // 4.2 again, and the sharpest temptation here: the value is derived from the catalog entry and
+    // the effect, so re-running that arithmetic would overwrite a price set by hand.
+    await visitRoute(page, '/fantasy/potion-generator', { title: POTION_TITLE });
+    await generatePinned(page);
+    await saveAs(page, 'The Priced Vial');
+
+    const panel = await openInWorkshop(page, 'The Priced Vial');
+    const value = panel.getByRole('spinbutton', { name: 'Value (cp)' });
+    await value.fill('250');
+
+    await panel.getByRole('spinbutton', { name: 'Magnitude' }).fill('90');
+    await expect(value).toHaveValue('250');
+  });
+
+  test('downloads a potion a referee can take to the table', async ({ page }) => {
+    // Requirement 6.3, and the first exports this tool has ever had.
+    await visitRoute(page, '/fantasy/potion-generator', { title: POTION_TITLE });
+    await generatePinned(page);
+    const name = await result(page).locator('h2').innerText();
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const file = await markdown;
+    expect(file.suggestedFilename()).toMatch(/^potion-.*\.md$/);
+
+    const contents = await new Response(await file.createReadStream()).text();
+    expect(contents).toContain(`# ${name}`);
+    expect(contents).toContain('## Effect');
+    expect(contents).toContain('## Sensory profile');
+    expect(contents).toContain('## Container');
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/^potion-.*\.pdf$/);
+  });
+
+  test('reproduces the same potion from the same seed', async ({ page }) => {
+    // Requirement 2.2. The page built a fresh `RNG(Date.now())` inside every press to draw the next
+    // seed, so the control was honoured and the seeds themselves came from the clock.
+    await visitRoute(page, '/fantasy/potion-generator', { title: POTION_TITLE });
+
+    await generatePinned(page, 'a-fixed-seed');
+    const first = await result(page).innerText();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await result(page).innerText()).toEqual(first);
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await result(page).innerText()).not.toEqual(first);
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -54,6 +54,7 @@ const SILENT_TOOL_PAGES = [
   { path: '/drug', title: 'Cyberpunk Drug Generator | Iron Arachne' },
   { path: '/fantasy/equipment-generator', title: 'Equipment Generator | Iron Arachne' },
   { path: '/fantasy/merchant', title: 'Fantasy Merchant Generator | Iron Arachne' },
+  { path: '/fantasy/potion-generator', title: 'Potion Generator | Iron Arachne' },
   {
     // The first reference tool in this list, and the reason it is worth naming: most of the spec
     // does not apply to a tool that produces no artifacts, so its silence was earned by sections

--- a/src/components/objects/PotionArtifactEditor.svelte
+++ b/src/components/objects/PotionArtifactEditor.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import DeleteButton from '$components/common/DeleteButton.svelte';
+  import Notice from '$components/common/Notice.svelte';
+  import { ITEM_RARITIES } from '$lib/equipment';
+  import type { Rarity } from '$lib/equipment';
+  import {
+    describeModification,
+    describePotionSnapshot,
+    removePotionModification,
+    setPotionContainerText,
+    setPotionDescription,
+    setPotionEffectText,
+    setPotionMagnitude,
+    setPotionRarity,
+    setPotionSensory,
+    setPotionText,
+    setPotionValue,
+    validatePotionSnapshot,
+    type PotionSensoryField,
+    type PotionSnapshot,
+    type PotionTextField,
+  } from '$lib/potions';
+
+  /**
+   * The editing view for a saved potion.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it.
+   *
+   * **The sensory profile and the effect are here, which is why a potion is not an `item`.**
+   * Decision 2 of docs/readiness-objects.md: an item editor has no field for a duration or a
+   * flavour, and folding the two kinds together would give one of them an editor that is wrong.
+   *
+   * **Nothing is recomputed.** Changing the magnitude does not reprice the potion, and no field
+   * rewrites the description — 4.2 forbids exactly that, and `$lib/potions`' `potion_editing.ts`
+   * says why at length. The button at the foot offers the generated wording back.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps this editor from rendering fields over
+   * something that is not a potion.
+   */
+  const accepted = $derived(validatePotionSnapshot(snapshot));
+  const potion = $derived<PotionSnapshot | undefined>(accepted.ok ? accepted.value : undefined);
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: PotionSnapshot) => PotionSnapshot): void {
+    if (potion === undefined) {
+      return;
+    }
+    onChange(change(potion));
+  }
+
+  const NAME_FIELDS: { field: PotionTextField; label: string }[] = [
+    { field: 'displayName', label: 'Potion name' },
+    { field: 'canonicalName', label: 'Base formula' },
+  ];
+
+  const SENSORY_FIELDS: { field: PotionSensoryField; label: string }[] = [
+    { field: 'appearance', label: 'Appearance' },
+    { field: 'viscosity', label: 'Viscosity' },
+    { field: 'flavor', label: 'Flavor' },
+    { field: 'scent', label: 'Scent' },
+  ];
+</script>
+
+{#if potion === undefined}
+  <Notice tone="danger">
+    These contents are stored as a potion but do not read as one, so there is nothing safe to edit
+    here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="potion-editor">
+    {#each NAME_FIELDS as entry (entry.field)}
+      <div class="input-group input-group--inline">
+        <label for="{uid}-{entry.field}">{entry.label}</label>
+        <input
+          id="{uid}-{entry.field}"
+          type="text"
+          value={potion[entry.field] ?? ''}
+          oninput={(event) =>
+            edit((current) => setPotionText(current, entry.field, event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+    {/each}
+
+    <div class="input-group input-group--inline">
+      <label for="{uid}-rarity">Rarity</label>
+      <select
+        id="{uid}-rarity"
+        value={potion.liquid.rarity}
+        onchange={(event) =>
+          edit((current) => setPotionRarity(current, event.currentTarget.value as Rarity))}
+      >
+        {#each ITEM_RARITIES as rarity (rarity)}
+          <option value={rarity}>{rarity}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="input-group input-group--inline">
+      <!-- In copper, which is the unit a value is stored in and the one the price lists quote. -->
+      <label for="{uid}-value">Value (cp)</label>
+      <input
+        id="{uid}-value"
+        type="number"
+        min="0"
+        value={potion.liquid.value}
+        oninput={(event) =>
+          edit((current) => setPotionValue(current, event.currentTarget.valueAsNumber))}
+      />
+    </div>
+
+    <h3 class="potion-editor__heading">Effect</h3>
+
+    <div class="input-group input-group--inline">
+      <label for="{uid}-effect-name">Effect name</label>
+      <input
+        id="{uid}-effect-name"
+        type="text"
+        value={potion.effect.name}
+        oninput={(event) =>
+          edit((current) => setPotionEffectText(current, 'name', event.currentTarget.value))}
+        autocomplete="off"
+      />
+    </div>
+
+    <div class="input-group">
+      <label for="{uid}-effect-description">What it does</label>
+      <textarea
+        id="{uid}-effect-description"
+        rows="3"
+        value={potion.effect.description}
+        oninput={(event) =>
+          edit((current) => setPotionEffectText(current, 'description', event.currentTarget.value))}
+      ></textarea>
+    </div>
+
+    <div class="input-group input-group--inline">
+      <label for="{uid}-magnitude">Magnitude</label>
+      <input
+        id="{uid}-magnitude"
+        type="number"
+        min="0"
+        value={potion.effect.magnitude}
+        oninput={(event) =>
+          edit((current) => setPotionMagnitude(current, event.currentTarget.valueAsNumber))}
+      />
+    </div>
+
+    <h3 class="potion-editor__heading">Sensory profile</h3>
+
+    {#each SENSORY_FIELDS as entry (entry.field)}
+      <div class="input-group input-group--inline">
+        <label for="{uid}-sensory-{entry.field}">{entry.label}</label>
+        <input
+          id="{uid}-sensory-{entry.field}"
+          type="text"
+          value={potion.sensory[entry.field]}
+          oninput={(event) =>
+            edit((current) => setPotionSensory(current, entry.field, event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+    {/each}
+
+    <h3 class="potion-editor__heading">Container</h3>
+
+    <div class="input-group input-group--inline">
+      <label for="{uid}-container-name">Container</label>
+      <input
+        id="{uid}-container-name"
+        type="text"
+        value={potion.container.name}
+        oninput={(event) =>
+          edit((current) => setPotionContainerText(current, 'name', event.currentTarget.value))}
+        autocomplete="off"
+      />
+    </div>
+
+    <div class="input-group">
+      <label for="{uid}-container-description">Container description</label>
+      <textarea
+        id="{uid}-container-description"
+        rows="2"
+        value={potion.container.description}
+        oninput={(event) =>
+          edit((current) =>
+            setPotionContainerText(current, 'description', event.currentTarget.value),
+          )}
+      ></textarea>
+    </div>
+
+    <!-- 6.4 in the editor as well as the exports: a potion with nothing done to the base formula
+         shows no modifications section rather than an empty heading. -->
+    {#if potion.modifications.length > 0}
+      <h3 class="potion-editor__heading">Modifications</h3>
+      <ul class="potion-editor__modifications">
+        {#each potion.modifications as modification, index (index)}
+          <li>
+            <span>{describeModification(modification)}</span>
+            <!-- Removed, not re-picked: a modification is what the roll did to the base formula and
+                 was applied to the numbers when it happened. Adding one from nowhere would claim a
+                 change that never touched them. -->
+            <DeleteButton
+              label="Remove {describeModification(modification)}"
+              onclick={() => edit((current) => removePotionModification(current, index))}
+            />
+          </li>
+        {/each}
+      </ul>
+    {/if}
+
+    <div class="input-group">
+      <!-- Qualified as "Potion description": the panel above has a field labelled "Name" that
+           renames the artifact, and two other descriptions sit near this one. -->
+      <label for="{uid}-description">Potion description</label>
+      <textarea
+        id="{uid}-description"
+        rows="4"
+        value={potion.liquid.description}
+        oninput={(event) =>
+          edit((current) => setPotionDescription(current, event.currentTarget.value))}
+      ></textarea>
+    </div>
+
+    <!-- Offered rather than done automatically, for the reason the header gives. -->
+    <BaseButton
+      onclick={() =>
+        edit((current) => setPotionDescription(current, describePotionSnapshot(current)))}
+    >
+      Rewrite the description from the fields
+    </BaseButton>
+  </div>
+{/if}
+
+<style>
+  .potion-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+    align-items: flex-start;
+  }
+
+  .potion-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .potion-editor input,
+  .potion-editor textarea,
+  .potion-editor select {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+
+  .potion-editor__heading {
+    margin: var(--s4) 0 0;
+  }
+
+  .potion-editor__modifications {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s3);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+  }
+
+  .potion-editor__modifications li {
+    align-items: center;
+    display: flex;
+    gap: var(--s4);
+    justify-content: space-between;
+  }
+</style>

--- a/src/components/objects/PotionGenerator.svelte
+++ b/src/components/objects/PotionGenerator.svelte
@@ -1,38 +1,87 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+  import { RNG } from '@ironarachne/rng';
+
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import CheckboxField from '$components/common/CheckboxField.svelte';
+  import ControlsPanel from '$components/common/ControlsPanel.svelte';
+  import GeneratorPage from '$components/layout/GeneratorPage.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
+  import SeedControls from '$components/common/SeedControls.svelte';
   import Stat from '$components/common/Stat.svelte';
   import StatBlock from '$components/common/StatBlock.svelte';
-  import { onMount } from 'svelte';
-  import { valueToString, COMMON_FANTASY } from '$lib/currency';
+  import { downloadTextFile } from '$lib/download';
+  import { downloadTextPdf } from '$lib/pdf';
   import {
-    describeDurationShort,
-    describeEffect,
-    generatePotion,
-    getDefaultPotionConfig,
-    type Potion,
+    POTION_ARTIFACT_KIND,
+    potionFileStem,
+    potionToDocument,
+    potionToMarkdown,
+    potionToText,
+    rollPotion,
+    toPotionSnapshot,
+    type PotionGeneratorConfigRecord,
+    type PotionSnapshot,
   } from '$lib/potions';
-  import { RNG } from '@ironarachne/rng';
-  import GeneratorPage from '$components/layout/GeneratorPage.svelte';
-  import SeedControls from '$components/common/SeedControls.svelte';
-  import CheckboxField from '$components/common/CheckboxField.svelte';
-  import BaseButton from '$components/common/BaseButton.svelte';
 
-  const initialSeed = new RNG(Date.now().toString()).randomString(13);
-  let seed = $state(initialSeed);
+  const TOOL_PATH = '/fantasy/potion-generator';
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. It used to build a whole new
+   * `RNG(Date.now())` *inside every press* to draw the next seed, so the seed control worked and
+   * the seeds themselves came from the clock — requirement 2.2's oldest failure in the pass.
+   */
+  const rng = new RNG(Date.now().toString());
+
+  let seed = $state(rng.randomString(13));
   let lockSeed = $state(false);
   let allowHomebrew = $state(false);
   let allowProceduralNames = $state(false);
 
-  let potion: Potion | null = $state(null);
+  /**
+   * The rolled potion, as it is stored.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every array and object in
+   * the payload in a Proxy, and `structuredClone` — what IndexedDB stores with — refuses one
+   * outright, so saving fails with `could not be cloned`. #66 and #67 both hit this.
+   */
+  let potion: PotionSnapshot | null = $state.raw(null);
+
+  /** The seed and settings the potion on screen was rolled from, which is its provenance. */
+  let rolledSeed = $state('');
+  let rolledConfig: PotionGeneratorConfigRecord = $state(configRecord());
+
+  const document_ = $derived(potion === null ? null : potionToDocument(potion));
+
+  function configRecord(): PotionGeneratorConfigRecord {
+    return { allowHomebrew, allowProceduralNames };
+  }
 
   function generate() {
     if (!lockSeed) {
-      seed = new RNG(Date.now().toString()).randomString(13);
+      seed = rng.randomString(13);
     }
+    rolledSeed = seed;
+    rolledConfig = configRecord();
+    // Stored as a snapshot straight away: the page renders the same shape a saved potion is read
+    // back in, so a result and a reopened artifact cannot show different things.
+    potion = toPotionSnapshot(rollPotion(rolledSeed, rolledConfig));
+  }
 
-    const config = getDefaultPotionConfig();
-    config.allowHomebrew = allowHomebrew;
-    config.allowProceduralNames = allowProceduralNames;
-    potion = generatePotion(seed, config);
+  function exportMarkdown() {
+    if (potion === null) return;
+    downloadTextFile(potionToMarkdown(potion), `${potionFileStem(potion)}.md`, 'text/markdown');
+  }
+
+  async function exportPdf() {
+    if (potion === null) return;
+    await downloadTextPdf(
+      potionToDocument(potion).title,
+      potionToText(potion),
+      `${potionFileStem(potion)}.pdf`,
+    );
   }
 
   onMount(() => {
@@ -40,7 +89,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/potion-generator" title="Potion Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Potion Generator">
   {#snippet description()}
     <p>
       Generate magical potions, oils, and ointments with procedural sensory details and SRD-based
@@ -48,79 +97,99 @@
     </p>
   {/snippet}
 
-  <SeedControls bind:seed bind:lockSeed label="Random Seed" />
+  <ControlsPanel>
+    <div class="checkbox-group">
+      <CheckboxField id="allowHomebrew" label="Allow Homebrew" bind:checked={allowHomebrew} />
+      <CheckboxField
+        id="allowProceduralNames"
+        label="Allow Variations"
+        bind:checked={allowProceduralNames}
+      />
+    </div>
 
-  <CheckboxField id="allowHomebrew" label="Allow Homebrew" bind:checked={allowHomebrew} />
-  <CheckboxField
-    id="allowProceduralNames"
-    label="Allow Variations"
-    bind:checked={allowProceduralNames}
+    <SeedControls bind:seed bind:lockSeed inline />
+
+    <BaseButton onclick={generate}>Generate</BaseButton>
+  </ControlsPanel>
+
+  <SaveArtifactButton
+    kind={POTION_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={potion}
+    seed={rolledSeed}
+    config={{ ...rolledConfig }}
+    defaultName={document_?.title ?? ''}
   />
 
-  <BaseButton onclick={generate}>Generate</BaseButton>
+  <div class="actions">
+    <BaseButton onclick={exportMarkdown} disabled={potion === null}>Download Markdown</BaseButton>
+    <BaseButton onclick={exportPdf} disabled={potion === null}>Download PDF</BaseButton>
+  </div>
 
-  {#if potion}
+  {#if potion && document_}
     <!-- A result surface is a panel, not a box with a border on it: the two layers,
          and the keyline, corner and padding are the system's. It wrote its own
          border, radius and padding until #124. -->
     <article class="potion-result panel">
       <div class="panel__field">
-        <h2>{potion.displayName}</h2>
+        <h2>{document_.title}</h2>
 
-        {#if potion.modifications.length > 0}
-          <Stat label="Modifications">
-            {potion.modifications.map((mod) => mod.kind).join(', ')}
-          </Stat>
-        {/if}
-
-        {#if potion.canonicalName && potion.canonicalName !== potion.displayName}
+        <!-- One block, from the presentation document, rather than four `Stat`s and a
+             `StatBlock` deciding for themselves what to show. 6.4: every line whose field is
+             empty is already gone by the time it gets here. -->
+        {#if document_.lines.length > 0}
           <StatBlock>
-            <Stat label="Base formula">{potion.canonicalName}</Stat>
+            {#each document_.lines as line (line.label)}
+              <Stat label={line.label}>{line.value}</Stat>
+            {/each}
           </StatBlock>
         {/if}
-        <StatBlock>
-          <Stat label="Rarity">{potion.liquid.rarity}</Stat>
-          <Stat label="Value">{valueToString(potion.liquid.value, COMMON_FANTASY)}</Stat>
-        </StatBlock>
-        <Stat label="Form">
-          {potion.liquid.properties.includes('oil')
-            ? 'oil'
-            : potion.liquid.properties.includes('ointment')
-              ? 'ointment'
-              : 'drink'}
-        </Stat>
 
         <h3>Effect</h3>
-        <p>{describeEffect(potion.effect)}</p>
-        <StatBlock>
-          <Stat label="Duration">{describeDurationShort(potion.effect.duration)}</Stat>
-          <Stat label="Magnitude">{potion.effect.magnitude}</Stat>
-        </StatBlock>
-
-        <h3>Sensory Profile</h3>
-        <ul>
+        <p>{document_.effect.description}</p>
+        {#if document_.effect.lines.length > 0}
           <StatBlock>
-            <Stat label="Appearance">{potion.sensory.appearance}</Stat>
-            <Stat label="Viscosity">{potion.sensory.viscosity}</Stat>
-            <Stat label="Flavor">{potion.sensory.flavor}</Stat>
-            <Stat label="Scent">{potion.sensory.scent}</Stat>
+            {#each document_.effect.lines as line (line.label)}
+              <Stat label={line.label}>{line.value}</Stat>
+            {/each}
           </StatBlock>
-        </ul>
+        {/if}
+
+        {#if document_.sensory.length > 0}
+          <h3>Sensory Profile</h3>
+          <!-- A `StatBlock` is a `<dl>`; it was wrapped in a `<ul>` here until #68, which is a
+               list whose only child is a definition list — invalid markup, and a screen reader
+               announcing a one-item list around four pairs. -->
+          <StatBlock>
+            {#each document_.sensory as line (line.label)}
+              <Stat label={line.label}>{line.value}</Stat>
+            {/each}
+          </StatBlock>
+        {/if}
 
         <h3>Container</h3>
-        <p>{potion.container.name}: {potion.container.description}</p>
-        <Stat label="Container value">
-          {valueToString(potion.container.value, COMMON_FANTASY)}
-        </Stat>
+        <p>{document_.container.name}: {document_.container.description}</p>
+        <StatBlock>
+          <Stat label="Container value">{document_.container.value}</Stat>
+        </StatBlock>
 
-        <h3>Description</h3>
-        <p>{potion.liquid.description}</p>
+        {#if document_.description !== ''}
+          <h3>Description</h3>
+          <p>{document_.description}</p>
+        {/if}
       </div>
     </article>
   {/if}
 </GeneratorPage>
 
 <style>
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+  }
+
   /* The keyline, the corner and the padding are the panel's now. What is left is where the
      result sits on the page. */
   .potion-result {

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -118,6 +118,11 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // everything it statically imports is 296 KB across 31 chunks, and through the entry point it is
   // 19.7 MB across 47.
   '$lib/merchants/merchant_artifact_kind',
+  // `$lib/potions`'s entry point reaches the generator, and from there the whole potion catalog,
+  // the sensory tables and `$lib/equipment`'s container generator. Measured on the build: through
+  // the kind module the registry chunk and everything it statically imports is 304 KB across 32
+  // chunks, and through the entry point it is 445 KB across 36.
+  '$lib/potions/potion_artifact_kind',
   // The eighteenth, the same library and the same reason: the star-system kind module holds
   // metadata and validation only, and its codec is a dynamic import.
   '$lib/astronomical_bodies/star_system_artifact_kind',

--- a/src/lib/potions/README.md
+++ b/src/lib/potions/README.md
@@ -58,3 +58,27 @@ the catalog under their usual names.
 
 Containers come from [`$lib/equipment`](../equipment/README.md) via `config.containerConfig`, which
 defaults to unlocked, liquid-capable containers.
+
+## The `potion` artifact kind
+
+A potion is a durable artifact (#68), and it is **its own kind rather than a share of `item`** —
+decision 2 of [docs/readiness-objects.md](../../../docs/readiness-objects.md). An item editor has no
+field for a duration or a flavour, and a potion editor has none for a combat profile; folding the
+two together would give one of them an editor that is wrong for half of what it opens.
+
+- **`potion_snapshot.ts`** — `PotionSnapshot` and the codec. `Potion` is plain throughout, so
+  nothing is converted; what the snapshot does is **stop storing the same thing twice**.
+  `generatePotion` writes the effect, the sensory profile and the display name into the liquid _and_
+  onto the potion beside it, so the stored liquid drops all three and they are rebuilt on read.
+  There is one place to edit an effect and one answer to what it is.
+- **`potion_artifact_kind.ts`** — the kind, its version, and a validator that normalises rather than
+  refuses: a missing sensory field reads as empty prose, an unreadable modification is dropped, and
+  an effect `parameters` union this build does not know is kept as it is rather than rejected.
+- **`potion_roll.ts`** — the one path from a seed, and the page's two checkboxes as a provenance
+  record.
+- **`potion_editing.ts`** — the setters, none of which recompute. Changing the magnitude does not
+  reprice the potion, and `describePotionSnapshot` offers the generated wording as an explicit
+  command.
+- **`potion_presentation.ts`** — the sheet, and the Markdown and PDF written from it. `potionForm`
+  lives here too: the page used to work out whether a potion was a drink, an oil or an ointment by
+  sniffing `liquid.properties` three levels of nested ternary deep, where nothing could test it.

--- a/src/lib/potions/index.ts
+++ b/src/lib/potions/index.ts
@@ -6,3 +6,8 @@ export * from './potion_descriptor';
 export * from './potion_sensory';
 export * from './potion_value';
 export * from './potion_naming';
+export * from './potion_artifact_kind';
+export * from './potion_editing';
+export * from './potion_presentation';
+export * from './potion_roll';
+export * from './potion_snapshot';

--- a/src/lib/potions/potion_artifact_kind.test.ts
+++ b/src/lib/potions/potion_artifact_kind.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  POTION_ARTIFACT_KIND,
+  POTION_PAYLOAD_VERSION,
+  migratePotionSnapshot,
+  potionArtifactKind,
+  potionName,
+  validatePotionSnapshot,
+} from './potion_artifact_kind';
+import { defaultPotionGeneratorConfigRecord, rollPotionSnapshot } from './potion_roll';
+
+const POTION = rollPotionSnapshot('kind-seed', defaultPotionGeneratorConfigRecord());
+
+function accepted(payload: unknown) {
+  const result = validatePotionSnapshot(payload);
+  if (!result.ok) {
+    throw new Error(`expected an accepted payload, got: ${result.message}`);
+  }
+  return result.value;
+}
+
+describe('potionArtifactKind', () => {
+  it('registers the id and version the pass assigned it', () => {
+    expect(potionArtifactKind.kind).toBe(POTION_ARTIFACT_KIND);
+    expect(POTION_ARTIFACT_KIND).toBe('potion');
+    expect(potionArtifactKind.payloadVersion).toBe(POTION_PAYLOAD_VERSION);
+    expect(POTION_PAYLOAD_VERSION).toBe(1);
+  });
+
+  it('is its own kind rather than a share of `item`', () => {
+    // Decision 2 of docs/readiness-objects.md, and a correction to what #68 assumed.
+    expect(POTION_ARTIFACT_KIND).not.toBe('item');
+  });
+
+  it('loads a codec that round-trips', async () => {
+    const codec = await potionArtifactKind.loadCodec();
+
+    expect(codec.toSnapshot(codec.fromSnapshot(POTION, undefined as never))).toEqual(POTION);
+  });
+});
+
+describe('validatePotionSnapshot', () => {
+  it('accepts a rolled potion unchanged', () => {
+    expect(accepted(POTION)).toEqual(POTION);
+  });
+
+  it('accepts one that has been through storage', () => {
+    expect(accepted(JSON.parse(JSON.stringify(POTION)))).toEqual(POTION);
+  });
+
+  it('refuses anything that is not an object', () => {
+    for (const payload of [null, undefined, 42, 'a potion', ['a potion']]) {
+      expect(validatePotionSnapshot(payload).ok, String(payload)).toBe(false);
+    }
+  });
+
+  it('refuses a payload with no display name, container, liquid or effect', () => {
+    for (const field of ['displayName', 'container', 'liquid', 'effect']) {
+      const broken: Record<string, unknown> = { ...POTION };
+      delete broken[field];
+
+      expect(validatePotionSnapshot(broken).ok, field).toBe(false);
+    }
+  });
+
+  it('refuses an effect with no name, which every reader prints', () => {
+    expect(validatePotionSnapshot({ ...POTION, effect: { description: 'x' } }).ok).toBe(false);
+  });
+
+  it('accepts an emptied display name, because clearing one is an editing decision', () => {
+    // 3.3 asks for a well-defined empty result rather than a refusal.
+    expect(accepted({ ...POTION, displayName: '' }).displayName).toBe('');
+  });
+
+  it('reads a missing sensory field as empty prose rather than refusing', () => {
+    const sparse = accepted({ ...POTION, sensory: { appearance: 'cloudy' } });
+
+    expect(sparse.sensory).toEqual({
+      appearance: 'cloudy',
+      viscosity: '',
+      flavor: '',
+      scent: '',
+    });
+  });
+
+  it('drops a modification with no recognisable tag', () => {
+    expect(
+      accepted({ ...POTION, modifications: [{ kind: 'tainted' }, 'tainted', {}] }).modifications,
+    ).toEqual([{ kind: 'tainted' }]);
+  });
+
+  it('empties modifications that are not a list', () => {
+    expect(accepted({ ...POTION, modifications: 'tainted' }).modifications).toEqual([]);
+  });
+
+  it('keeps a parameters union this build may not know', () => {
+    // The presentation reads it defensively; refusing a potion over a parameter nothing prints
+    // would lose the whole artifact to save a line.
+    const exotic = accepted({
+      ...POTION,
+      effect: { ...POTION.effect, parameters: { kind: 'chronomantic', turns: 3 } },
+    });
+
+    expect(exotic.effect.parameters).toEqual({ kind: 'chronomantic', turns: 3 });
+  });
+
+  it('drops an empty base formula rather than storing it blank', () => {
+    expect(accepted({ ...POTION, canonicalName: '' }).canonicalName).toBeUndefined();
+  });
+});
+
+describe('migratePotionSnapshot', () => {
+  it('rejects rather than pretending there has been another shape', () => {
+    // Requirement 7.3 has one step to exercise and it is the absence of one.
+    const result = migratePotionSnapshot({ displayName: 'x' }, 0);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? '' : result.reason).toBe('unsupported-version');
+    expect(result.ok ? '' : result.message).toContain('payload version 0');
+  });
+});
+
+describe('potionName', () => {
+  it('prefers the label on the bottle', () => {
+    expect(potionName(POTION)).toBe(POTION.displayName);
+  });
+
+  it('falls back to the base formula, then to the kind', () => {
+    expect(potionName({ ...POTION, displayName: '  ', canonicalName: 'Potion of Healing' })).toBe(
+      'Potion of Healing',
+    );
+    expect(potionName({ ...POTION, displayName: '', canonicalName: undefined })).toBe('Potion');
+  });
+});

--- a/src/lib/potions/potion_artifact_kind.ts
+++ b/src/lib/potions/potion_artifact_kind.ts
@@ -1,0 +1,202 @@
+import potion from '$lib/assets/icons/set2/potion-full.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  isStringArray,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+import type { Container } from '$lib/equipment';
+
+import type { PotionSnapshot, StoredPotionLiquid } from './potion_snapshot';
+import type { PotionEffect, PotionModification, PotionSensoryProfile } from './potion_types';
+
+/**
+ * Stable artifact kind id. Unqualified: a potion is neither a game system's nor a setting's, per
+ * the kind table in docs/tool-readiness.md.
+ *
+ * **Its own kind rather than a share of `item`**, which is decision 2 of docs/readiness-objects.md
+ * and a correction to what this issue assumed. A `Potion` is a container, a liquid, an effect, a
+ * sensory profile and a list of modifications; an `Item` is none of those below the first two.
+ * Folding them together would produce one editor that is wrong for half of what it opens — the
+ * item editor has no field for a duration or a flavour, and the potion editor has none for a
+ * combat profile.
+ */
+export const POTION_ARTIFACT_KIND = 'potion' as const;
+
+/** Version 1. The first shape a potion has been stored in. */
+export const POTION_PAYLOAD_VERSION = 1 as const;
+
+function readNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function readText(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+/**
+ * The sensory profile, normalised.
+ *
+ * All four fields are prose a referee may clear, so an empty one is accepted; what is not accepted
+ * is a missing one, because the sheet prints all four and `undefined` would print as the word.
+ */
+function readSensory(value: unknown): PotionSensoryProfile {
+  const record = asRecord(value) ?? {};
+  return {
+    appearance: readText(record.appearance),
+    viscosity: readText(record.viscosity),
+    flavor: readText(record.flavor),
+    scent: readText(record.scent),
+  };
+}
+
+/**
+ * The effect, normalised.
+ *
+ * `duration` and `parameters` are unions this build may not recognise — a payload written against a
+ * catalog with a seventh parameter kind, say. Both are kept as they are rather than policed: the
+ * presentation reads them defensively, and refusing a potion over a parameter nothing prints would
+ * lose the whole artifact to save a line.
+ */
+function readEffect(value: unknown): PotionEffect | undefined {
+  const record = asRecord(value);
+  if (record === null || typeof record.name !== 'string') {
+    return undefined;
+  }
+  return {
+    ...(record as unknown as PotionEffect),
+    id: readText(record.id),
+    name: record.name,
+    description: readText(record.description),
+    magnitude: readNumber(record.magnitude, 0),
+  };
+}
+
+/** One modification. A tagged object with no recognisable tag is dropped rather than printed. */
+function readModification(value: unknown): PotionModification | undefined {
+  const record = asRecord(value);
+  return record === null || typeof record.kind !== 'string'
+    ? undefined
+    : (record as unknown as PotionModification);
+}
+
+/**
+ * Reads a stored potion, normalising rather than refusing wherever it honestly can.
+ *
+ * What is checked is what every reader depends on: a display name, a container and a liquid that
+ * are objects, and an effect with a name. Everything else degrades — an unreadable modification is
+ * dropped, a missing sensory field reads as empty prose, and a missing number reads as zero.
+ *
+ * An emptied display name is accepted, because a referee who has cleared it on the way to writing
+ * their own has made an editing decision — 3.3 asks for a well-defined empty result, not a refusal.
+ */
+export function validatePotionSnapshot(payload: unknown): PayloadResult<PotionSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'Potion payload is not an object');
+  }
+  if (typeof record.displayName !== 'string') {
+    return rejectedPayload('invalid-payload', 'Potion payload has no usable displayName');
+  }
+
+  const container = asRecord(record.container);
+  if (container === null || typeof container.name !== 'string') {
+    return rejectedPayload('invalid-payload', 'Potion payload has no usable container');
+  }
+
+  const liquid = asRecord(record.liquid);
+  if (liquid === null) {
+    return rejectedPayload('invalid-payload', 'Potion payload has no usable liquid');
+  }
+
+  const effect = readEffect(record.effect);
+  if (effect === undefined) {
+    return rejectedPayload('invalid-payload', 'Potion payload has no usable effect');
+  }
+
+  return acceptedPayload({
+    container: {
+      ...(container as unknown as Container),
+      name: container.name,
+      description: readText(container.description),
+      value: readNumber(container.value, 0),
+      properties: isStringArray(container.properties) ? container.properties : [],
+      contents: isStringArray(container.contents) ? container.contents : [],
+    },
+    liquid: {
+      ...(liquid as unknown as StoredPotionLiquid),
+      id: readText(liquid.id),
+      description: readText(liquid.description),
+      value: readNumber(liquid.value, 0),
+      weight: readNumber(liquid.weight, 0),
+      properties: isStringArray(liquid.properties) ? liquid.properties : [],
+    },
+    displayName: record.displayName,
+    ...(typeof record.canonicalName === 'string' && record.canonicalName !== ''
+      ? { canonicalName: record.canonicalName }
+      : {}),
+    sensory: readSensory(record.sensory),
+    effect,
+    modifications: Array.isArray(record.modifications)
+      ? record.modifications
+          .map(readModification)
+          .filter((modification): modification is PotionModification => modification !== undefined)
+      : [],
+  });
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day
+ * the shape changes — a kind without one looks complete right up until it silently drops someone's
+ * work, and local-only means there is no server-side migration to fall back on.
+ */
+export function migratePotionSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<PotionSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Potions have no migration from payload version ${from}; version ${POTION_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/** What to call a saved potion: its display name, which is what the bottle's label would say. */
+export function potionName(snapshot: PotionSnapshot): string {
+  const name = snapshot.displayName.trim();
+  if (name !== '') {
+    return name;
+  }
+  const canonical = (snapshot.canonicalName ?? '').trim();
+  return canonical === '' ? 'Potion' : canonical;
+}
+
+/**
+ * A potion as an artifact.
+ *
+ * The codec is a dynamic import for consistency with every other kind rather than for weight:
+ * reading a potion resolves nothing against the catalog, because a stored one already holds
+ * everything it is.
+ */
+export const potionArtifactKind = defineArtifactKind<
+  import('./potion_types').Potion,
+  PotionSnapshot
+>({
+  kind: POTION_ARTIFACT_KIND,
+  displayName: 'Potion',
+  icon: potion,
+  payloadVersion: POTION_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { toPotionSnapshot, potionFromSnapshotWithRng } = await import('./potion_snapshot.js');
+    return {
+      toSnapshot: toPotionSnapshot,
+      fromSnapshot: potionFromSnapshotWithRng,
+    };
+  },
+  nameOf: potionName,
+  validate: validatePotionSnapshot,
+  migrate: migratePotionSnapshot,
+});

--- a/src/lib/potions/potion_editing.test.ts
+++ b/src/lib/potions/potion_editing.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  describePotionSnapshot,
+  removePotionModification,
+  setPotionContainerText,
+  setPotionDescription,
+  setPotionEffectText,
+  setPotionMagnitude,
+  setPotionRarity,
+  setPotionSensory,
+  setPotionText,
+  setPotionValue,
+} from './potion_editing';
+import { rollPotion } from './potion_roll';
+import { toPotionSnapshot, type PotionSnapshot } from './potion_snapshot';
+
+const POTION = toPotionSnapshot(
+  rollPotion('editing-seed', { allowHomebrew: false, allowProceduralNames: false }),
+);
+
+/** A rolled potion carrying at least one modification. */
+function modified(): PotionSnapshot {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const potion = rollPotion(`modified-${attempt}`, {
+      allowHomebrew: true,
+      allowProceduralNames: true,
+    });
+    if (potion.modifications.length > 0) {
+      return toPotionSnapshot(potion);
+    }
+  }
+  throw new Error('no seed in 200 produced a modified potion');
+}
+
+describe('setPotionText', () => {
+  it('changes one field and nothing else', () => {
+    const renamed = setPotionText(POTION, 'displayName', 'Draught of Second Thoughts');
+
+    expect(renamed.displayName).toBe('Draught of Second Thoughts');
+    expect(renamed.effect).toEqual(POTION.effect);
+    expect(POTION.displayName).not.toBe('Draught of Second Thoughts');
+  });
+
+  it('removes an emptied base formula rather than storing it blank', () => {
+    const named = setPotionText(POTION, 'canonicalName', 'Potion of Healing');
+
+    expect(named.canonicalName).toBe('Potion of Healing');
+    expect('canonicalName' in setPotionText(named, 'canonicalName', '  ')).toBe(false);
+  });
+});
+
+describe('the effect fields', () => {
+  it('rewrite the name and the sentence', () => {
+    expect(setPotionEffectText(POTION, 'name', 'Reconsideration').effect.name).toBe(
+      'Reconsideration',
+    );
+    expect(setPotionEffectText(POTION, 'description', 'It helps.').effect.description).toBe(
+      'It helps.',
+    );
+  });
+
+  it('take a magnitude, flooring a cleared or negative one', () => {
+    expect(setPotionMagnitude(POTION, 40).effect.magnitude).toBe(40);
+    expect(setPotionMagnitude(POTION, Number.NaN).effect.magnitude).toBe(0);
+    expect(setPotionMagnitude(POTION, -5).effect.magnitude).toBe(0);
+  });
+
+  it('do not reprice the potion', () => {
+    // 4.2, and the sharpest temptation here: `resolveCatalogValue` derives the value from the
+    // catalog entry and the effect, so re-running it would be arithmetic on a number a referee may
+    // have set deliberately.
+    expect(setPotionMagnitude(POTION, 99).liquid.value).toBe(POTION.liquid.value);
+  });
+});
+
+describe('setPotionValue and setPotionRarity', () => {
+  it('set the field they name, flooring a cleared value', () => {
+    expect(setPotionValue(POTION, 250).liquid.value).toBe(250);
+    expect(setPotionValue(POTION, Number.NaN).liquid.value).toBe(0);
+    expect(setPotionRarity(POTION, 'legendary').liquid.rarity).toBe('legendary');
+  });
+});
+
+describe('setPotionSensory', () => {
+  it('rewrites one of the four fields', () => {
+    const edited = setPotionSensory(POTION, 'flavor', 'like cold iron');
+
+    expect(edited.sensory.flavor).toBe('like cold iron');
+    expect(edited.sensory.scent).toBe(POTION.sensory.scent);
+  });
+
+  it('accepts an emptied field, which a referee may want', () => {
+    expect(setPotionSensory(POTION, 'scent', '').sensory.scent).toBe('');
+  });
+});
+
+describe('setPotionContainerText', () => {
+  it('rewrites the bottle', () => {
+    expect(setPotionContainerText(POTION, 'name', 'a chipped vial').container.name).toBe(
+      'a chipped vial',
+    );
+  });
+});
+
+describe('removePotionModification', () => {
+  it('drops one, leaving the effect where it is', () => {
+    // A modification was applied to the numbers when it happened; removing it says the referee has
+    // decided it did not, not that the arithmetic should run backwards.
+    const withModifications = modified();
+    const removed = removePotionModification(withModifications, 0);
+
+    expect(removed.modifications).toHaveLength(withModifications.modifications.length - 1);
+    expect(removed.effect).toEqual(withModifications.effect);
+  });
+
+  it('does nothing for a modification that is not there', () => {
+    expect(removePotionModification(POTION, 99)).toBe(POTION);
+    expect(removePotionModification(POTION, -1)).toBe(POTION);
+  });
+});
+
+describe('describePotionSnapshot', () => {
+  it('rebuilds the generated wording', () => {
+    expect(describePotionSnapshot(POTION)).toBe(POTION.liquid.description);
+  });
+
+  it('follows an edited sensory field, which is what makes the button worth having', () => {
+    const edited = setPotionSensory(POTION, 'scent', 'of wet slate');
+
+    expect(describePotionSnapshot(edited)).toContain('wet slate');
+  });
+
+  it('is never applied on its own', () => {
+    // The guard 4.2 asks for: every setter here leaves the description alone.
+    expect(setPotionSensory(POTION, 'flavor', 'sour').liquid.description).toBe(
+      POTION.liquid.description,
+    );
+    expect(setPotionEffectText(POTION, 'name', 'Something Else').liquid.description).toBe(
+      POTION.liquid.description,
+    );
+  });
+
+  it('is what the button writes, and only then', () => {
+    const edited = setPotionSensory(POTION, 'scent', 'of wet slate');
+    const rewritten = setPotionDescription(edited, describePotionSnapshot(edited));
+
+    expect(rewritten.liquid.description).toContain('wet slate');
+  });
+});

--- a/src/lib/potions/potion_editing.ts
+++ b/src/lib/potions/potion_editing.ts
@@ -1,0 +1,118 @@
+/**
+ * Editing a saved potion, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction, and it is what lets the editing
+ * framework compare what is on screen against what was read to decide whether anything needs
+ * saving.
+ *
+ * **Nothing here recomputes anything.** Two temptations, both refused for the reason 4.2 gives:
+ *
+ * - `describePotion` in `potion_descriptor.ts` builds the prose out of the name, the sensory
+ *   profile and the effect, so a form that re-ran it on every change would throw away a
+ *   hand-written description on the next keystroke elsewhere. It is offered as a button instead,
+ *   the shape the drug and item editors both use.
+ * - **Changing the magnitude does not reprice the potion.** `resolveCatalogValue` derives the value
+ *   from the catalog entry and the effect, and re-running it here would be arithmetic on a number a
+ *   referee may have set deliberately. The value is a field of its own and is edited directly.
+ *
+ * **A modification is removed, not re-picked.** The modifications are what the roll did to the base
+ * formula — a potency tier, a duration change — and they were already applied to the effect when it
+ * was generated. Dropping a new one in from nowhere would claim a change that never happened to the
+ * numbers; removing one says the referee has decided it did not.
+ */
+
+import { describePotion } from './potion_descriptor.js';
+import { potionForm } from './potion_presentation.js';
+import { potionFromSnapshot, type PotionSnapshot } from './potion_snapshot.js';
+import type { Rarity } from '$lib/equipment';
+
+/** The potion's own text fields, all of which a referee may rewrite. */
+export type PotionTextField = 'displayName' | 'canonicalName';
+
+/** The four sensory fields. */
+export type PotionSensoryField = 'appearance' | 'viscosity' | 'flavor' | 'scent';
+
+export function setPotionText(
+  snapshot: PotionSnapshot,
+  field: PotionTextField,
+  value: string,
+): PotionSnapshot {
+  // The base formula is removed rather than stored empty: a potion whose canonical name has been
+  // cleared has no base formula, and the sheet drops the line rather than printing a blank one.
+  if (field === 'canonicalName' && value.trim() === '') {
+    const next = { ...snapshot };
+    delete next.canonicalName;
+    return next;
+  }
+  return { ...snapshot, [field]: value };
+}
+
+/** The composed prose, which lives on the liquid. */
+export function setPotionDescription(snapshot: PotionSnapshot, value: string): PotionSnapshot {
+  return { ...snapshot, liquid: { ...snapshot.liquid, description: value } };
+}
+
+export function setPotionSensory(
+  snapshot: PotionSnapshot,
+  field: PotionSensoryField,
+  value: string,
+): PotionSnapshot {
+  return { ...snapshot, sensory: { ...snapshot.sensory, [field]: value } };
+}
+
+/** The effect's name or its sentence. */
+export function setPotionEffectText(
+  snapshot: PotionSnapshot,
+  field: 'name' | 'description',
+  value: string,
+): PotionSnapshot {
+  return { ...snapshot, effect: { ...snapshot.effect, [field]: value } };
+}
+
+/** The effect's magnitude, floored at zero. */
+export function setPotionMagnitude(snapshot: PotionSnapshot, magnitude: number): PotionSnapshot {
+  const usable = Number.isFinite(magnitude) && magnitude > 0 ? magnitude : 0;
+  return { ...snapshot, effect: { ...snapshot.effect, magnitude: usable } };
+}
+
+/** The liquid's value, floored at zero. */
+export function setPotionValue(snapshot: PotionSnapshot, value: number): PotionSnapshot {
+  const usable = Number.isFinite(value) && value > 0 ? value : 0;
+  return { ...snapshot, liquid: { ...snapshot.liquid, value: usable } };
+}
+
+export function setPotionRarity(snapshot: PotionSnapshot, rarity: Rarity): PotionSnapshot {
+  return { ...snapshot, liquid: { ...snapshot.liquid, rarity } };
+}
+
+/** The container's name or its description. */
+export function setPotionContainerText(
+  snapshot: PotionSnapshot,
+  field: 'name' | 'description',
+  value: string,
+): PotionSnapshot {
+  return { ...snapshot, container: { ...snapshot.container, [field]: value } };
+}
+
+/** Drop one modification. See the header for why nothing adds one. */
+export function removePotionModification(snapshot: PotionSnapshot, index: number): PotionSnapshot {
+  if (index < 0 || index >= snapshot.modifications.length) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    modifications: snapshot.modifications.filter((_modification, at) => at !== index),
+  };
+}
+
+/**
+ * The description the generator would write for this potion as it now stands.
+ *
+ * Offered rather than applied, and never called automatically. The liquid's `name`, `effect` and
+ * `sensory` are rebuilt from the potion's own by `potionFromSnapshot`, which is why the composer
+ * can be handed a live potion here and see the edits.
+ */
+export function describePotionSnapshot(snapshot: PotionSnapshot): string {
+  return describePotion(potionFromSnapshot(snapshot), potionForm(snapshot));
+}

--- a/src/lib/potions/potion_presentation.test.ts
+++ b/src/lib/potions/potion_presentation.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  removePotionModification,
+  setPotionContainerText,
+  setPotionDescription,
+  setPotionSensory,
+  setPotionText,
+} from './potion_editing';
+import {
+  describeModification,
+  potionDisplayName,
+  potionFileStem,
+  potionForm,
+  potionToDocument,
+  potionToMarkdown,
+  potionToText,
+  potionValueText,
+} from './potion_presentation';
+import { rollPotion } from './potion_roll';
+import { toPotionSnapshot, type PotionSnapshot } from './potion_snapshot';
+
+const POTION = toPotionSnapshot(
+  rollPotion('presentation-seed', { allowHomebrew: false, allowProceduralNames: false }),
+);
+
+/** A rolled potion of the form asked for, found by trying seeds. */
+function ofForm(form: 'oil' | 'ointment'): PotionSnapshot {
+  for (let attempt = 0; attempt < 400; attempt++) {
+    const snapshot = toPotionSnapshot(
+      rollPotion(`${form}-${attempt}`, { allowHomebrew: false, allowProceduralNames: false }),
+    );
+    if (potionForm(snapshot) === form) {
+      return snapshot;
+    }
+  }
+  throw new Error(`no seed in 400 produced ${form}`);
+}
+
+function labels(snapshot: PotionSnapshot): string[] {
+  return potionToDocument(snapshot).lines.map((line) => line.label);
+}
+
+describe('potionDisplayName', () => {
+  it('prefers the label on the bottle and falls back twice', () => {
+    expect(potionDisplayName(POTION)).toBe(POTION.displayName);
+    expect(
+      potionDisplayName({ ...POTION, displayName: ' ', canonicalName: 'Potion of Healing' }),
+    ).toBe('Potion of Healing');
+    expect(potionDisplayName({ ...POTION, displayName: '', canonicalName: undefined })).toBe(
+      'Potion',
+    );
+  });
+});
+
+describe('potionForm', () => {
+  it('reads the form out of the properties the generator wrote', () => {
+    // The page did this inline in a nested ternary, where nothing could test it.
+    expect(potionForm(ofForm('oil'))).toBe('oil');
+    expect(potionForm(ofForm('ointment'))).toBe('ointment');
+  });
+
+  it('defaults to a drink, which is what a potion is unless it says otherwise', () => {
+    expect(potionForm({ ...POTION, liquid: { ...POTION.liquid, properties: [] } })).toBe('drink');
+  });
+});
+
+describe('potionValueText', () => {
+  it('quotes a price in coins and writes out nothing rather than leaving it blank', () => {
+    // The fault #65 found in the price lists: `valueToString(0)` is the empty string.
+    expect(potionValueText(100)).toBe('1 gp');
+    expect(potionValueText(0)).toBe('0 cp');
+  });
+});
+
+describe('describeModification', () => {
+  it('reads a tagged union as a sentence a referee can use', () => {
+    expect(describeModification({ kind: 'tainted' })).toBe('tainted');
+    expect(describeModification({ kind: 'homebrew' })).toBe('homebrew');
+    expect(describeModification({ kind: 'duration', change: 'extended' })).toBe(
+      'extended duration',
+    );
+    expect(describeModification({ kind: 'potency', tier: 'heightened', magnitudeDelta: 10 })).toBe(
+      'heightened (magnitude +10)',
+    );
+  });
+
+  it('names a kind this build does not know rather than printing nothing', () => {
+    expect(
+      describeModification({ kind: 'chronomantic' } as unknown as Parameters<
+        typeof describeModification
+      >[0]),
+    ).toBe('chronomantic');
+  });
+});
+
+describe('potionToDocument', () => {
+  it('arranges the potion, its effect, its senses and its bottle', () => {
+    const document = potionToDocument(POTION);
+
+    expect(document.title).toBe(POTION.displayName);
+    expect(labels(POTION)).toContain('Form');
+    expect(labels(POTION)).toContain('Rarity');
+    expect(labels(POTION)).toContain('Value');
+    expect(document.effect.description).not.toBe('');
+    expect(document.sensory).toHaveLength(4);
+    expect(document.container.name).toBe(POTION.container.name);
+  });
+
+  it('drops a base formula that says the same thing as the name', () => {
+    // 6.4: printing "Base formula: Potion of Healing" under a heading reading "Potion of Healing"
+    // is a line that says nothing.
+    const same = { ...POTION, canonicalName: POTION.displayName };
+
+    expect(labels(same)).not.toContain('Base formula');
+    expect(labels({ ...POTION, canonicalName: 'Potion of Healing' })).toContain('Base formula');
+  });
+
+  it('drops the modifications line when nothing was done to the formula', () => {
+    expect(labels({ ...POTION, modifications: [] })).not.toContain('Modifications');
+    expect(labels({ ...POTION, modifications: [{ kind: 'tainted' }] })).toContain('Modifications');
+  });
+
+  it('drops every sensory field that has been cleared', () => {
+    const stripped = (['appearance', 'viscosity', 'flavor', 'scent'] as const).reduce(
+      (snapshot, field) => setPotionSensory(snapshot, field, ''),
+      POTION,
+    );
+
+    expect(potionToDocument(stripped).sensory).toEqual([]);
+  });
+});
+
+describe('potionToMarkdown', () => {
+  it('writes the potion, the effect, the senses and the bottle', () => {
+    const markdown = potionToMarkdown(POTION);
+
+    expect(markdown.startsWith(`# ${POTION.displayName}\n\n`)).toBe(true);
+    expect(markdown).toContain('- Rarity: ');
+    expect(markdown).toContain('## Effect');
+    expect(markdown).toContain('## Sensory profile');
+    expect(markdown).toContain('## Container');
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('prints no sensory heading when every field has been cleared', () => {
+    const stripped = (['appearance', 'viscosity', 'flavor', 'scent'] as const).reduce(
+      (snapshot, field) => setPotionSensory(snapshot, field, ''),
+      POTION,
+    );
+
+    expect(potionToMarkdown(stripped)).not.toContain('## Sensory profile');
+  });
+
+  it('prints no container heading for a potion with no bottle left', () => {
+    expect(potionToMarkdown(setPotionContainerText(POTION, 'name', ''))).not.toContain(
+      '## Container',
+    );
+  });
+
+  it('exports a potion emptied of everything as little more than its name', () => {
+    const bare = setPotionDescription(
+      setPotionContainerText(
+        (['appearance', 'viscosity', 'flavor', 'scent'] as const).reduce(
+          (snapshot, field) => setPotionSensory(snapshot, field, ''),
+          setPotionText({ ...POTION, modifications: [] }, 'canonicalName', ''),
+        ),
+        'name',
+        '',
+      ),
+      '',
+    );
+    const markdown = potionToMarkdown(bare);
+
+    expect(markdown).not.toContain('## Sensory profile');
+    expect(markdown).not.toContain('## Container');
+    expect(markdown).toContain(`# ${POTION.displayName}`);
+  });
+
+  it('has no run of blank lines anywhere in it', () => {
+    expect(potionToMarkdown(POTION)).not.toMatch(/\n\s*\n\s*\n/);
+  });
+});
+
+describe('potionToText', () => {
+  it('writes the same sheet without the title the PDF draws itself', () => {
+    const text = potionToText(POTION);
+
+    expect(text).not.toContain(`# ${POTION.displayName}`);
+    expect(text).toContain('Effect');
+    expect(text).toContain('Sensory profile');
+    expect(text).toContain('Container: ');
+    expect(text.endsWith('\n')).toBe(false);
+  });
+
+  it('has no run of blank lines anywhere in it', () => {
+    expect(potionToText(POTION)).not.toMatch(/\n\s*\n\s*\n/);
+  });
+});
+
+describe('potionFileStem', () => {
+  it('reduces a name to something a filesystem takes', () => {
+    expect(potionFileStem({ ...POTION, displayName: "Ashgrave's Weeping Draught" })).toBe(
+      'potion-ashgrave-s-weeping-draught',
+    );
+  });
+
+  it('falls back for a name that reduces to nothing', () => {
+    expect(potionFileStem({ ...POTION, displayName: '???', canonicalName: undefined })).toBe(
+      'potion',
+    );
+  });
+});
+
+describe('a potion with its modifications removed', () => {
+  it('still reads as a potion', () => {
+    // The editor can strip them one at a time; the sheet must not develop a hole.
+    let stripped = POTION;
+    while (stripped.modifications.length > 0) {
+      stripped = removePotionModification(stripped, 0);
+    }
+
+    expect(potionToDocument(stripped).title).toBe(POTION.displayName);
+    expect(potionToMarkdown(stripped)).not.toContain('Modifications');
+  });
+});

--- a/src/lib/potions/potion_presentation.ts
+++ b/src/lib/potions/potion_presentation.ts
@@ -1,0 +1,221 @@
+/**
+ * A potion arranged for reading, and the Markdown and PDF exports written from it.
+ *
+ * This tool had no export at all. It also had one piece of logic in the component that belonged
+ * here: the page worked out whether a potion was a drink, an oil or an ointment by sniffing
+ * `liquid.properties` for the words, three levels of nested ternary deep, where nothing could test
+ * it. `potionForm` owns that now.
+ *
+ * 6.4 applies section by section: a potion with no modifications prints no modifications line, one
+ * whose base formula is the same as its display name prints no base formula, and one emptied of
+ * everything exports its name alone.
+ */
+
+import { COMMON_FANTASY, valueToString } from '$lib/currency';
+
+import { describeDurationShort, describeEffect } from './potion_descriptor';
+import type { PotionSnapshot } from './potion_snapshot';
+import type { PotionForm, PotionModification } from './potion_types';
+
+/** One line of the sheet: a label and what it says. */
+export type PotionLine = {
+  label: string;
+  value: string;
+};
+
+/** A potion arranged for reading, independent of the format it is finally written in. */
+export type PotionDocument = {
+  title: string;
+  lines: PotionLine[];
+  /** The effect sentence, and the two numbers under it. */
+  effect: { description: string; lines: PotionLine[] };
+  sensory: PotionLine[];
+  container: { name: string; description: string; value: string };
+  /** The composed prose the generator wrote. */
+  description: string;
+};
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+/** What to head the document with: the label on the bottle, falling back to the base formula. */
+export function potionDisplayName(snapshot: PotionSnapshot): string {
+  const name = snapshot.displayName.trim();
+  if (name !== '') {
+    return name;
+  }
+  const canonical = (snapshot.canonicalName ?? '').trim();
+  return canonical === '' ? 'Potion' : canonical;
+}
+
+/**
+ * Whether the potion is a drink, an oil or an ointment.
+ *
+ * The form is pushed into `liquid.properties` at generation time beside the catalog entry's tags,
+ * so it is read back out of them. The page did this inline in a nested ternary; it is one function
+ * with one test now, and it defaults to `drink` because that is what a potion is unless it says
+ * otherwise.
+ */
+export function potionForm(snapshot: PotionSnapshot): PotionForm {
+  if (snapshot.liquid.properties.includes('oil')) {
+    return 'oil';
+  }
+  if (snapshot.liquid.properties.includes('ointment')) {
+    return 'ointment';
+  }
+  return 'drink';
+}
+
+/** A price, in the currency the rest of the site quotes prices in. */
+export function potionValueText(value: number): string {
+  return value <= 0 ? '0 cp' : valueToString(value, COMMON_FANTASY);
+}
+
+/** One modification, as a reader meets it rather than as a tagged union. */
+export function describeModification(modification: PotionModification): string {
+  switch (modification.kind) {
+    case 'potency':
+      return `${modification.tier} (magnitude ${modification.magnitudeDelta >= 0 ? '+' : ''}${modification.magnitudeDelta})`;
+    case 'duration':
+      return `${modification.change} duration`;
+    case 'tainted':
+      return 'tainted';
+    case 'homebrew':
+      return 'homebrew';
+    default:
+      // A modification kind this build does not know is still a modification a payload carries.
+      return (modification as { kind: string }).kind;
+  }
+}
+
+/** Arrange a potion for reading. */
+export function potionToDocument(snapshot: PotionSnapshot): PotionDocument {
+  const canonical = (snapshot.canonicalName ?? '').trim();
+
+  return {
+    title: potionDisplayName(snapshot),
+    lines: [
+      // 6.4: a base formula the same as the display name says nothing, so it is not printed.
+      {
+        label: 'Base formula',
+        value: canonical === snapshot.displayName.trim() ? '' : canonical,
+      },
+      { label: 'Form', value: potionForm(snapshot) },
+      { label: 'Rarity', value: snapshot.liquid.rarity },
+      { label: 'Value', value: potionValueText(snapshot.liquid.value) },
+      {
+        label: 'Modifications',
+        value: snapshot.modifications.map(describeModification).join(', '),
+      },
+    ].filter((line) => isPrintable(line.value)),
+    effect: {
+      description: describeEffect(snapshot.effect),
+      lines: [
+        { label: 'Duration', value: describeDurationShort(snapshot.effect.duration) },
+        { label: 'Magnitude', value: String(snapshot.effect.magnitude) },
+      ].filter((line) => isPrintable(line.value)),
+    },
+    sensory: [
+      { label: 'Appearance', value: snapshot.sensory.appearance },
+      { label: 'Viscosity', value: snapshot.sensory.viscosity },
+      { label: 'Flavor', value: snapshot.sensory.flavor },
+      { label: 'Scent', value: snapshot.sensory.scent },
+    ].filter((line) => isPrintable(line.value)),
+    container: {
+      name: snapshot.container.name,
+      description: snapshot.container.description,
+      value: potionValueText(snapshot.container.value),
+    },
+    description: snapshot.liquid.description.trim(),
+  };
+}
+
+function labelledList(lines: PotionLine[], bullet: string): string {
+  return lines.map((line) => `${bullet}${line.label}: ${line.value}`).join('\n');
+}
+
+/** A potion as Markdown, for a referee who keeps their treasure in their own notes. */
+export function potionToMarkdown(snapshot: PotionSnapshot): string {
+  const document = potionToDocument(snapshot);
+  const blocks = [`# ${document.title}`];
+
+  if (document.lines.length > 0) {
+    blocks.push(labelledList(document.lines, '- '));
+  }
+  if (isPrintable(document.description)) {
+    blocks.push(document.description);
+  }
+
+  const effect = ['## Effect'];
+  if (isPrintable(document.effect.description)) {
+    effect.push(document.effect.description);
+  }
+  if (document.effect.lines.length > 0) {
+    effect.push(labelledList(document.effect.lines, '- '));
+  }
+  if (effect.length > 1) {
+    blocks.push(effect.join('\n\n'));
+  }
+
+  if (document.sensory.length > 0) {
+    blocks.push(['## Sensory profile', labelledList(document.sensory, '- ')].join('\n\n'));
+  }
+
+  if (isPrintable(document.container.name)) {
+    const container = ['## Container', `**${document.container.name}**`];
+    if (isPrintable(document.container.description)) {
+      container.push(document.container.description);
+    }
+    container.push(`- Value: ${document.container.value}`);
+    blocks.push(container.join('\n\n'));
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** The body of the PDF: the same document without the title the PDF draws itself. */
+export function potionToText(snapshot: PotionSnapshot): string {
+  const document = potionToDocument(snapshot);
+  const blocks: string[] = [];
+
+  if (document.lines.length > 0) {
+    blocks.push(labelledList(document.lines, ''));
+  }
+  if (isPrintable(document.description)) {
+    blocks.push(document.description);
+  }
+
+  const effect = ['Effect'];
+  if (isPrintable(document.effect.description)) {
+    effect.push(`  ${document.effect.description}`);
+  }
+  effect.push(...document.effect.lines.map((line) => `  ${line.label}: ${line.value}`));
+  if (effect.length > 1) {
+    blocks.push(effect.join('\n'));
+  }
+
+  if (document.sensory.length > 0) {
+    blocks.push(['Sensory profile', labelledList(document.sensory, '  ')].join('\n'));
+  }
+
+  if (isPrintable(document.container.name)) {
+    const container = [`Container: ${document.container.name}`];
+    if (isPrintable(document.container.description)) {
+      container.push(`  ${document.container.description}`);
+    }
+    container.push(`  Value: ${document.container.value}`);
+    blocks.push(container.join('\n'));
+  }
+
+  return blocks.join('\n\n');
+}
+
+/** A filename stem for an exported potion, reduced to something a filesystem takes. */
+export function potionFileStem(snapshot: PotionSnapshot): string {
+  const stem = potionDisplayName(snapshot)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' || stem === 'potion' ? 'potion' : `potion-${stem}`;
+}

--- a/src/lib/potions/potion_roll.test.ts
+++ b/src/lib/potions/potion_roll.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultPotionGeneratorConfigRecord,
+  readPotionGeneratorConfig,
+  rollPotion,
+  rollPotionSnapshot,
+  toPotionGeneratorConfig,
+} from './potion_roll';
+import { toPotionSnapshot } from './potion_snapshot';
+
+const CONFIG = defaultPotionGeneratorConfigRecord();
+
+describe('rollPotion', () => {
+  it('gives the same potion for the same seed and settings', () => {
+    // Requirement 2.2. `generatePotion` was already pure; the page drew each new seed from a fresh
+    // `RNG(Date.now())` inside every press.
+    expect(toPotionSnapshot(rollPotion('fixed', CONFIG))).toEqual(
+      toPotionSnapshot(rollPotion('fixed', CONFIG)),
+    );
+  });
+
+  it('gives a different potion for a different seed', () => {
+    expect(toPotionSnapshot(rollPotion('one', CONFIG))).not.toEqual(
+      toPotionSnapshot(rollPotion('two', CONFIG)),
+    );
+  });
+
+  it('rolls something from the catalog with the defaults', () => {
+    const potion = rollPotion('catalog', CONFIG);
+
+    expect(potion.displayName).not.toBe('');
+    expect(potion.effect.name).not.toBe('');
+    expect(potion.container.name).not.toBe('');
+  });
+
+  it('honours the two settings', () => {
+    const full = toPotionGeneratorConfig({ allowHomebrew: true, allowProceduralNames: true });
+
+    expect(full.allowHomebrew).toBe(true);
+    expect(full.allowProceduralNames).toBe(true);
+    // The catalog and the container rules stay the library's.
+    expect(full.containerConfig.onlyLiquidContainers).toBe(true);
+  });
+});
+
+describe('readPotionGeneratorConfig', () => {
+  it('reads back what the page wrote', () => {
+    const written = { allowHomebrew: true, allowProceduralNames: true };
+
+    expect(readPotionGeneratorConfig(written)).toEqual(written);
+  });
+
+  it('falls back to the defaults for anything it does not recognise', () => {
+    // A config written by a build that spelled these differently should re-roll the ordinary way
+    // rather than from a field it misread.
+    expect(readPotionGeneratorConfig({})).toEqual(CONFIG);
+    expect(readPotionGeneratorConfig({ allowHomebrew: 'yes' }).allowHomebrew).toBe(false);
+  });
+});
+
+describe('rollPotionSnapshot', () => {
+  it('is the roller a re-roll takes, and matches the page', () => {
+    expect(rollPotionSnapshot('seed', CONFIG)).toEqual(
+      toPotionSnapshot(rollPotion('seed', CONFIG)),
+    );
+  });
+
+  it('re-rolls the same potion a stored provenance describes', () => {
+    // Requirement 4.3: the destructive command puts the rolled potion back.
+    const provenance = { seed: 'stored', config: { allowHomebrew: true } };
+
+    expect(
+      rollPotionSnapshot(provenance.seed, readPotionGeneratorConfig(provenance.config)),
+    ).toEqual(rollPotionSnapshot('stored', { allowHomebrew: true, allowProceduralNames: false }));
+  });
+});

--- a/src/lib/potions/potion_roll.ts
+++ b/src/lib/potions/potion_roll.ts
@@ -1,0 +1,84 @@
+/**
+ * The single path from a seed to a potion, and the record of how it was rolled.
+ *
+ * `generatePotion` was already a pure function of seed and config. The page was not: it built a
+ * `new RNG(Date.now().toString())` **inside every press** to draw the next seed, so the seed
+ * control was honoured and the seeds themselves came from the clock — requirement 2.2's oldest
+ * failure in the pass, and the one `adnd_character_roll.ts` first fixed. Pressing Generate draws a
+ * fresh seed from the page's own RNG now, and the roll is this function.
+ *
+ * `getDefaultPotionConfig` does not read the clock, contrary to the blanket note in
+ * `docs/tool-readiness.md` about fifteen `getDefault*Config` helpers. It returns three literals and
+ * a container config, and takes no RNG at all.
+ */
+
+import { getDefaultPotionConfig } from './potion_generator_config.js';
+import type { PotionGeneratorConfig } from './potion_generator_config.js';
+import { generatePotion } from './potion_generation.js';
+import { toPotionSnapshot, type PotionSnapshot } from './potion_snapshot.js';
+import type { Potion } from './potion_types.js';
+
+/**
+ * What the generator records about how it rolled, and what a re-roll reads back.
+ *
+ * Stated as a type so the two ends — what is written as provenance and what a re-roll expects to
+ * find — are in one place and drift loudly instead of quietly. It is the page's two checkboxes and
+ * nothing else: the catalog, the container rules and the sensory tables are the library's, not the
+ * user's.
+ */
+export type PotionGeneratorConfigRecord = {
+  allowHomebrew: boolean;
+  allowProceduralNames: boolean;
+};
+
+/** The settings a page opens on, and what an unreadable provenance record falls back to. */
+export function defaultPotionGeneratorConfigRecord(): PotionGeneratorConfigRecord {
+  return { allowHomebrew: false, allowProceduralNames: false };
+}
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * Anything unrecognisable falls back to the default rather than being coerced: a config written by
+ * a build that spelled these differently should re-roll the ordinary way, not from a field it
+ * misread.
+ */
+export function readPotionGeneratorConfig(
+  config: Record<string, unknown>,
+): PotionGeneratorConfigRecord {
+  const defaults = defaultPotionGeneratorConfigRecord();
+  return {
+    allowHomebrew:
+      typeof config.allowHomebrew === 'boolean' ? config.allowHomebrew : defaults.allowHomebrew,
+    allowProceduralNames:
+      typeof config.allowProceduralNames === 'boolean'
+        ? config.allowProceduralNames
+        : defaults.allowProceduralNames,
+  };
+}
+
+/** The settings as the whole generator config the library's own roller takes. */
+export function toPotionGeneratorConfig(
+  config: PotionGeneratorConfigRecord,
+): PotionGeneratorConfig {
+  const full = getDefaultPotionConfig();
+  full.allowHomebrew = config.allowHomebrew;
+  full.allowProceduralNames = config.allowProceduralNames;
+  return full;
+}
+
+/** Roll a potion — the one path the generator page and a re-roll both take. */
+export function rollPotion(seed: string, config: PotionGeneratorConfigRecord): Potion {
+  return generatePotion(seed, toPotionGeneratorConfig(config));
+}
+
+/**
+ * Roll a fresh potion as a snapshot — the destructive half of editing (requirement 4.3), and what
+ * `ARTIFACT_EDITORS` registers as this kind's roller.
+ */
+export function rollPotionSnapshot(
+  seed: string,
+  config: PotionGeneratorConfigRecord,
+): PotionSnapshot {
+  return toPotionSnapshot(rollPotion(seed, config));
+}

--- a/src/lib/potions/potion_snapshot.test.ts
+++ b/src/lib/potions/potion_snapshot.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import { defaultPotionGeneratorConfigRecord, rollPotion } from './potion_roll';
+import { potionFromSnapshot, toPotionSnapshot } from './potion_snapshot';
+
+const CONFIG = defaultPotionGeneratorConfigRecord();
+const POTION = rollPotion('snapshot-seed', CONFIG);
+const SNAPSHOT = toPotionSnapshot(POTION);
+
+/** A seed that rolls a potion carrying at least one modification. */
+function modified() {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const potion = rollPotion(`modified-${attempt}`, {
+      allowHomebrew: true,
+      allowProceduralNames: true,
+    });
+    if (potion.modifications.length > 0) {
+      return toPotionSnapshot(potion);
+    }
+  }
+  throw new Error('no seed in 200 produced a modified potion');
+}
+
+describe('toPotionSnapshot', () => {
+  it('keeps the container, the liquid, the effect and the sensory profile', () => {
+    expect(SNAPSHOT.container.name).not.toBe('');
+    expect(SNAPSHOT.liquid.id).not.toBe('');
+    expect(SNAPSHOT.effect.name).not.toBe('');
+    expect(SNAPSHOT.sensory.appearance).not.toBe('');
+  });
+
+  it('stores the effect and the sensory profile once, not twice', () => {
+    // `generatePotion` writes both into the liquid *and* onto the potion beside it. Two copies of
+    // one fact is a shape where an editor changes one and the other goes stale.
+    expect('effect' in SNAPSHOT.liquid).toBe(false);
+    expect('sensory' in SNAPSHOT.liquid).toBe(false);
+    expect('name' in SNAPSHOT.liquid).toBe(false);
+  });
+
+  it('keeps the two ids that say which bottle this liquid is in', () => {
+    expect(SNAPSHOT.container.contents).toContain(SNAPSHOT.liquid.id);
+    expect(SNAPSHOT.liquid.containerId).toBe(SNAPSHOT.container.id);
+  });
+});
+
+describe('potionFromSnapshot', () => {
+  it('round-trips everything that matters', () => {
+    // Requirement 7.2.
+    expect(toPotionSnapshot(potionFromSnapshot(SNAPSHOT))).toEqual(SNAPSHOT);
+  });
+
+  it('rebuilds the live potion the generator produced', () => {
+    expect(potionFromSnapshot(SNAPSHOT)).toEqual(POTION);
+  });
+
+  it('round-trips a modified potion', () => {
+    const withModifications = modified();
+
+    expect(withModifications.modifications.length).toBeGreaterThan(0);
+    expect(toPotionSnapshot(potionFromSnapshot(withModifications))).toEqual(withModifications);
+  });
+
+  it('survives a trip through JSON, which is what storage is', () => {
+    expect(potionFromSnapshot(JSON.parse(JSON.stringify(SNAPSHOT)))).toEqual(POTION);
+  });
+
+  it('puts the three derived fields back where the live type expects them', () => {
+    const live = potionFromSnapshot(SNAPSHOT);
+
+    expect(live.liquid.name).toBe(SNAPSHOT.displayName);
+    expect(live.liquid.effect).toEqual(SNAPSHOT.effect);
+    expect(live.liquid.sensory).toEqual(SNAPSHOT.sensory);
+  });
+
+  it('follows an edited name and effect into the liquid, which is the point', () => {
+    // The reason the duplication went: there is one place to edit an effect and one answer to what
+    // it is.
+    const edited = {
+      ...SNAPSHOT,
+      displayName: 'Draught of Second Thoughts',
+      effect: { ...SNAPSHOT.effect, name: 'Reconsideration' },
+    };
+    const live = potionFromSnapshot(edited);
+
+    expect(live.liquid.name).toBe('Draught of Second Thoughts');
+    expect(live.liquid.effect.name).toBe('Reconsideration');
+  });
+
+  it('copies deeply enough that an editor cannot reach the stored record', () => {
+    const read = potionFromSnapshot(SNAPSHOT);
+
+    read.modifications.push({ kind: 'tainted' });
+    read.container.contents.push('tampered');
+    read.liquid.properties.push('tampered');
+
+    expect(SNAPSHOT.modifications).toHaveLength(POTION.modifications.length);
+    expect(SNAPSHOT.container.contents).not.toContain('tampered');
+    expect(SNAPSHOT.liquid.properties).not.toContain('tampered');
+  });
+
+  it('recomputes nothing on read', () => {
+    // Requirement 4.2: a value a referee set by hand is the potion's value, not an input to a
+    // catalog lookup that runs again every time the artifact is opened.
+    const edited = { ...SNAPSHOT, liquid: { ...SNAPSHOT.liquid, value: 7 } };
+
+    expect(potionFromSnapshot(edited).liquid.value).toBe(7);
+  });
+});

--- a/src/lib/potions/potion_snapshot.ts
+++ b/src/lib/potions/potion_snapshot.ts
@@ -1,0 +1,119 @@
+/**
+ * Writing a potion for storage, and reading one back.
+ *
+ * `Potion` is plain throughout — the container and the liquid are `Item`s, the effect is a record
+ * with a duration and an optional parameters union, and the modifications are tagged objects — so
+ * the codec converts nothing. What it does do is **stop storing the same thing twice**.
+ *
+ * `generatePotion` writes the effect, the sensory profile and the display name into the liquid *and*
+ * onto the potion beside it: `liquid.effect === effect`, `liquid.sensory === sensory`, and
+ * `liquid.name === displayName`. Two copies of one fact is a shape where an editor changes one and
+ * the other goes stale, which is requirement 4.2's failure mode dressed as a data model. The
+ * snapshot keeps the potion's copy and rebuilds the liquid's on read, so there is one place to edit
+ * an effect and one answer to what it is.
+ *
+ * Nothing else is dropped. The container's `contents` and the liquid's `containerId` point at each
+ * other, and both stay: they are two ids, they are what says which bottle this liquid is in, and a
+ * reader that had to infer the pairing would be inventing it.
+ */
+
+import type { Container } from '$lib/equipment';
+
+import type {
+  Potion,
+  PotionEffect,
+  PotionLiquid,
+  PotionModification,
+  PotionSensoryProfile,
+} from './potion_types.js';
+
+/**
+ * The liquid as it is stored: everything except the three fields the potion already holds.
+ *
+ * `name`, `effect` and `sensory` are rebuilt on read from `displayName`, `effect` and `sensory`.
+ */
+export type StoredPotionLiquid = Omit<PotionLiquid, 'name' | 'effect' | 'sensory'>;
+
+/** A potion as it is stored. */
+export type PotionSnapshot = {
+  container: Container;
+  liquid: StoredPotionLiquid;
+  displayName: string;
+  canonicalName?: string;
+  sensory: PotionSensoryProfile;
+  effect: PotionEffect;
+  modifications: PotionModification[];
+};
+
+function copyEffect(effect: PotionEffect): PotionEffect {
+  return {
+    ...effect,
+    duration: { ...effect.duration },
+    ...(effect.elements === undefined ? {} : { elements: [...effect.elements] }),
+    ...(effect.spheres === undefined ? {} : { spheres: [...effect.spheres] }),
+    ...(effect.statOffsets === undefined ? {} : { statOffsets: { ...effect.statOffsets } }),
+    ...(effect.parameters === undefined ? {} : { parameters: { ...effect.parameters } }),
+  };
+}
+
+function copyContainer(container: Container): Container {
+  return {
+    ...container,
+    properties: [...container.properties],
+    contents: [...container.contents],
+    ...(container.lock === undefined ? {} : { lock: { ...container.lock } }),
+  };
+}
+
+function copyStoredLiquid(liquid: PotionLiquid | StoredPotionLiquid): StoredPotionLiquid {
+  const { ...rest } = liquid as StoredPotionLiquid & Partial<PotionLiquid>;
+  delete (rest as Partial<PotionLiquid>).name;
+  delete (rest as Partial<PotionLiquid>).effect;
+  delete (rest as Partial<PotionLiquid>).sensory;
+  return { ...rest, properties: [...liquid.properties] };
+}
+
+export function toPotionSnapshot(potion: Potion): PotionSnapshot {
+  return {
+    container: copyContainer(potion.container),
+    liquid: copyStoredLiquid(potion.liquid),
+    displayName: potion.displayName,
+    ...(potion.canonicalName === undefined ? {} : { canonicalName: potion.canonicalName }),
+    sensory: { ...potion.sensory },
+    effect: copyEffect(potion.effect),
+    modifications: potion.modifications.map((modification) => ({ ...modification })),
+  };
+}
+
+/**
+ * Nothing is recomputed on read.
+ *
+ * The liquid's three derived fields are rebuilt — that is not recomputation, it is the same value
+ * put back where the live type expects it. The value, the rarity and the description are the
+ * potion's own, and re-deriving any of them from the catalog would overwrite what a referee
+ * changed by hand.
+ */
+export function potionFromSnapshot(snapshot: PotionSnapshot): Potion {
+  const sensory = { ...snapshot.sensory };
+  const effect = copyEffect(snapshot.effect);
+
+  return {
+    container: copyContainer(snapshot.container),
+    liquid: {
+      ...copyStoredLiquid(snapshot.liquid),
+      name: snapshot.displayName,
+      effect,
+      sensory,
+    } as PotionLiquid,
+    displayName: snapshot.displayName,
+    ...(snapshot.canonicalName === undefined ? {} : { canonicalName: snapshot.canonicalName }),
+    sensory,
+    effect,
+    modifications: snapshot.modifications.map((modification) => ({ ...modification })),
+  };
+}
+
+/** The codec's reading half, with the signature the registry hands it. The RNG is unused. */
+export function potionFromSnapshotWithRng(snapshot: PotionSnapshot, _rng: unknown): Potion {
+  return potionFromSnapshot(snapshot);
+}

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -127,6 +127,7 @@ describe('TOOL_CATALOG', () => {
       '/fantasy/family',
       '/fantasy/merchant',
       '/fantasy/organization',
+      '/fantasy/potion-generator',
       '/culture',
       '/fantasy/dcc/character',
       '/fantasy/religion',
@@ -141,6 +142,7 @@ describe('TOOL_CATALOG', () => {
       '/word-generator-cheat-sheet',
       '/fantasy/equipment-generator',
       '/fantasy/merchant',
+      '/fantasy/potion-generator',
     ];
 
     const claimingMore = TOOL_CATALOG.filter(
@@ -250,6 +252,7 @@ describe('toolsWithMaturity', () => {
       '/fantasy/family',
       '/fantasy/merchant',
       '/fantasy/organization',
+      '/fantasy/potion-generator',
       '/fantasy/religion',
       '/fantasy/settlement',
       '/heraldry',
@@ -324,6 +327,7 @@ describe('filterTools', () => {
       '/fantasy/equipment',
       '/fantasy/equipment-generator',
       '/fantasy/merchant',
+      '/fantasy/potion-generator',
     ]);
   });
 

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -435,12 +435,18 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     genres: ['fantasy'],
     tags: ['equipment'],
   }),
+  // Release-ready, assessed section by section against docs/workshop.md and recorded in
+  // docs/readiness-objects.md (#68). It saves as `potion` — its own kind rather than a share of
+  // `item`, per decision 2 of that document, because an item editor has no field for a duration or
+  // a flavour — has an editor in `ARTIFACT_EDITORS`, and exports Markdown and PDF, the first
+  // exports it has ever had. Its roll is deterministic from the seed via `potion_roll.ts`. 1.4
+  // needed nothing: this label has always read `Fantasy Potion`, whatever the issue says.
   defineTool({
     path: '/fantasy/potion-generator',
     label: 'Fantasy Potion',
     kind: 'generator',
     domain: 'objects',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     genres: ['fantasy'],
     tags: ['magic'],
   }),

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -269,6 +269,16 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         rollMerchantSnapshot(provenance.seed, readMerchantGeneratorConfig(provenance.config));
     },
   },
+  potion: {
+    loadEditor: () => import('$components/objects/PotionArtifactEditor.svelte'),
+    /** The page's two checkboxes, read back through the roll module's own reader. */
+    loadRoller: async () => {
+      const { readPotionGeneratorConfig, rollPotionSnapshot } =
+        await import('$lib/potions/potion_roll.js');
+      return (provenance) =>
+        rollPotionSnapshot(provenance.seed, readPotionGeneratorConfig(provenance.config));
+    },
+  },
   'arms-manufacturer': {
     loadEditor: () => import('$components/factions/ArmsManufacturerArtifactEditor.svelte'),
     /**

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -35,6 +35,7 @@ describe('artifact kind catalog', () => {
       'drug',
       'item',
       'merchant',
+      'potion',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -51,6 +51,11 @@ import { itemArtifactKind } from '$lib/equipment/item_artifact_kind';
 // everything it statically imports is 296 KB across 31 chunks; through the entry point it is
 // 19.7 MB across 47.
 import { merchantArtifactKind } from '$lib/merchants/merchant_artifact_kind';
+// Deep, and measured the way its neighbours were: `$lib/potions`'s entry point reaches the
+// generator, and from there the whole potion catalog, the sensory tables and `$lib/equipment`'s
+// container generator. Through the kind module the registry chunk and everything it statically
+// imports is 304 KB across 32 chunks; through the entry point it is 445 KB across 36.
+import { potionArtifactKind } from '$lib/potions/potion_artifact_kind';
 import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
 import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
 import { settlementArtifactKind } from '$lib/settlements/settlement_artifact_kind';
@@ -93,6 +98,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, drugArtifactKind);
   registerArtifactKind(registry, itemArtifactKind);
   registerArtifactKind(registry, merchantArtifactKind);
+  registerArtifactKind(registry, potionArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Closes #68. Takes `/fantasy/potion-generator` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the design in `docs/readiness-objects.md`.

## Kind `potion`, not a share of `item`

Decision 2 of the objects document, and **a correction to what this issue assumed**. An item editor has no field for a duration or a flavour, and a potion editor has none for a combat profile; folding the two together would give one of them an editor that is wrong for half of what it opens. The editor's sensory and effect fields are what that decision buys, and `e2e/potion.spec.ts` drives them for exactly that reason.

**1.4 needed nothing.** The catalog has always read `Fantasy Potion`, not `Fantasy Potion Generator` — the design already recorded this.

## Three things the design did not anticipate

- **The payload stored the same thing twice.** `generatePotion` writes the effect, the sensory profile and the display name into the liquid *and* onto the potion beside it: `liquid.effect === effect`, `liquid.sensory === sensory`, `liquid.name === displayName`. Two copies of one fact is a shape where an editor changes one and the other goes stale — requirement 4.2's failure mode dressed as a data model. The snapshot keeps the potion's copy and rebuilds the liquid's on read, so there is one place to edit an effect and one answer to what it is.
- **The page decided the potion's form by sniffing its properties**, three levels of nested ternary deep, where nothing could test it. `potionForm` owns that now — the same shape of finding the reference tools kept producing, this time in a generator.
- **The sensory profile was a `<ul>` wrapped around a `<dl>`.** A list whose only child is a definition list is invalid markup and announces a one-item list around four pairs (6.2). It is a `StatBlock` alone now.

## The seed, and the Proxy

- **The seed came from the clock inside every press.** This page built a whole `new RNG(Date.now().toString())` per press to draw the next seed — requirement 2.2's *oldest* failure in the pass, rather than the newer `$effect` form #66 and #67 had.
- **`$state.raw`** again, making it three tools running: deep-reactive `$state` wraps the payload's arrays in Proxies and `structuredClone` refuses them.

## The rest of the sections

- **6.3** — Markdown and PDF, the first exports this tool has ever had.
- **6.4** — a base formula that repeats the name is dropped, as are an empty modifications line, a cleared sensory field, and a bottle with no name left.
- **4** — an editor in `ARTIFACT_EDITORS` covering the names, rarity, value, effect, the four senses, the container and the prose. Nothing recomputes: changing the magnitude does not reprice the potion, and the generated wording is an explicit button. A modification can be removed but not added, because a modification is what the roll *did* to the numbers.
- **7.2–7.4** — round-trip (including a modified potion), migration, and a full generate/save/reopen/edit journey.

## Measurement

The deep import of the kind module is measured as the allowlist rule requires: **304 KB across 32 chunks** through the kind module, **445 KB across 36** through `$lib/potions`' entry point.

## Verification

`npm run verify` is green, and `npm run verify:all` was run before opening this: 5,919 unit tests and 607 Playwright tests, including the new `e2e/potion.spec.ts` and the mobile pass at all five widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QEan2y9qHFJnvoM1dci8L
