### PR TITLE
Take the spooky starship generator to Release-ready

### DIFF
--- a/docs/readiness-objects.md
+++ b/docs/readiness-objects.md
@@ -305,6 +305,26 @@ Like the chop shop, `src/lib/spooky_ship/index.ts` is a single file whose `gener
   this tool and the four genre-neutral ones and nothing else — a fact about the catalog, worth
   knowing when the project-genre work lands.
 
+**As built (#71).** The cheapest tool of the pass, and it landed as designed: `{ text }`, a
+textarea, and the library split into types and generation for 8.3. Three things worth recording:
+
+- **The kind question the issue asks to be settled deliberately is settled, and building it
+  confirms the answer.** A `StarshipSWN` is a hull with a mass, a power budget and a hardpoint
+  allocation; this is a sentence about something adrift. One kind would put a fittings editor in
+  front of a paragraph, and a vault listing could not keep a haunted freighter apart from a corvette
+  a player is flying. Two registrations is the whole cost.
+- **The seed fault was here too**, in both of its forms: reseeded from the field inside an
+  `$effect`, and again inside `generate()`. That is five tools running.
+- **The registry imports this one through its entry point**, unlike its neighbours, and the
+  measurement is what says so rather than a feeling: 431 KB across 43 chunks through the entry point
+  against 429 KB across 41 through the kind module. Two kilobytes does not buy an allowlist entry,
+  and an entry with nothing behind it is how that rule rots.
+
+**The maturity suite's Experimental exemplar moved to `/language`.** `e2e/tool_maturity.spec.ts`
+needs one Experimental tool to prove a badge reaches a screen, and it had been rewritten three times
+— planet, drug, spooky ship — as each reached Release-ready. `/language` is in another domain, so
+the objects pass stops rewriting it.
+
 ## #72 — Stars Without Number starship
 
 `SWNStarship` is `{ name, className, manufacturer, hullType, currentCrew, totalCost, tonsOfCargo,

--- a/e2e/spooky_ship.spec.ts
+++ b/e2e/spooky_ship.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `spooky-ship` kind: generate, save, reopen, edit.
+ *
+ * This is the half no unit test can settle. The library tests prove a derelict round-trips
+ * through the codec and that each editing function changes one field; what they cannot prove is
+ * that a user can press Generate, keep the result, come back to it in a different page, change
+ * something, and still have the paragraph they saved. Every step of that crosses a boundary the unit
+ * tests stub out — the artifact store, IndexedDB, the editor registry, and a page reload.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+
+const SHIP_TITLE = 'Spooky Ship Generator | Iron Arachne';
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool on this page has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+test.describe('a spooky ship', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'The Drift');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/spooky-ship', { title: SHIP_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a derelict to keep straight away.
+    await expect(page.locator('.ship')).toBeVisible();
+    await saveAs(page, 'The Silent Hulk');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test.
+    const panel = await openInWorkshop(page, 'The Silent Hulk');
+
+    // Typed rather than filled: the point is that the editor's own binding carries keystrokes
+    // through to the snapshot it announces. The value is one no roll produces.
+    const description = panel.getByRole('textbox', { name: 'Ship description' });
+    await description.fill('');
+    await description.pressSequentially('The hull is warm to the touch.');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    // And it survived the round trip through IndexedDB, which is the whole claim.
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'The Silent Hulk');
+    await expect(reopened.getByRole('textbox', { name: 'Ship description' })).toHaveValue(
+      'The hull is warm to the touch.',
+    );
+  });
+
+  test('downloads the paragraph a referee can take to the table', async ({ page }) => {
+    // Requirement 6.3, and the first exports this tool has ever had.
+    await visitRoute(page, '/spooky-ship', { title: SHIP_TITLE });
+    const paragraph = await page.locator('.ship').innerText();
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const markdownFile = await markdown;
+    expect(markdownFile.suggestedFilename()).toMatch(/\.md$/);
+    const contents = await new Response(await markdownFile.createReadStream()).text();
+    expect(contents).toContain(paragraph);
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/\.pdf$/);
+  });
+
+  test('reproduces the same derelict from the same seed', async ({ page }) => {
+    // Requirement 2.2. The seed control was there and honoured; what was not reproducible was the
+    // seed itself, because the page reseeded its own RNG from the field inside an `$effect` and
+    // again inside `generate()`, so each press depended on the *text* of the previous one.
+    await visitRoute(page, '/spooky-ship', { title: SHIP_TITLE });
+    const ship = page.locator('.ship');
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const first = await ship.innerText();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await ship.innerText()).toEqual(first);
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await ship.innerText()).not.toEqual(first);
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -19,10 +19,11 @@ import { visitRoute } from './helpers';
 const maturityBadge = (page: Page) => page.locator('.maturity__level');
 
 const TOOL_PAGES = [
-  // Was `/planet` until #61 and `/drug` until #64, both of which reached Release-ready. Any
-  // Experimental tool serves here; the spooky starship is one with a stable title and no renderer
-  // to wait for.
-  { path: '/spooky-ship', title: 'Spooky Ship Generator | Iron Arachne', level: 'Experimental' },
+  // Was `/planet` until #61, `/drug` until #64 and `/spooky-ship` until #71, all of which reached
+  // Release-ready. Any Experimental tool serves here; the language generator is one with a stable
+  // title and no renderer to wait for, and it is in another domain, so this list stops being
+  // rewritten every time the objects pass finishes a tool.
+  { path: '/language', title: 'Language Generator | Iron Arachne', level: 'Experimental' },
 ] as const;
 
 /** The release-ready tools, which must say nothing at all. */
@@ -57,6 +58,7 @@ const SILENT_TOOL_PAGES = [
   { path: '/fantasy/potion-generator', title: 'Potion Generator | Iron Arachne' },
   { path: '/fantasy/weapon', title: 'Magic Weapon Generator | Iron Arachne' },
   { path: '/fantasy/treasure-hoard', title: 'Treasure Hoard Generator | Iron Arachne' },
+  { path: '/spooky-ship', title: 'Spooky Ship Generator | Iron Arachne' },
   {
     // The first reference tool in this list, and the reason it is worth naming: most of the spec
     // does not apply to a tool that produces no artifacts, so its silence was earned by sections
@@ -112,7 +114,7 @@ for (const entry of SILENT_TOOL_PAGES) {
 }
 
 test('maturity: a tool page says what its level promises', async ({ page }) => {
-  await visitRoute(page, '/spooky-ship', { title: 'Spooky Ship Generator | Iron Arachne' });
+  await visitRoute(page, '/language', { title: 'Language Generator | Iron Arachne' });
 
   // The sentence, not just the pill: "Experimental" means nothing to a visitor who has not read
   // the design document, and the point is that they can decide before they invest work.
@@ -185,11 +187,16 @@ test('maturity: the tool browser marks every tool that has something to warn abo
   await expect(browser.getByRole('button', { name: /^Fantasy Organization/ })).not.toContainText(
     'Experimental',
   );
-  // Planet was the still-marked case until #61 took it to Release-ready. The drug generator is
-  // Experimental and mountable, so it holds that end of the assertion now.
+  // Planet was the still-marked case until #61 took it to Release-ready, then the drug until #64
+  // and the spooky starship until #71. The language generator holds that end of the assertion now,
+  // and it is in another domain, so this stops being rewritten every time the objects pass finishes
+  // a tool.
   await expect(browser.getByRole('button', { name: /^Planet/ })).not.toContainText('Experimental');
   await expect(browser.getByRole('button', { name: /^Cyberpunk Drug/ })).not.toContainText(
     'Experimental',
   );
-  await expect(browser.getByRole('button', { name: /^Spooky Ship/ })).toContainText('Experimental');
+  await expect(browser.getByRole('button', { name: /^Spooky Ship/ })).not.toContainText(
+    'Experimental',
+  );
+  await expect(browser.getByRole('button', { name: /^Language/ })).toContainText('Experimental');
 });

--- a/src/components/objects/SpookyShipArtifactEditor.svelte
+++ b/src/components/objects/SpookyShipArtifactEditor.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import Notice from '$components/common/Notice.svelte';
+  import {
+    setSpookyShipText,
+    validateSpookyShipSnapshot,
+    type SpookyShipSnapshot,
+  } from '$lib/spooky_ship';
+
+  /**
+   * The editing view for a saved derelict: a textarea, which is the honest editing view for prose
+   * and satisfies requirement 4.1 completely — the one field displayed is the field. Dirty state,
+   * saving, and the destructive re-roll belong to the surface around it.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  const accepted = $derived(validateSpookyShipSnapshot(snapshot));
+  const ship = $derived<SpookyShipSnapshot | undefined>(accepted.ok ? accepted.value : undefined);
+</script>
+
+{#if ship === undefined}
+  <Notice tone="danger">
+    These contents are stored as a spooky ship but do not read as one, so there is nothing safe to
+    edit here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <!-- "Ship description" rather than "Description": the panel above has fields of its own, and two
+       controls with the same accessible name in one region is the 6.2 failure. -->
+  <div class="input-group input-group--inline ship-editor">
+    <label for="{uid}-text">Ship description</label>
+    <textarea
+      id="{uid}-text"
+      rows="10"
+      value={ship.text}
+      oninput={(event) => onChange(setSpookyShipText(ship, event.currentTarget.value))}
+    ></textarea>
+  </div>
+{/if}
+
+<style>
+  .ship-editor {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .ship-editor textarea {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+</style>

--- a/src/components/objects/SpookyShipGenerator.svelte
+++ b/src/components/objects/SpookyShipGenerator.svelte
@@ -1,26 +1,54 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import * as SpookyShip from '$lib/spooky_ship';
   import { RNG } from '@ironarachne/rng';
-  import GeneratorPage from '$components/layout/GeneratorPage.svelte';
-  import SeedControls from '$components/common/SeedControls.svelte';
-  import BaseButton from '$components/common/BaseButton.svelte';
 
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import GeneratorPage from '$components/layout/GeneratorPage.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
+  import SeedControls from '$components/common/SeedControls.svelte';
+  import { downloadTextFile } from '$lib/download';
+  import { downloadTextPdf } from '$lib/pdf';
+  import * as SpookyShip from '$lib/spooky_ship';
+
+  const TOOL_PATH = '/spooky-ship';
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. It used to be reseeded from the seed
+   * field inside an `$effect` *and* again inside `generate()`, so the next press's seed depended on
+   * the text of the previous one — the same requirement 2.2 failure the rest of this domain had.
+   */
   const rng = new RNG(Date.now().toString());
   let seed = $state(rng.randomString(13));
-  $effect(() => {
-    rng.setSeed(seed);
-  });
   let lockSeed = $state(false);
 
-  let shipDescription = $state('');
+  let ship = $state.raw<SpookyShip.SpookyShip | null>(null);
+  const shipSnapshot = $derived(ship === null ? null : SpookyShip.toSpookyShipSnapshot(ship));
 
   function generate() {
     if (!lockSeed) {
       seed = rng.randomString(13);
     }
-    rng.setSeed(seed);
-    shipDescription = SpookyShip.generate(rng);
+    ship = SpookyShip.rollSpookyShip(seed);
+  }
+
+  function exportMarkdown() {
+    if (ship === null) return;
+    downloadTextFile(
+      SpookyShip.spookyShipToMarkdown(ship),
+      `${SpookyShip.SPOOKY_SHIP_FILE_STEM}.md`,
+      'text/markdown',
+    );
+  }
+
+  async function exportPdf() {
+    if (ship === null) return;
+    await downloadTextPdf(
+      SpookyShip.SPOOKY_SHIP_DISPLAY_NAME,
+      SpookyShip.spookyShipToText(ship),
+      `${SpookyShip.SPOOKY_SHIP_FILE_STEM}.pdf`,
+    );
   }
 
   onMount(() => {
@@ -28,7 +56,7 @@
   });
 </script>
 
-<GeneratorPage toolPath="/spooky-ship" title="Spooky Ship Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Spooky Ship Generator">
   {#snippet description()}
     <p>Generate a spooky ship description.</p>
   {/snippet}
@@ -37,5 +65,28 @@
 
   <BaseButton onclick={generate}>Generate</BaseButton>
 
-  <p>{shipDescription}</p>
+  <SaveArtifactButton
+    kind={SpookyShip.SPOOKY_SHIP_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={shipSnapshot}
+    {seed}
+    defaultName={SpookyShip.SPOOKY_SHIP_DISPLAY_NAME}
+  />
+
+  {#if ship}
+    <div class="ship-exports">
+      <BaseButton onclick={exportMarkdown}>Download Markdown</BaseButton>
+      <BaseButton onclick={exportPdf}>Download PDF</BaseButton>
+    </div>
+
+    <p class="ship">{ship.text}</p>
+  {/if}
 </GeneratorPage>
+
+<style>
+  .ship-exports {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+</style>

--- a/src/lib/spooky_ship/README.md
+++ b/src/lib/spooky_ship/README.md
@@ -1,11 +1,42 @@
 # Spooky ship
 
-Procedural one-paragraph “derelict ship in space” descriptions for the Spooky Ship route.
+Procedural one-paragraph "derelict ship in space" descriptions for the Spooky Ship route: a size, a
+ship type, an intro, an origin and a twist, assembled from five phrase tables.
+
+Still the only tool on the site carrying two genres, and the only one carrying `horror`.
 
 ## Usage
 
 ```ts
 import * as SpookyShip from '$lib/spooky_ship';
 
-const blurb = SpookyShip.generate();
+const ship = SpookyShip.rollSpookyShip('some seed');
+
+ship.text;
 ```
+
+`generate(rng)` returns the bare paragraph and is unchanged; `generateSpookyShip(rng)` wraps it in
+the library's one type, which is what a snapshot, an editor and an export hold.
+
+## The `spooky-ship` artifact kind
+
+A derelict is a durable artifact (#71), and the payload is `{ text }` — decision 4 of
+[docs/tool-readiness.md](../../../docs/tool-readiness.md): a prose generator's artifact is the
+prose.
+
+**Its own kind rather than a `starship` shared with `/swn/starship`**, which #71 asks to be settled
+deliberately. Decision 6 of [docs/readiness-objects.md](../../../docs/readiness-objects.md) settles
+it: the two are the same noun from opposite directions and nothing else. A `StarshipSWN` is a hull
+with a mass, power and hardpoint budget; this is a sentence about something adrift. Sharing a kind
+would put a fittings editor in front of a paragraph, and a vault listing could not keep a haunted
+freighter apart from a corvette a player is flying.
+
+- **`spooky_ship_types.ts`** and **`spooky_ship_generation.ts`** — the split CODE_STYLE.md asks for
+  (8.3). This library was a single `index.ts` holding both.
+- **`spooky_ship_roll.ts`** — the one path from a seed. There is no config record: the page has one
+  control and it is the seed.
+- **`spooky_ship_snapshot.ts`** — the codec, which is the identity function and is tested as one.
+- **`spooky_ship_editing.ts`** — one setter, because a textarea over the paragraph is the whole of
+  requirement 4.1 here.
+- **`spooky_ship_presentation.ts`** — the Markdown and PDF. A derelict whose text has been emptied
+  exports its heading and no blank paragraph beneath it (6.4).

--- a/src/lib/spooky_ship/index.ts
+++ b/src/lib/spooky_ship/index.ts
@@ -1,72 +1,7 @@
-import type { RNG } from '@ironarachne/rng';
-import * as Words from '@ironarachne/words';
-
-export function generate(rng: RNG) {
-  const description = `${Words.capitalize(randomIntro(rng))} ${randomOrigin(rng)} ${randomTwist(rng)}`;
-
-  return description;
-}
-
-function randomSize(rng: RNG) {
-  return rng.item(['gigantic', 'immense', 'large', 'huge', 'colossal', 'vast']);
-}
-
-function randomShip(rng: RNG) {
-  return rng.item([
-    'derelict',
-    'freighter',
-    'hulk',
-    'mining vessel',
-    'warship',
-    'passenger liner',
-    'merchant ship',
-  ]);
-}
-
-function randomIntro(rng: RNG) {
-  const size = randomSize(rng);
-  const part1 = rng.item([
-    `${Words.article(size)} ${size} ${randomShip(rng)} ${rng.item([
-      'drifts',
-      'floats',
-    ])} in space ${rng.item(['in front of you', 'here'])}, `,
-    `a ${randomShip(rng)} of ${size} proportions is adrift here, `,
-  ]);
-
-  const part2 = rng.item([
-    'its outer hull breached in several places.',
-    'surrounded by strange, dancing lights.',
-    'partially obscured by a thick, dark nebula.',
-    'its hull shattered and fragmented.',
-    'floating endlessly in the vast nothinginess of space.',
-    'floating in a cloud of debris.',
-    'inexorably being drawn towards a nearby star.',
-  ]);
-
-  return part1 + part2;
-}
-
-function randomOrigin(rng: RNG) {
-  return rng.item([
-    "It matches no known ship design you've ever seen.",
-    'It appears to be of an ancient design.',
-    'There is something distinctly alien about its features.',
-    "The ship's contours make it seem familiar, but all identification is obscured or destroyed.",
-    "While the ship's design is familiar, it appears to have been heavily modified.",
-    "The ship's barely recognizable but it is definitely a model familiar to you.",
-  ]);
-}
-
-function randomTwist(rng: RNG) {
-  return rng.item([
-    'Strangely, you are getting life readings from deep within it...',
-    'There appears to be an active power source somewhere on the ship.',
-    'A distress beacon from the ship beeps weakly.',
-    'There is evidence of a fire fight, but the weapon marks match nothing in your experience.',
-    'Gashes have been ripped in the hull in some places. They appear to be made by... claws?',
-    'Thick layers of ice surround several rips in the hull.',
-    'Faint filaments of light surround the vessel, reminiscent of string loosely tangled around something.',
-    'Several holes have been burned into the hull. The burn marks are consistent with damage caused by acid.',
-    'Fire has consumed several sections of the ship, but it appears that some compartments still hold atmosphere.',
-  ]);
-}
+export type * from './spooky_ship_types';
+export * from './spooky_ship_generation';
+export * from './spooky_ship_artifact_kind';
+export * from './spooky_ship_editing';
+export * from './spooky_ship_presentation';
+export * from './spooky_ship_roll';
+export * from './spooky_ship_snapshot';

--- a/src/lib/spooky_ship/spooky_ship_artifact_kind.test.ts
+++ b/src/lib/spooky_ship/spooky_ship_artifact_kind.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SPOOKY_SHIP_ARTIFACT_KIND,
+  SPOOKY_SHIP_PAYLOAD_VERSION,
+  migrateSpookyShipSnapshot,
+  spookyShipArtifactKind,
+  validateSpookyShipSnapshot,
+} from './spooky_ship_artifact_kind';
+import { SPOOKY_SHIP_DISPLAY_NAME } from './spooky_ship_presentation';
+import { rollSpookyShipSnapshot } from './spooky_ship_roll';
+
+const SHIP = rollSpookyShipSnapshot('kind-seed');
+
+describe('spookyShipArtifactKind', () => {
+  it('registers the id and version the pass assigned it', () => {
+    expect(spookyShipArtifactKind.kind).toBe(SPOOKY_SHIP_ARTIFACT_KIND);
+    expect(SPOOKY_SHIP_ARTIFACT_KIND).toBe('spooky-ship');
+    expect(spookyShipArtifactKind.payloadVersion).toBe(SPOOKY_SHIP_PAYLOAD_VERSION);
+    expect(SPOOKY_SHIP_PAYLOAD_VERSION).toBe(1);
+  });
+
+  it('is its own kind rather than a starship shared with /swn/starship', () => {
+    // The question #71 asks to be settled deliberately, and decision 6 of
+    // docs/readiness-objects.md settling it: one shape, two kinds.
+    expect(SPOOKY_SHIP_ARTIFACT_KIND).not.toBe('starship');
+    expect(SPOOKY_SHIP_ARTIFACT_KIND).not.toBe('starship.swn');
+  });
+
+  it('names one after the tool rather than after its contents', () => {
+    // A paragraph has no name of its own.
+    expect(spookyShipArtifactKind.nameOf(SHIP)).toBe(SPOOKY_SHIP_DISPLAY_NAME);
+  });
+
+  it('loads a codec that round-trips', async () => {
+    const codec = await spookyShipArtifactKind.loadCodec();
+
+    expect(codec.toSnapshot(codec.fromSnapshot(SHIP, undefined as never))).toEqual(SHIP);
+  });
+});
+
+describe('validateSpookyShipSnapshot', () => {
+  it('accepts a rolled derelict unchanged', () => {
+    const result = validateSpookyShipSnapshot(SHIP);
+
+    expect(result.ok).toBe(true);
+    expect(result.ok ? result.value : null).toEqual(SHIP);
+  });
+
+  it('accepts an emptied paragraph, because clearing one is an editing decision', () => {
+    // 3.3 asks for a well-defined empty result rather than a refusal.
+    const result = validateSpookyShipSnapshot({ text: '' });
+
+    expect(result.ok ? result.value.text : null).toBe('');
+  });
+
+  it('refuses anything without a text field', () => {
+    for (const payload of [null, undefined, 42, 'adrift', ['adrift'], {}, { text: 42 }]) {
+      expect(validateSpookyShipSnapshot(payload).ok, String(payload)).toBe(false);
+    }
+  });
+
+  it('keeps only the text, so a payload carrying more does not smuggle it through', () => {
+    const result = validateSpookyShipSnapshot({ text: 'adrift', crew: ['nobody'] });
+
+    expect(result.ok ? result.value : null).toEqual({ text: 'adrift' });
+  });
+});
+
+describe('migrateSpookyShipSnapshot', () => {
+  it('rejects rather than pretending there has been another shape', () => {
+    // Requirement 7.3 has one step to exercise and it is the absence of one.
+    const result = migrateSpookyShipSnapshot({ text: 'adrift' }, 0);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? '' : result.reason).toBe('unsupported-version');
+    expect(result.ok ? '' : result.message).toContain('payload version 0');
+  });
+});

--- a/src/lib/spooky_ship/spooky_ship_artifact_kind.ts
+++ b/src/lib/spooky_ship/spooky_ship_artifact_kind.ts
@@ -1,0 +1,74 @@
+// A grave, not a vessel. A derelict is a tomb drifting in the dark, which is the half of this tool
+// that is horror rather than science fiction — and it leaves the vehicle glyphs to `/swn/starship`,
+// which is a ship somebody is flying.
+import grave from '$lib/assets/icons/set2/grave.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  hasStringFields,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import { SPOOKY_SHIP_DISPLAY_NAME } from './spooky_ship_presentation';
+import type { SpookyShipSnapshot } from './spooky_ship_snapshot';
+import type { SpookyShip } from './spooky_ship_types';
+
+/**
+ * Stable artifact kind id.
+ *
+ * **Its own kind rather than a `starship` shared with `/swn/starship`**, which #71 asks to be
+ * settled deliberately rather than by default. Decision 6 of docs/readiness-objects.md settles it,
+ * and building both halves confirms the reasoning: a `StarshipSWN` is a hull with a mass, a power
+ * budget and a hardpoint allocation, and this is a sentence about something adrift. Sharing a kind
+ * would put a fittings editor in front of a paragraph, and a vault listing could no longer keep a
+ * haunted freighter apart from a corvette a player is flying. Two registrations is the whole cost.
+ */
+export const SPOOKY_SHIP_ARTIFACT_KIND = 'spooky-ship' as const;
+
+/** Version 1. The first shape a derelict has been stored in. */
+export const SPOOKY_SHIP_PAYLOAD_VERSION = 1 as const;
+
+/**
+ * Checks the one thing reading depends on: a text field. An empty one is accepted — a referee who
+ * has cleared the paragraph on the way to writing their own has made an editing decision, and 3.3
+ * asks for a well-defined empty result rather than a refusal.
+ */
+export function validateSpookyShipSnapshot(payload: unknown): PayloadResult<SpookyShipSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'Spooky ship payload is not an object');
+  }
+  if (!hasStringFields(record, ['text'])) {
+    return rejectedPayload('invalid-payload', 'Spooky ship payload needs a text field');
+  }
+  return acceptedPayload({ text: record.text as string });
+}
+
+/** There has only ever been version 1, so this rejects rather than pretending otherwise. */
+export function migrateSpookyShipSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<SpookyShipSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Spooky ships have no migration from payload version ${from}; version ${SPOOKY_SHIP_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/** A derelict as an artifact. */
+export const spookyShipArtifactKind = defineArtifactKind<SpookyShip, SpookyShipSnapshot>({
+  kind: SPOOKY_SHIP_ARTIFACT_KIND,
+  displayName: SPOOKY_SHIP_DISPLAY_NAME,
+  icon: grave,
+  payloadVersion: SPOOKY_SHIP_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { toSpookyShipSnapshot, spookyShipFromSnapshotWithRng } =
+      await import('./spooky_ship_snapshot.js');
+    return { toSnapshot: toSpookyShipSnapshot, fromSnapshot: spookyShipFromSnapshotWithRng };
+  },
+  nameOf: () => SPOOKY_SHIP_DISPLAY_NAME,
+  validate: validateSpookyShipSnapshot,
+  migrate: migrateSpookyShipSnapshot,
+});

--- a/src/lib/spooky_ship/spooky_ship_editing.test.ts
+++ b/src/lib/spooky_ship/spooky_ship_editing.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { setSpookyShipText } from './spooky_ship_editing';
+import { rollSpookyShipSnapshot } from './spooky_ship_roll';
+
+const SHIP = rollSpookyShipSnapshot('editing-seed');
+
+describe('setSpookyShipText', () => {
+  it('rewrites the paragraph, which is the whole of requirement 4.1 here', () => {
+    const edited = setSpookyShipText(SHIP, 'The hull is warm to the touch.');
+
+    expect(edited.text).toBe('The hull is warm to the touch.');
+    expect(SHIP.text).not.toBe('The hull is warm to the touch.');
+  });
+
+  it('accepts an emptied paragraph on the way to writing another', () => {
+    expect(setSpookyShipText(SHIP, '').text).toBe('');
+  });
+});

--- a/src/lib/spooky_ship/spooky_ship_editing.ts
+++ b/src/lib/spooky_ship/spooky_ship_editing.ts
@@ -1,0 +1,11 @@
+/**
+ * Editing a saved derelict. One field, one function: the paragraph is the artifact, and the
+ * textarea over it is the whole of requirement 4.1. The destructive command is a re-roll from
+ * provenance, which is `spooky_ship_roll.ts` and a button of its own (4.3).
+ */
+
+import type { SpookyShipSnapshot } from './spooky_ship_snapshot';
+
+export function setSpookyShipText(snapshot: SpookyShipSnapshot, text: string): SpookyShipSnapshot {
+  return { ...snapshot, text };
+}

--- a/src/lib/spooky_ship/spooky_ship_generation.test.ts
+++ b/src/lib/spooky_ship/spooky_ship_generation.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it } from 'vitest';
 import { RNG } from '@ironarachne/rng';
-import { generate } from './index';
+import { generate, generateSpookyShip } from './spooky_ship_generation';
 
 const SIZES = ['gigantic', 'immense', 'large', 'huge', 'colossal', 'vast'];
 const SHIPS = [
@@ -12,6 +12,15 @@ const SHIPS = [
   'passenger liner',
   'merchant ship',
 ];
+
+describe('generateSpookyShip', () => {
+  it('wraps the paragraph in the library one type', () => {
+    // What the snapshot, the editor and the exports all hold, rather than a bare string passed
+    // around. The chop shop settled this shape; decision 6 of docs/readiness-objects.md gives the
+    // two prose generators one shape and two kinds.
+    expect(generateSpookyShip(new RNG('wrapped'))).toEqual({ text: generate(new RNG('wrapped')) });
+  });
+});
 
 describe('generate', () => {
   it('is deterministic for a given seed', () => {

--- a/src/lib/spooky_ship/spooky_ship_generation.ts
+++ b/src/lib/spooky_ship/spooky_ship_generation.ts
@@ -1,0 +1,89 @@
+/**
+ * The derelict's prose, assembled from four phrase tables: size, ship type, intro, origin and
+ * twist.
+ *
+ * `generate` returns the bare paragraph, as it always has; `generateSpookyShip` wraps it in the
+ * library's one type so that a snapshot, an editor and an export have a value to hold rather than
+ * a string to pass around. That is the shape the chop shop settled — decision 6 of
+ * docs/readiness-objects.md gives the two prose generators one shape and two kinds.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+import * as Words from '@ironarachne/words';
+
+import type { SpookyShip } from './spooky_ship_types.js';
+
+/** A derelict as a value. The paragraph is the whole of it. */
+export function generateSpookyShip(rng: RNG): SpookyShip {
+  return { text: generate(rng) };
+}
+
+export function generate(rng: RNG) {
+  const description = `${Words.capitalize(randomIntro(rng))} ${randomOrigin(rng)} ${randomTwist(rng)}`;
+
+  return description;
+}
+
+function randomSize(rng: RNG) {
+  return rng.item(['gigantic', 'immense', 'large', 'huge', 'colossal', 'vast']);
+}
+
+function randomShip(rng: RNG) {
+  return rng.item([
+    'derelict',
+    'freighter',
+    'hulk',
+    'mining vessel',
+    'warship',
+    'passenger liner',
+    'merchant ship',
+  ]);
+}
+
+function randomIntro(rng: RNG) {
+  const size = randomSize(rng);
+  const part1 = rng.item([
+    `${Words.article(size)} ${size} ${randomShip(rng)} ${rng.item([
+      'drifts',
+      'floats',
+    ])} in space ${rng.item(['in front of you', 'here'])}, `,
+    `a ${randomShip(rng)} of ${size} proportions is adrift here, `,
+  ]);
+
+  const part2 = rng.item([
+    'its outer hull breached in several places.',
+    'surrounded by strange, dancing lights.',
+    'partially obscured by a thick, dark nebula.',
+    'its hull shattered and fragmented.',
+    'floating endlessly in the vast nothinginess of space.',
+    'floating in a cloud of debris.',
+    'inexorably being drawn towards a nearby star.',
+  ]);
+
+  return part1 + part2;
+}
+
+function randomOrigin(rng: RNG) {
+  return rng.item([
+    "It matches no known ship design you've ever seen.",
+    'It appears to be of an ancient design.',
+    'There is something distinctly alien about its features.',
+    "The ship's contours make it seem familiar, but all identification is obscured or destroyed.",
+    "While the ship's design is familiar, it appears to have been heavily modified.",
+    "The ship's barely recognizable but it is definitely a model familiar to you.",
+  ]);
+}
+
+function randomTwist(rng: RNG) {
+  return rng.item([
+    'Strangely, you are getting life readings from deep within it...',
+    'There appears to be an active power source somewhere on the ship.',
+    'A distress beacon from the ship beeps weakly.',
+    'There is evidence of a fire fight, but the weapon marks match nothing in your experience.',
+    'Gashes have been ripped in the hull in some places. They appear to be made by... claws?',
+    'Thick layers of ice surround several rips in the hull.',
+    'Faint filaments of light surround the vessel, reminiscent of string loosely tangled around something.',
+    'Several holes have been burned into the hull. The burn marks are consistent with damage caused by acid.',
+    'Fire has consumed several sections of the ship, but it appears that some compartments still hold atmosphere.',
+  ]);
+}

--- a/src/lib/spooky_ship/spooky_ship_presentation.test.ts
+++ b/src/lib/spooky_ship/spooky_ship_presentation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SPOOKY_SHIP_DISPLAY_NAME,
+  SPOOKY_SHIP_FILE_STEM,
+  spookyShipToDocument,
+  spookyShipToMarkdown,
+  spookyShipToText,
+} from './spooky_ship_presentation';
+import { rollSpookyShip } from './spooky_ship_roll';
+
+const SHIP = rollSpookyShip('presentation-seed');
+
+describe('spookyShipToDocument', () => {
+  it('is a heading and a paragraph', () => {
+    expect(spookyShipToDocument(SHIP)).toEqual({
+      title: SPOOKY_SHIP_DISPLAY_NAME,
+      paragraphs: [SHIP.text],
+    });
+  });
+
+  it('drops an emptied paragraph rather than carrying a blank one', () => {
+    // 6.4.
+    expect(spookyShipToDocument({ text: '   ' }).paragraphs).toEqual([]);
+  });
+});
+
+describe('spookyShipToMarkdown', () => {
+  it('writes the heading and the paragraph', () => {
+    const markdown = spookyShipToMarkdown(SHIP);
+
+    expect(markdown).toBe(`# ${SPOOKY_SHIP_DISPLAY_NAME}\n\n${SHIP.text}\n`);
+  });
+
+  it('writes the heading alone for an emptied derelict', () => {
+    expect(spookyShipToMarkdown({ text: '' })).toBe(`# ${SPOOKY_SHIP_DISPLAY_NAME}\n`);
+  });
+});
+
+describe('spookyShipToText', () => {
+  it('writes the paragraph without the title the PDF draws itself', () => {
+    expect(spookyShipToText(SHIP)).toBe(SHIP.text);
+    expect(spookyShipToText(SHIP)).not.toContain(`# ${SPOOKY_SHIP_DISPLAY_NAME}`);
+  });
+
+  it('is empty for an emptied derelict rather than a blank line', () => {
+    expect(spookyShipToText({ text: '' })).toBe('');
+  });
+});
+
+describe('SPOOKY_SHIP_FILE_STEM', () => {
+  it('names the file a download lands in', () => {
+    expect(SPOOKY_SHIP_FILE_STEM).toBe('spooky-ship');
+  });
+});

--- a/src/lib/spooky_ship/spooky_ship_presentation.ts
+++ b/src/lib/spooky_ship/spooky_ship_presentation.ts
@@ -1,0 +1,39 @@
+/**
+ * A derelict arranged for reading, and the Markdown and PDF exports written from it.
+ *
+ * A paragraph under a heading is the whole document. 6.4 still applies: a ship whose text has been
+ * emptied exports its heading and no blank paragraph beneath it.
+ */
+
+import type { SpookyShip } from './spooky_ship_types';
+
+/** What the vault and the exports call one; a paragraph has no name of its own. */
+export const SPOOKY_SHIP_DISPLAY_NAME = 'Spooky Ship';
+
+/** A derelict arranged for reading, independent of the format it is finally written in. */
+export type SpookyShipDocument = {
+  title: string;
+  paragraphs: string[];
+};
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+export function spookyShipToDocument(ship: SpookyShip): SpookyShipDocument {
+  return { title: SPOOKY_SHIP_DISPLAY_NAME, paragraphs: [ship.text].filter(isPrintable) };
+}
+
+/** A derelict as Markdown, for a referee who wants it in their own notes. */
+export function spookyShipToMarkdown(ship: SpookyShip): string {
+  const document = spookyShipToDocument(ship);
+  return `${[`# ${document.title}`, ...document.paragraphs].join('\n\n')}\n`;
+}
+
+/** The body of the PDF: the paragraph, without the title the PDF draws as its own heading. */
+export function spookyShipToText(ship: SpookyShip): string {
+  return spookyShipToDocument(ship).paragraphs.join('\n\n');
+}
+
+/** A filename stem for an exported derelict. */
+export const SPOOKY_SHIP_FILE_STEM = 'spooky-ship';

--- a/src/lib/spooky_ship/spooky_ship_roll.test.ts
+++ b/src/lib/spooky_ship/spooky_ship_roll.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollSpookyShip, rollSpookyShipSnapshot } from './spooky_ship_roll';
+
+describe('rollSpookyShip', () => {
+  it('gives the same derelict for the same seed', () => {
+    // Requirement 2.2. The page reseeded its own RNG from the seed field inside an `$effect` and
+    // again inside `generate()`, so the next press depended on the text of the previous one.
+    expect(rollSpookyShip('fixed')).toEqual(rollSpookyShip('fixed'));
+  });
+
+  it('gives a different derelict for a different seed', () => {
+    const texts = new Set(['a', 'b', 'c', 'd', 'e', 'f'].map((seed) => rollSpookyShip(seed).text));
+
+    expect(texts.size).toBeGreaterThan(1);
+  });
+
+  it('always writes something', () => {
+    for (let index = 0; index < 20; index++) {
+      const ship = rollSpookyShip(`seed-${index}`);
+
+      expect(ship.text.trim(), `seed-${index}`).not.toBe('');
+      expect(ship.text, `seed-${index}`).not.toContain('undefined');
+    }
+  });
+
+  it('re-rolls the same derelict a stored provenance describes', () => {
+    // Requirement 4.3: the destructive command puts the rolled paragraph back. There is no config
+    // record — this page has one control and it is the seed.
+    expect(rollSpookyShipSnapshot('stored')).toEqual(rollSpookyShipSnapshot('stored'));
+  });
+});

--- a/src/lib/spooky_ship/spooky_ship_roll.ts
+++ b/src/lib/spooky_ship/spooky_ship_roll.ts
@@ -1,0 +1,27 @@
+/**
+ * The single path from a seed to a derelict.
+ *
+ * `SpookyShipGenerator.svelte` reseeded its own RNG from the seed field inside an `$effect` and
+ * again inside `generate()`, so the seed of the next press depended on the *text* of the previous
+ * one — the same requirement 2.2 failure #66, #67, #69 and #70 all had. The roll is a pure
+ * function of the seed now.
+ *
+ * There is no config record: the page has one control and it is the seed, so recording anything
+ * else would describe controls this tool does not have.
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import { generateSpookyShip } from './spooky_ship_generation';
+import { toSpookyShipSnapshot, type SpookyShipSnapshot } from './spooky_ship_snapshot';
+import type { SpookyShip } from './spooky_ship_types';
+
+/** Roll a derelict from a seed — the one path the generator page and a re-roll both take. */
+export function rollSpookyShip(seed: string): SpookyShip {
+  return generateSpookyShip(new RNG(seed));
+}
+
+/** Roll a fresh derelict as a snapshot — the destructive half of editing (requirement 4.3). */
+export function rollSpookyShipSnapshot(seed: string): SpookyShipSnapshot {
+  return toSpookyShipSnapshot(rollSpookyShip(seed));
+}

--- a/src/lib/spooky_ship/spooky_ship_snapshot.test.ts
+++ b/src/lib/spooky_ship/spooky_ship_snapshot.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollSpookyShip, rollSpookyShipSnapshot } from './spooky_ship_roll';
+import { spookyShipFromSnapshot, toSpookyShipSnapshot } from './spooky_ship_snapshot';
+
+const SHIP = rollSpookyShip('snapshot-seed');
+
+describe('toSpookyShipSnapshot', () => {
+  it('keeps the paragraph, which is the whole of it', () => {
+    expect(toSpookyShipSnapshot(SHIP)).toEqual({ text: SHIP.text });
+  });
+
+  it('copies rather than handing the same object back', () => {
+    expect(toSpookyShipSnapshot(SHIP)).not.toBe(SHIP);
+  });
+});
+
+describe('spookyShipFromSnapshot', () => {
+  it('round-trips everything that matters', () => {
+    // Requirement 7.2.
+    expect(spookyShipFromSnapshot(toSpookyShipSnapshot(SHIP))).toEqual(SHIP);
+  });
+
+  it('survives a trip through JSON, which is what storage is', () => {
+    const stored = JSON.parse(JSON.stringify(toSpookyShipSnapshot(SHIP)));
+
+    expect(spookyShipFromSnapshot(stored)).toEqual(SHIP);
+  });
+
+  it('recomputes nothing on read', () => {
+    // 4.2: the paragraph comes back as it was stored, however far a referee has rewritten it.
+    expect(spookyShipFromSnapshot({ text: 'A judge wrote this by hand.' }).text).toBe(
+      'A judge wrote this by hand.',
+    );
+  });
+
+  it('keeps an emptied paragraph, which is an editing decision rather than a fault', () => {
+    expect(spookyShipFromSnapshot({ text: '' }).text).toBe('');
+  });
+});
+
+describe('rollSpookyShipSnapshot', () => {
+  it('is the roller a re-roll takes, and matches the page', () => {
+    expect(rollSpookyShipSnapshot('seed')).toEqual(toSpookyShipSnapshot(rollSpookyShip('seed')));
+  });
+});

--- a/src/lib/spooky_ship/spooky_ship_snapshot.ts
+++ b/src/lib/spooky_ship/spooky_ship_snapshot.ts
@@ -1,0 +1,28 @@
+/**
+ * Writing a derelict for storage, and reading one back.
+ *
+ * The identity function, tested: a derelict is one string, so there is nothing to strip, resolve
+ * or copy. The module exists for the contract — every kind has a codec, and a codec that happens
+ * to be trivial is not a reason to wire it differently from its neighbours.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+
+import type { SpookyShip } from './spooky_ship_types';
+
+/** A derelict as it is stored: the type as it stands. */
+export type SpookyShipSnapshot = SpookyShip;
+
+export function toSpookyShipSnapshot(ship: SpookyShip): SpookyShipSnapshot {
+  return { text: ship.text };
+}
+
+/** Nothing is recomputed: the paragraph comes back as it was stored (requirement 4.2). */
+export function spookyShipFromSnapshot(snapshot: SpookyShipSnapshot): SpookyShip {
+  return { text: snapshot.text };
+}
+
+/** The codec's reading half, with the signature the registry hands it. The RNG is unused. */
+export function spookyShipFromSnapshotWithRng(snapshot: SpookyShipSnapshot, _rng: RNG): SpookyShip {
+  return spookyShipFromSnapshot(snapshot);
+}

--- a/src/lib/spooky_ship/spooky_ship_types.ts
+++ b/src/lib/spooky_ship/spooky_ship_types.ts
@@ -1,0 +1,17 @@
+/**
+ * A haunted derelict: a paragraph of prose, and nothing else.
+ *
+ * Decision 4 of docs/tool-readiness.md: a prose generator's artifact is the prose. The thing a
+ * user wants to keep is the paragraph, the editing view is a textarea, and the re-roll is the
+ * whole tool.
+ *
+ * **Its own kind rather than a share of `starship`**, which #71 asks to be settled deliberately.
+ * Decision 6 of docs/readiness-objects.md settles it: this and `/swn/starship` are the same noun
+ * from opposite directions and nothing else. A `StarshipSWN` is a hull with a mass, power and
+ * hardpoint budget; this is a sentence about something drifting in the dark. One kind would put a
+ * fitting editor in front of a paragraph, and a vault listing could not keep a haunted freighter
+ * apart from a corvette a player is flying.
+ */
+export type SpookyShip = {
+  text: string;
+};

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -147,6 +147,7 @@ describe('TOOL_CATALOG', () => {
       '/fantasy/potion-generator',
       '/fantasy/weapon',
       '/fantasy/treasure-hoard',
+      '/spooky-ship',
     ];
 
     const claimingMore = TOOL_CATALOG.filter(
@@ -265,6 +266,7 @@ describe('toolsWithMaturity', () => {
       '/planet',
       '/region',
       '/species-stats',
+      '/spooky-ship',
       '/star-nation',
       '/star-system',
       '/swn/character',

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -485,12 +485,21 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
     genres: ['fantasy'],
     tags: ['treasure'],
   }),
+  // Release-ready, assessed section by section against docs/workshop.md and recorded in
+  // docs/readiness-objects.md (#71). It saves as `spooky-ship` — its own kind rather than a
+  // `starship` shared with /swn/starship, which the issue asks to be settled deliberately and
+  // decision 6 of that document settles: one shape, two kinds, so a vault listing can keep a
+  // haunted freighter apart from a corvette a player is flying. It has an editor in
+  // `ARTIFACT_EDITORS` and exports Markdown and PDF, the first exports it has ever had, and the
+  // library is split into types, generation and the five kind modules for 8.3.
+  //
+  // Still the only tool on the site carrying two genres, and the only one carrying `horror`.
   defineTool({
     path: '/spooky-ship',
     label: 'Spooky Ship',
     kind: 'generator',
     domain: 'objects',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     genres: ['scifi', 'horror'],
     tags: ['starship'],
   }),

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -312,6 +312,14 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
         rollTreasureHoardSnapshot(provenance.seed, readTreasureHoardConfig(provenance.config));
     },
   },
+  'spooky-ship': {
+    loadEditor: () => import('$components/objects/SpookyShipArtifactEditor.svelte'),
+    /** The seed and nothing else: the page has one control, and the paragraph is the whole roll. */
+    loadRoller: async () => {
+      const { rollSpookyShipSnapshot } = await import('$lib/spooky_ship/spooky_ship_roll.js');
+      return (provenance) => rollSpookyShipSnapshot(provenance.seed);
+    },
+  },
   'arms-manufacturer': {
     loadEditor: () => import('$components/factions/ArmsManufacturerArtifactEditor.svelte'),
     /**

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -37,6 +37,7 @@ describe('artifact kind catalog', () => {
       'merchant',
       'potion',
       'treasure-hoard',
+      'spooky-ship',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -23,6 +23,12 @@ import { starNationArtifactKind } from '$lib/civilizations/star_nation_artifact_
 // Through the entry point, unlike its neighbours: `$lib/chopshop` is a few kilobytes of prose and
 // nothing heavier, so there is no measurement that would justify a deep import.
 import { chopShopArtifactKind } from '$lib/chopshop';
+// Through the entry point, like the chop shop beside it and for the same reason — and measured
+// rather than assumed: `$lib/spooky_ship` is four phrase tables, so the registry chunk and
+// everything it statically imports is 431 KB across 43 chunks through the entry point and 429 KB
+// across 41 through the kind module. Two kilobytes is not a deep import; an allowlist entry with
+// nothing behind it is how that rule rots.
+import { spookyShipArtifactKind } from '$lib/spooky_ship';
 import { familyArtifactKind } from '$lib/families/family_artifact_kind';
 import { encounterArtifactKind } from '$lib/encounters/encounter_artifact_kind';
 import { cultureArtifactKind } from '$lib/culture/culture_artifact_kind';
@@ -105,6 +111,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, merchantArtifactKind);
   registerArtifactKind(registry, potionArtifactKind);
   registerArtifactKind(registry, treasureHoardArtifactKind);
+  registerArtifactKind(registry, spookyShipArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Closes #71. Takes `/spooky-ship` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the design in `docs/readiness-objects.md`.

The cheapest tool of the pass, and it landed as designed: payload `{ text }`, editor a textarea, and the library split into types and generation for 8.3 — it had been a single `index.ts` holding both.

## The kind question, settled deliberately

`spooky-ship` is **its own kind** rather than a `starship` shared with `/swn/starship`, which this issue asks to be settled on purpose rather than by default. Decision 6 of the objects document settles it, and building it confirms the reasoning: a `StarshipSWN` is a hull with a mass, a power budget and a hardpoint allocation; this is a sentence about something adrift. One kind would put a fittings editor in front of a paragraph, and a vault listing could not keep a haunted freighter apart from a corvette a player is flying. Two registrations is the whole cost.

## The seed, and the measurement

- **The seed fault was here in both of its forms** — reseeded from the field inside an `$effect` *and* again inside `generate()`. That is five tools running.
- **The registry imports this one through its entry point**, unlike most of its neighbours, and the measurement is what says so rather than a feeling: **431 KB across 43 chunks** through the entry point against **429 KB across 41** through the kind module. Two kilobytes does not buy an allowlist entry, and an entry with nothing behind it is how that rule rots.

## The rest of the sections

- **6.3** — Markdown and PDF, the first exports this tool has ever had.
- **6.4** — a derelict whose text has been emptied exports its heading and no blank paragraph beneath it.
- **4** — an editor in `ARTIFACT_EDITORS`: a textarea, which is requirement 4.1 completely when the one field displayed is the field.
- **7.2–7.4** — round-trip, migration, and a full generate/save/reopen/edit journey.
- **5.1** does not bind: nothing this tool takes as input has an artifact kind.

## One thing outside the tool

`e2e/tool_maturity.spec.ts` needs one Experimental tool to prove a badge reaches a screen, and it had been rewritten three times — planet, drug, spooky ship — as each reached Release-ready. It points at `/language` now, which is in another domain, so the objects pass stops rewriting it.

## Verification

`npm run verify` is green, and `npm run verify:all` was run before opening this: 6,042 unit tests and 626 Playwright tests, including the new `e2e/spooky_ship.spec.ts` and the mobile pass at all five widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QEan2y9qHFJnvoM1dci8L
