### PR TITLE
Take the language generator to Release-ready

### DIFF
--- a/docs/readiness-utilities.md
+++ b/docs/readiness-utilities.md
@@ -51,6 +51,45 @@ translation machinery, not in the language.
 - **6.3 is a real loss today.** A conlang is a document — the phonology, the typology, and the
   lexicon as a two-column glossary. Markdown and PDF, from one presentation document.
 
+**As built (#74).** It landed as designed — kind `language`, the lexicon stored whole, a bespoke
+searchable editor, and the `SeedControls` the tool had never had. Four things worth recording:
+
+- **The measurement the issue asked for: 1,760 words and about 144 KB of JSON.** That is the
+  largest payload the site stores and it is not close to mattering. `$lib/storage_status` warns at
+  80% of what `navigator.storage.estimate()` reports, so a user would need thousands of languages
+  to reach the first thing the vault would say to them. Storing the lexicon whole was never the
+  risk the issue was right to check for.
+
+- **Determinism holds, and the test compares the lexicon word for word** rather than comparing two
+  objects and trusting `toEqual` to have looked. That is the test #74 asks for, and it is what makes
+  the re-roll honest: this design stores the lexicon rather than relying on regeneration, but 4.3
+  does rely on it, and a re-roll that returned a different language each press would be a button
+  that lies.
+
+- **The failure was 2.3, not 2.2.** Every other tool in the pass had a seed control that worked and
+  an RNG reseeded in the wrong place. This one rendered no `SeedControls` at all and drew a fresh
+  seed from `Date.now()` inside `generate()` — so a language a user liked could not be got back,
+  because there was nothing to write down. Different fault, same fix.
+
+- **`/language` was the last Experimental tool, and `e2e/tool_maturity.spec.ts` changed shape.**
+  That spec exists to prove a maturity level reaches a screen, and it had a list of one — rewritten
+  four times as planet, drug, spooky ship and finally this tool each reached Release-ready. The
+  catalog is now release-ready end to end, so no page can show a badge and the list has nowhere to
+  point. It asserts site-wide silence instead, and carries a note saying to restore the two tests
+  the day a tool ships below Release-ready. The badge's own logic stays covered by
+  `src/lib/tools/tools.test.ts`; what is genuinely no longer covered is the wiring from that logic
+  to `ToolMaturityBadge` on a real page, and keeping a fixture route alive to exercise it would cost
+  more than it is worth.
+
+**On #28.** This kind is the one that issue declined to mint, and building it is not a reversal of
+it. #28's warning was specific: naming a kind after a language while storing only the
+`NameGeneratorSet` a culture consumes would be a mismatch expensive to undo once artifacts existed
+in users' browsers. This payload is the whole language — phonology, typology, morphology and the
+entire lexicon — so that mismatch cannot arise. What #28 left open stays open: culture still owns
+its `nameGenerators` outright, there is no `payloadVersion` step for culture, and whether a
+_name-generator set_ deserves a kind of its own remains the smaller question to ask if settlement,
+region, family and character ever justify it.
+
 ## #75 — Species height and weight calculator
 
 A reference tool: sections 3, 4 and 5 do not apply, and neither do 2.2–2.4. The bar is sections 1,

--- a/e2e/language.spec.ts
+++ b/e2e/language.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+/**
+ * Requirement 7.4 for the `language` kind: generate, save, reopen, edit.
+ *
+ * This is the half no unit test can settle. The library tests prove a language round-trips through
+ * the codec and that each editing function changes one field; what they cannot prove is that a user
+ * can press Generate, keep the result, come back to it in a different page, change something, and
+ * still have the language they saved. Every step of that crosses a boundary the unit tests stub out
+ * — the artifact store, IndexedDB, the editor registry, and a page reload.
+ *
+ * It matters more here than for most kinds, because this is the largest payload the site stores:
+ * 1,760 words and about 144 KB of JSON per language. A round trip that works on a settlement is not
+ * evidence that one works on this.
+ *
+ * Accessibility (6.2) is asserted here rather than in a separate spec because the only honest test
+ * of "operable by keyboard, with meaningful accessible names" is reaching the controls by those
+ * names, which is what these tests do throughout.
+ */
+
+const projectsPage = (page: Page) => page.locator('section.projects');
+const vault = (page: Page) => page.locator('section.vault');
+const inspector = (page: Page) => page.getByRole('region', { name: 'Inspector' });
+const saveArtifact = (page: Page) => page.locator('.save-artifact');
+
+const LANGUAGE_TITLE = 'Language Generator | Iron Arachne';
+
+async function openEmpty(page: Page): Promise<void> {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase('ironarachne.vault');
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      }),
+  );
+  await page.reload({ waitUntil: 'load' });
+}
+
+async function createProject(page: Page, name: string): Promise<void> {
+  await page.goto('/projects/');
+  await projectsPage(page).getByLabel('New project').fill(name);
+  await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+  await expect(projectsPage(page).locator('.project-card', { hasText: name })).toBeVisible();
+}
+
+/**
+ * Keep whatever the tool on this page has made, under a name of its own.
+ *
+ * The confirmation is the button's own status line rather than a project listing: on a tool's own
+ * route there is no project view to watch, which is requirement 3.7 — a tool must be savable from
+ * where it lives, not only from the bench.
+ */
+async function saveAs(page: Page, name: string): Promise<void> {
+  await saveArtifact(page).getByRole('button', { name: 'Save to project' }).click();
+  await saveArtifact(page).getByLabel('Name', { exact: true }).fill(name);
+  await saveArtifact(page).getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(saveArtifact(page).getByRole('status')).toContainText(`Saved “${name}”`);
+}
+
+const vaultRow = (page: Page, name: string) =>
+  vault(page).getByRole('button', { name: new RegExp(`^${name}( |$)`) });
+
+/** Open a saved artifact in the workshop panel that edits it. */
+async function openInWorkshop(page: Page, name: string) {
+  await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+  await expect(vaultRow(page, name)).toBeVisible();
+  await vaultRow(page, name).click();
+  await inspector(page).getByRole('button', { name: 'Open in workshop' }).click();
+  await page
+    .locator('section.project-view')
+    .getByRole('button', { name: new RegExp(`^${name}( |$)`) })
+    .click();
+  const panel = page.locator('.artifact-panel');
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+test.describe('a constructed language', () => {
+  test.beforeEach(async ({ page }) => {
+    await openEmpty(page);
+    await createProject(page, 'The Sundered Coast');
+  });
+
+  test('is generated, saved, reopened, and edited', async ({ page }) => {
+    await visitRoute(page, '/language', { title: LANGUAGE_TITLE });
+
+    // The generator rolls on mount (2.4), so there is a language to keep straight away.
+    await expect(page.getByText('Word order', { exact: true })).toBeVisible();
+    await saveAs(page, 'Kethric');
+
+    // Reopened somewhere else entirely, after a reload, which is what makes this a durability test
+    // rather than a state test — and what proves a 144 KB payload survives the round trip.
+    const panel = await openInWorkshop(page, 'Kethric');
+
+    // Typed rather than filled: the point is that the editor's own binding carries keystrokes
+    // through to the snapshot it announces. The value is one no roll produces.
+    const orthography = panel.getByRole('textbox', { name: 'Orthography' });
+    await orthography.fill('');
+    await orthography.pressSequentially('Written in a borrowed abjad.');
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'Kethric');
+    await expect(reopened.getByRole('textbox', { name: 'Orthography' })).toHaveValue(
+      'Written in a borrowed abjad.',
+    );
+  });
+
+  test('is edited one word at a time, through the search box', async ({ page }) => {
+    // Requirement 4.4 on the half that makes this editor bespoke. A lexicon of 1,760 words is not
+    // a form: the search box is the only way through it, and each row has to carry its index into
+    // the *unfiltered* lexicon so that typing in the search box cannot rewrite the wrong word.
+    await visitRoute(page, '/language', { title: LANGUAGE_TITLE });
+    await saveAs(page, 'Velmish');
+
+    const panel = await openInWorkshop(page, 'Velmish');
+    const count = panel.getByRole('status');
+    await expect(count).toContainText('words');
+
+    await panel.getByRole('searchbox', { name: 'Search the lexicon' }).fill('stone');
+    await expect(count).not.toContainText(/^1,?7\d\d of/);
+
+    // The first match, rewritten and saved, then found again after a reload under its new form.
+    const form = panel.getByRole('textbox', { name: /Word \d+ form/ }).first();
+    await form.fill('zzyzx');
+    await panel.getByRole('button', { name: 'Save changes' }).click();
+    await expect(panel.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+    await page.reload({ waitUntil: 'load' });
+    const reopened = await openInWorkshop(page, 'Velmish');
+    await reopened.getByRole('searchbox', { name: 'Search the lexicon' }).fill('zzyzx');
+    await expect(reopened.getByRole('textbox', { name: /Word \d+ form/ }).first()).toHaveValue(
+      'zzyzx',
+    );
+  });
+
+  test('downloads the glossary a conlanger can keep', async ({ page }) => {
+    // Requirement 6.3, and the first exports this tool has ever had — which the issue calls a real
+    // loss, a conlang being a document.
+    await visitRoute(page, '/language', { title: LANGUAGE_TITLE });
+
+    const markdown = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Markdown' }).click();
+    const markdownFile = await markdown;
+    expect(markdownFile.suggestedFilename()).toMatch(/\.md$/);
+    const contents = await new Response(await markdownFile.createReadStream()).text();
+    expect(contents).toContain('## Typology');
+    expect(contents).toContain('## Nouns');
+    // 6.4: no heading with nothing under it.
+    expect(contents).not.toMatch(/## [^\n]+\n\n(##|$)/);
+
+    const pdf = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download PDF' }).click();
+    expect((await pdf).suggestedFilename()).toMatch(/\.pdf$/);
+  });
+
+  test('reproduces the same language from the same seed', async ({ page }) => {
+    // Requirement 2.3, which is what actually failed here rather than 2.2: the page rendered no
+    // seed control at all and drew a fresh seed from `Date.now()` on every press, so a language a
+    // user liked could not be got back — there was nothing to write down.
+    await visitRoute(page, '/language', { title: LANGUAGE_TITLE });
+    const heading = page.getByRole('heading', { level: 2 });
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-fixed-seed');
+    await page.getByLabel('Lock Seed').check();
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    const first = await heading.innerText();
+
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await heading.innerText()).toEqual(first);
+
+    await page.getByLabel('Seed', { exact: true }).fill('a-different-seed');
+    await page.getByRole('button', { name: 'Generate', exact: true }).click();
+    expect(await heading.innerText()).not.toEqual(first);
+  });
+});

--- a/e2e/tool_maturity.spec.ts
+++ b/e2e/tool_maturity.spec.ts
@@ -14,17 +14,32 @@ import { visitRoute } from './helpers';
  *
  * The expected levels are written out rather than imported from `$lib/tools`, in keeping with the
  * rest of `e2e/`: a spec that read the catalog would pass whatever the catalog happened to say.
+ *
+ * **Since #74 there is no Experimental tool left, and this file changed shape because of it.** It
+ * had a list of one — rewritten four times as planet, drug, spooky ship and finally the language
+ * generator each reached Release-ready — whose job was to prove a level reaches a screen. The
+ * catalog is now release-ready end to end, so no page can show a badge, and a list of one has
+ * nowhere left to point.
+ *
+ * What replaces it is the assertion that the site is silent everywhere, plus the note below on what
+ * to restore. The badge's own logic — which levels show, what each promises — is unit-tested in
+ * `src/lib/tools/tools.test.ts` and is not what was lost here; what is no longer covered is the
+ * wiring from that logic to `ToolMaturityBadge` on a real page. **The day a tool is added at
+ * Experimental or Beta, put it back in `TOOL_PAGES` below and restore the two tests that read it.**
+ * That is cheaper than keeping a fixture route alive to exercise a badge nothing currently shows.
  */
 
 const maturityBadge = (page: Page) => page.locator('.maturity__level');
 
-const TOOL_PAGES = [
-  // Was `/planet` until #61, `/drug` until #64 and `/spooky-ship` until #71, all of which reached
-  // Release-ready. Any Experimental tool serves here; the language generator is one with a stable
-  // title and no renderer to wait for, and it is in another domain, so this list stops being
-  // rewritten every time the objects pass finishes a tool.
-  { path: '/language', title: 'Language Generator | Iron Arachne', level: 'Experimental' },
-] as const;
+/**
+ * The tools that must show a level, and there are none.
+ *
+ * Was `/planet` until #61, `/drug` until #64, `/spooky-ship` until #71 and `/language` until #74 —
+ * each in turn the last Experimental tool on the site, and each promoted out of the role. Kept as
+ * an empty list rather than deleted so that adding one entry is all it takes to get the assertion
+ * back; see the note at the top of this file.
+ */
+const TOOL_PAGES: { path: string; title: string; level: string }[] = [];
 
 /** The release-ready tools, which must say nothing at all. */
 const SILENT_TOOL_PAGES = [
@@ -59,6 +74,7 @@ const SILENT_TOOL_PAGES = [
   { path: '/fantasy/weapon', title: 'Magic Weapon Generator | Iron Arachne' },
   { path: '/fantasy/treasure-hoard', title: 'Treasure Hoard Generator | Iron Arachne' },
   { path: '/spooky-ship', title: 'Spooky Ship Generator | Iron Arachne' },
+  { path: '/language', title: 'Language Generator | Iron Arachne' },
   {
     path: '/swn/starship',
     title: 'Stars Without Number Starship Generator | Iron Arachne',
@@ -117,12 +133,17 @@ for (const entry of SILENT_TOOL_PAGES) {
   });
 }
 
-test('maturity: a tool page says what its level promises', async ({ page }) => {
+test('maturity: no tool page says anything, every tool being release-ready', async ({ page }) => {
+  // The counterpart to `TOOL_PAGES` being empty, and the reason it is asserted rather than left
+  // implied: this is a true statement about the site today, and it stops being true the moment a
+  // tool ships below Release-ready. A spec that simply dropped the check would go quiet instead.
+  //
+  // The sentence a badge shows — "Experimental" means nothing to a visitor who has not read the
+  // design document — is covered by `maturityDescription` in `src/lib/tools/tools.test.ts`.
   await visitRoute(page, '/language', { title: 'Language Generator | Iron Arachne' });
 
-  // The sentence, not just the pill: "Experimental" means nothing to a visitor who has not read
-  // the design document, and the point is that they can decide before they invest work.
-  await expect(page.locator('.maturity__detail').first()).toContainText('may change or disappear');
+  await expect(page.locator('.maturity__detail')).toHaveCount(0);
+  await expect(maturityBadge(page)).toHaveCount(0);
 });
 
 test('maturity: the home page does not advertise release-ready either', async ({ page }) => {
@@ -148,11 +169,13 @@ test('maturity: the tool browser marks every tool that has something to warn abo
   const tools = browser.locator('.tool-browser__tool');
   await expect(tools.first()).toBeVisible();
 
-  // Exactly the release-ready tools are unmarked, and every one of them is mountable so every one
-  // is listed here. Counted rather than spot-checked: a tool that quietly lost its badge would
-  // otherwise pass every assertion below it.
+  // Every tool in the browser is unmarked, the catalog being release-ready end to end since #74.
+  // Counted against the rendered total rather than against `SILENT_TOOL_PAGES`, which is the subset
+  // with a route this file also visits: the claim here is that *nothing* is marked, and comparing
+  // two numbers that must now both equal the whole would say less than it appears to.
   const unmarked = tools.filter({ hasNot: page.locator('.maturity__level') });
-  await expect(unmarked).toHaveCount(SILENT_TOOL_PAGES.length);
+  await expect(unmarked).toHaveCount(await tools.count());
+  await expect(browser.locator('.maturity__level')).toHaveCount(0);
 
   await expect(browser.getByRole('button', { name: /^Culture/ })).not.toContainText(
     'Release-ready',
@@ -202,5 +225,10 @@ test('maturity: the tool browser marks every tool that has something to warn abo
   await expect(browser.getByRole('button', { name: /^Spooky Ship/ })).not.toContainText(
     'Experimental',
   );
-  await expect(browser.getByRole('button', { name: /^Language/ })).toContainText('Experimental');
+  // Was the still-marked case until #74 took it to Release-ready — as planet, the drug and the
+  // spooky starship were before it. There is no still-marked case now, which is what the count
+  // above asserts.
+  await expect(browser.getByRole('button', { name: /^Language/ })).not.toContainText(
+    'Experimental',
+  );
 });

--- a/src/components/utilities/LanguageArtifactEditor.svelte
+++ b/src/components/utilities/LanguageArtifactEditor.svelte
@@ -1,0 +1,443 @@
+<script lang="ts">
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import Notice from '$components/common/Notice.svelte';
+  import {
+    addLexiconWord,
+    filterLexicon,
+    languageSyllablePatternText,
+    lexiconSpeechParts,
+    removeLexiconWord,
+    setLanguageArticleSystem,
+    setLanguageMorphologyAffix,
+    setLanguageMorphologyPlacement,
+    setLanguagePossessionKind,
+    setLanguagePossessionMarker,
+    setLanguageSyllablePattern,
+    setLanguageText,
+    setLanguageWordOrder,
+    setLexiconWordField,
+    validateLanguageSnapshot,
+    ARTICLE_SYSTEM_CHOICES,
+    LANGUAGE_TEXT_FIELDS,
+    MORPHOLOGY_AFFIX_FIELDS,
+    POSSESSION_KIND_CHOICES,
+    WORD_ORDER_CHOICES,
+    type ArticleSystem,
+    type LanguageSnapshot,
+    type LanguageTextField,
+    type MorphologyAffixField,
+    type PossessionStrategy,
+    type WordOrder,
+  } from '$lib/languages';
+
+  /**
+   * The editing view for a saved constructed language.
+   *
+   * It owns its fields and nothing else. Dirty state, saving, renaming the artifact, the warning
+   * before edits are discarded, and the destructive re-roll all belong to the surface around it.
+   *
+   * **The lexicon is why this is bespoke.** 1,760 words is not a form, and a `SnapshotFieldEditor`
+   * over it would be unusable — the typology fields would fit that shape and the glossary never
+   * would. What a conlanger does is look a word up and rewrite it, so the lexicon is a search box
+   * over a list, and each row carries its index into the *unfiltered* lexicon so that typing in the
+   * search box cannot make a handler rewrite the wrong word.
+   *
+   * **Nothing recomputes.** Changing the syllable template does not rebuild the words that were
+   * built from it, and changing the plural affix does not re-inflect the lexicon: a conlanger who
+   * rewrote a word has made a decision, and 4.2 says the payload is authoritative. Rebuilding from
+   * the rules is the destructive re-roll, which the surface offers separately.
+   */
+  type Props = {
+    snapshot: unknown;
+    onChange: (snapshot: unknown) => void;
+  };
+
+  const { snapshot, onChange }: Props = $props();
+
+  const uid = $props.id();
+
+  /**
+   * The snapshot as this kind's own validator accepts it, or nothing.
+   *
+   * The prop is `unknown` because the framework holds payloads of every kind, and narrowing it
+   * through `validate` rather than a cast is what keeps this editor from rendering fields over
+   * something that is not a language.
+   */
+  const accepted = $derived(validateLanguageSnapshot(snapshot));
+  const language = $derived<LanguageSnapshot | undefined>(accepted.ok ? accepted.value : undefined);
+
+  let query = $state('');
+  let speechPartFilter = $state('');
+
+  /**
+   * How many glossary rows are rendered at once.
+   *
+   * A cap rather than a virtual list: the search box is the real way through 1,760 words, and a
+   * page of fifty is enough to see that a search worked. "Show more" raises it for the user who
+   * genuinely wants to scroll. Rendering all of them would put several thousand inputs in the DOM
+   * inside a panel, which is slow enough to feel broken.
+   */
+  const PAGE = 50;
+  let shown = $state(PAGE);
+
+  const speechParts = $derived(language === undefined ? [] : lexiconSpeechParts(language));
+  const matches = $derived(
+    language === undefined ? [] : filterLexicon(language, query, speechPartFilter),
+  );
+  const visible = $derived(matches.slice(0, shown));
+
+  /** Applies one edit. Every handler goes through here so `onChange` is called in one place. */
+  function edit(change: (current: LanguageSnapshot) => LanguageSnapshot): void {
+    if (language === undefined) {
+      return;
+    }
+    onChange(change(language));
+  }
+
+  const TEXT_LABELS: Record<LanguageTextField, string> = {
+    name: 'Name',
+    phonemeSetName: 'Phoneme set',
+    syllableProfile: 'Syllable profile',
+    orthographySummary: 'Orthography',
+  };
+
+  const AFFIX_LABELS: Record<MorphologyAffixField, string> = {
+    pluralAffix: 'Plural affix',
+    pastAffix: 'Past-tense affix',
+  };
+
+  const PLACEMENT_FOR: Record<MorphologyAffixField, 'pluralPlacement' | 'pastPlacement'> = {
+    pluralAffix: 'pluralPlacement',
+    pastAffix: 'pastPlacement',
+  };
+
+  const POSSESSION_LABELS: Record<PossessionStrategy['kind'], string> = {
+    none: 'Unmarked',
+    juxtapose_possessor_before: 'Possessor before the possessed',
+    juxtapose_possessor_after: 'Possessor after the possessed',
+    marker_on_possessed: 'Marked on the possessed',
+  };
+
+  const ARTICLE_LABELS: Record<ArticleSystem, string> = {
+    none: 'No articles',
+    definite_and_indefinite: 'Definite and indefinite',
+    definite_only: 'Definite only',
+  };
+</script>
+
+{#if language === undefined}
+  <Notice tone="danger">
+    These contents are stored as a language but do not read as one, so there is nothing safe to edit
+    here. {accepted.ok ? '' : accepted.message}
+  </Notice>
+{:else}
+  <div class="language-editor">
+    <fieldset>
+      <legend>What it is</legend>
+
+      {#each LANGUAGE_TEXT_FIELDS as field (field)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-{field}">{TEXT_LABELS[field]}</label>
+          <input
+            id="{uid}-{field}"
+            type="text"
+            value={language[field]}
+            oninput={(event) =>
+              edit((current) => setLanguageText(current, field, event.currentTarget.value))}
+            autocomplete="off"
+          />
+        </div>
+      {/each}
+
+      <div class="input-group input-group--inline">
+        <!-- Typed as the `CVC` string a conlanger writes. Anything that is not a C or a V is
+             dropped as they type rather than refused, which is what keeps the field from fighting
+             a half-finished keystroke. -->
+        <label for="{uid}-pattern">Syllable template</label>
+        <input
+          id="{uid}-pattern"
+          type="text"
+          value={languageSyllablePatternText(language)}
+          oninput={(event) =>
+            edit((current) => setLanguageSyllablePattern(current, event.currentTarget.value))}
+          autocomplete="off"
+        />
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Syntax</legend>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-word-order">Word order</label>
+        <select
+          id="{uid}-word-order"
+          value={language.wordOrder}
+          onchange={(event) =>
+            edit((current) =>
+              setLanguageWordOrder(current, event.currentTarget.value as WordOrder),
+            )}
+        >
+          {#each WORD_ORDER_CHOICES as choice (choice)}
+            <option value={choice}>{choice}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-articles">Articles</label>
+        <select
+          id="{uid}-articles"
+          value={language.articleSystem}
+          onchange={(event) =>
+            edit((current) =>
+              setLanguageArticleSystem(current, event.currentTarget.value as ArticleSystem),
+            )}
+        >
+          {#each ARTICLE_SYSTEM_CHOICES as choice (choice)}
+            <option value={choice}>{ARTICLE_LABELS[choice]}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-possession">Possession</label>
+        <select
+          id="{uid}-possession"
+          value={language.possessionStrategy.kind}
+          onchange={(event) =>
+            edit((current) =>
+              setLanguagePossessionKind(
+                current,
+                event.currentTarget.value as PossessionStrategy['kind'],
+              ),
+            )}
+        >
+          {#each POSSESSION_KIND_CHOICES as choice (choice)}
+            <option value={choice}>{POSSESSION_LABELS[choice]}</option>
+          {/each}
+        </select>
+      </div>
+
+      <!-- Only the one variant carries an affix, so only it offers the fields for one. -->
+      {#if language.possessionStrategy.kind === 'marker_on_possessed'}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-possession-affix">Possession marker</label>
+          <input
+            id="{uid}-possession-affix"
+            type="text"
+            value={language.possessionStrategy.affix}
+            oninput={(event) =>
+              edit((current) =>
+                setLanguagePossessionMarker(current, { affix: event.currentTarget.value }),
+              )}
+            autocomplete="off"
+          />
+          <label for="{uid}-possession-placement">Possession marker placement</label>
+          <select
+            id="{uid}-possession-placement"
+            value={language.possessionStrategy.placement}
+            onchange={(event) =>
+              edit((current) =>
+                setLanguagePossessionMarker(current, {
+                  placement: event.currentTarget.value as 'prefix' | 'suffix',
+                }),
+              )}
+          >
+            <option value="prefix">prefix</option>
+            <option value="suffix">suffix</option>
+          </select>
+        </div>
+      {/if}
+    </fieldset>
+
+    <fieldset>
+      <legend>Morphology</legend>
+
+      {#each MORPHOLOGY_AFFIX_FIELDS as field (field)}
+        <div class="input-group input-group--inline">
+          <label for="{uid}-{field}">{AFFIX_LABELS[field]}</label>
+          <input
+            id="{uid}-{field}"
+            type="text"
+            value={language.morphology[field]}
+            oninput={(event) =>
+              edit((current) =>
+                setLanguageMorphologyAffix(current, field, event.currentTarget.value),
+              )}
+            autocomplete="off"
+          />
+          <label for="{uid}-{field}-placement">{AFFIX_LABELS[field]} placement</label>
+          <select
+            id="{uid}-{field}-placement"
+            value={language.morphology[PLACEMENT_FOR[field]]}
+            onchange={(event) =>
+              edit((current) =>
+                setLanguageMorphologyPlacement(
+                  current,
+                  PLACEMENT_FOR[field],
+                  event.currentTarget.value as 'prefix' | 'suffix',
+                ),
+              )}
+          >
+            <option value="prefix">prefix</option>
+            <option value="suffix">suffix</option>
+          </select>
+        </div>
+      {/each}
+    </fieldset>
+
+    <fieldset>
+      <legend>Lexicon</legend>
+
+      <div class="input-group input-group--inline">
+        <label for="{uid}-search">Search the lexicon</label>
+        <input
+          id="{uid}-search"
+          type="search"
+          bind:value={query}
+          oninput={() => (shown = PAGE)}
+          autocomplete="off"
+          placeholder="a word or its meaning"
+        />
+        <label for="{uid}-part">Part of speech</label>
+        <select id="{uid}-part" bind:value={speechPartFilter} onchange={() => (shown = PAGE)}>
+          <option value="">All</option>
+          {#each speechParts as part (part)}
+            <option value={part}>{part}</option>
+          {/each}
+        </select>
+      </div>
+
+      <p class="language-editor__count" role="status">
+        {matches.length} of {language.lexicon.words.length} words
+        {#if matches.length > visible.length}· showing {visible.length}{/if}
+      </p>
+
+      <!-- 6.4 in the editor too: a search that matches nothing says so rather than showing an
+           empty table under a heading. -->
+      {#if matches.length === 0}
+        <Notice>No words match that search.</Notice>
+      {/if}
+
+      {#each visible as entry (entry.index)}
+        <div class="language-editor__word inset">
+          <div class="input-group input-group--inline">
+            <label for="{uid}-word-{entry.index}-root">Word {entry.index + 1} form</label>
+            <input
+              id="{uid}-word-{entry.index}-root"
+              type="text"
+              value={entry.word.root}
+              oninput={(event) =>
+                edit((current) =>
+                  setLexiconWordField(current, entry.index, 'root', event.currentTarget.value),
+                )}
+              autocomplete="off"
+            />
+            <label for="{uid}-word-{entry.index}-meaning">Word {entry.index + 1} meaning</label>
+            <input
+              id="{uid}-word-{entry.index}-meaning"
+              type="text"
+              value={entry.word.meaning}
+              oninput={(event) =>
+                edit((current) =>
+                  setLexiconWordField(current, entry.index, 'meaning', event.currentTarget.value),
+                )}
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="input-group input-group--inline">
+            <label for="{uid}-word-{entry.index}-pronunciation">
+              Word {entry.index + 1} pronunciation
+            </label>
+            <input
+              id="{uid}-word-{entry.index}-pronunciation"
+              type="text"
+              value={entry.word.pronunciation}
+              oninput={(event) =>
+                edit((current) =>
+                  setLexiconWordField(
+                    current,
+                    entry.index,
+                    'pronunciation',
+                    event.currentTarget.value,
+                  ),
+                )}
+              autocomplete="off"
+            />
+            <span class="language-editor__part">{entry.word.speechPart}</span>
+            <BaseButton
+              aria-label="Remove word {entry.index + 1}"
+              onclick={() => edit((current) => removeLexiconWord(current, entry.index))}
+            >
+              Remove
+            </BaseButton>
+          </div>
+        </div>
+      {/each}
+
+      {#if matches.length > visible.length}
+        <BaseButton onclick={() => (shown += PAGE)}>Show more words</BaseButton>
+      {/if}
+
+      <BaseButton
+        onclick={() => edit((current) => addLexiconWord(current, speechPartFilter || 'noun'))}
+      >
+        Add a {speechPartFilter || 'noun'}
+      </BaseButton>
+    </fieldset>
+  </div>
+{/if}
+
+<style>
+  .language-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    min-width: 0;
+    align-items: flex-start;
+  }
+
+  .language-editor fieldset {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .language-editor .input-group {
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .language-editor input,
+  .language-editor select {
+    min-width: 0;
+    flex: 1 1 4rem;
+    width: 100%;
+  }
+
+  /* `inset` rather than a hand-rolled border and radius: the panel language owns those. */
+  .language-editor__word {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+    align-items: flex-start;
+    min-width: 0;
+    padding: var(--s4);
+    width: 100%;
+  }
+
+  .language-editor__count,
+  .language-editor__part {
+    color: var(--ink-faint);
+    margin: 0;
+  }
+
+  .language-editor__part {
+    font: var(--t-micro);
+    letter-spacing: var(--t-micro-tracking);
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+</style>

--- a/src/components/utilities/LanguageGenerator.svelte
+++ b/src/components/utilities/LanguageGenerator.svelte
@@ -1,50 +1,115 @@
 <script lang="ts">
-  import Stat from '$components/common/Stat.svelte';
-  import StatBlock from '$components/common/StatBlock.svelte';
   import { onMount } from 'svelte';
   import { RNG } from '@ironarachne/rng';
+
+  import BaseButton from '$components/common/BaseButton.svelte';
+  import GeneratorPage from '$components/layout/GeneratorPage.svelte';
+  import SaveArtifactButton from '$components/common/SaveArtifactButton.svelte';
+  import SeedControls from '$components/common/SeedControls.svelte';
+  import Stat from '$components/common/Stat.svelte';
+  import StatBlock from '$components/common/StatBlock.svelte';
+  import { downloadTextFile } from '$lib/download';
+  import { downloadTextPdf } from '$lib/pdf';
   import {
     applyMorphologicalAffix,
-    generateConstructedLanguage,
-    getDefaultLanguageGeneratorConfig,
+    articleDescription,
     getLexiconWordsBySpeechPart,
+    glossaryLine,
+    languageDisplayName,
+    languageFileStem,
+    languageToMarkdown,
+    languageToText,
+    possessionDescription,
+    rollLanguage,
+    speechPartHeading,
+    toLanguageSnapshot,
     translateConstructedLanguageSentenceToEnglish,
     translateEnglishSentenceToConstructedLanguage,
-    type ConstructedLanguage,
+    LANGUAGE_ARTIFACT_KIND,
+    type LanguageSnapshot,
   } from '$lib/languages';
-  import GeneratorPage from '$components/layout/GeneratorPage.svelte';
-  import BaseButton from '$components/common/BaseButton.svelte';
 
-  let language: ConstructedLanguage | undefined = $state();
+  const TOOL_PATH = '/language';
+
+  /**
+   * The page's own RNG, which is what a new seed is drawn from.
+   *
+   * Seeded from the clock once, at mount, and never again. This tool failed requirement 2.3
+   * outright rather than 2.2's usual reseeding fault: there was no seed control at all, and
+   * `generate()` drew a fresh seed from `Date.now()` every press — so a language a user liked could
+   * not be got back, because there was nothing to write down.
+   */
+  const rng = new RNG(Date.now().toString());
+  let seed = $state(rng.randomString(13));
+  let lockSeed = $state(false);
+
+  /**
+   * The language on screen, held as its stored form.
+   *
+   * `$state.raw`, and not as a preference. Deep-reactive `$state` wraps every array and object in a
+   * Proxy, and `structuredClone` — what IndexedDB stores with — refuses a Proxy outright, so saving
+   * fails with `could not be cloned`. This is also the largest payload on the site: a lexicon of
+   * 1,760 words is 1,760 Proxies the page would otherwise be creating on every render.
+   */
+  let language = $state.raw<LanguageSnapshot | null>(null);
+
   let englishTranslationInput = $state('the cat sees a dog');
   let conlangTranslationInput = $state('');
   let englishToConlangResult = $state('');
   let conlangToEnglishResult = $state('');
 
+  /** The parts of speech the glossary prints, in the order the dictionary reads. */
+  const GLOSSARY_PARTS = [
+    'pronoun',
+    'article',
+    'preposition',
+    'number',
+    'question',
+    'interjection',
+    'adverb',
+    'adjective',
+    'verb',
+    'noun',
+  ];
+
   function runEnglishToConlang() {
-    if (!language) {
-      return;
-    }
+    if (language === null) return;
     const out = translateEnglishSentenceToConstructedLanguage(englishTranslationInput, language);
     englishToConlangResult = out.ok ? out.text : out.message;
   }
 
   function runConlangToEnglish() {
-    if (!language) {
-      return;
-    }
+    if (language === null) return;
     const out = translateConstructedLanguageSentenceToEnglish(conlangTranslationInput, language);
     conlangToEnglishResult = out.ok ? out.text : out.message;
   }
 
   function generate() {
-    const seed = new RNG(Date.now().toString()).randomString(13);
-    const rng = new RNG(seed);
-    const config = getDefaultLanguageGeneratorConfig(rng);
-    language = generateConstructedLanguage(config);
+    if (!lockSeed) {
+      seed = rng.randomString(13);
+    }
+    language = toLanguageSnapshot(rollLanguage(seed));
     englishToConlangResult = '';
     conlangToEnglishResult = '';
     conlangTranslationInput = '';
+  }
+
+  function exportMarkdown() {
+    if (language === null) return;
+    downloadTextFile(
+      languageToMarkdown(language),
+      `${languageFileStem(language)}.md`,
+      'text/markdown',
+    );
+  }
+
+  async function exportPdf() {
+    if (language === null) return;
+    await downloadTextPdf(
+      languageDisplayName(language),
+      languageToText(language),
+      `${languageFileStem(language)}.pdf`,
+    );
   }
 
   onMount(() => {
@@ -52,22 +117,44 @@
   });
 </script>
 
-<GeneratorPage toolPath="/language" title="Language Generator">
+<GeneratorPage toolPath={TOOL_PATH} title="Language Generator">
   {#snippet description()}
-    <p>This generates fictional languages. This is mostly useful for debugging.</p>
+    <p>
+      Generate a constructed language: a phonology, a syllable template, a morphology, and a lexicon
+      of about 1,700 words, with simple two-way translation.
+    </p>
   {/snippet}
+
+  <SeedControls bind:seed bind:lockSeed />
 
   <BaseButton onclick={generate}>Generate</BaseButton>
 
+  <SaveArtifactButton
+    kind={LANGUAGE_ARTIFACT_KIND}
+    toolPath={TOOL_PATH}
+    snapshot={language}
+    {seed}
+    defaultName={language === null ? '' : languageDisplayName(language)}
+  />
+
   {#if language}
-    <h2>{language.name}</h2>
+    <h2>{languageDisplayName(language)}</h2>
+
+    <div class="language-exports">
+      <BaseButton onclick={exportMarkdown}>Download Markdown</BaseButton>
+      <BaseButton onclick={exportPdf}>Download PDF</BaseButton>
+    </div>
+
     <StatBlock>
       <Stat label="Word order">{language.wordOrder}</Stat>
-      <Stat label="Article system">{language.articleSystem}</Stat>
-      <Stat label="Possession strategy">{language.possessionStrategy.kind}</Stat>
+      <Stat label="Phoneme set">{language.phonemeSetName}</Stat>
       <Stat label="Syllable template">{language.syllableProfile}</Stat>
-      <Stat label="Orthography">{language.orthographySummary}</Stat>
     </StatBlock>
+
+    <p>{articleDescription(language)}</p>
+    <p>{possessionDescription(language)}</p>
+    <p>{language.orthographySummary}</p>
+
     <Stat label="Sample morphology">
       plural {language.morphology.pluralPlacement}
       <code>{language.morphology.pluralAffix}</code>
@@ -81,83 +168,70 @@
       English input is SVO; conlang output follows this language's word order. Conlang→English
       expects tokens in that same order.
     </p>
-    <div>
+    <div class="input-group">
       <label for="en-to-con">English → {language.name}</label>
       <input id="en-to-con" type="text" bind:value={englishTranslationInput} />
-      <BaseButton onclick={runEnglishToConlang}>Translate</BaseButton>
-      <p><code>{englishToConlangResult}</code></p>
+      <BaseButton onclick={runEnglishToConlang}>Translate to {language.name}</BaseButton>
+      {#if englishToConlangResult !== ''}
+        <p role="status"><code>{englishToConlangResult}</code></p>
+      {/if}
     </div>
-    <div>
+    <div class="input-group">
       <label for="con-to-en">{language.name} → English</label>
       <input id="con-to-en" type="text" bind:value={conlangTranslationInput} />
-      <BaseButton onclick={runConlangToEnglish}>Translate</BaseButton>
-      <p><code>{conlangToEnglishResult}</code></p>
+      <BaseButton onclick={runConlangToEnglish}>Translate to English</BaseButton>
+      {#if conlangToEnglishResult !== ''}
+        <p role="status"><code>{conlangToEnglishResult}</code></p>
+      {/if}
     </div>
 
-    <h3>{language.name} Dictionary</h3>
+    <h3>{languageDisplayName(language)} Dictionary</h3>
 
-    <h4>Pronouns</h4>
-    {#each getLexiconWordsBySpeechPart(language.lexicon, 'pronoun') as word, i (`pronoun-${i}`)}
-      <p>{word.root} ({word.speechPart}, /{word.pronunciation}/): "{word.meaning}"</p>
-    {/each}
+    <!-- 6.4 on screen as well as in the exports: a part of speech the lexicon has none of prints
+         no heading, rather than an empty list under one. -->
+    {#each GLOSSARY_PARTS as speechPart (speechPart)}
+      {@const words = getLexiconWordsBySpeechPart(language.lexicon, speechPart)}
+      {#if words.length > 0}
+        <h4>{speechPartHeading(speechPart)}</h4>
 
-    <h4>Articles</h4>
-    {#each getLexiconWordsBySpeechPart(language.lexicon, 'article') as word, i (`article-${i}`)}
-      <p>{word.root} ({word.speechPart}, /{word.pronunciation}/): "{word.meaning}"</p>
-    {/each}
-
-    <h4>Prepositions</h4>
-    {#each getLexiconWordsBySpeechPart(language.lexicon, 'preposition') as word, i (`preposition-${i}`)}
-      <p>{word.root} ({word.speechPart}, /{word.pronunciation}/): "{word.meaning}"</p>
-    {/each}
-
-    <h4>Numbers</h4>
-    {#each getLexiconWordsBySpeechPart(language.lexicon, 'number') as word, i (`number-${i}`)}
-      <p>{word.root} ({word.speechPart}, /{word.pronunciation}/): "{word.meaning}"</p>
-    {/each}
-
-    <h4>Questions</h4>
-    {#each getLexiconWordsBySpeechPart(language.lexicon, 'question') as word, i (`question-${i}`)}
-      <p>{word.root} ({word.speechPart}, /{word.pronunciation}/): "{word.meaning}"</p>
-    {/each}
-
-    <h4>Interjections</h4>
-    {#each getLexiconWordsBySpeechPart(language.lexicon, 'interjection') as word, i (`interjection-${i}`)}
-      <p>{word.root} ({word.speechPart}, /{word.pronunciation}/): "{word.meaning}"</p>
-    {/each}
-
-    <h4>Adverbs</h4>
-    {#each getLexiconWordsBySpeechPart(language.lexicon, 'adverb') as word, i (`adverb-${i}`)}
-      <p>{word.root} ({word.speechPart}, /{word.pronunciation}/): "{word.meaning}"</p>
-    {/each}
-
-    <h4>Adjectives</h4>
-    {#each getLexiconWordsBySpeechPart(language.lexicon, 'adjective') as word, i (`adjective-${i}`)}
-      <p>{word.root} ({word.speechPart}, /{word.pronunciation}/): "{word.meaning}"</p>
-    {/each}
-
-    <h4>Verbs</h4>
-    {#each getLexiconWordsBySpeechPart(language.lexicon, 'verb') as word, i (`verb-${i}`)}
-      <p>
-        {word.root} ({word.speechPart}, /{word.pronunciation}/): "{word.meaning}" · past:
-        {applyMorphologicalAffix(
-          word.root,
-          language.morphology.pastAffix,
-          language.morphology.pastPlacement,
-        )}
-      </p>
-    {/each}
-
-    <h4>Nouns</h4>
-    {#each getLexiconWordsBySpeechPart(language.lexicon, 'noun') as word, i (`noun-${i}`)}
-      <p>
-        {word.root} ({word.speechPart}, /{word.pronunciation}/): "{word.meaning}" · plural:
-        {applyMorphologicalAffix(
-          word.root,
-          language.morphology.pluralAffix,
-          language.morphology.pluralPlacement,
-        )}
-      </p>
+        <ul class="glossary">
+          {#each words as word, index (index)}
+            <li>
+              {glossaryLine(word)}
+              {#if speechPart === 'noun'}
+                · plural {applyMorphologicalAffix(
+                  word.root,
+                  language.morphology.pluralAffix,
+                  language.morphology.pluralPlacement,
+                )}
+              {:else if speechPart === 'verb'}
+                · past {applyMorphologicalAffix(
+                  word.root,
+                  language.morphology.pastAffix,
+                  language.morphology.pastPlacement,
+                )}
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {/if}
     {/each}
   {/if}
 </GeneratorPage>
+
+<style>
+  .language-exports {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .glossary {
+    margin: 0 0 var(--s4);
+    padding-left: 1.25rem;
+  }
+
+  .glossary li {
+    overflow-wrap: anywhere;
+  }
+</style>

--- a/src/lib/languages/README.md
+++ b/src/lib/languages/README.md
@@ -145,4 +145,20 @@ Run: `npm test -- --run src/lib/languages/`
 - **Conlang parse** — Expects tokens in an order consistent with the language’s **`wordOrder`** and **`possessionStrategy`**; ambiguous noun sequences can be mis-parsed.
 - **Possession `none`** — Conlang string does not encode the possessor; round-trip English may omit the possessor when translating back from conlang.
 
+## Saving a language
+
+The language generator is Release-ready (issue [#74](https://github.com/ironarachne/ironarachne/issues/74)), which means everything it produces can be kept:
+
+- [`language_snapshot.ts`](language_snapshot.ts) — the stored form. It is very nearly the identity function, because a `ConstructedLanguage` carries no closures; the module says so explicitly rather than leaving a reader to wonder what was stripped. The `Map`s and `Set`s this library uses live in the translation machinery, which builds them from a language rather than storing them in one.
+- [`language_artifact_kind.ts`](language_artifact_kind.ts) — the `language` kind: validation, the payload version, and what to call an artifact whose language was never named.
+- [`language_roll.ts`](language_roll.ts) — the single path from a seed to a language. Both the generator page and a re-roll from the vault go through it.
+- [`language_editing.ts`](language_editing.ts) — one function per field, each returning a new snapshot. Nothing recomputes anything, and `filterLexicon` is what makes a 1,760-word glossary editable at all.
+- [`language_presentation.ts`](language_presentation.ts) — the language as a document, and the Markdown and PDF exports written from it. Empty sections are dropped here rather than in each renderer.
+
+**The lexicon is stored whole rather than regenerated from the seed.** A user who renames one word has edited the language, and requirement 4.2 of [the readiness spec](../../../docs/workshop.md#tool-release-readiness) says a seed may not overrule that. Regeneration is a re-roll, and a re-roll is the destructive command.
+
+The size is measured rather than feared: a generated language is **1,760 words and about 144 KB of JSON**. That is the largest payload the site stores, and still two orders of magnitude below the point at which [`$lib/storage_status`](../storage_status/README.md) says anything — it warns at 80% of what `navigator.storage.estimate()` reports.
+
+**This is the kind [#28](https://github.com/ironarachne/ironarachne/issues/28) declined to mint, and minting it now is not a reversal.** #28 warned that naming a kind after a language and storing only the `NameGeneratorSet` a culture consumes would be expensive to undo. This kind stores the larger thing whole, so that mismatch cannot arise. What #28 left open stays open: a culture still owns its `nameGenerators` outright, there is no `payloadVersion` step for culture, and whether a _name-generator set_ deserves a kind of its own is still the smaller question to ask if settlement, region, family and character ever justify it.
+
 For a small interactive demo, see the **`/language`** route in the app.

--- a/src/lib/languages/index.ts
+++ b/src/lib/languages/index.ts
@@ -12,6 +12,11 @@ export {
 export { getDefaultLanguageGeneratorConfig } from './generatorconfig.js';
 export { applyMorphologicalAffix, generateConstructedLanguage } from './generator.js';
 export { createLexicon, getLexiconWordsBySpeechPart } from './lexicon.js';
+export * from './language_artifact_kind.js';
+export * from './language_editing.js';
+export * from './language_presentation.js';
+export * from './language_roll.js';
+export * from './language_snapshot.js';
 export {
   buildLexiconTranslationIndex,
   lookupWordByMeaning,

--- a/src/lib/languages/language_artifact_kind.test.ts
+++ b/src/lib/languages/language_artifact_kind.test.ts
@@ -1,0 +1,170 @@
+import { RNG } from '@ironarachne/rng';
+import { describe, expect, it } from 'vitest';
+
+import {
+  languageArtifactKind,
+  languageName,
+  migrateLanguageSnapshot,
+  validateLanguageSnapshot,
+  LANGUAGE_ARTIFACT_KIND,
+  LANGUAGE_PAYLOAD_VERSION,
+} from './language_artifact_kind';
+import { rollLanguageSnapshot } from './language_roll';
+import type { LanguageSnapshot } from './language_snapshot';
+
+const SNAPSHOT = rollLanguageSnapshot('kind-seed');
+
+/** The payload as it comes out of the store: plain JSON, with nothing typed about it. */
+function stored(snapshot: LanguageSnapshot): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(snapshot)) as Record<string, unknown>;
+}
+
+describe('the kind', () => {
+  it('is unqualified: a language is neither a system nor a setting', () => {
+    expect(LANGUAGE_ARTIFACT_KIND).toBe('language');
+    expect(languageArtifactKind.payloadVersion).toBe(LANGUAGE_PAYLOAD_VERSION);
+  });
+
+  it('stores the larger thing, which is what keeps it clear of what #28 warned about', () => {
+    // #28 warned that naming a kind after a language and storing only a `NameGeneratorSet` would be
+    // expensive to undo. This payload is the whole language, lexicon included.
+    const result = validateLanguageSnapshot(stored(SNAPSHOT));
+
+    expect(result.ok && result.value.lexicon.words.length).toBeGreaterThan(1000);
+    expect(result.ok && result.value.phonemeSetName).toBe(SNAPSHOT.phonemeSetName);
+    expect(result.ok && result.value.morphology.pluralAffix).toBe(SNAPSHOT.morphology.pluralAffix);
+  });
+
+  it('round-trips through its own codec', async () => {
+    const codec = await languageArtifactKind.loadCodec();
+    const language = codec.fromSnapshot(
+      stored(SNAPSHOT) as unknown as LanguageSnapshot,
+      new RNG('unused'),
+    );
+
+    expect(codec.toSnapshot(language)).toEqual(SNAPSHOT);
+  });
+});
+
+describe('validateLanguageSnapshot', () => {
+  it('accepts what the roller produces', () => {
+    expect(validateLanguageSnapshot(stored(SNAPSHOT))).toMatchObject({ ok: true });
+  });
+
+  it('refuses something that is not an object', () => {
+    expect(validateLanguageSnapshot('a language').ok).toBe(false);
+    expect(validateLanguageSnapshot(null).ok).toBe(false);
+  });
+
+  it('refuses a payload with no name, that being what a vault listing shows', () => {
+    const result = validateLanguageSnapshot({ ...stored(SNAPSHOT), name: '   ' });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toBe('invalid-payload');
+  });
+
+  it('reads a language with no lexicon as one with an empty lexicon', () => {
+    // Requirement 3.3. A language whose words a user deleted still has a phonology, a word order
+    // and a morphology, and refusing to open it would strip them of all three.
+    const result = validateLanguageSnapshot({ ...stored(SNAPSHOT), lexicon: 'gone' });
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.value.lexicon.words).toEqual([]);
+    expect(result.ok && result.value.wordOrder).toBe(SNAPSHOT.wordOrder);
+  });
+
+  it('drops a word with no meaning rather than taking the language with it', () => {
+    const result = validateLanguageSnapshot({
+      ...stored(SNAPSHOT),
+      lexicon: {
+        words: [
+          { root: 'ven', pronunciation: 'vɛn', speechPart: 'noun', meaning: 'stone' },
+          { root: 'orphan', speechPart: 'noun' },
+          42,
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.value.lexicon.words.map((word) => word.meaning)).toEqual(['stone']);
+  });
+
+  it('falls back on an unrecognised word order or article system', () => {
+    const result = validateLanguageSnapshot({
+      ...stored(SNAPSHOT),
+      wordOrder: 'XYZ',
+      articleSystem: 'sometimes',
+    });
+
+    expect(result.ok && result.value.wordOrder).toBe('SVO');
+    expect(result.ok && result.value.articleSystem).toBe('none');
+  });
+
+  it('reads a possession marker that lost its affix as an unmarked language', () => {
+    // The one field where keeping an unrecognised value is not an option: a `marker_on_possessed`
+    // with no affix is a variant the translator cannot use.
+    const result = validateLanguageSnapshot({
+      ...stored(SNAPSHOT),
+      possessionStrategy: { kind: 'marker_on_possessed' },
+    });
+
+    expect(result.ok && result.value.possessionStrategy).toEqual({ kind: 'none' });
+  });
+
+  it('keeps a possession marker that has one', () => {
+    const result = validateLanguageSnapshot({
+      ...stored(SNAPSHOT),
+      possessionStrategy: { kind: 'marker_on_possessed', affix: 'ka', placement: 'prefix' },
+    });
+
+    expect(result.ok && result.value.possessionStrategy).toEqual({
+      kind: 'marker_on_possessed',
+      affix: 'ka',
+      placement: 'prefix',
+    });
+  });
+
+  it('keeps only C and V in a syllable pattern', () => {
+    const result = validateLanguageSnapshot({
+      ...stored(SNAPSHOT),
+      syllablePattern: ['C', 'V', 'X', 7, 'C'],
+    });
+
+    expect(result.ok && result.value.syllablePattern).toEqual(['C', 'V', 'C']);
+  });
+
+  it('gives a missing morphology a usable default', () => {
+    const result = validateLanguageSnapshot({ ...stored(SNAPSHOT), morphology: undefined });
+
+    expect(result.ok && result.value.morphology).toEqual({
+      pluralAffix: '',
+      pastAffix: '',
+      pluralPlacement: 'suffix',
+      pastPlacement: 'suffix',
+    });
+  });
+});
+
+describe('migrateLanguageSnapshot', () => {
+  it('refuses every version, there having only ever been one', () => {
+    // Requirement 7.3 with one payload version: the step that does not exist is asserted as not
+    // existing, so the day a second shape lands there is a test to fill in rather than write.
+    for (const from of [0, 2, 99]) {
+      const result = migrateLanguageSnapshot(stored(SNAPSHOT), from);
+
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toBe('unsupported-version');
+      expect(result.ok === false && result.message).toContain(`version ${from}`);
+    }
+  });
+});
+
+describe('languageName', () => {
+  it('is the language name', () => {
+    expect(languageName(SNAPSHOT)).toBe(SNAPSHOT.name);
+  });
+
+  it('has something to call a language with no name', () => {
+    expect(languageName({ ...SNAPSHOT, name: '  ' })).toBe('Language');
+  });
+});

--- a/src/lib/languages/language_artifact_kind.ts
+++ b/src/lib/languages/language_artifact_kind.ts
@@ -1,0 +1,232 @@
+import scroll from '$lib/assets/icons/set2/scroll.svg?raw';
+import {
+  acceptedPayload,
+  asRecord,
+  defineArtifactKind,
+  rejectedPayload,
+  type PayloadResult,
+} from '$lib/artifact_kinds';
+
+import type { ConstructedLanguage, SyllableSegment, Word } from './language_types';
+import type { LanguageSnapshot } from './language_snapshot';
+
+/**
+ * Stable artifact kind id.
+ *
+ * Unqualified: a constructed language is neither a game system's nor a setting's. Genre-neutral
+ * too, so every project sees it — one of the few tools on the site that is.
+ *
+ * **This is the kind [#28](https://github.com/ironarachne/ironarachne/issues/28) declined to
+ * mint, and it is worth saying why minting it now is not a reversal.** #28 asked whether the
+ * artifact should be a `NameGeneratorSet` — the six naming patterns a culture consumes — or a
+ * language, and warned that "naming the kind after the larger thing and storing only the smaller
+ * one is expensive to undo once artifacts exist in users' browsers". It closed on *neither*,
+ * because the generator behind the name was unfinished and nothing consumed it.
+ *
+ * What this kind stores is the larger thing, whole: phonology, morphology, typology and the entire
+ * lexicon. So the mismatch #28 warned about is the one thing that cannot arise here. What #28 left
+ * open stays open — culture still owns its `NameGeneratorSet` outright, there is no
+ * `payloadVersion` step for culture, and whether a *name-generator set* deserves a kind of its own
+ * is still the smaller and more honest question to ask if settlement, region, family and character
+ * ever justify it.
+ */
+export const LANGUAGE_ARTIFACT_KIND = 'language' as const;
+
+/** Version 1. The first shape a language has been stored in. */
+export const LANGUAGE_PAYLOAD_VERSION = 1 as const;
+
+const WORD_ORDERS = ['SVO', 'SOV', 'VSO', 'VOS', 'OVS', 'OSV'];
+
+const ARTICLE_SYSTEMS = ['none', 'definite_and_indefinite', 'definite_only'];
+
+const POSSESSION_KINDS = [
+  'none',
+  'juxtapose_possessor_before',
+  'juxtapose_possessor_after',
+  'marker_on_possessed',
+];
+
+const AFFIX_PLACEMENTS = ['prefix', 'suffix'];
+
+function readText(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function readChoice(value: unknown, allowed: string[], fallback: string): string {
+  return typeof value === 'string' && allowed.includes(value) ? value : fallback;
+}
+
+/**
+ * One word of the lexicon, normalised.
+ *
+ * A word with no meaning is dropped: the meaning is the English side of the glossary and what the
+ * translation index keys on, so a word without one cannot be looked up and would print as a form
+ * glossing nothing. Everything else degrades, because a glossary line missing a pronunciation is
+ * still a glossary line.
+ */
+function readWord(value: unknown): Word | undefined {
+  const record = asRecord(value);
+  if (record === null || typeof record.meaning !== 'string' || record.meaning === '') {
+    return undefined;
+  }
+  return {
+    root: readText(record.root),
+    pronunciation: readText(record.pronunciation),
+    speechPart: readText(record.speechPart),
+    meaning: record.meaning,
+  };
+}
+
+/**
+ * The lexicon, which is the bulk of the payload and the half a user edits.
+ *
+ * A lexicon that is not a list at all becomes an empty one rather than a refusal. That is
+ * requirement 3.3: a language whose words a user has deleted down to nothing is still a language —
+ * it has a phonology, a word order and a morphology — and refusing to open it would strip them of
+ * all three to punish them for the fourth.
+ */
+function readLexicon(value: unknown): { words: Word[] } {
+  const record = asRecord(value);
+  if (record === null || !Array.isArray(record.words)) {
+    return { words: [] };
+  }
+  return {
+    words: record.words.map(readWord).filter((word): word is Word => word !== undefined),
+  };
+}
+
+/** The four affixes and placements a language inflects with. */
+function readMorphology(value: unknown): LanguageSnapshot['morphology'] {
+  const record = asRecord(value) ?? {};
+  return {
+    pluralAffix: readText(record.pluralAffix),
+    pastAffix: readText(record.pastAffix),
+    pluralPlacement: readChoice(record.pluralPlacement, AFFIX_PLACEMENTS, 'suffix') as
+      | 'prefix'
+      | 'suffix',
+    pastPlacement: readChoice(record.pastPlacement, AFFIX_PLACEMENTS, 'suffix') as
+      | 'prefix'
+      | 'suffix',
+  };
+}
+
+/**
+ * How the language marks possession — a discriminated union, and the one field where an
+ * unrecognised value cannot simply be kept.
+ *
+ * A `marker_on_possessed` needs an affix and a placement for the translator to use, so a payload
+ * claiming that kind without them is read as the variant it actually is: `none`. Falling back to
+ * `none` rather than refusing keeps 3.3 — a language that has lost its possession rule still has
+ * every other rule.
+ */
+function readPossessionStrategy(value: unknown): LanguageSnapshot['possessionStrategy'] {
+  const record = asRecord(value);
+  if (record === null) {
+    return { kind: 'none' };
+  }
+  const kind = readChoice(record.kind, POSSESSION_KINDS, 'none');
+  if (kind !== 'marker_on_possessed') {
+    return { kind } as LanguageSnapshot['possessionStrategy'];
+  }
+  if (typeof record.affix !== 'string') {
+    return { kind: 'none' };
+  }
+  return {
+    kind: 'marker_on_possessed',
+    affix: record.affix,
+    placement: readChoice(record.placement, AFFIX_PLACEMENTS, 'suffix') as 'prefix' | 'suffix',
+  };
+}
+
+/** The syllable template, as the list of consonant and vowel slots a word is built from. */
+function readSyllablePattern(value: unknown): SyllableSegment[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((entry): entry is SyllableSegment => entry === 'C' || entry === 'V');
+}
+
+/**
+ * Reads a stored language, normalising rather than refusing wherever it honestly can.
+ *
+ * The one hard requirement is a name, because that is what a vault listing shows and what every
+ * heading in the exports is written under. Everything below it degrades to a well-defined default,
+ * which is what 3.3 asks for — and it matters more here than for most kinds, because this payload
+ * is the biggest on the site and a refusal would strip a user of the most work.
+ */
+export function validateLanguageSnapshot(payload: unknown): PayloadResult<LanguageSnapshot> {
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'Language payload is not an object');
+  }
+  if (typeof record.name !== 'string' || record.name.trim() === '') {
+    return rejectedPayload('invalid-payload', 'Language payload has no name');
+  }
+
+  return acceptedPayload({
+    name: record.name,
+    phonemeSetName: readText(record.phonemeSetName),
+    wordOrder: readChoice(record.wordOrder, WORD_ORDERS, 'SVO') as LanguageSnapshot['wordOrder'],
+    syllableProfile: readText(record.syllableProfile),
+    syllablePattern: readSyllablePattern(record.syllablePattern),
+    morphology: readMorphology(record.morphology),
+    orthographySummary: readText(record.orthographySummary),
+    lexicon: readLexicon(record.lexicon),
+    articleSystem: readChoice(
+      record.articleSystem,
+      ARTICLE_SYSTEMS,
+      'none',
+    ) as LanguageSnapshot['articleSystem'],
+    possessionStrategy: readPossessionStrategy(record.possessionStrategy),
+  });
+}
+
+/**
+ * There has only ever been version 1, so this rejects rather than pretending otherwise.
+ *
+ * It is here because the contract requires it, and it is where the first real step goes the day the
+ * shape changes. A kind without one looks complete right up until it silently drops someone's work
+ * — and local-only means there is no server-side migration to fall back on.
+ */
+export function migrateLanguageSnapshot(
+  _payload: unknown,
+  from: number,
+): PayloadResult<LanguageSnapshot> {
+  return rejectedPayload(
+    'unsupported-version',
+    `Languages have no migration from payload version ${from}; version ${LANGUAGE_PAYLOAD_VERSION} is the only shape there has been`,
+  );
+}
+
+/** What to call a saved language: its name, which the generator always gives it. */
+export function languageName(snapshot: LanguageSnapshot): string {
+  const given = snapshot.name.trim();
+  return given === '' ? 'Language' : given;
+}
+
+/**
+ * A constructed language as an artifact.
+ *
+ * The codec is cheap on both sides — the snapshot is the language, and reading one back copies it —
+ * so unlike settlement or heraldry there is no expensive half to keep out of the chunk that merely
+ * lists a project. It is still loaded on demand, because the contract is the same for every kind
+ * and a codec that happens to be cheap today is not a reason to wire it differently from its
+ * neighbours.
+ */
+export const languageArtifactKind = defineArtifactKind<ConstructedLanguage, LanguageSnapshot>({
+  kind: LANGUAGE_ARTIFACT_KIND,
+  displayName: 'Language',
+  icon: scroll,
+  payloadVersion: LANGUAGE_PAYLOAD_VERSION,
+  loadCodec: async () => {
+    const { languageFromSnapshotWithRng, toLanguageSnapshot } =
+      await import('./language_snapshot.js');
+    return {
+      toSnapshot: toLanguageSnapshot,
+      fromSnapshot: languageFromSnapshotWithRng,
+    };
+  },
+  nameOf: languageName,
+  validate: validateLanguageSnapshot,
+  migrate: migrateLanguageSnapshot,
+});

--- a/src/lib/languages/language_editing.test.ts
+++ b/src/lib/languages/language_editing.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addLexiconWord,
+  filterLexicon,
+  languageSyllablePatternText,
+  lexiconSpeechParts,
+  removeLexiconWord,
+  setLanguageArticleSystem,
+  setLanguageMorphologyAffix,
+  setLanguageMorphologyPlacement,
+  setLanguagePossessionKind,
+  setLanguagePossessionMarker,
+  setLanguageSyllablePattern,
+  setLanguageText,
+  setLanguageWordOrder,
+  setLexiconWordField,
+} from './language_editing';
+import { rollLanguageSnapshot } from './language_roll';
+
+const LANGUAGE = rollLanguageSnapshot('editing-seed');
+
+describe('the identity fields', () => {
+  it('rewrites one without disturbing the lexicon', () => {
+    const renamed = setLanguageText(LANGUAGE, 'name', 'Kethric');
+
+    expect(renamed.name).toBe('Kethric');
+    expect(renamed.lexicon).toBe(LANGUAGE.lexicon);
+    expect(LANGUAGE.name).not.toBe('Kethric');
+  });
+});
+
+describe('the syllable template', () => {
+  it('reads and writes the CVC string a conlanger types', () => {
+    const changed = setLanguageSyllablePattern(LANGUAGE, 'cvc');
+
+    expect(changed.syllablePattern).toEqual(['C', 'V', 'C']);
+    expect(languageSyllablePatternText(changed)).toBe('CVC');
+  });
+
+  it('drops anything that is not a slot rather than fighting a half-typed field', () => {
+    expect(setLanguageSyllablePattern(LANGUAGE, 'C-V x C').syllablePattern).toEqual([
+      'C',
+      'V',
+      'C',
+    ]);
+    expect(setLanguageSyllablePattern(LANGUAGE, '').syllablePattern).toEqual([]);
+  });
+
+  it('does not rebuild the words that were built from the old template', () => {
+    // Requirement 4.2: a conlanger who rewrote a word has made a decision, and regenerating the
+    // lexicon whenever a rule changed would throw away every one of them.
+    expect(setLanguageSyllablePattern(LANGUAGE, 'V').lexicon).toBe(LANGUAGE.lexicon);
+  });
+});
+
+describe('the syntax fields', () => {
+  it('changes the word order and the article system on their own', () => {
+    expect(setLanguageWordOrder(LANGUAGE, 'OSV').wordOrder).toBe('OSV');
+    expect(setLanguageArticleSystem(LANGUAGE, 'definite_only').articleSystem).toBe('definite_only');
+  });
+
+  it('gives a new possession marker a plausible affix rather than an empty one', () => {
+    // An empty affix is one the translator emits as nothing, which reads as a bug rather than as a
+    // field waiting to be filled in. Started from an explicitly unmarked language, because this
+    // seed's own language already marks possession and switching to the kind it already has is the
+    // no-op the next test asserts.
+    const unmarked = setLanguagePossessionKind(LANGUAGE, 'none');
+    const marked = setLanguagePossessionKind(unmarked, 'marker_on_possessed');
+
+    expect(marked.possessionStrategy).toEqual({
+      kind: 'marker_on_possessed',
+      affix: LANGUAGE.morphology.pluralAffix,
+      placement: 'suffix',
+    });
+  });
+
+  it('leaves an existing marker alone rather than resetting it', () => {
+    const marked = setLanguagePossessionKind(
+      setLanguagePossessionKind(LANGUAGE, 'none'),
+      'marker_on_possessed',
+    );
+    const edited = setLanguagePossessionMarker(marked, { affix: 'zu', placement: 'prefix' });
+
+    expect(setLanguagePossessionKind(edited, 'marker_on_possessed')).toBe(edited);
+    expect(edited.possessionStrategy).toEqual({
+      kind: 'marker_on_possessed',
+      affix: 'zu',
+      placement: 'prefix',
+    });
+  });
+
+  it('discards the affix when switching to a variant that has none', () => {
+    const marked = setLanguagePossessionKind(
+      setLanguagePossessionKind(LANGUAGE, 'none'),
+      'marker_on_possessed',
+    );
+
+    expect(
+      setLanguagePossessionKind(marked, 'juxtapose_possessor_before').possessionStrategy,
+    ).toEqual({ kind: 'juxtapose_possessor_before' });
+  });
+
+  it('ignores a marker edit on a language that has no marker', () => {
+    const unmarked = setLanguagePossessionKind(LANGUAGE, 'none');
+
+    expect(setLanguagePossessionMarker(unmarked, { affix: 'zu' })).toBe(unmarked);
+  });
+});
+
+describe('the morphology', () => {
+  it('changes one affix and its placement without re-inflecting the lexicon', () => {
+    const changed = setLanguageMorphologyPlacement(
+      setLanguageMorphologyAffix(LANGUAGE, 'pluralAffix', 'oth'),
+      'pluralPlacement',
+      'prefix',
+    );
+
+    expect(changed.morphology.pluralAffix).toBe('oth');
+    expect(changed.morphology.pluralPlacement).toBe('prefix');
+    expect(changed.morphology.pastAffix).toBe(LANGUAGE.morphology.pastAffix);
+    expect(changed.lexicon).toBe(LANGUAGE.lexicon);
+  });
+});
+
+describe('the lexicon', () => {
+  it('rewrites one word without disturbing its neighbours', () => {
+    const changed = setLexiconWordField(LANGUAGE, 3, 'root', 'zzyzx');
+
+    expect(changed.lexicon.words[3].root).toBe('zzyzx');
+    expect(changed.lexicon.words[2]).toBe(LANGUAGE.lexicon.words[2]);
+    expect(changed.lexicon.words[4]).toBe(LANGUAGE.lexicon.words[4]);
+  });
+
+  it('ignores an index that is not there', () => {
+    expect(setLexiconWordField(LANGUAGE, -1, 'root', 'x')).toBe(LANGUAGE);
+    expect(setLexiconWordField(LANGUAGE, 99_999, 'root', 'x')).toBe(LANGUAGE);
+    expect(removeLexiconWord(LANGUAGE, 99_999)).toBe(LANGUAGE);
+  });
+
+  it('takes a word out', () => {
+    const gone = removeLexiconWord(LANGUAGE, 0);
+
+    expect(gone.lexicon.words.length).toBe(LANGUAGE.lexicon.words.length - 1);
+    expect(gone.lexicon.words[0]).toBe(LANGUAGE.lexicon.words[1]);
+  });
+
+  it('adds a blank word of the part of speech asked for', () => {
+    const added = addLexiconWord(LANGUAGE, 'verb');
+    const word = added.lexicon.words[added.lexicon.words.length - 1];
+
+    expect(word).toEqual({ root: '', pronunciation: '', speechPart: 'verb', meaning: '' });
+  });
+});
+
+describe('filterLexicon', () => {
+  it('returns every word when nothing is asked for', () => {
+    expect(filterLexicon(LANGUAGE, '').length).toBe(LANGUAGE.lexicon.words.length);
+  });
+
+  it('carries the index into the unfiltered lexicon, not into the filtered view', () => {
+    // The whole reason this returns pairs: an index into a filtered list changes as the user types
+    // in the search box, and a handler holding one would rewrite the wrong word.
+    const matches = filterLexicon(LANGUAGE, LANGUAGE.lexicon.words[500].meaning);
+    const found = matches.find((entry) => entry.index === 500);
+
+    expect(found?.word).toBe(LANGUAGE.lexicon.words[500]);
+  });
+
+  it('matches on the gloss and on the form, case-insensitively', () => {
+    const word = LANGUAGE.lexicon.words[10];
+
+    expect(filterLexicon(LANGUAGE, word.meaning.toUpperCase()).length).toBeGreaterThan(0);
+    expect(filterLexicon(LANGUAGE, word.root.toUpperCase()).length).toBeGreaterThan(0);
+  });
+
+  it('narrows to one part of speech', () => {
+    const verbs = filterLexicon(LANGUAGE, '', 'verb');
+
+    expect(verbs.length).toBeGreaterThan(0);
+    expect(verbs.every((entry) => entry.word.speechPart === 'verb')).toBe(true);
+  });
+
+  it('returns nothing for a search that matches nothing', () => {
+    expect(filterLexicon(LANGUAGE, 'qqqqzzzz-not-a-word')).toEqual([]);
+  });
+});
+
+describe('lexiconSpeechParts', () => {
+  it('lists each part of speech once', () => {
+    const parts = lexiconSpeechParts(LANGUAGE);
+
+    expect(parts).toContain('noun');
+    expect(parts).toContain('verb');
+    expect(new Set(parts).size).toBe(parts.length);
+    expect([...parts].sort()).toEqual(parts);
+  });
+});

--- a/src/lib/languages/language_editing.ts
+++ b/src/lib/languages/language_editing.ts
@@ -1,0 +1,260 @@
+/**
+ * Editing a stored constructed language, one field at a time.
+ *
+ * Every function here takes a snapshot and returns a new one, changing nothing in place. That is
+ * requirement 4.4 of docs/workshop.md satisfied by construction — renaming the language must not
+ * disturb its lexicon, and rewriting one gloss must not touch its neighbours — and it is what lets
+ * the editing framework compare what is on screen against what was read to decide whether anything
+ * needs saving.
+ *
+ * **Nothing here recomputes anything.** Changing the syllable template does not rebuild the words
+ * that were built from it, and changing the plural affix does not re-inflect the lexicon. That is
+ * requirement 4.2 taken seriously rather than a gap: a conlanger who has rewritten a word has made
+ * a decision, and a form that regenerated the lexicon whenever a rule changed would throw away
+ * every one of those decisions at a keystroke. Rebuilding a language from its rules is the
+ * destructive re-roll, and it lives in `language_roll.ts`.
+ */
+
+import type { LanguageSnapshot } from './language_snapshot.js';
+import type {
+  ArticleSystem,
+  PossessionStrategy,
+  SyllableSegment,
+  Word,
+  WordOrder,
+} from './language_types.js';
+
+/** The identity and description fields a user may rewrite. */
+export const LANGUAGE_TEXT_FIELDS = [
+  'name',
+  'phonemeSetName',
+  'syllableProfile',
+  'orthographySummary',
+] as const;
+
+export type LanguageTextField = (typeof LANGUAGE_TEXT_FIELDS)[number];
+
+/** The six word orders the generator draws from, and what the editor offers. */
+export const WORD_ORDER_CHOICES: WordOrder[] = ['SVO', 'SOV', 'VSO', 'VOS', 'OVS', 'OSV'];
+
+/** The three article systems. */
+export const ARTICLE_SYSTEM_CHOICES: ArticleSystem[] = [
+  'none',
+  'definite_and_indefinite',
+  'definite_only',
+];
+
+/** The four ways a language may mark possession. */
+export const POSSESSION_KIND_CHOICES: PossessionStrategy['kind'][] = [
+  'none',
+  'juxtapose_possessor_before',
+  'juxtapose_possessor_after',
+  'marker_on_possessed',
+];
+
+/** The four morphology fields: two affixes and where each one attaches. */
+export const MORPHOLOGY_AFFIX_FIELDS = ['pluralAffix', 'pastAffix'] as const;
+
+export type MorphologyAffixField = (typeof MORPHOLOGY_AFFIX_FIELDS)[number];
+
+export const MORPHOLOGY_PLACEMENT_FIELDS = ['pluralPlacement', 'pastPlacement'] as const;
+
+export type MorphologyPlacementField = (typeof MORPHOLOGY_PLACEMENT_FIELDS)[number];
+
+/** The three fields of one lexicon entry a conlanger rewrites. */
+export const WORD_FIELDS = ['root', 'pronunciation', 'meaning'] as const;
+
+export type WordField = (typeof WORD_FIELDS)[number];
+
+export function setLanguageText(
+  snapshot: LanguageSnapshot,
+  field: LanguageTextField,
+  value: string,
+): LanguageSnapshot {
+  return { ...snapshot, [field]: value };
+}
+
+export function setLanguageWordOrder(
+  snapshot: LanguageSnapshot,
+  wordOrder: WordOrder,
+): LanguageSnapshot {
+  return { ...snapshot, wordOrder };
+}
+
+export function setLanguageArticleSystem(
+  snapshot: LanguageSnapshot,
+  articleSystem: ArticleSystem,
+): LanguageSnapshot {
+  return { ...snapshot, articleSystem };
+}
+
+/**
+ * The syllable template, typed as the `CVC` string a conlanger writes rather than picked slot by
+ * slot.
+ *
+ * Anything that is not a C or a V is dropped rather than rejected: a user part-way through typing
+ * `CVC` has typed `CV` and then a keystroke that is not yet a letter, and a field that refused
+ * would fight them. The label keeps whatever they typed, so the two do not have to agree — which is
+ * the honest arrangement, `syllableProfile` being a name for the pattern rather than a derivation
+ * of it.
+ */
+export function setLanguageSyllablePattern(
+  snapshot: LanguageSnapshot,
+  value: string,
+): LanguageSnapshot {
+  const segments = value
+    .toUpperCase()
+    .split('')
+    .filter((character): character is SyllableSegment => character === 'C' || character === 'V');
+  return { ...snapshot, syllablePattern: segments };
+}
+
+/** The syllable pattern as the string the editor shows and `setLanguageSyllablePattern` parses. */
+export function languageSyllablePatternText(snapshot: LanguageSnapshot): string {
+  return snapshot.syllablePattern.join('');
+}
+
+export function setLanguageMorphologyAffix(
+  snapshot: LanguageSnapshot,
+  field: MorphologyAffixField,
+  value: string,
+): LanguageSnapshot {
+  return { ...snapshot, morphology: { ...snapshot.morphology, [field]: value } };
+}
+
+export function setLanguageMorphologyPlacement(
+  snapshot: LanguageSnapshot,
+  field: MorphologyPlacementField,
+  value: 'prefix' | 'suffix',
+): LanguageSnapshot {
+  return { ...snapshot, morphology: { ...snapshot.morphology, [field]: value } };
+}
+
+/**
+ * Change which of the four possession strategies the language uses.
+ *
+ * Switching *to* `marker_on_possessed` needs an affix and a placement the variant did not carry
+ * before, so it starts with the plural affix and a suffix — a plausible marker the user then
+ * edits, rather than an empty one the translator would silently emit as nothing. Switching away
+ * discards them, which is what the union says: the other three variants have no affix to keep.
+ */
+export function setLanguagePossessionKind(
+  snapshot: LanguageSnapshot,
+  kind: PossessionStrategy['kind'],
+): LanguageSnapshot {
+  if (kind !== 'marker_on_possessed') {
+    return { ...snapshot, possessionStrategy: { kind } as PossessionStrategy };
+  }
+  if (snapshot.possessionStrategy.kind === 'marker_on_possessed') {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    possessionStrategy: {
+      kind: 'marker_on_possessed',
+      affix: snapshot.morphology.pluralAffix,
+      placement: 'suffix',
+    },
+  };
+}
+
+/** The possession marker's own affix and placement, when the language has one. */
+export function setLanguagePossessionMarker(
+  snapshot: LanguageSnapshot,
+  change: { affix?: string; placement?: 'prefix' | 'suffix' },
+): LanguageSnapshot {
+  if (snapshot.possessionStrategy.kind !== 'marker_on_possessed') {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    possessionStrategy: { ...snapshot.possessionStrategy, ...change },
+  };
+}
+
+function updateWord(
+  snapshot: LanguageSnapshot,
+  index: number,
+  change: (word: Word) => Word,
+): LanguageSnapshot {
+  if (index < 0 || index >= snapshot.lexicon.words.length) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    lexicon: {
+      words: snapshot.lexicon.words.map((word, at) => (at === index ? change(word) : word)),
+    },
+  };
+}
+
+/**
+ * One field of one word.
+ *
+ * The index is into the whole lexicon rather than into a filtered view, so a searchable editor has
+ * to carry the real index alongside what it shows. That is deliberate: an index into a filtered
+ * list changes as the user types in the search box, and a handler holding one would rewrite the
+ * wrong word the moment the filter moved.
+ */
+export function setLexiconWordField(
+  snapshot: LanguageSnapshot,
+  index: number,
+  field: WordField,
+  value: string,
+): LanguageSnapshot {
+  return updateWord(snapshot, index, (word) => ({ ...word, [field]: value }));
+}
+
+/** Take one word out of the language. A conlanger pruning a lexicon is editing it. */
+export function removeLexiconWord(snapshot: LanguageSnapshot, index: number): LanguageSnapshot {
+  if (index < 0 || index >= snapshot.lexicon.words.length) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    lexicon: { words: snapshot.lexicon.words.filter((_word, at) => at !== index) },
+  };
+}
+
+/** Add a word of a given part of speech, for the coinage the generator did not think of. */
+export function addLexiconWord(snapshot: LanguageSnapshot, speechPart: string): LanguageSnapshot {
+  return {
+    ...snapshot,
+    lexicon: {
+      words: [...snapshot.lexicon.words, { root: '', pronunciation: '', speechPart, meaning: '' }],
+    },
+  };
+}
+
+/** One lexicon entry, with the index into the unfiltered lexicon that identifies it. */
+export type IndexedWord = { word: Word; index: number };
+
+/**
+ * The lexicon narrowed to what a user is looking for, each entry keeping its real index.
+ *
+ * A lexicon is 1,760 words, so a searchable view is the only editing view that is usable at all —
+ * which is why this is not a `SnapshotFieldEditor` case, as the design says. The match is on the
+ * gloss and the form both, because a conlanger looks a word up from either side of the glossary,
+ * and it is case-insensitive because nobody searching a dictionary is thinking about case.
+ */
+export function filterLexicon(
+  snapshot: LanguageSnapshot,
+  query: string,
+  speechPart = '',
+): IndexedWord[] {
+  const needle = query.trim().toLowerCase();
+  return snapshot.lexicon.words
+    .map((word, index) => ({ word, index }))
+    .filter(({ word }) => speechPart === '' || word.speechPart === speechPart)
+    .filter(
+      ({ word }) =>
+        needle === '' ||
+        word.meaning.toLowerCase().includes(needle) ||
+        word.root.toLowerCase().includes(needle),
+    );
+}
+
+/** Every part of speech the lexicon actually uses, in the order a glossary prints them. */
+export function lexiconSpeechParts(snapshot: LanguageSnapshot): string[] {
+  return [...new Set(snapshot.lexicon.words.map((word) => word.speechPart))].sort();
+}

--- a/src/lib/languages/language_presentation.test.ts
+++ b/src/lib/languages/language_presentation.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollLanguageSnapshot } from './language_roll';
+import {
+  articleDescription,
+  glossaryLine,
+  glossarySections,
+  languageDisplayName,
+  languageFileStem,
+  languageToDocument,
+  languageToMarkdown,
+  languageToText,
+  possessionDescription,
+  speechPartHeading,
+} from './language_presentation';
+import type { LanguageSnapshot } from './language_snapshot';
+
+const LANGUAGE = rollLanguageSnapshot('presentation-seed');
+
+function headings(snapshot: LanguageSnapshot): string[] {
+  return languageToDocument(snapshot).sections.map((entry) => entry.heading);
+}
+
+/** A language stripped to its rules, for the empty-section cases. */
+function withWords(words: LanguageSnapshot['lexicon']['words']): LanguageSnapshot {
+  return { ...LANGUAGE, lexicon: { words } };
+}
+
+describe('languageToDocument', () => {
+  it('prints the blocks a conlang document is read from', () => {
+    expect(headings(LANGUAGE)).toEqual(
+      expect.arrayContaining(['Typology', 'Orthography', 'Morphology', 'Syntax', 'Nouns']),
+    );
+  });
+
+  it('drops a part of speech the lexicon has none of', () => {
+    // 6.4: a user who has deleted every adjective should not be handed an Adjectives heading with
+    // nothing beneath it.
+    const nounsOnly = withWords(
+      LANGUAGE.lexicon.words.filter((word) => word.speechPart === 'noun'),
+    );
+
+    expect(headings(nounsOnly)).toContain('Nouns');
+    expect(headings(nounsOnly)).not.toContain('Adjectives');
+    expect(headings(nounsOnly)).not.toContain('Verbs');
+  });
+
+  it('still prints the rules for a language with no words left at all', () => {
+    // Requirement 3.3's counterpart in the exports: an emptied lexicon is still a language.
+    const empty = withWords([]);
+
+    expect(headings(empty)).toContain('Typology');
+    expect(headings(empty)).toContain('Syntax');
+    expect(headings(empty)).not.toContain('Nouns');
+  });
+
+  it('drops the orthography section when there is nothing to say', () => {
+    expect(headings({ ...LANGUAGE, orthographySummary: '   ' })).not.toContain('Orthography');
+  });
+
+  it('drops a morphology line whose affix is empty rather than printing a blank rule', () => {
+    const noPlural = {
+      ...LANGUAGE,
+      morphology: { ...LANGUAGE.morphology, pluralAffix: '' },
+    };
+    const document = languageToDocument(noPlural);
+    const morphology = document.sections.find((entry) => entry.heading === 'Morphology');
+
+    expect(morphology?.items.some((item) => item.startsWith('Plural:'))).toBe(false);
+    expect(morphology?.items.some((item) => item.startsWith('Past tense:'))).toBe(true);
+  });
+
+  it('drops the morphology section entirely when the language inflects for nothing', () => {
+    const uninflected = {
+      ...LANGUAGE,
+      morphology: { ...LANGUAGE.morphology, pluralAffix: '', pastAffix: '' },
+    };
+
+    expect(headings(uninflected)).not.toContain('Morphology');
+  });
+
+  it('shows an inflection on a real word, an affix alone being hard to read', () => {
+    const document = languageToDocument(LANGUAGE);
+    const morphology = document.sections.find((entry) => entry.heading === 'Morphology');
+
+    expect(morphology?.items[0]).toContain('becomes');
+  });
+
+  it('prints the inflection rule without an example when there is no word to show it on', () => {
+    const document = languageToDocument(withWords([]));
+    const morphology = document.sections.find((entry) => entry.heading === 'Morphology');
+
+    expect(morphology?.items.some((item) => item.startsWith('Plural:'))).toBe(true);
+    expect(morphology?.items.every((item) => !item.includes('becomes'))).toBe(true);
+  });
+});
+
+describe('the glossary', () => {
+  it('groups by part of speech and alphabetises by gloss within each', () => {
+    // The generator emits words in bucket order, which is neither what a reader wants nor stable
+    // to diff against.
+    const nouns = glossarySections(LANGUAGE).find((entry) => entry.heading === 'Nouns');
+    const glosses = nouns?.items ?? [];
+
+    expect(glosses.length).toBeGreaterThan(0);
+    const meanings = glosses.map((line) => line.split(' — ')[1]);
+    expect(meanings).toEqual([...meanings].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it('prints a line as form, pronunciation and gloss', () => {
+    expect(
+      glossaryLine({ root: 'ven', pronunciation: 'vɛn', speechPart: 'noun', meaning: 'stone' }),
+    ).toBe('ven /vɛn/ — stone');
+  });
+
+  it('omits the pronunciation when there is none rather than printing empty slashes', () => {
+    expect(
+      glossaryLine({ root: 'ven', pronunciation: '', speechPart: 'noun', meaning: 'stone' }),
+    ).toBe('ven — stone');
+  });
+
+  it('pluralises a part of speech for its heading', () => {
+    expect(speechPartHeading('noun')).toBe('Nouns');
+    expect(speechPartHeading('adverb')).toBe('Adverbs');
+    expect(speechPartHeading('')).toBe('Other');
+  });
+});
+
+describe('the prose descriptions', () => {
+  it('says what the language does with articles', () => {
+    expect(articleDescription({ ...LANGUAGE, articleSystem: 'none' })).toContain('no articles');
+    expect(articleDescription({ ...LANGUAGE, articleSystem: 'definite_only' })).toContain(
+      'no indefinite one',
+    );
+    expect(articleDescription({ ...LANGUAGE, articleSystem: 'definite_and_indefinite' })).toContain(
+      'both',
+    );
+  });
+
+  it('says how the language marks possession, in words rather than as a union tag', () => {
+    expect(possessionDescription({ ...LANGUAGE, possessionStrategy: { kind: 'none' } })).toContain(
+      'unmarked',
+    );
+    expect(
+      possessionDescription({
+        ...LANGUAGE,
+        possessionStrategy: { kind: 'juxtapose_possessor_before' },
+      }),
+    ).toContain('before');
+    expect(
+      possessionDescription({
+        ...LANGUAGE,
+        possessionStrategy: { kind: 'marker_on_possessed', affix: 'ka', placement: 'suffix' },
+      }),
+    ).toContain('suffix “ka”');
+  });
+});
+
+describe('the exports', () => {
+  it('writes Markdown headed by the language name', () => {
+    const markdown = languageToMarkdown(LANGUAGE);
+
+    expect(markdown.startsWith(`# ${LANGUAGE.name}`)).toBe(true);
+    expect(markdown).toContain('## Typology');
+    expect(markdown).toContain(`- Word order: ${LANGUAGE.wordOrder}`);
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('never writes a heading with nothing under it', () => {
+    // The claim 6.4 actually makes, asserted over the rendered text rather than the model.
+    const markdown = languageToMarkdown(withWords([]));
+
+    expect(markdown).not.toMatch(/## [^\n]+\n\n(##|$)/);
+  });
+
+  it('writes the PDF body without the title the PDF draws itself', () => {
+    const text = languageToText(LANGUAGE);
+
+    expect(text).not.toContain(`# ${LANGUAGE.name}`);
+    expect(text).toContain('Typology');
+    expect(text).toContain(`  Word order: ${LANGUAGE.wordOrder}`);
+  });
+
+  it('names the file after the language', () => {
+    expect(languageFileStem({ ...LANGUAGE, name: 'Keth Ric' })).toBe('language-keth-ric');
+  });
+
+  it('has a name and a filename for a language that has neither', () => {
+    expect(languageDisplayName({ ...LANGUAGE, name: '  ' })).toBe('Language');
+    expect(languageFileStem({ ...LANGUAGE, name: '???' })).toBe('language');
+  });
+});

--- a/src/lib/languages/language_presentation.ts
+++ b/src/lib/languages/language_presentation.ts
@@ -1,0 +1,216 @@
+/**
+ * A constructed language arranged for reading, and the Markdown and PDF exports written from it.
+ *
+ * **6.3 was a real loss here, and the issue says so.** A conlang *is* a document — the phonology,
+ * the typology, the morphology, and the lexicon as a two-column glossary — and this tool had no
+ * export at all. A user who generated a language they liked could read it on screen and take
+ * nothing away.
+ *
+ * 6.4 comes with it. A language whose lexicon has been pruned of every adjective must not print an
+ * Adjectives heading over nothing, and one with no possession marker must not print a line
+ * describing an affix it does not have. Every section is dropped by construction when what would go
+ * under it is empty.
+ *
+ * The glossary is grouped by part of speech and alphabetised by gloss, which is what makes it a
+ * dictionary rather than a dump: the generator emits words in bucket order, which is neither the
+ * order a reader wants nor a stable one to diff against.
+ */
+
+import { applyMorphologicalAffix } from './generator.js';
+import type { LanguageSnapshot } from './language_snapshot.js';
+import type { Word } from './language_types.js';
+
+/** One heading and what sits under it. A section with neither prose nor items is not printed. */
+export type LanguageSection = {
+  heading: string;
+  paragraphs: string[];
+  items: string[];
+};
+
+/** A language arranged for reading, independent of the format it is finally written in. */
+export type LanguageDocument = {
+  title: string;
+  sections: LanguageSection[];
+};
+
+function isPrintable(value: string): boolean {
+  return value.trim() !== '';
+}
+
+function section(heading: string, paragraphs: string[], items: string[] = []): LanguageSection {
+  return { heading, paragraphs: paragraphs.filter(isPrintable), items: items.filter(isPrintable) };
+}
+
+function hasContent(entry: LanguageSection): boolean {
+  return entry.paragraphs.length > 0 || entry.items.length > 0;
+}
+
+/** A part of speech as a heading: `noun` reads as `Nouns`. */
+export function speechPartHeading(speechPart: string): string {
+  if (speechPart === '') {
+    return 'Other';
+  }
+  const capitalised = speechPart.charAt(0).toUpperCase() + speechPart.slice(1);
+  return capitalised.endsWith('s') ? capitalised : `${capitalised}s`;
+}
+
+/** How the language marks possession, in words rather than as a union tag. */
+export function possessionDescription(snapshot: LanguageSnapshot): string {
+  const strategy = snapshot.possessionStrategy;
+  if (strategy.kind === 'none') {
+    return 'Possession is unmarked.';
+  }
+  if (strategy.kind === 'juxtapose_possessor_before') {
+    return 'Possession is shown by placing the possessor before the thing possessed.';
+  }
+  if (strategy.kind === 'juxtapose_possessor_after') {
+    return 'Possession is shown by placing the possessor after the thing possessed.';
+  }
+  return `Possession is marked on the thing possessed, with the ${strategy.placement} “${strategy.affix}”.`;
+}
+
+/** What the language does with articles, in words. */
+export function articleDescription(snapshot: LanguageSnapshot): string {
+  if (snapshot.articleSystem === 'none') {
+    return 'The language has no articles.';
+  }
+  if (snapshot.articleSystem === 'definite_only') {
+    return 'The language has a definite article and no indefinite one.';
+  }
+  return 'The language has both definite and indefinite articles.';
+}
+
+function typologyLines(snapshot: LanguageSnapshot): string[] {
+  const pattern = snapshot.syllablePattern.join('');
+  return [
+    `Word order: ${snapshot.wordOrder}`,
+    isPrintable(snapshot.phonemeSetName) ? `Phoneme set: ${snapshot.phonemeSetName}` : '',
+    isPrintable(snapshot.syllableProfile) ? `Syllable profile: ${snapshot.syllableProfile}` : '',
+    isPrintable(pattern) ? `Syllable template: ${pattern}` : '',
+  ];
+}
+
+/**
+ * The two inflections the language has, each shown on a real word from the lexicon.
+ *
+ * An affix on its own is hard to read — `-ka` says less than `venka` beside `ven` does — so each
+ * line carries an example when the lexicon has one to give. A language with no nouns prints the
+ * plural rule without an example rather than not printing it.
+ */
+function morphologyLines(snapshot: LanguageSnapshot): string[] {
+  const { morphology } = snapshot;
+  const firstNoun = snapshot.lexicon.words.find((word) => word.speechPart === 'noun');
+  const firstVerb = snapshot.lexicon.words.find((word) => word.speechPart === 'verb');
+
+  const lines: string[] = [];
+  if (isPrintable(morphology.pluralAffix)) {
+    const example =
+      firstNoun === undefined
+        ? ''
+        : ` — ${firstNoun.root} becomes ${applyMorphologicalAffix(firstNoun.root, morphology.pluralAffix, morphology.pluralPlacement)}`;
+    lines.push(`Plural: ${morphology.pluralPlacement} “${morphology.pluralAffix}”${example}`);
+  }
+  if (isPrintable(morphology.pastAffix)) {
+    const example =
+      firstVerb === undefined
+        ? ''
+        : ` — ${firstVerb.root} becomes ${applyMorphologicalAffix(firstVerb.root, morphology.pastAffix, morphology.pastPlacement)}`;
+    lines.push(`Past tense: ${morphology.pastPlacement} “${morphology.pastAffix}”${example}`);
+  }
+  return lines;
+}
+
+/** One glossary line: the form, how it sounds, and what it means. */
+export function glossaryLine(word: Word): string {
+  const pronunciation = isPrintable(word.pronunciation) ? ` /${word.pronunciation}/` : '';
+  return `${word.root}${pronunciation} — ${word.meaning}`;
+}
+
+/**
+ * The lexicon as a glossary, grouped by part of speech and alphabetised by gloss within each.
+ *
+ * A part of speech with no words left produces no section at all, which is 6.4: a user who has
+ * deleted every adjective should not be handed an Adjectives heading with nothing beneath it.
+ */
+export function glossarySections(snapshot: LanguageSnapshot): LanguageSection[] {
+  const byPart = new Map<string, Word[]>();
+  for (const word of snapshot.lexicon.words) {
+    const bucket = byPart.get(word.speechPart);
+    if (bucket === undefined) {
+      byPart.set(word.speechPart, [word]);
+    } else {
+      bucket.push(word);
+    }
+  }
+
+  return [...byPart.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([speechPart, words]) =>
+      section(
+        speechPartHeading(speechPart),
+        [],
+        [...words].sort((a, b) => a.meaning.localeCompare(b.meaning)).map(glossaryLine),
+      ),
+    )
+    .filter(hasContent);
+}
+
+/** Arrange a language for reading. Every empty section is dropped here, once. */
+export function languageToDocument(snapshot: LanguageSnapshot): LanguageDocument {
+  const sections = [
+    section('Typology', [], typologyLines(snapshot)),
+    section(
+      'Orthography',
+      isPrintable(snapshot.orthographySummary) ? [snapshot.orthographySummary] : [],
+    ),
+    section('Morphology', [], morphologyLines(snapshot)),
+    section('Syntax', [articleDescription(snapshot), possessionDescription(snapshot)]),
+    ...glossarySections(snapshot),
+  ];
+
+  return {
+    title: languageDisplayName(snapshot),
+    sections: sections.filter(hasContent),
+  };
+}
+
+/** What to head the document with. */
+export function languageDisplayName(snapshot: LanguageSnapshot): string {
+  const given = snapshot.name.trim();
+  return given === '' ? 'Language' : given;
+}
+
+/** A language as Markdown, for a conlanger who wants the glossary in their own notes. */
+export function languageToMarkdown(snapshot: LanguageSnapshot): string {
+  const document = languageToDocument(snapshot);
+  const blocks = [`# ${document.title}`];
+
+  for (const entry of document.sections) {
+    blocks.push(`## ${entry.heading}`);
+    blocks.push(...entry.paragraphs);
+    if (entry.items.length > 0) {
+      blocks.push(entry.items.map((item) => `- ${item}`).join('\n'));
+    }
+  }
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+/** The body of the PDF: the same document without the title the PDF draws as its own heading. */
+export function languageToText(snapshot: LanguageSnapshot): string {
+  const document = languageToDocument(snapshot);
+  return document.sections
+    .map((entry) =>
+      [entry.heading, ...entry.paragraphs, ...entry.items.map((item) => `  ${item}`)].join('\n'),
+    )
+    .join('\n\n');
+}
+
+/** A filename stem for an exported language: its name, reduced to something a filesystem takes. */
+export function languageFileStem(snapshot: LanguageSnapshot): string {
+  const stem = languageDisplayName(snapshot)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return stem === '' ? 'language' : `language-${stem}`;
+}

--- a/src/lib/languages/language_roll.test.ts
+++ b/src/lib/languages/language_roll.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { rollLanguage, rollLanguageSnapshot } from './language_roll';
+
+describe('rollLanguage', () => {
+  /**
+   * Requirement 2.2, and the test #74 explicitly asks for.
+   *
+   * "Regenerate from the seed" is only ever a storage strategy if it actually holds, and the way to
+   * know is to generate the same language twice from one seed and compare the lexicon word for
+   * word. This design stores the lexicon rather than relying on regeneration — but the re-roll does
+   * rely on it, so the property is what makes 4.3 honest rather than a button that returns
+   * something different every time it is pressed.
+   */
+  it('gives the same language, word for word, from the same seed', () => {
+    for (let index = 0; index < 10; index += 1) {
+      const seed = `determinism-${index}`;
+      const first = rollLanguage(seed);
+      const second = rollLanguage(seed);
+
+      expect(second.name).toBe(first.name);
+      expect(second.lexicon.words.length).toBe(first.lexicon.words.length);
+      for (let word = 0; word < first.lexicon.words.length; word += 1) {
+        expect(second.lexicon.words[word]).toEqual(first.lexicon.words[word]);
+      }
+      expect(second).toEqual(first);
+    }
+  });
+
+  it('gives a different language for a different seed', () => {
+    const names = new Set(
+      Array.from({ length: 20 }, (_value, index) => rollLanguage(`vary-${index}`).name),
+    );
+
+    expect(names.size).toBeGreaterThan(1);
+  });
+
+  it('names every language it rolls, so a vault listing can tell them apart', () => {
+    // Requirement 3.5, and what `nameOf` depends on.
+    for (let index = 0; index < 20; index += 1) {
+      expect(rollLanguage(`named-${index}`).name.trim()).not.toBe('');
+    }
+  });
+
+  it('rolls a lexicon of a usable size', () => {
+    // Measured rather than assumed, because #74 asks for the number: about 1,760 words and 144 KB
+    // of JSON, which is the largest payload the site stores and still far below anything
+    // `$lib/storage_status` reports on.
+    const language = rollLanguage('size-seed');
+    const bytes = new TextEncoder().encode(JSON.stringify(language)).length;
+
+    expect(language.lexicon.words.length).toBeGreaterThan(1000);
+    expect(bytes).toBeLessThan(1_000_000);
+  });
+
+  it('rolls a snapshot that is the snapshot of the language it rolled', () => {
+    expect(rollLanguageSnapshot('same-seed')).toEqual(rollLanguage('same-seed'));
+  });
+});

--- a/src/lib/languages/language_roll.ts
+++ b/src/lib/languages/language_roll.ts
@@ -1,0 +1,43 @@
+/**
+ * The single path from a seed to a constructed language.
+ *
+ * Requirement 2.2 of docs/workshop.md wants the same seed and settings to give the same language,
+ * and 2.3 wants the seed on screen. **This tool failed 2.3 outright**: `LanguageGenerator.svelte`
+ * rendered no `SeedControls` at all and drew a fresh seed from `Date.now()` inside `generate()`, so
+ * a language a user liked could not be got back — there was nothing to write down. The page now
+ * carries the control and the roll below is a pure function of the seed.
+ *
+ * `getDefaultLanguageGeneratorConfig` takes an RNG rather than defaulting one, so this library is
+ * not among the fifteen helpers across six libraries that the readiness spine found seeding
+ * themselves from the clock. The config is built here all the same, in one place, so the page and a
+ * re-roll cannot drift apart in what they hand the generator.
+ *
+ * **There is no config to record.** The generator's only input is the phoneme-set table, which is
+ * the library's rather than the user's — a provenance carrying every phoneme set would be storing a
+ * table. Everything else about a language is drawn from the seed, so the seed is the whole
+ * provenance.
+ */
+
+import { RNG } from '@ironarachne/rng';
+
+import { generateConstructedLanguage } from './generator.js';
+import { getDefaultLanguageGeneratorConfig } from './generatorconfig.js';
+import type { ConstructedLanguage } from './language_types.js';
+import { toLanguageSnapshot, type LanguageSnapshot } from './language_snapshot.js';
+
+/** Roll a language from a seed — the one path the generator page and a re-roll both take. */
+export function rollLanguage(seed: string): ConstructedLanguage {
+  return generateConstructedLanguage(getDefaultLanguageGeneratorConfig(new RNG(seed)));
+}
+
+/**
+ * Roll a fresh language snapshot from the seed it was first made with — the destructive half of
+ * editing (requirement 4.3), and what `ARTIFACT_EDITORS` registers as this kind's roller.
+ *
+ * This is the one place a lexicon is regenerated rather than read, and that asymmetry is the point:
+ * storing the lexicon makes an edit survive, and re-rolling from the seed is how a user asks for a
+ * different language rather than a corrected one.
+ */
+export function rollLanguageSnapshot(seed: string): LanguageSnapshot {
+  return toLanguageSnapshot(rollLanguage(seed));
+}

--- a/src/lib/languages/language_snapshot.test.ts
+++ b/src/lib/languages/language_snapshot.test.ts
@@ -1,0 +1,88 @@
+import { RNG } from '@ironarachne/rng';
+import { describe, expect, it } from 'vitest';
+
+import { rollLanguage } from './language_roll';
+import {
+  languageFromSnapshot,
+  languageFromSnapshotWithRng,
+  toLanguageSnapshot,
+} from './language_snapshot';
+
+const LANGUAGE = rollLanguage('snapshot-seed');
+const SNAPSHOT = toLanguageSnapshot(LANGUAGE);
+
+describe('toLanguageSnapshot', () => {
+  it('carries every field, there being no closure to strip', () => {
+    // The library is twenty-nine modules; the payload is ten fields of plain data. The Maps and
+    // Sets live in the translation machinery, which builds them from a language rather than
+    // storing them in one.
+    expect(SNAPSHOT).toEqual(LANGUAGE);
+  });
+
+  it('is storable', () => {
+    expect(() => structuredClone(SNAPSHOT)).not.toThrow();
+  });
+
+  it('hands back a fresh object graph, so an editor cannot write into the page', () => {
+    expect(SNAPSHOT.lexicon).not.toBe(LANGUAGE.lexicon);
+    expect(SNAPSHOT.lexicon.words[0]).not.toBe(LANGUAGE.lexicon.words[0]);
+    expect(SNAPSHOT.morphology).not.toBe(LANGUAGE.morphology);
+    expect(SNAPSHOT.syllablePattern).not.toBe(LANGUAGE.syllablePattern);
+  });
+
+  it('stores the lexicon whole rather than a seed to rebuild it from', () => {
+    // #74 asks whether to store the lexicon or regenerate it. The answer is store: a user who
+    // renames one word has edited the language, and 4.2 says a seed may not overrule that.
+    expect(SNAPSHOT.lexicon.words.length).toBeGreaterThan(1000);
+    expect(SNAPSHOT.lexicon.words[0].meaning).toBe(LANGUAGE.lexicon.words[0].meaning);
+  });
+});
+
+describe('the round trip', () => {
+  // Requirement 7.2, over a spread of seeds rather than one, because a language's shape varies:
+  // the possession strategy is a union whose `marker_on_possessed` variant carries two fields the
+  // other three do not.
+  it('is lossless across many seeds', () => {
+    for (let index = 0; index < 20; index += 1) {
+      const language = rollLanguage(`round-trip-${index}`);
+
+      expect(languageFromSnapshot(toLanguageSnapshot(language))).toEqual(language);
+    }
+  });
+
+  it('is lossless for a language that marks possession with an affix', () => {
+    const marked = {
+      ...SNAPSHOT,
+      possessionStrategy: {
+        kind: 'marker_on_possessed' as const,
+        affix: 'ka',
+        placement: 'suffix' as const,
+      },
+    };
+
+    expect(languageFromSnapshot(marked)).toEqual(marked);
+  });
+
+  it('does not regenerate the lexicon on the way back', () => {
+    // The words in a stored language are the words the user kept. Re-running `createLexicon` over
+    // them would be the re-roll wearing a read's clothing.
+    const edited = {
+      ...SNAPSHOT,
+      lexicon: {
+        words: SNAPSHOT.lexicon.words.map((word, index) =>
+          index === 0 ? { ...word, root: 'zzyzx' } : word,
+        ),
+      },
+    };
+
+    expect(languageFromSnapshot(edited).lexicon.words[0].root).toBe('zzyzx');
+  });
+
+  it('draws nothing from the RNG the registry hands it', () => {
+    const rng = new RNG('unused');
+
+    expect(languageFromSnapshotWithRng(SNAPSHOT, rng)).toEqual(
+      languageFromSnapshotWithRng(SNAPSHOT, rng),
+    );
+  });
+});

--- a/src/lib/languages/language_snapshot.ts
+++ b/src/lib/languages/language_snapshot.ts
@@ -1,0 +1,90 @@
+/**
+ * Writing a constructed language snapshot, and reading one back.
+ *
+ * **The conversion is very nearly the identity function, and that is worth stating rather than
+ * leaving a reader to wonder what was missed.** `src/lib/languages` is the largest library behind
+ * any single tool — twenty-nine modules of phonology, morphology, lexicon, typology and two-way
+ * translation — but a `ConstructedLanguage` is not proportional to that. It is ten fields of plain
+ * data: strings, a string union, a four-field `Morphology`, a discriminated `PossessionStrategy`,
+ * and a `Lexicon` that is a list of four-field `Word`s. The `Map`s and `Set`s this library uses
+ * live in the translation machinery, which builds them from a language rather than storing them in
+ * one. A search here for a function-typed field on a language returns nothing, so there is no
+ * closure to strip and nothing to resolve by name on the way back.
+ *
+ * **The lexicon is stored whole.** #74 asks whether to store it or regenerate it from the seed, and
+ * the answer is store. A user who renames one word has edited the language, and requirement 4.2
+ * says a seed may not overrule that. Regeneration is a re-roll, and a re-roll is the destructive
+ * command — which is exactly the distinction `language_roll.ts` implements.
+ *
+ * The size is measured rather than feared: a generated language is 1,760 words and about 144 KB of
+ * JSON. That is the largest payload any tool here stores, and it is still two orders of magnitude
+ * below the point at which `$lib/storage_status` says anything — it warns at 80% of what
+ * `navigator.storage.estimate()` reports, and a user would need thousands of languages to reach it.
+ */
+
+import type { RNG } from '@ironarachne/rng';
+
+import type { ConstructedLanguage, Lexicon, Word } from './language_types.js';
+
+/**
+ * A constructed language as it is stored.
+ *
+ * An alias rather than a mapped type, because there is nothing to map: the stored shape and the
+ * live shape are the same shape. Named all the same, so the kind, the validator and the editor
+ * speak in snapshots like every other kind, and so the day the two shapes diverge there is a name
+ * to diverge.
+ */
+export type LanguageSnapshot = ConstructedLanguage;
+
+/** One word, copied, so an editor cannot write through into a language the page is rendering. */
+function copyWord(word: Word): Word {
+  return { ...word };
+}
+
+/** The lexicon, copied one level deeper than the rest: it is the half an editor rewrites. */
+function copyLexicon(lexicon: Lexicon): Lexicon {
+  return { words: lexicon.words.map(copyWord) };
+}
+
+/**
+ * A fresh language, deep enough that nothing shared reaches the store.
+ *
+ * The lexicon's words are copied individually because they are what the editor rewrites; the
+ * syllable pattern is copied because it is an array; `morphology` and `possessionStrategy` are
+ * copied because they are records the editor replaces wholesale. Nothing below that needs copying,
+ * every remaining field being a string.
+ */
+export function toLanguageSnapshot(language: ConstructedLanguage): LanguageSnapshot {
+  return {
+    ...language,
+    syllablePattern: [...language.syllablePattern],
+    morphology: { ...language.morphology },
+    possessionStrategy: { ...language.possessionStrategy },
+    lexicon: copyLexicon(language.lexicon),
+  };
+}
+
+/**
+ * A stored language back into the live one the library works with.
+ *
+ * Nothing is recomputed and nothing is re-rolled. In particular the lexicon is not regenerated: the
+ * words in a stored language are the words the user kept, and re-running `createLexicon` over them
+ * would be the re-roll wearing a read's clothing.
+ */
+export function languageFromSnapshot(snapshot: LanguageSnapshot): ConstructedLanguage {
+  return toLanguageSnapshot(snapshot);
+}
+
+/**
+ * The codec's reading half, with the signature the registry hands it.
+ *
+ * The RNG is unused, and that is the correct amount of use for it. It exists for kinds that rebuild
+ * name generators; a language is finished when it is stored, and drawing anything from a seed on
+ * the way back would be regenerating over the user's edits.
+ */
+export function languageFromSnapshotWithRng(
+  snapshot: LanguageSnapshot,
+  _rng: RNG,
+): ConstructedLanguage {
+  return languageFromSnapshot(snapshot);
+}

--- a/src/lib/library_imports.test.ts
+++ b/src/lib/library_imports.test.ts
@@ -74,6 +74,13 @@ const ALLOWED_DEEP_IMPORTS = new Set([
   // everything it statically imports is 425.2 KB across 44 chunks and `/swn/starship` is 501.5 KB
   // across 64; through the entry point they are 19.4 MB across 61 and 19.4 MB across 77. The kind
   // module holds metadata and validation only, and its codec is a dynamic import.
+  // `$lib/languages`'s entry point reaches the lexicon's eleven word-bucket lists and the
+  // themed-noun table, plus the whole English↔conlang translation layer. Measured on the build:
+  // through the kind module the registry chunk and everything it statically imports is 429.5 KB
+  // across 45 chunks, and through the entry point it is 474.5 KB across 47 — the same band that
+  // bought `$lib/treasure` its entry. The kind module holds metadata and validation only, and its
+  // codec is a dynamic import.
+  '$lib/languages/language_artifact_kind',
   '$lib/swn/swn_starship_artifact_kind',
   '$lib/swn/swn_starship_editing',
   '$lib/swn/swn_starship_presentation',

--- a/src/lib/tools/tool_catalog.test.ts
+++ b/src/lib/tools/tool_catalog.test.ts
@@ -149,6 +149,7 @@ describe('TOOL_CATALOG', () => {
       '/fantasy/weapon',
       '/fantasy/treasure-hoard',
       '/spooky-ship',
+      '/language',
     ];
 
     const claimingMore = TOOL_CATALOG.filter(
@@ -264,6 +265,7 @@ describe('toolsWithMaturity', () => {
       '/fantasy/treasure-hoard',
       '/fantasy/weapon',
       '/heraldry',
+      '/language',
       '/planet',
       '/region',
       '/species-stats',

--- a/src/lib/tools/tool_catalog.ts
+++ b/src/lib/tools/tool_catalog.ts
@@ -527,12 +527,23 @@ export const TOOL_CATALOG: ToolTypes.Tool[] = [
   // The workshop is deliberately absent. It is a surface rather than an instrument — the bench
   // the tools below are worked on — and this catalog holds instruments; see decision 9 in
   // docs/workshop.md. It is reached from `NAV_DESTINATIONS`, as Projects and the Result Vault are.
+  // Release-ready, assessed section by section against docs/workshop.md and recorded in
+  // docs/readiness-utilities.md (#74). It saves as `language`, holding the whole
+  // `ConstructedLanguage` — phonology, typology, morphology and the entire lexicon — which is the
+  // one thing that keeps it clear of the mismatch #28 warned about: the kind is named after the
+  // larger thing and stores the larger thing. Culture still owns its `NameGeneratorSet` outright,
+  // so nothing here is a payload step for culture.
+  //
+  // The largest payload the site stores: 1,760 words and about 144 KB of JSON, measured, which is
+  // two orders of magnitude below anything `$lib/storage_status` reports on. It has an editor in
+  // `ARTIFACT_EDITORS` and exports Markdown and PDF, the first exports it has ever had, and it
+  // gained the `SeedControls` it had never had — 2.3, not 2.2, was the failure here.
   defineTool({
     path: '/language',
     label: 'Language',
     kind: 'generator',
     domain: 'utilities',
-    maturity: 'experimental',
+    maturity: 'release-ready',
     tags: ['naming', 'worldbuilding'],
   }),
   // Release-ready, assessed section by section against docs/workshop.md and recorded in

--- a/src/lib/workshop/artifact_editors.ts
+++ b/src/lib/workshop/artifact_editors.ts
@@ -331,6 +331,17 @@ export const ARTIFACT_EDITORS: ArtifactEditorRegistry = {
       return (provenance) => rollSwnStarshipSnapshot(provenance.seed);
     },
   },
+  language: {
+    loadEditor: () => import('$components/utilities/LanguageArtifactEditor.svelte'),
+    /**
+     * The seed and nothing else: the tool has one control, and the phoneme-set table the generator
+     * draws from is the library's rather than the user's.
+     */
+    loadRoller: async () => {
+      const { rollLanguageSnapshot } = await import('$lib/languages/language_roll.js');
+      return (provenance) => rollLanguageSnapshot(provenance.seed);
+    },
+  },
   'arms-manufacturer': {
     loadEditor: () => import('$components/factions/ArmsManufacturerArtifactEditor.svelte'),
     /**

--- a/src/lib/workshop/artifact_kind_catalog.test.ts
+++ b/src/lib/workshop/artifact_kind_catalog.test.ts
@@ -39,6 +39,7 @@ describe('artifact kind catalog', () => {
       'treasure-hoard',
       'spooky-ship',
       'starship.swn',
+      'language',
     ]);
   });
 

--- a/src/lib/workshop/artifact_kind_catalog.ts
+++ b/src/lib/workshop/artifact_kind_catalog.ts
@@ -68,6 +68,13 @@ import { potionArtifactKind } from '$lib/potions/potion_artifact_kind';
 // through the entry point it is 477 KB across 43.
 import { treasureHoardArtifactKind } from '$lib/treasure/treasure_hoard_artifact_kind';
 import { heraldryArtifactKind } from '$lib/heraldry/heraldry_artifact_kind';
+// Deep, and measured the way its neighbours were: `$lib/languages`'s entry point reaches the
+// lexicon's eleven word-bucket lists and the themed-noun table, plus the whole English↔conlang
+// translation layer. Through the kind module the registry chunk and everything it statically
+// imports is 429.5 KB across 45 chunks; through the entry point it is 474.5 KB across 47. Forty-five
+// kilobytes is the same band that bought `$lib/treasure` its entry, and well clear of the two that
+// did not buy `$lib/spooky_ship` one.
+import { languageArtifactKind } from '$lib/languages/language_artifact_kind';
 import { religionArtifactKind } from '$lib/religion/religion_artifact_kind';
 import { settlementArtifactKind } from '$lib/settlements/settlement_artifact_kind';
 import { swnCharacterArtifactKind } from '$lib/swn/swn_character_artifact_kind';
@@ -116,6 +123,7 @@ function buildArtifactKindRegistry(): ArtifactKindRegistry {
   registerArtifactKind(registry, treasureHoardArtifactKind);
   registerArtifactKind(registry, spookyShipArtifactKind);
   registerArtifactKind(registry, swnStarshipArtifactKind);
+  registerArtifactKind(registry, languageArtifactKind);
   return registry;
 }
 


### PR DESCRIPTION
Closes #74. Takes `/language` from Experimental to Release-ready against the readiness spec in `docs/workshop.md`, following the design in `docs/readiness-utilities.md`.

Kind `language`, unqualified and genre-neutral, storing the whole `ConstructedLanguage` — phonology, typology, morphology and the entire lexicon. The library is twenty-nine modules but the payload is ten fields of plain data: the `Map`s and `Set`s live in the translation machinery, which builds them from a language rather than storing them in one.

## Four things worth recording

- **The measurement the issue asks for: 1,760 words and about 144 KB of JSON.** That is the largest payload the site stores and it is not close to mattering — `$lib/storage_status` warns at 80% of what `navigator.storage.estimate()` reports, so a user would need thousands of languages to reach the first thing the vault would say to them. The lexicon is stored whole rather than regenerated from the seed: a user who renames one word has edited the language, and 4.2 says a seed may not overrule that.

- **Determinism holds, and the test compares the lexicon word for word** rather than comparing two objects and trusting `toEqual` to have looked. This design stores the lexicon rather than relying on regeneration, but 4.3 does rely on it, and a re-roll that returned a different language each press would be a button that lies.

- **The failure here was 2.3, not 2.2.** Every other tool in the pass had a seed control that worked and an RNG reseeded in the wrong place. This one rendered no `SeedControls` at all and drew a fresh seed from `Date.now()` inside `generate()`, so a language a user liked could not be got back — there was nothing to write down.

- **`/language` was the last Experimental tool, and `e2e/tool_maturity.spec.ts` changed shape because of it.** That spec exists to prove a maturity level reaches a screen, and it had a list of one, rewritten four times as planet, drug, spooky ship and finally this tool each reached Release-ready. The catalog is now release-ready end to end, so no page *can* show a badge and the list has nowhere left to point. It asserts site-wide silence instead and carries a note saying to restore the two tests the day a tool ships below Release-ready. The badge's own logic stays covered by `src/lib/tools/tools.test.ts`; what is genuinely no longer covered is the wiring from that logic to `ToolMaturityBadge` on a real page, and keeping a fixture route alive to exercise it would cost more than it is worth. **Flagging that as a coverage loss rather than a clean win.**

## On #28

The issue says to read #28 first, and it is worth saying plainly: this is the kind that issue declined to mint, and building it is not a reversal of it.

#28's warning was specific — naming a kind after a language while storing only the `NameGeneratorSet` a culture consumes would be a mismatch expensive to undo once artifacts existed in users' browsers. This payload is the whole language, so that mismatch cannot arise. What #28 left open stays open: culture still owns its `nameGenerators` outright, there is **no `payloadVersion` step for culture**, and whether a *name-generator set* deserves a kind of its own remains the smaller question to ask if settlement, region, family and character ever justify it. The reconciliation is recorded in the kind module, the library README and the design doc so the two issues do not read as contradicting each other.

## The rest

The editor is bespoke because the lexicon is: 1,760 words is not a form, so it is a search box over a list, and each row carries its index into the *unfiltered* lexicon so that typing in the search box cannot make a handler rewrite the wrong word.

6.3 is Markdown and PDF, the first exports this tool has ever had — the issue calls their absence a real loss, a conlang being a document.

## Verification

`npm run verify` is green.

`npm run verify:all`'s browser suite is green apart from the pre-existing `ArtifactPanel` flake tracked from #203: `uw_character.spec.ts:136`, the same test that failed on an unmodified checkout of `main` during that work, and which passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RbE1EfenGuuSyoD4Sd6Ta
