### PR TITLE
Take the fantasy weapon generator to Release-ready

### DIFF
--- a/docs/readiness-objects.md
+++ b/docs/readiness-objects.md
@@ -78,6 +78,40 @@ the records the document asks for. Four things this section did not anticipate:
   payload, and IndexedDB's structured clone refuses one — `[object Array] could not be cloned`. The
   list is `$state.raw`, which is what a payload the page only ever replaces wholesale wants anyway.
 
+**As built (#69).** The kind is shared as designed, and the tool needed nothing new to store: the
+snapshot, the editor and the presentation are all #66's, reached through the kind. What it needed
+was its own roll module and four corrections.
+
+- **Two of the three Category options crashed the page.** "melee" and "ranged" were passed through
+  `itemMinorType`, which matches a weapon _type's name_ — "battleaxe", "crossbow". The filter came
+  back empty, `rng.item([])` was `undefined`, and generation threw
+  `Cannot read properties of undefined`. `EquipmentGenerationConfig` gains a
+  `weaponRangeCategory`, and a type name that matches nothing now widens to the whole table rather
+  than throwing.
+- **One kind, two provenance shapes.** This section says the two tools are told apart by the tool
+  path, and that is true of a vault listing — but it is also true of the **re-roll**, which the
+  section does not say. Their controls differ, so `ARTIFACT_EDITORS` branches on the path exactly as
+  the AD&D pair does; one reader would have re-rolled a consecrated sword out of the wrong settings.
+- **The theme is resolved before it is recorded.** The page drew a domain from its own RNG when the
+  control read "any", so the roll depended on something the provenance did not record. Resolving
+  from the seed and storing the result is what 3.6 asks for, and it is also what keeps
+  `$lib/equipment` from importing `$lib/religion` — which is a **cycle**: religion reaches
+  characters, which reaches archetypes, which reaches back here for their gear. The symptom was
+  every archetype table reading `undefined` at module load in seventeen unrelated test files.
+- **The page showed a heading and one paragraph.** The damage, the value, the weight, the material
+  and the enchantment it had just rolled were all invisible, which would also have left the editor
+  with fields answering to nothing on screen. It renders `itemToDocument` now, as #66 does.
+
+**5.1 binds, and the issue guessed right about why.** The `$lib/religion` import is the theme list:
+a weapon is themed on a religious domain. A saved religion narrows that list to the domains its own
+gods claim, because a weapon consecrated to a domain no god in that religion holds is not a weapon
+of that religion. `religionDomainNames` is new in `$lib/religion` and is the whole of it.
+
+**One bug found in #66's own work**: the card keyed its property badges by the tag value, and a
+weapon's properties repeat — the type name, the damage type and an enchantment's `tagsAdded` all
+land in the same list. A duplicate key is a Svelte error that takes the page down with it, which is
+what an empty result article turned out to be. Both cards key by index now.
+
 **#69's genre question answers itself.** The issue asks whether the tool should carry a sci-fi tag
 because `src/lib/weapons` has a `scifi.ts`. `WeaponGenerator.svelte` does not import
 `$lib/weapons` at all — the only importer anywhere is `$lib/arms_manufacturer`, which is #53 and is

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -55,6 +55,7 @@ const SILENT_TOOL_PAGES = [
   { path: '/fantasy/equipment-generator', title: 'Equipment Generator | Iron Arachne' },
   { path: '/fantasy/merchant', title: 'Fantasy Merchant Generator | Iron Arachne' },
   { path: '/fantasy/potion-generator', title: 'Potion Generator | Iron Arachne' },
+  { path: '/fantasy/weapon', title: 'Magic Weapon Generator | Iron Arachne' },
   {
     // The first reference tool in this list, and the reason it is worth naming: most of the spec
     // does not apply to a tool that produces no artifacts, so its silence was earned by sections

--- a/e2e/weapon.spec.ts
+++ b/e2e/weapon.spec.ts
@@ -1,0 +1,203 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the magic weapon generator (#69).
+ *
+ * It shares the kind `item` with `/fantasy/equipment-generator` — decision 1 of
+ * docs/readiness-objects.md — so the editor, the snapshot and the presentation are all #66's. What
+ * is this tool's own is the roll: a theme drawn from a religious domain, a range category, and a
+ * provenance the registry has to tell apart from the equipment generator's by tool path.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const WEAPON_TITLE = 'Magic Weapon Generator | Iron Arachne';
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+const result = (page: Page) => page.locator('.weapon-result');
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+/** A pinned press, so the weapon on screen is the same one every run. */
+async function generatePinned(page: Page, seed = 'a-fixed-seed'): Promise<void> {
+  await page.getByLabel('Seed', { exact: true }).fill(seed);
+  await page.getByLabel('Lock Seed').check();
+  await page.getByRole('button', { name: 'Generate', exact: true }).click();
+  await expect(result(page)).toBeVisible();
+}
+
+test.describe('a magic weapon', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'The Reliquary');
+  });
+
+  test('generates on every category, which two of three used to crash on', async ({ page }) => {
+    // The bug this issue did not know it had: "melee" and "ranged" were passed through
+    // `itemMinorType`, matched no weapon type at all, and generation threw
+    // `Cannot read properties of undefined`.
+    await visitRoute(page, '/fantasy/weapon', { title: WEAPON_TITLE });
+
+    for (const category of ['melee', 'ranged', 'any']) {
+      await page.getByLabel('Category').selectOption(category);
+      await page.getByRole('button', { name: 'Generate', exact: true }).click();
+      await expect(result(page).locator('h2'), category).not.toBeEmpty();
+    }
+  });
+
+  test('shows what it rolled, not just a name and a sentence', async ({ page }) => {
+    // The page rendered a heading and one paragraph, with the damage, the value, the weight, the
+    // material and the enchantment it had just rolled all invisible.
+    await visitRoute(page, '/fantasy/weapon', { title: WEAPON_TITLE });
+    await generatePinned(page);
+
+    // A stat is a `<dt>`/`<dd>` pair, so the key carries no colon of its own.
+    for (const label of ['Damage', 'Value', 'Material', 'Enchantment']) {
+      await expect(result(page).getByText(label, { exact: true }), label).toBeVisible();
+    }
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/fantasy/weapon', { title: WEAPON_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a weapon to keep straight away.
+    await expect(result(page)).toBeVisible();
+    await saveAs(page, 'The Consecrated Blade');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test. The editor is #66's, shared through the kind.
+    const panel = await openInWorkshop(page, 'The Consecrated Blade');
+    const unique = panel.getByRole('textbox', { name: 'Unique name' });
+    await unique.fill('');
+    await unique.pressSequentially('Vowbreaker');
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'The Consecrated Blade');
+    await expect(reopened.getByRole('textbox', { name: 'Unique name' })).toHaveValue('Vowbreaker');
+  });
+
+  test('reproduces the same weapon from the same seed, theme included', async ({ page }) => {
+    // Requirement 2.2, twice over: the page reseeded its own RNG from the seed field, and it drew
+    // the theme from that same stream when the control read "any" — so the roll depended on
+    // something the provenance did not record.
+    await visitRoute(page, '/fantasy/weapon', { title: WEAPON_TITLE });
+
+    await generatePinned(page, 'a-fixed-seed');
+    const first = await result(page).innerText();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await result(page).innerText()).toEqual(first);
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await result(page).innerText()).not.toEqual(first);
+  });
+
+  test('downloads a weapon a player can take to the table', async ({ page }) => {
+    // Requirement 6.3, and the first exports this tool has ever had.
+    await visitRoute(page, '/fantasy/weapon', { title: WEAPON_TITLE });
+    await generatePinned(page);
+    const name = await result(page).locator('h2').innerText();
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const file = await markdown;
+    expect(file.suggestedFilename()).toMatch(/^item-.*\.md$/);
+
+    const contents = await new Response(await file.createReadStream()).text();
+    expect(contents).toContain(`# ${name}`);
+    expect(contents).toContain('- Damage: ');
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/^item-.*\.pdf$/);
+  });
+
+  test('generates its own theme when there is nothing to consecrate to', async ({ page }) => {
+    // Requirement 5.3. A project with no saved religions has nothing to offer, so the picker
+    // renders nothing at all and the weapon themes on any of the fifty-eight domains.
+    await visitRoute(page, '/fantasy/weapon', { title: WEAPON_TITLE });
+
+    await expect(page.getByLabel('Consecrate this weapon to a saved religion')).toHaveCount(0);
+    await generatePinned(page);
+    await expect(result(page).getByText('Enchantment', { exact: true })).toBeVisible();
+  });
+
+  test('narrows the themes to a referenced religion', async ({ page }) => {
+    // Requirement 5.1: a weapon consecrated to a domain no god in that religion holds is not a
+    // weapon of that religion, so the list narrows rather than merely being annotated.
+    await visitRoute(page, '/fantasy/religion', { title: 'Religion Generator | Iron Arachne' });
+    await saveAs(page, 'The Ashen Covenant');
+
+    await visitRoute(page, '/fantasy/weapon', { title: WEAPON_TITLE });
+    const themes = page.getByLabel('Theme');
+    const before = await themes.locator('option').count();
+
+    await page.getByLabel('Consecrate this weapon to a saved religion').check();
+    await page.getByLabel('Religion', { exact: true }).selectOption({ index: 1 });
+    await expect.poll(async () => themes.locator('option').count()).toBeLessThan(before);
+
+    await generatePinned(page);
+    await saveAs(page, 'The Covenant Blade');
+
+    // The reference travels with the artifact, which is what a reference is for.
+    await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+    await vaultRow(page, 'The Covenant Blade').click();
+    // The inspector humanises a reference's role, so the raw `consecrated-to` is not what shows.
+    await expect(inspector(page)).toContainText('Consecrated to');
+  });
+});

--- a/src/components/objects/EquipmentGenerator.svelte
+++ b/src/components/objects/EquipmentGenerator.svelte
@@ -165,7 +165,10 @@
           </div>
           {#if document_.properties.length > 0}
             <div class="tags">
-              {#each document_.properties as tag (tag)}
+              <!-- Keyed by index, not by the tag: a weapon's properties can repeat — the type name, the
+                     damage type and an enchantment's `tagsAdded` all land in the same list — and a duplicate
+                     key is a Svelte error that takes the whole page down with it. -->
+              {#each document_.properties as tag, index (index)}
                 <!-- `plain` because a card can carry a dozen of these: bordered pills stop
                      annotating the item and start shouting over it. -->
                 <Badge plain>{tag}</Badge>

--- a/src/components/objects/WeaponGenerator.svelte
+++ b/src/components/objects/WeaponGenerator.svelte
@@ -1,58 +1,150 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { domains } from '$lib/religion';
-  import * as Equipment from '$lib/equipment';
-  import type { Item } from '$lib/equipment';
-  import * as RNG from '@ironarachne/rng';
-  import { getDefaultGenerationConfig } from '$lib/equipment';
+  import { RNG } from '@ironarachne/rng';
+
+  import Badge from '$components/common/Badge.svelte';
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import ControlsPanel from '$components/common/ControlsPanel.svelte';
   import GeneratorPage from '$components/layout/GeneratorPage.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
+  import SavedArtifactPicker from '$components/common/SavedArtifactPicker.svelte';
   import SeedControls from '$components/common/SeedControls.svelte';
   import SelectField from '$components/common/SelectField.svelte';
-  import BaseButton from '$components/common/BaseButton.svelte';
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
+  import type { ArtifactReference } from '$lib/artifacts';
+  import { downloadTextFile } from '$lib/download';
+  import {
+    ITEM_ARTIFACT_KIND,
+    WEAPON_ANY,
+    defaultWeaponGeneratorConfigRecord,
+    WEAPON_RANGE_CHOICES,
+    itemDisplayName,
+    itemFileStem,
+    itemToDocument,
+    itemToMarkdown,
+    itemToText,
+    resolveWeaponTheme,
+    rollWeapon,
+    toItemSnapshot,
+    type ItemSnapshot,
+    type WeaponGeneratorConfigRecord,
+  } from '$lib/equipment';
+  import { downloadTextPdf } from '$lib/pdf';
+  import {
+    RELIGION_ARTIFACT_KIND,
+    domains,
+    religionDomainNames,
+    type RestoredReligion,
+  } from '$lib/religion';
 
-  const themes = domains.map((domain) => domain.name).sort();
-  const categories = ['any', 'melee', 'ranged'];
+  const TOOL_PATH = '/fantasy/weapon';
 
-  const rng = new RNG.RNG(Date.now().toString());
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. It used to be reseeded from the seed
+   * field inside an `$effect` — the same requirement 2.2 failure #66 and #67 found — and it also
+   * drew the theme from this stream when the control read "any", so the roll depended on something
+   * the provenance did not record. `resolveWeaponTheme` takes the theme from the seed now.
+   */
+  const rng = new RNG(Date.now().toString());
+
   let seed = $state(rng.randomString(13));
-  $effect(() => {
-    rng.setSeed(seed);
-  });
   let lockSeed = $state(false);
 
-  let category = $state('any');
-  let theme = $state('any');
-  let weapon: Item | null = $state(null);
+  let theme = $state(WEAPON_ANY);
+  let rangeCategory: WeaponGeneratorConfigRecord['rangeCategory'] = $state(WEAPON_ANY);
 
-  function generateWeapon(cat: string, thm: string, genRng: RNG.RNG) {
-    let domainName = thm;
-    if (thm === 'any') {
-      domainName = genRng.item(domains).name;
-    }
+  /** Composition, opt-in (rule 1, docs/workshop.md). */
+  let useReligion = $state(false);
+  // The picker hands back what the kind's codec produces, which for a religion is the religion
+  // plus the seed and options it was rolled with.
+  let referencedReligion: RestoredReligion | undefined = $state();
+  let religionReference: ArtifactReference | undefined = $state();
 
-    const config = getDefaultGenerationConfig();
-    config.itemMajorType = 'weapon';
-    config.enchantments = Equipment.filterEnchantmentsByTags([domainName], Equipment.ENCHANTMENTS);
-    config.decorations = Equipment.filterDecorationsByTags([domainName], Equipment.DECORATIONS);
-    config.enchantmentChance = 100;
-    config.decorationChance = 100;
-    config.useUniqueNames = true;
+  /**
+   * The rolled weapon, as it is stored.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every array in the payload
+   * in a Proxy, and `structuredClone` — what IndexedDB stores with — refuses one outright.
+   */
+  let weapon: ItemSnapshot | null = $state.raw(null);
 
-    if (cat !== 'any') {
-      config.itemMinorType = cat;
-    }
+  /** The seed and settings the weapon on screen was rolled from, which is its provenance. */
+  let rolledSeed = $state('');
+  let rolledConfig: WeaponGeneratorConfigRecord = $state(defaultWeaponGeneratorConfigRecord());
 
-    const newWeapon = Equipment.generateItem(seed, config);
+  /**
+   * Every domain a weapon may be themed on.
+   *
+   * Read here rather than in `$lib/equipment`: religion reaches characters, which reaches
+   * archetypes, which reaches back into equipment for its gear — so the roll module takes the names
+   * as a parameter and this page is where they come from.
+   */
+  const allThemes = domains.map((domain) => domain.name).sort();
 
-    return newWeapon;
+  /**
+   * The themes on offer: every domain, or only the ones a referenced religion's gods claim.
+   *
+   * Requirement 5.1. A weapon consecrated to a domain no god in this religion holds is not a weapon
+   * of that religion, so the list narrows rather than merely being annotated — which is also what
+   * makes the reference worth recording.
+   */
+  const themes = $derived(
+    useReligion && referencedReligion !== undefined
+      ? religionDomainNames(referencedReligion.religion)
+      : allThemes,
+  );
+
+  const references = $derived(religionReference === undefined ? [] : [religionReference]);
+
+  const document_ = $derived(weapon === null ? null : itemToDocument(weapon));
+
+  /**
+   * The settings as the roll used them.
+   *
+   * The theme is **resolved** before it is recorded: a provenance saying `any` would need the
+   * domain list to re-roll, and would produce a different weapon the day that list changed. What is
+   * stored is the domain the weapon was actually consecrated to, which is what 3.6 asks for.
+   */
+  function configRecord(rollSeed: string): WeaponGeneratorConfigRecord {
+    return { theme: resolveWeaponTheme(rollSeed, theme, themes), rangeCategory };
   }
+
+  /**
+   * Keeps the theme honest when the offer narrows.
+   *
+   * Referencing a religion whose gods do not claim the currently chosen domain would otherwise
+   * leave a select showing a value that is no longer in its own list.
+   */
+  $effect(() => {
+    if (theme !== WEAPON_ANY && !themes.includes(theme)) {
+      theme = WEAPON_ANY;
+    }
+  });
 
   function generate() {
     if (!lockSeed) {
       seed = rng.randomString(13);
     }
-    rng.setSeed(seed);
-    weapon = generateWeapon(category, theme, rng);
+    rolledSeed = seed;
+    rolledConfig = configRecord(rolledSeed);
+    weapon = toItemSnapshot(rollWeapon(rolledSeed, rolledConfig));
+  }
+
+  function exportMarkdown() {
+    if (weapon === null) return;
+    downloadTextFile(itemToMarkdown(weapon), `${itemFileStem(weapon)}.md`, 'text/markdown');
+  }
+
+  async function exportPdf() {
+    if (weapon === null) return;
+    await downloadTextPdf(
+      itemDisplayName(weapon),
+      itemToText(weapon),
+      `${itemFileStem(weapon)}.pdf`,
+    );
   }
 
   onMount(() => {
@@ -60,22 +152,114 @@
   });
 </script>
 
-<GeneratorPage toolPath="/fantasy/weapon" title="Magic Weapon Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Magic Weapon Generator">
   {#snippet description()}
     <p>This generates a unique magical weapon.</p>
   {/snippet}
 
-  <SelectField id="theme" label="Theme" bind:value={theme} options={['any', ...themes]} />
+  <ControlsPanel>
+    <SelectField id="theme" label="Theme" bind:value={theme} options={[WEAPON_ANY, ...themes]} />
 
-  <SelectField id="category" label="Category" bind:value={category} options={categories} />
+    <!-- "melee" and "ranged" were passed through `itemMinorType` until #69, where they matched no
+         weapon type at all and generation threw. They narrow the table by range category now. -->
+    <SelectField
+      id="category"
+      label="Category"
+      bind:value={rangeCategory}
+      options={[...WEAPON_RANGE_CHOICES]}
+    />
 
-  <SeedControls bind:seed bind:lockSeed />
+    <SeedControls bind:seed bind:lockSeed inline />
 
-  <BaseButton onclick={generate}>Generate</BaseButton>
+    <BaseButton onclick={generate}>Generate</BaseButton>
+  </ControlsPanel>
 
-  {#if weapon}
-    <h2>{weapon.uniqueName}</h2>
+  <!-- Requirement 5.1. An offer: the checkbox starts off, and a weapon handed nothing themes on
+       any of the fifty-eight domains exactly as it did before (5.3). -->
+  <SavedArtifactPicker
+    kind={RELIGION_ARTIFACT_KIND}
+    role="consecrated-to"
+    checkboxLabel="Consecrate this weapon to a saved religion"
+    selectLabel="Religion"
+    bind:enabled={useReligion}
+    bind:value={referencedReligion}
+    bind:reference={religionReference}
+  />
 
-    <p>{weapon.description}</p>
+  <SaveArtifactButton
+    kind={ITEM_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={weapon}
+    seed={rolledSeed}
+    config={{ ...rolledConfig }}
+    defaultName={weapon === null ? '' : itemDisplayName(weapon)}
+    {references}
+  />
+
+  <div class="actions">
+    <BaseButton onclick={exportMarkdown} disabled={weapon === null}>Download Markdown</BaseButton>
+    <BaseButton onclick={exportPdf} disabled={weapon === null}>Download PDF</BaseButton>
+  </div>
+
+  {#if weapon && document_}
+    <!-- A result surface is a panel: the two layers, and the keyline, corner and padding are the
+         system's. The page showed a heading and one paragraph until #69, with the damage, the
+         value, the weight, the material and the enchantment it had just rolled all invisible —
+         which would also have left the editor with fields answering to nothing on screen. -->
+    <article class="weapon-result panel">
+      <div class="panel__field">
+        <h2>{document_.title}</h2>
+
+        {#if document_.description !== ''}
+          <p class="description">{document_.description}</p>
+        {/if}
+
+        {#if document_.lines.length > 0}
+          <StatBlock>
+            {#each document_.lines as line (line.label)}
+              <Stat label={line.label}>{line.value}</Stat>
+            {/each}
+          </StatBlock>
+        {/if}
+
+        {#if document_.properties.length > 0}
+          <div class="tags">
+            <!-- Keyed by index, not by the tag: a weapon's properties can repeat — the type name, the
+                     damage type and an enchantment's `tagsAdded` all land in the same list — and a duplicate
+                     key is a Svelte error that takes the whole page down with it. -->
+            {#each document_.properties as tag, index (index)}
+              <!-- `plain` because a weapon can carry a dozen of these: bordered pills stop
+                   annotating the item and start shouting over it. -->
+              <Badge plain>{tag}</Badge>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </article>
   {/if}
 </GeneratorPage>
+
+<style>
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+  }
+
+  .weapon-result {
+    margin-top: var(--s7);
+  }
+
+  .weapon-result .description {
+    color: var(--ink-muted);
+    font-style: italic;
+  }
+
+  .weapon-result .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--s3);
+    margin-top: var(--s4);
+  }
+</style>

--- a/src/lib/equipment/README.md
+++ b/src/lib/equipment/README.md
@@ -31,6 +31,11 @@ by only one of the two tools that made it. The provenance's tool path says which
   generated wording as an explicit command.
 - **`item_presentation.ts`** — the sheet, and the Markdown and PDF written from it, for one item or
   for a whole press.
+- **`weapon_roll.ts`** — `/fantasy/weapon`'s own roll. That tool is this generator with the major
+  type fixed and the enchantment tables narrowed to one religious domain, so it shares the kind and
+  needs its own settings: a theme and a range category rather than a major type and three switches.
+  `ARTIFACT_EDITORS` tells the two provenance shapes apart by the tool path, as the AD&D pair does.
+  `resolveWeaponTheme` takes an `any` theme from the seed, so a re-roll produces the same weapon.
 
 ## The fantasy price lists
 

--- a/src/lib/equipment/generation.ts
+++ b/src/lib/equipment/generation.ts
@@ -26,6 +26,16 @@ import { DECORATIONS } from './decorations';
 export type EquipmentGenerationConfig = {
   itemMajorType: 'any' | 'weapon' | 'armor';
   itemMinorType?: string;
+  /**
+   * Narrow the weapon table to melee or to ranged.
+   *
+   * Separate from `itemMinorType`, which names a *type* — "battleaxe", "crossbow". The magic weapon
+   * generator's Category control passed "melee" and "ranged" through `itemMinorType` until #69,
+   * where they matched no type at all: the filter came back empty, `rng.item([])` returned
+   * `undefined`, and generation threw `Cannot read properties of undefined`. Two of that control's
+   * three options crashed the page.
+   */
+  weaponRangeCategory?: 'melee' | 'ranged';
   useRefine: boolean;
   useEnchant: boolean;
   useDecorate: boolean;
@@ -103,6 +113,32 @@ export function roundValue(value: number): number {
   return Math.round(value / 10000) * 10000; // > 10000 gp: Round to 100 gp
 }
 
+/**
+ * The rows a name narrows a table to, or the whole table when it narrows it to nothing.
+ *
+ * Widening rather than throwing is the same discipline the rest of the pass applies to a stored
+ * value this build no longer recognises: an item from a table that has lost the type asked for is a
+ * better answer than no item at all, and `rng.item([])` is `undefined` rather than an error anybody
+ * could read.
+ */
+function narrowByName<T extends { name: string }>(table: T[], name: string | undefined): T[] {
+  if (name === undefined) {
+    return table;
+  }
+  const narrowed = table.filter((entry) => entry.name === name);
+  return narrowed.length > 0 ? narrowed : table;
+}
+
+/** The weapon types a config allows: narrowed by range category first, then by type name. */
+function chooseWeaponTypes(config: EquipmentGenerationConfig): WeaponType[] {
+  const byRange =
+    config.weaponRangeCategory === undefined
+      ? weaponTypes
+      : weaponTypes.filter((type) => type.rangeCategory === config.weaponRangeCategory);
+  const usable = byRange.length > 0 ? byRange : weaponTypes;
+  return narrowByName(usable, config.itemMinorType);
+}
+
 export function generateItem(seed: string, config: EquipmentGenerationConfig): Item {
   const rng = new RNG.RNG(seed);
 
@@ -114,23 +150,9 @@ export function generateItem(seed: string, config: EquipmentGenerationConfig): I
   }
 
   if (typeChoice === 'weapon') {
-    if (config.itemMinorType) {
-      const filteredTypes = weaponTypes.filter((t) => t.name === config.itemMinorType);
-      const type = rng.item(filteredTypes);
-      baseItem = createBaseWeapon(type, rng);
-    } else {
-      const type = rng.item(weaponTypes);
-      baseItem = createBaseWeapon(type, rng);
-    }
+    baseItem = createBaseWeapon(rng.item(chooseWeaponTypes(config)), rng);
   } else {
-    if (config.itemMinorType) {
-      const filteredTypes = armorTypes.filter((t) => t.name === config.itemMinorType);
-      const type = rng.item(filteredTypes);
-      baseItem = createBaseArmor(type, rng);
-    } else {
-      const type = rng.item(armorTypes);
-      baseItem = createBaseArmor(type, rng);
-    }
+    baseItem = createBaseArmor(rng.item(narrowByName(armorTypes, config.itemMinorType)), rng);
   }
 
   // Phase 1: Foundry (Always run)
@@ -188,6 +210,7 @@ export function getDefaultGenerationConfig(): EquipmentGenerationConfig {
   return {
     itemMajorType: 'any',
     itemMinorType: undefined,
+    weaponRangeCategory: undefined,
     useRefine: true,
     useEnchant: true,
     useDecorate: true,

--- a/src/lib/equipment/index.ts
+++ b/src/lib/equipment/index.ts
@@ -25,5 +25,6 @@ export * from './item_presentation';
 export * from './item_roll';
 export * from './item_snapshot';
 export * from './price_lists';
+export * from './weapon_roll';
 export type * from './list';
 export type * from './price_list_types';

--- a/src/lib/equipment/weapon_roll.test.ts
+++ b/src/lib/equipment/weapon_roll.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateItem, getDefaultGenerationConfig } from './generation';
+import { toItemSnapshot } from './item_snapshot';
+import {
+  WEAPON_ANY,
+  WEAPON_RANGE_CHOICES,
+  WEAPON_TOOL_PATH,
+  defaultWeaponGeneratorConfigRecord,
+  readWeaponGeneratorConfig,
+  resolveWeaponTheme,
+  rollWeapon,
+  rollWeaponSnapshot,
+  toWeaponGenerationConfig,
+} from './weapon_roll';
+import { weaponTypes } from './weapons';
+
+const CONFIG = defaultWeaponGeneratorConfigRecord();
+
+/** Stand-in for the domain names the page reads out of `$lib/religion`. */
+const THEMES = ['air', 'animals', 'fire', 'war', 'water'];
+
+describe('the Category control, which used to crash the page', () => {
+  it('threw before #69, because "melee" names no weapon type', () => {
+    // The bug, stated as the thing that is no longer true: `melee` and `ranged` were passed
+    // through `itemMinorType`, which matches a type's *name* — "battleaxe", "crossbow". The filter
+    // came back empty, `rng.item([])` was `undefined`, and generation threw.
+    expect(weaponTypes.map((type) => type.name)).not.toContain('melee');
+    expect(weaponTypes.map((type) => type.rangeCategory)).toContain('melee');
+  });
+
+  it('narrows the table by range category instead', () => {
+    for (const rangeCategory of ['melee', 'ranged'] as const) {
+      for (let attempt = 0; attempt < 20; attempt++) {
+        const weapon = rollWeapon(`range-${attempt}`, { ...CONFIG, rangeCategory });
+        const type = weaponTypes.find((entry) => entry.name === weapon.itemMinorType);
+
+        expect(type?.rangeCategory, `${rangeCategory} ${attempt}`).toBe(rangeCategory);
+      }
+    }
+  });
+
+  it('widens rather than throwing when a type name matches nothing', () => {
+    // The same discipline the rest of the pass applies to a stored value this build no longer
+    // recognises: an item from a wider table beats no item at all.
+    const config = getDefaultGenerationConfig();
+    config.itemMajorType = 'weapon';
+    config.itemMinorType = 'plasma glaive';
+
+    expect(() => generateItem('widened', config)).not.toThrow();
+  });
+});
+
+describe('rollWeapon', () => {
+  it('gives the same weapon for the same seed and settings', () => {
+    // Requirement 2.2.
+    expect(toItemSnapshot(rollWeapon('fixed', CONFIG))).toEqual(
+      toItemSnapshot(rollWeapon('fixed', CONFIG)),
+    );
+  });
+
+  it('gives a different weapon for a different seed', () => {
+    expect(toItemSnapshot(rollWeapon('one', CONFIG))).not.toEqual(
+      toItemSnapshot(rollWeapon('two', CONFIG)),
+    );
+  });
+
+  it('always rolls a weapon, and always names it', () => {
+    const weapon = rollWeapon('named', CONFIG);
+
+    expect(weapon.itemMajorType).toBe('weapon');
+    expect(weapon.uniqueName).toBeTypeOf('string');
+    expect(weapon.uniqueName).not.toBe('');
+  });
+
+  it('themes the enchantment on the domain asked for', () => {
+    const weapon = rollWeapon('themed', { ...CONFIG, theme: 'fire' });
+
+    expect(weapon.enchantment).toBeDefined();
+    expect(weapon.decoration).toBeDefined();
+  });
+
+  it('draws from the whole table for "any", which is what "any theme" says', () => {
+    expect(() => rollWeapon('untethered', { ...CONFIG, theme: WEAPON_ANY })).not.toThrow();
+    expect(toWeaponGenerationConfig(CONFIG).enchantments.length).toBeGreaterThan(
+      toWeaponGenerationConfig({ ...CONFIG, theme: 'fire' }).enchantments.length,
+    );
+  });
+});
+
+describe('resolveWeaponTheme', () => {
+  it('takes the theme from the seed rather than from the page', () => {
+    // The second half of this tool's 2.2 failure, and the harder half to see: the seed control
+    // worked, and the theme behind it came from the page's own stream.
+    const first = resolveWeaponTheme('a-fixed-seed', WEAPON_ANY, THEMES);
+
+    expect(resolveWeaponTheme('a-fixed-seed', WEAPON_ANY, THEMES)).toBe(first);
+    expect(THEMES).toContain(first);
+  });
+
+  it('draws a different theme for a different seed', () => {
+    const drawn = new Set(
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].map((seed) =>
+        resolveWeaponTheme(seed, WEAPON_ANY, THEMES),
+      ),
+    );
+
+    expect(drawn.size).toBeGreaterThan(1);
+  });
+
+  it('keeps a theme that was asked for', () => {
+    expect(resolveWeaponTheme('seed', 'fire', THEMES)).toBe('fire');
+  });
+
+  it('leaves "any" alone when there are no themes to draw from', () => {
+    expect(resolveWeaponTheme('seed', WEAPON_ANY, [])).toBe(WEAPON_ANY);
+  });
+
+  it('is what the page records, so a re-roll needs no domain list', () => {
+    // The whole reason the resolve happens before the record: a stored `any` would re-roll from a
+    // list this module cannot reach, and would change the day that list did.
+    const resolved = resolveWeaponTheme('any-seed', WEAPON_ANY, THEMES);
+    const recorded = { ...CONFIG, theme: resolved };
+
+    expect(resolved).not.toBe(WEAPON_ANY);
+    expect(toItemSnapshot(rollWeapon('any-seed', recorded))).toEqual(
+      toItemSnapshot(rollWeapon('any-seed', readWeaponGeneratorConfig(recorded))),
+    );
+  });
+});
+
+describe('readWeaponGeneratorConfig', () => {
+  it('reads back what the page wrote', () => {
+    const written = { theme: 'fire', rangeCategory: 'ranged' as const };
+
+    expect(readWeaponGeneratorConfig(written)).toEqual(written);
+  });
+
+  it('falls back to the defaults for anything it does not recognise', () => {
+    expect(readWeaponGeneratorConfig({})).toEqual(CONFIG);
+    expect(readWeaponGeneratorConfig({ rangeCategory: 'thrown' }).rangeCategory).toBe(WEAPON_ANY);
+    expect(readWeaponGeneratorConfig({ theme: '' }).theme).toBe(WEAPON_ANY);
+  });
+
+  it('keeps a theme this build may no longer have', () => {
+    // It still narrows the enchantment tables by tag, and a tag may outlive the domain that named
+    // it.
+    expect(readWeaponGeneratorConfig({ theme: 'chronomancy' }).theme).toBe('chronomancy');
+  });
+
+  it('accepts every range choice the page offers', () => {
+    for (const rangeCategory of WEAPON_RANGE_CHOICES) {
+      expect(readWeaponGeneratorConfig({ rangeCategory }).rangeCategory).toBe(rangeCategory);
+    }
+  });
+});
+
+describe('toWeaponGenerationConfig', () => {
+  it('fixes the major type and forces both flourishes', () => {
+    const full = toWeaponGenerationConfig({ ...CONFIG, theme: 'fire' });
+
+    expect(full.itemMajorType).toBe('weapon');
+    expect(full.enchantmentChance).toBe(100);
+    expect(full.decorationChance).toBe(100);
+    expect(full.useUniqueNames).toBe(true);
+  });
+
+  it('leaves the range category unset for "any"', () => {
+    expect(toWeaponGenerationConfig(CONFIG).weaponRangeCategory).toBeUndefined();
+    expect(
+      toWeaponGenerationConfig({ ...CONFIG, rangeCategory: 'melee' }).weaponRangeCategory,
+    ).toBe('melee');
+  });
+});
+
+describe('rollWeaponSnapshot', () => {
+  it('is the roller a re-roll takes, and matches the page', () => {
+    expect(rollWeaponSnapshot('seed', CONFIG)).toEqual(toItemSnapshot(rollWeapon('seed', CONFIG)));
+  });
+
+  it('names the tool path the registry tells the two shapes apart by', () => {
+    expect(WEAPON_TOOL_PATH).toBe('/fantasy/weapon');
+  });
+});

--- a/src/lib/equipment/weapon_roll.ts
+++ b/src/lib/equipment/weapon_roll.ts
@@ -1,0 +1,151 @@
+/**
+ * The single path from a seed to a magic weapon, and the record of how it was rolled.
+ *
+ * `/fantasy/weapon` is `/fantasy/equipment-generator` with the major type fixed and the
+ * enchantment and decoration tables narrowed to one religious domain — which is why the two share
+ * the kind `item`, per decision 1 of docs/readiness-objects.md, and why they need two roll modules
+ * rather than one. Their controls are different: this tool asks for a theme and a range category,
+ * that one asks for a major type and three switches.
+ *
+ * **The `$lib/weapons` question the issue raises answers itself, and the answer is in this file's
+ * absence of an import.** `WeaponGenerator.svelte` never imported that library — it uses
+ * `$lib/equipment` and `domains` from `$lib/religion`. The only importer of `$lib/weapons` anywhere
+ * is `$lib/arms_manufacturer`, which is tagged `scifi` already. Nothing science-fictional is
+ * reachable from this route, so the `fantasy` tag is right as it stands and the sci-fi code is not
+ * dead, it belongs to another tool.
+ *
+ * **The theme is resolved from the seed and then recorded**, rather than drawn from the page's own
+ * stream. The page drew a random domain from its RNG when the control read "any", which made the
+ * roll depend on something the provenance did not record — requirement 2.2 failing one level up
+ * from the usual place. What is stored is the domain that was actually used, which is what 3.6 asks
+ * for and what `character_roll.ts` does with its own resolved values.
+ *
+ * **The domain list is a parameter, not an import.** `$lib/religion` reaches `$lib/characters`,
+ * which reaches `$lib/archetypes`, which reaches back here for its equipment configs — so importing
+ * religion from this file is a cycle, and the symptom is every archetype table coming back
+ * `undefined` at module load in seventeen unrelated test files. The caller passes the names in; this
+ * module never needs to know where they came from.
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import { DECORATIONS } from './decorations.js';
+import { filterDecorationsByTags } from './decorator.js';
+import { ENCHANTMENTS } from './enchantments.js';
+import { filterEnchantmentsByTags } from './enchanter.js';
+import { generateItem, getDefaultGenerationConfig } from './generation.js';
+import type { EquipmentGenerationConfig } from './generation.js';
+import { toItemSnapshot, type ItemSnapshot, type RolledItem } from './item_snapshot.js';
+
+/** The tool path whose provenance this module reads. */
+export const WEAPON_TOOL_PATH = '/fantasy/weapon';
+
+/** The generator's own value for "let the seed choose", in both of its selects. */
+export const WEAPON_ANY = 'any' as const;
+
+/** What the range-category control offers. */
+export const WEAPON_RANGE_CHOICES = ['any', 'melee', 'ranged'] as const;
+
+export type WeaponRangeChoice = (typeof WEAPON_RANGE_CHOICES)[number];
+
+/**
+ * What the generator records about how it rolled, and what a re-roll reads back.
+ *
+ * Stated as a type so the two ends — what is written as provenance and what a re-roll expects to
+ * find — are in one place and drift loudly instead of quietly. It is the page's two selects.
+ */
+export type WeaponGeneratorConfigRecord = {
+  /** A religious domain by name, or `any` to let the seed choose one. */
+  theme: string;
+  rangeCategory: WeaponRangeChoice;
+};
+
+/** The settings a page opens on, and what an unreadable provenance record falls back to. */
+export function defaultWeaponGeneratorConfigRecord(): WeaponGeneratorConfigRecord {
+  return { theme: WEAPON_ANY, rangeCategory: WEAPON_ANY };
+}
+
+function isRangeChoice(value: unknown): value is WeaponRangeChoice {
+  return typeof value === 'string' && (WEAPON_RANGE_CHOICES as readonly string[]).includes(value);
+}
+
+/**
+ * Read a stored provenance config back into the settings a roll needs.
+ *
+ * A theme this build no longer has is kept rather than dropped: it still narrows the enchantment
+ * tables by tag, and the tag may outlive the domain that named it. What a re-roll does with a theme
+ * that matches nothing is `resolveWeaponTheme`'s business.
+ */
+export function readWeaponGeneratorConfig(
+  config: Record<string, unknown>,
+): WeaponGeneratorConfigRecord {
+  const defaults = defaultWeaponGeneratorConfigRecord();
+  return {
+    theme: typeof config.theme === 'string' && config.theme !== '' ? config.theme : defaults.theme,
+    rangeCategory: isRangeChoice(config.rangeCategory)
+      ? config.rangeCategory
+      : defaults.rangeCategory,
+  };
+}
+
+/**
+ * The domain a roll themes on: the one asked for, or one drawn from the seed.
+ *
+ * Derived from the seed rather than from the page's own stream, and the caller records what comes
+ * back — so a saved weapon's provenance names a concrete domain and a re-roll needs no domain list
+ * at all. That was the second half of this tool's 2.2 failure and the harder half to see: the seed
+ * control worked, and the theme behind it did not come from the seed.
+ *
+ * An `any` that reaches a roll anyway — an older provenance, or an empty list — means no tag
+ * filter, which is the honest reading of "any theme" and is what `toWeaponGenerationConfig` does
+ * with it.
+ */
+export function resolveWeaponTheme(seed: string, theme: string, themes: string[]): string {
+  if (theme !== WEAPON_ANY) {
+    return theme;
+  }
+  return themes.length === 0 ? WEAPON_ANY : new RNG(`${seed}-theme`).item(themes);
+}
+
+/** The settings as the whole generation config the library's own roller takes. */
+export function toWeaponGenerationConfig(
+  config: WeaponGeneratorConfigRecord,
+): EquipmentGenerationConfig {
+  const full = getDefaultGenerationConfig();
+
+  full.itemMajorType = 'weapon';
+  // `any` means no tag filter: the whole table, which is what "any theme" says.
+  if (config.theme !== WEAPON_ANY) {
+    full.enchantments = filterEnchantmentsByTags([config.theme], ENCHANTMENTS);
+    full.decorations = filterDecorationsByTags([config.theme], DECORATIONS);
+  }
+  full.enchantmentChance = 100;
+  full.decorationChance = 100;
+  full.useUniqueNames = true;
+  if (config.rangeCategory !== WEAPON_ANY) {
+    full.weaponRangeCategory = config.rangeCategory;
+  }
+
+  return full;
+}
+
+/**
+ * Roll a magic weapon — the one path the generator page and a re-roll both take.
+ *
+ * The config's theme is the one that was used, not the one that was asked for: the page resolves
+ * `any` before it rolls and records what came back.
+ */
+export function rollWeapon(seed: string, config: WeaponGeneratorConfigRecord): RolledItem {
+  return generateItem(seed, toWeaponGenerationConfig(config));
+}
+
+/**
+ * Roll a fresh weapon as a snapshot — the destructive half of editing (requirement 4.3), and what
+ * `ARTIFACT_EDITORS` reaches for when an `item`'s provenance names this tool.
+ */
+export function rollWeaponSnapshot(
+  seed: string,
+  config: WeaponGeneratorConfigRecord,
+): ItemSnapshot {
+  return toItemSnapshot(rollWeapon(seed, config));
+}

--- a/src/lib/religion/index.ts
+++ b/src/lib/religion/index.ts
@@ -42,4 +42,5 @@ export {
 
 export * as ReligionCategories from './categories';
 export * from './domains';
+export * from './religion_domains';
 export * from './religion_saved_state';

--- a/src/lib/religion/religion_domains.test.ts
+++ b/src/lib/religion/religion_domains.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { religionFromSnapshot } from './religion_snapshot';
+import { religionDomainNames } from './religion_domains';
+import { rollReligionSnapshot } from './religion_roll';
+import type { Religion } from './religion_types';
+
+/**
+ * A rolled religion, read back into the live shape the domain reader takes.
+ *
+ * `religionFromSnapshot` returns a `RestoredReligion` — the religion plus the seed and the options
+ * it was rolled with — so the religion itself is one field in.
+ */
+function rolled(seed: string): Religion {
+  return religionFromSnapshot(rollReligionSnapshot(seed)).religion;
+}
+
+describe('religionDomainNames', () => {
+  it('names every domain a religion pantheon claims, deduplicated and sorted', () => {
+    const religion = rolled('domains-seed');
+    const names = religionDomainNames(religion);
+
+    // `pantheon` is `Pantheon | null` on the live type and may be absent altogether on a restored
+    // one, which is why the reader uses optional chaining rather than a null check.
+    if ((religion.pantheon?.members.length ?? 0) > 0) {
+      expect(names.length).toBeGreaterThan(0);
+      expect([...new Set(names)]).toEqual(names);
+      expect([...names].sort()).toEqual(names);
+    }
+  });
+
+  it('names only domains its own gods hold', () => {
+    const religion = rolled('narrow-seed');
+    const held = new Set(
+      (religion.pantheon?.members ?? []).flatMap((deity) =>
+        [deity.domains.primary, deity.domains.secondary, deity.domains.tertiary]
+          .filter((domain) => domain !== null)
+          .map((domain) => domain.name),
+      ),
+    );
+
+    for (const name of religionDomainNames(religion)) {
+      expect(held.has(name), name).toBe(true);
+    }
+  });
+
+  it('yields nothing for a tradition with no gods', () => {
+    // A weapon cannot be consecrated to a god a religion does not have; the caller falls back to
+    // offering every domain rather than an empty select.
+    const godless = { pantheon: null } as unknown as Religion;
+
+    expect(religionDomainNames(godless)).toEqual([]);
+  });
+
+  it('skips a deity whose domain slots are empty', () => {
+    const sparse = {
+      pantheon: {
+        members: [{ domains: { primary: null, secondary: null, tertiary: null } }],
+      },
+    } as unknown as Religion;
+
+    expect(religionDomainNames(sparse)).toEqual([]);
+  });
+});

--- a/src/lib/religion/religion_domains.ts
+++ b/src/lib/religion/religion_domains.ts
@@ -1,0 +1,28 @@
+/**
+ * The domains a religion's gods actually claim.
+ *
+ * Written for #69, which consecrates a magic weapon to a saved religion: a weapon themed on a
+ * domain no god in that religion holds is not a weapon of that religion, so the tool narrows its
+ * theme list to this rather than annotating the full fifty-eight.
+ *
+ * A religion with no pantheon — the non-theistic categories generate one — yields nothing, and the
+ * caller falls back to offering every domain. That is the honest answer rather than an empty
+ * select: a tradition with no gods has no gods to consecrate to.
+ */
+
+import type { Religion } from './religion_types.js';
+
+/** Every domain named by any deity of a religion's pantheon, deduplicated and sorted. */
+export function religionDomainNames(religion: Religion): string[] {
+  const names = new Set<string>();
+
+  for (const deity of religion.pantheon?.members ?? []) {
+    for (const domain of [deity.domains.primary, deity.domains.secondary, deity.domains.tertiary]) {
+      if (domain !== null && domain.name !== '') {
+        names.add(domain.name);
+      }
+    }
+  }
+
+  return [...names].sort();
+}

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -132,6 +132,7 @@ describe('TOOL_CATALOG', () => {
       '/fantasy/dcc/character',
       '/fantasy/religion',
       '/fantasy/settlement',
+      '/fantasy/weapon',
       '/heraldry',
       '/swn/character',
       '/unchartedworlds/character',
@@ -143,6 +144,7 @@ describe('TOOL_CATALOG', () => {
       '/fantasy/equipment-generator',
       '/fantasy/merchant',
       '/fantasy/potion-generator',
+      '/fantasy/weapon',
     ];
 
     const claimingMore = TOOL_CATALOG.filter(
@@ -255,6 +257,7 @@ describe('toolsWithMaturity', () => {
       '/fantasy/potion-generator',
       '/fantasy/religion',
       '/fantasy/settlement',
+      '/fantasy/weapon',
       '/heraldry',
       '/planet',
       '/region',
@@ -328,6 +331,7 @@ describe('filterTools', () => {
       '/fantasy/equipment-generator',
       '/fantasy/merchant',
       '/fantasy/potion-generator',
+      '/fantasy/weapon',
     ]);
   });
 

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -450,12 +450,22 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     genres: ['fantasy'],
     tags: ['magic'],
   }),
+  // Release-ready, assessed section by section against docs/workshop.md and recorded in
+  // docs/readiness-objects.md (#69). It saves as `item`, the kind decision 1 of that document gives
+  // it to share with /fantasy/equipment-generator, and the two are told apart by the provenance's
+  // tool path — which is also what picks the right re-roll, because their controls differ. It has
+  // an editor in `ARTIFACT_EDITORS`, composes a religion by reference (5.1), and exports Markdown
+  // and PDF. Its roll is deterministic from the seed via `weapon_roll.ts`, theme included.
+  //
+  // The genre question the issue raises answers itself: `WeaponGenerator.svelte` never imported
+  // `$lib/weapons`, whose only importer is `$lib/arms_manufacturer` (already `scifi`). Nothing
+  // science-fictional is reachable from here, so `fantasy` alone is right.
   defineTool({
     path: '/fantasy/weapon',
     label: 'Fantasy Magic Weapon',
     kind: 'generator',
     domain: 'objects',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     genres: ['fantasy'],
     tags: ['equipment', 'magic'],
   }),

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -7,6 +7,13 @@ import type { ArtifactKind } from '$lib/artifact_kinds';
  */
 const ADND_BUILDER_TOOL_PATH = '/fantasy/adnd/character/build';
 
+/**
+ * The magic weapon generator's catalog path, which is how an `item`'s provenance says a weapon
+ * generator rolled it rather than the equipment generator. Written out rather than imported from
+ * `$lib/tools` so that this module keeps to the registries it belongs beside.
+ */
+const WEAPON_TOOL_PATH = '/fantasy/weapon';
+
 import type { ArtifactEditorEntry, ArtifactEditorRegistry } from './workshop_types';
 
 /**
@@ -238,18 +245,34 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
   item: {
     loadEditor: () => import('$components/objects/ItemArtifactEditor.svelte'),
     /**
-     * The page's four controls, read back through the roll module's own reader.
+     * One kind, two tools, two provenance shapes, told apart by the tool path.
      *
-     * One kind, two tools, and unlike the AD&D pair they re-roll the same way: `/fantasy/weapon`
-     * is this generator with the major type fixed, so its provenance is a config this reader
-     * already understands. The tool path is what tells a vault listing which made an item, not
-     * what tells a re-roll how.
+     * `/fantasy/weapon` is the equipment generator with the major type fixed and the enchantment
+     * tables narrowed to one religious domain — but its *controls* are a theme and a range
+     * category, where the equipment generator's are a major type and three switches. #69 assumed
+     * one reader would serve both; it would have re-rolled a consecrated sword out of the wrong
+     * settings.
+     *
+     * The two readers are separate on purpose and neither may accept the other's record, which is
+     * the shape the AD&D pair settled for the same reason.
      */
     loadRoller: async () => {
-      const { readEquipmentGeneratorConfig, rollItemSnapshot } =
-        await import('$lib/equipment/item_roll.js');
-      return (provenance) =>
-        rollItemSnapshot(provenance.seed, readEquipmentGeneratorConfig(provenance.config));
+      const [equipment, weapon] = await Promise.all([
+        import('$lib/equipment/item_roll.js'),
+        import('$lib/equipment/weapon_roll.js'),
+      ]);
+      return (provenance) => {
+        if (provenance.toolPath === WEAPON_TOOL_PATH) {
+          return weapon.rollWeaponSnapshot(
+            provenance.seed,
+            weapon.readWeaponGeneratorConfig(provenance.config),
+          );
+        }
+        return equipment.rollItemSnapshot(
+          provenance.seed,
+          equipment.readEquipmentGeneratorConfig(provenance.config),
+        );
+      };
     },
   },
   merchant: {


### PR DESCRIPTION
Closes #69. Takes `/fantasy/weapon` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the design in `docs/readiness-objects.md`.

It saves as **`item`**, the kind decision 1 of the objects document gives it to share with `/fantasy/equipment-generator` — so the snapshot, the editor and the presentation are all #66's, reached through the kind. What it needed was its own roll module and four corrections.

**The genre question answers itself**, as the design said: this tool never imported `$lib/weapons`, whose only importer is `$lib/arms_manufacturer` (already `scifi`). Nothing science-fictional is reachable from here and the `fantasy` tag is right as it stands.

## Two of the three Category options crashed the page

"melee" and "ranged" were passed through `itemMinorType`, which matches a weapon **type's name** — "battleaxe", "crossbow". The filter came back empty, `rng.item([])` was `undefined`, and generation threw `Cannot read properties of undefined`. `EquipmentGenerationConfig` gains a `weaponRangeCategory`, and a type name that matches nothing now widens to the whole table rather than throwing.

## One kind, two provenance shapes

The design says the tool path tells the two tools apart in a vault listing, which is true. It does not say the **re-roll** needs the same distinction, which it does: their controls differ, so `ARTIFACT_EDITORS` branches on the path exactly as the AD&D pair does. One reader would have re-rolled a consecrated sword out of the wrong settings.

## The theme is resolved before it is recorded

The page drew a domain from its own RNG when the control read "any", so the roll depended on something the provenance did not record. Resolving from the seed and storing the result is what 3.6 asks for — **and it is also what keeps `$lib/equipment` from importing `$lib/religion`, which is a cycle**: religion reaches characters, which reaches archetypes, which reaches back into equipment for their gear. The symptom was every archetype table reading `undefined` at module load in seventeen unrelated test files.

## The page showed a heading and one paragraph

The damage, the value, the weight, the material and the enchantment it had just rolled were all invisible — which would also have left the editor with fields answering to nothing on screen. It renders `itemToDocument` now, as #66 does.

## 5.1, and the issue guessed right about why

The `$lib/religion` import is the theme list: a weapon is themed on a religious domain. A saved religion narrows that list to the domains **its own gods claim**, because a weapon consecrated to a domain no god in that religion holds is not a weapon of that religion. `religionDomainNames` is new in `$lib/religion` and is the whole of it.

## A bug found in #66's own work

Both cards keyed their property badges by the tag value, and a weapon's properties repeat — the type name, the damage type and an enchantment's `tagsAdded` all land in the same list. A duplicate key is a Svelte error that takes the whole page down with it, which is what an empty result article turned out to be. Both key by index now.

## Verification

`npm run verify` is green, and `npm run verify:all` was run before opening this: 5,944 unit tests and 615 Playwright tests, including the new `e2e/weapon.spec.ts` — which generates on all three categories, the two that used to throw included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QEan2y9qHFJnvoM1dci8L
