### PR TITLE
Add ruleset registry contracts

### DIFF
--- a/src/lib/rulesets/README.md
+++ b/src/lib/rulesets/README.md
@@ -1,0 +1,18 @@
+# Rulesets
+
+`$lib/rulesets` is the shared boundary between system-neutral domain data and rules-owned
+mechanics. A `RulesetRef` pins a stable ruleset id and release; a `QualifiedMechanics` envelope
+records which package interprets one opaque payload.
+
+The catalog is closed for values authored by this build and tolerant on reads. Unknown ids,
+releases, payloads, sources, and versions return a `RulesetResult` failure instead of being guessed
+or coerced. A `MechanicsSet` may hold one variant per ruleset release, allowing derivation to add a
+new system without replacing existing or user-edited mechanics.
+
+Rules-data licensing is attached to exact `RulesDataSource` records. Production sources must pass
+`defineRulesDataSource`, which refuses incomplete metadata, unapproved scopes, and material not
+approved for redistribution. A descriptor cites source ids; `rulesetNotices` resolves and
+deduplicates the notices required by selected releases.
+
+The full contract, dependency rules, and migration plan are in
+[`docs/rules-system.md`](../../../docs/rules-system.md).

--- a/src/lib/rulesets/index.ts
+++ b/src/lib/rulesets/index.ts
@@ -1,0 +1,6 @@
+export * from './ruleset_catalog.js';
+export * from './ruleset_definitions.js';
+export * from './ruleset_results.js';
+export * from './ruleset_sources.js';
+export * from './ruleset_types.js';
+export * from './rulesets.js';

--- a/src/lib/rulesets/ironarachne/definition.ts
+++ b/src/lib/rulesets/ironarachne/definition.ts
@@ -1,0 +1,6 @@
+import { defineRuleset } from '../ruleset_definitions';
+import { IRONARACHNE_RULESET_DESCRIPTOR } from './descriptor';
+
+export const ironArachneRuleset = defineRuleset({
+  descriptor: IRONARACHNE_RULESET_DESCRIPTOR,
+});

--- a/src/lib/rulesets/ironarachne/descriptor.ts
+++ b/src/lib/rulesets/ironarachne/descriptor.ts
@@ -1,0 +1,18 @@
+import type { RulesetDescriptor, RulesetRef } from '../ruleset_types';
+import { IRONARACHNE_ORIGINAL_SOURCE } from './source_manifest';
+
+export const IRONARACHNE_RULESET_REF: RulesetRef = {
+  id: 'ironarachne',
+  release: '1',
+};
+
+/**
+ * The compatibility release exists before its services move from the old common libraries.
+ * Empty capabilities make that partial state explicit to callers.
+ */
+export const IRONARACHNE_RULESET_DESCRIPTOR: RulesetDescriptor = {
+  ref: IRONARACHNE_RULESET_REF,
+  displayName: 'Iron Arachne',
+  capabilities: [],
+  sourceIds: [IRONARACHNE_ORIGINAL_SOURCE.id],
+};

--- a/src/lib/rulesets/ironarachne/source_manifest.ts
+++ b/src/lib/rulesets/ironarachne/source_manifest.ts
@@ -1,0 +1,17 @@
+import { defineRulesDataSource } from '../ruleset_sources';
+
+/** Source record for Iron Arachne's existing normalized mechanics. */
+export const IRONARACHNE_ORIGINAL_SOURCE = defineRulesDataSource({
+  id: 'ironarachne.normalized-mechanics.v1',
+  title: 'Iron Arachne normalized mechanics',
+  version: '1',
+  publisher: 'Iron Arachne contributors',
+  grant: {
+    id: 'project-original',
+    name: 'Original project content',
+    scope: 'original',
+    notice: 'Original mechanics authored for Iron Arachne.',
+  },
+  attribution: 'Iron Arachne contributors',
+  redistributable: true,
+});

--- a/src/lib/rulesets/ruleset_catalog.ts
+++ b/src/lib/rulesets/ruleset_catalog.ts
@@ -1,0 +1,59 @@
+import { IRONARACHNE_RULESET_DESCRIPTOR, IRONARACHNE_RULESET_REF } from './ironarachne/descriptor';
+import { IRONARACHNE_ORIGINAL_SOURCE } from './ironarachne/source_manifest';
+import type {
+  RulesDataSource,
+  RulesetDefinition,
+  RulesetDescriptor,
+  RulesetRef,
+} from './ruleset_types';
+
+type RulesetCatalogEntry = {
+  descriptor: RulesetDescriptor;
+  load: () => Promise<RulesetDefinition>;
+};
+
+const RULESET_CATALOG: RulesetCatalogEntry[] = [
+  {
+    descriptor: IRONARACHNE_RULESET_DESCRIPTOR,
+    load: async () => {
+      const { ironArachneRuleset } = await import('./ironarachne/definition.js');
+      return ironArachneRuleset;
+    },
+  },
+];
+
+const RULES_DATA_SOURCES: RulesDataSource[] = [IRONARACHNE_ORIGINAL_SOURCE];
+
+export function sameRulesetRef(left: RulesetRef, right: RulesetRef): boolean {
+  return left.id === right.id && left.release === right.release;
+}
+
+export function allRulesets(): RulesetDescriptor[] {
+  return RULESET_CATALOG.map(({ descriptor }) => ({
+    ...descriptor,
+    ref: { ...descriptor.ref },
+    capabilities: [...descriptor.capabilities],
+    sourceIds: [...descriptor.sourceIds],
+  }));
+}
+
+export function allRulesDataSources(): RulesDataSource[] {
+  return RULES_DATA_SOURCES.map((source) => ({
+    ...source,
+    grant: { ...source.grant },
+  }));
+}
+
+export function findRulesetDescriptor(ref: RulesetRef): RulesetDescriptor | undefined {
+  return RULESET_CATALOG.find(({ descriptor }) => sameRulesetRef(descriptor.ref, ref))?.descriptor;
+}
+
+export function findRulesetLoader(ref: RulesetRef): (() => Promise<RulesetDefinition>) | undefined {
+  return RULESET_CATALOG.find(({ descriptor }) => sameRulesetRef(descriptor.ref, ref))?.load;
+}
+
+export function findRulesDataSource(id: string): RulesDataSource | undefined {
+  return RULES_DATA_SOURCES.find((source) => source.id === id);
+}
+
+export { IRONARACHNE_RULESET_REF };

--- a/src/lib/rulesets/ruleset_definitions.ts
+++ b/src/lib/rulesets/ruleset_definitions.ts
@@ -1,0 +1,44 @@
+import { MECHANICS_SUBJECTS } from './ruleset_types';
+import type { RulesetCapability, RulesetDefinition, RulesetDescriptor } from './ruleset_types';
+
+function hasCapability(descriptor: RulesetDescriptor, capability: RulesetCapability): boolean {
+  return descriptor.capabilities.includes(capability);
+}
+
+/**
+ * Defines one runtime package and rejects a descriptor that lies about its implemented services.
+ * This is a developer error, so it throws while the module is loaded rather than becoming a
+ * stored-data failure later.
+ */
+export function defineRuleset(definition: RulesetDefinition): RulesetDefinition {
+  const { descriptor } = definition;
+  const duplicateCapability = descriptor.capabilities.find(
+    (capability, index) => descriptor.capabilities.indexOf(capability) !== index,
+  );
+  if (duplicateCapability !== undefined) {
+    throw new Error(`ruleset capability "${duplicateCapability}" is declared more than once`);
+  }
+
+  for (const subject of MECHANICS_SUBJECTS) {
+    const version = definition.mechanics?.schemaVersion(subject);
+    if (hasCapability(descriptor, subject) !== (version !== undefined)) {
+      throw new Error('ruleset mechanics codec and subject capabilities do not agree');
+    }
+    if (version !== undefined && (!Number.isInteger(version) || version < 1)) {
+      throw new Error(`ruleset ${subject} mechanics schema version must be a positive integer`);
+    }
+  }
+
+  const services: [RulesetCapability, unknown][] = [
+    ['currency', definition.currency],
+    ['equipment', definition.equipment],
+    ['treasure-items', definition.treasureItems],
+  ];
+  for (const [capability, service] of services) {
+    if (hasCapability(descriptor, capability) !== (service !== undefined)) {
+      throw new Error(`ruleset ${capability} service and capability do not agree`);
+    }
+  }
+
+  return definition;
+}

--- a/src/lib/rulesets/ruleset_results.ts
+++ b/src/lib/rulesets/ruleset_results.ts
@@ -1,0 +1,12 @@
+import type { RulesetFailureReason, RulesetResult } from './ruleset_types';
+
+export function acceptedRuleset<T>(value: T): RulesetResult<T> {
+  return { ok: true, value };
+}
+
+export function rejectedRuleset(
+  reason: RulesetFailureReason,
+  message: string,
+): RulesetResult<never> {
+  return { ok: false, reason, message };
+}

--- a/src/lib/rulesets/ruleset_sources.ts
+++ b/src/lib/rulesets/ruleset_sources.ts
@@ -1,0 +1,32 @@
+import { CONTENT_SCOPES } from './ruleset_types';
+import type { RulesDataSource } from './ruleset_types';
+
+function isNonEmpty(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+/**
+ * Production source manifests pass through this gate. Research-only or ambiguous grants are kept
+ * outside the production catalog rather than receiving a permissive fallback.
+ */
+export function defineRulesDataSource(source: RulesDataSource): RulesDataSource {
+  if (
+    !isNonEmpty(source.id) ||
+    !isNonEmpty(source.title) ||
+    !isNonEmpty(source.version) ||
+    !isNonEmpty(source.publisher) ||
+    !isNonEmpty(source.grant.id) ||
+    !isNonEmpty(source.grant.name) ||
+    !isNonEmpty(source.grant.notice) ||
+    !isNonEmpty(source.attribution)
+  ) {
+    throw new Error('rules data source metadata must not be empty');
+  }
+  if (!(CONTENT_SCOPES as readonly unknown[]).includes(source.grant.scope)) {
+    throw new Error(`rules data source "${source.id}" has no approved content scope`);
+  }
+  if (source.redistributable !== true) {
+    throw new Error(`rules data source "${source.id}" is not approved for redistribution`);
+  }
+  return source;
+}

--- a/src/lib/rulesets/ruleset_types.ts
+++ b/src/lib/rulesets/ruleset_types.ts
@@ -1,0 +1,162 @@
+import type { GameSystem } from '$lib/tools';
+import type { RNG } from '@ironarachne/rng';
+
+/** Rulesets this build may author. Stored values still cross a runtime validation boundary. */
+export const RULESET_IDS = ['ironarachne', 'adnd-2e', 'dcc', 'dnd-5e'] as const;
+
+export type RulesetId = (typeof RULESET_IDS)[number];
+
+export const MECHANICS_SUBJECTS = ['actor', 'item', 'potion', 'spell', 'hoard'] as const;
+
+export type MechanicsSubject = (typeof MECHANICS_SUBJECTS)[number];
+
+export const MECHANICS_ORIGINS = ['migrated', 'generated', 'user'] as const;
+
+export type MechanicsOrigin = (typeof MECHANICS_ORIGINS)[number];
+
+export const RULESET_CAPABILITIES = [
+  ...MECHANICS_SUBJECTS,
+  'currency',
+  'equipment',
+  'treasure-items',
+] as const;
+
+export type RulesetCapability = (typeof RULESET_CAPABILITIES)[number];
+
+/** Stable identity for one compatible rules-data release. `release` is never a floating alias. */
+export type RulesetRef = {
+  id: RulesetId;
+  release: string;
+};
+
+export const CONTENT_SCOPES = ['mechanics', 'open-content', 'permission', 'original'] as const;
+
+export type ContentScope = (typeof CONTENT_SCOPES)[number];
+
+export type LicenseGrant = {
+  id: string;
+  name: string;
+  url?: string;
+  scope: ContentScope;
+  notice: string;
+};
+
+/** One exact source of rules data, rather than a licence claim about a whole game. */
+export type RulesDataSource = {
+  id: string;
+  title: string;
+  version: string;
+  publisher: string;
+  url?: string;
+  grant: LicenseGrant;
+  attribution: string;
+  redistributable: true;
+};
+
+export type RulesetDescriptor = {
+  ref: RulesetRef;
+  displayName: string;
+  gameSystem?: GameSystem;
+  capabilities: RulesetCapability[];
+  sourceIds: string[];
+};
+
+/** The rules-owned portion of an otherwise shared entity. */
+export type QualifiedMechanics = {
+  ruleset: RulesetRef;
+  subject: MechanicsSubject;
+  schemaVersion: number;
+  origin: MechanicsOrigin;
+  sourceIds: string[];
+  payload: unknown;
+};
+
+export type MechanicsSet = {
+  variants: QualifiedMechanics[];
+};
+
+export type MechanicsPresentation = {
+  title?: string;
+  lines: string[];
+};
+
+export type CurrencyDenominationDefinition = {
+  id: string;
+  name: string;
+  symbol?: string;
+  value: number;
+  weight?: number;
+};
+
+export type CurrencyDefinition = {
+  baseDenominationId: string;
+  denominations: CurrencyDenominationDefinition[];
+};
+
+export type RulesNeutralItem = {
+  id: string;
+  name: string;
+  description: string;
+  weight: number;
+};
+
+export type MechanicsCodec = {
+  schemaVersion: (subject: MechanicsSubject) => number | undefined;
+  validate: (
+    subject: MechanicsSubject,
+    payload: unknown,
+    schemaVersion: number,
+  ) => RulesetResult<unknown>;
+  migrate: (
+    subject: MechanicsSubject,
+    payload: unknown,
+    fromVersion: number,
+  ) => RulesetResult<unknown>;
+  present: (subject: MechanicsSubject, payload: unknown) => MechanicsPresentation;
+};
+
+export type CurrencyRules = {
+  definition: CurrencyDefinition;
+  format: (amount: number, denominationId: string) => string;
+};
+
+export type EquipmentRules = {
+  validateItem: (payload: unknown) => RulesetResult<unknown>;
+  presentItem: (payload: unknown) => MechanicsPresentation;
+};
+
+export type TreasureItemRules<TContext = unknown> = {
+  derive: (
+    item: Readonly<RulesNeutralItem>,
+    existing: Readonly<MechanicsSet>,
+    context: TContext,
+    rng: RNG,
+  ) => RulesetResult<QualifiedMechanics>;
+};
+
+/**
+ * Runtime behavior for one release. Optional services must agree exactly with the descriptor's
+ * capabilities; a catalog entry may exist before all of its mechanics do.
+ */
+export type RulesetDefinition = {
+  descriptor: RulesetDescriptor;
+  mechanics?: MechanicsCodec;
+  currency?: CurrencyRules;
+  equipment?: EquipmentRules;
+  treasureItems?: TreasureItemRules;
+};
+
+export type RulesetFailureReason =
+  | 'unknown-ruleset'
+  | 'unknown-release'
+  | 'unsupported-capability'
+  | 'invalid-mechanics'
+  | 'unsupported-version'
+  | 'migration-failed'
+  | 'variant-conflict'
+  | 'unknown-source'
+  | 'ruleset-load-failed';
+
+export type RulesetResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; reason: RulesetFailureReason; message: string };

--- a/src/lib/rulesets/rulesets.test.ts
+++ b/src/lib/rulesets/rulesets.test.ts
@@ -1,0 +1,341 @@
+import { RNG } from '@ironarachne/rng';
+import { describe, expect, it } from 'vitest';
+
+import {
+  IRONARACHNE_RULESET_REF,
+  RULESET_IDS,
+  acceptedRuleset,
+  addMechanicsVariant,
+  allRulesDataSources,
+  allRulesets,
+  defineRulesDataSource,
+  defineRuleset,
+  deriveTreasureItemMechanics,
+  getRuleset,
+  mechanicsFor,
+  migrateQualifiedMechanics,
+  rejectedRuleset,
+  rulesetNotices,
+  sameRulesetRef,
+  validateQualifiedMechanics,
+  type MechanicsCodec,
+  type QualifiedMechanics,
+  type RulesDataSource,
+  type RulesetDescriptor,
+  type RulesetRef,
+} from './index.js';
+
+const genericItem: QualifiedMechanics = {
+  ruleset: IRONARACHNE_RULESET_REF,
+  subject: 'item',
+  schemaVersion: 1,
+  origin: 'migrated',
+  sourceIds: ['ironarachne.normalized-mechanics.v1'],
+  payload: { value: 100, attack: 50 },
+};
+
+describe('ruleset catalog', () => {
+  it('publishes the closed id vocabulary and the compatibility release', () => {
+    expect(RULESET_IDS).toEqual(['ironarachne', 'adnd-2e', 'dcc', 'dnd-5e']);
+    expect(allRulesets()).toEqual([
+      expect.objectContaining({
+        ref: IRONARACHNE_RULESET_REF,
+        displayName: 'Iron Arachne',
+        capabilities: [],
+      }),
+    ]);
+  });
+
+  it('returns defensive catalog and source copies', () => {
+    const descriptors = allRulesets();
+    descriptors[0].sourceIds.push('invented');
+    descriptors[0].ref.release = 'changed';
+
+    const sources = allRulesDataSources();
+    sources[0].grant.notice = 'changed';
+
+    expect(allRulesets()[0].sourceIds).toEqual(['ironarachne.normalized-mechanics.v1']);
+    expect(allRulesets()[0].ref.release).toBe('1');
+    expect(allRulesDataSources()[0].grant.notice).toBe(
+      'Original mechanics authored for Iron Arachne.',
+    );
+  });
+
+  it('compares both parts of a ref', () => {
+    expect(sameRulesetRef(IRONARACHNE_RULESET_REF, { ...IRONARACHNE_RULESET_REF })).toBe(true);
+    expect(
+      sameRulesetRef(IRONARACHNE_RULESET_REF, { ...IRONARACHNE_RULESET_REF, release: '2' }),
+    ).toBe(false);
+    expect(
+      sameRulesetRef(IRONARACHNE_RULESET_REF, {
+        id: 'dcc',
+        release: IRONARACHNE_RULESET_REF.release,
+      }),
+    ).toBe(false);
+  });
+
+  it('loads a known definition lazily', async () => {
+    const result = await getRuleset(IRONARACHNE_RULESET_REF);
+    expect(result).toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        descriptor: expect.objectContaining({ ref: IRONARACHNE_RULESET_REF }),
+      }),
+    });
+  });
+
+  it('distinguishes unknown ids and releases', async () => {
+    const unknownId = await getRuleset({
+      id: 'newer-system',
+      release: '1',
+    } as unknown as RulesetRef);
+    const unknownRelease = await getRuleset({ id: 'ironarachne', release: 'newer' });
+    const unregisteredKnownId = await getRuleset({ id: 'dcc', release: '1' });
+    const emptyRelease = await getRuleset({ id: 'ironarachne', release: '' });
+    const blankRelease = await getRuleset({ id: 'ironarachne', release: '   ' });
+
+    expect(unknownId).toMatchObject({ ok: false, reason: 'unknown-ruleset' });
+    expect(unknownRelease).toMatchObject({ ok: false, reason: 'unknown-release' });
+    expect(unregisteredKnownId).toMatchObject({ ok: false, reason: 'unknown-release' });
+    expect(emptyRelease).toMatchObject({ ok: false, reason: 'unknown-release' });
+    expect(blankRelease).toMatchObject({ ok: false, reason: 'unknown-release' });
+  });
+});
+
+describe('definition integrity', () => {
+  const descriptor = (capabilities: RulesetDescriptor['capabilities']): RulesetDescriptor => ({
+    ref: IRONARACHNE_RULESET_REF,
+    displayName: 'Test',
+    capabilities,
+    sourceIds: [],
+  });
+  const codec: MechanicsCodec = {
+    schemaVersion: () => 1,
+    validate: (_subject, payload) => acceptedRuleset(payload),
+    migrate: (_subject, payload) => acceptedRuleset(payload),
+    present: () => ({ lines: [] }),
+  };
+  const itemCodec: MechanicsCodec = {
+    ...codec,
+    schemaVersion: (subject) => (subject === 'item' ? 1 : undefined),
+  };
+
+  it('accepts an honest partial definition', () => {
+    const definition = { descriptor: descriptor([]) };
+    expect(defineRuleset(definition)).toBe(definition);
+  });
+
+  it('rejects duplicate capabilities', () => {
+    expect(() =>
+      defineRuleset({ descriptor: descriptor(['item', 'item']), mechanics: codec }),
+    ).toThrow('declared more than once');
+  });
+
+  it('requires mechanics capabilities and their codec to agree', () => {
+    expect(() => defineRuleset({ descriptor: descriptor(['item']) })).toThrow(
+      'mechanics codec and subject capabilities do not agree',
+    );
+    expect(() => defineRuleset({ descriptor: descriptor([]), mechanics: codec })).toThrow(
+      'mechanics codec and subject capabilities do not agree',
+    );
+    expect(
+      defineRuleset({ descriptor: descriptor(['item']), mechanics: itemCodec }).mechanics,
+    ).toBe(itemCodec);
+  });
+
+  it('requires positive integer mechanics schema versions', () => {
+    const invalidCodec = { ...itemCodec, schemaVersion: () => 0 };
+    expect(() =>
+      defineRuleset({
+        descriptor: descriptor(['actor', 'item', 'potion', 'spell', 'hoard']),
+        mechanics: invalidCodec,
+      }),
+    ).toThrow('schema version must be a positive integer');
+  });
+
+  it('requires named services and capabilities to agree', () => {
+    const currency = {
+      definition: { baseDenominationId: 'coin', denominations: [] },
+      format: (amount: number) => `${amount}`,
+    };
+    expect(() => defineRuleset({ descriptor: descriptor(['currency']) })).toThrow(
+      'currency service and capability do not agree',
+    );
+    expect(() => defineRuleset({ descriptor: descriptor([]), currency })).toThrow(
+      'currency service and capability do not agree',
+    );
+    expect(defineRuleset({ descriptor: descriptor(['currency']), currency }).currency).toBe(
+      currency,
+    );
+  });
+});
+
+describe('rules data sources', () => {
+  const source: RulesDataSource = {
+    id: 'test.source',
+    title: 'Test source',
+    version: '1',
+    publisher: 'Test publisher',
+    grant: {
+      id: 'test-grant',
+      name: 'Test grant',
+      scope: 'original',
+      notice: 'A notice.',
+    },
+    attribution: 'Test author',
+    redistributable: true,
+  };
+
+  it('accepts a complete redistributable source', () => {
+    expect(defineRulesDataSource(source)).toBe(source);
+  });
+
+  it('rejects incomplete metadata', () => {
+    expect(() => defineRulesDataSource({ ...source, title: ' ' })).toThrow(
+      'metadata must not be empty',
+    );
+  });
+
+  it('rejects unknown scopes and non-redistributable material', () => {
+    expect(() =>
+      defineRulesDataSource({
+        ...source,
+        grant: { ...source.grant, scope: 'unknown' },
+      } as unknown as RulesDataSource),
+    ).toThrow('no approved content scope');
+    expect(() =>
+      defineRulesDataSource({ ...source, redistributable: false } as unknown as RulesDataSource),
+    ).toThrow('not approved for redistribution');
+  });
+});
+
+describe('qualified mechanics', () => {
+  it('validates and copies a complete envelope', () => {
+    const result = validateQualifiedMechanics(genericItem);
+    expect(result).toEqual({ ok: true, value: genericItem });
+    if (result.ok) {
+      expect(result.value).not.toBe(genericItem);
+      expect(result.value.sourceIds).not.toBe(genericItem.sourceIds);
+    }
+  });
+
+  it.each([
+    [null, 'invalid-mechanics'],
+    [{ ...genericItem, ruleset: null }, 'unknown-ruleset'],
+    [{ ...genericItem, ruleset: { id: 'ironarachne' } }, 'unknown-release'],
+    [{ ...genericItem, ruleset: { id: 'ironarachne', release: '2' } }, 'unknown-release'],
+    [{ ...genericItem, subject: 'weapon' }, 'invalid-mechanics'],
+    [{ ...genericItem, schemaVersion: 0 }, 'unsupported-version'],
+    [{ ...genericItem, schemaVersion: 1.2 }, 'unsupported-version'],
+    [{ ...genericItem, origin: 'converted' }, 'invalid-mechanics'],
+    [{ ...genericItem, sourceIds: [1] }, 'invalid-mechanics'],
+    [{ ...genericItem, sourceIds: ['missing.source'] }, 'unknown-source'],
+    [
+      {
+        ruleset: IRONARACHNE_RULESET_REF,
+        subject: 'item',
+        schemaVersion: 1,
+        origin: 'migrated',
+        sourceIds: [],
+      },
+      'invalid-mechanics',
+    ],
+  ])('rejects malformed mechanics %#', (value, reason) => {
+    expect(validateQualifiedMechanics(value)).toMatchObject({ ok: false, reason });
+  });
+
+  it('adds a new variant without mutating the set', () => {
+    const original = { variants: [] };
+    const result = addMechanicsVariant(original, genericItem);
+
+    expect(result).toEqual({ ok: true, value: { variants: [genericItem] } });
+    expect(original.variants).toEqual([]);
+  });
+
+  it('rejects invalid and duplicate variants', () => {
+    expect(
+      addMechanicsVariant({ variants: [] }, {
+        ...genericItem,
+        subject: 'wrong',
+      } as unknown as QualifiedMechanics),
+    ).toMatchObject({ ok: false, reason: 'invalid-mechanics' });
+    expect(addMechanicsVariant({ variants: [genericItem] }, genericItem)).toMatchObject({
+      ok: false,
+      reason: 'variant-conflict',
+    });
+  });
+
+  it('looks up an exact variant', () => {
+    const set = { variants: [genericItem] };
+    expect(mechanicsFor(set, IRONARACHNE_RULESET_REF)).toBe(genericItem);
+    expect(mechanicsFor(set, { id: 'ironarachne', release: '2' })).toBeUndefined();
+  });
+
+  it('reports that the compatibility descriptor has no codec yet', async () => {
+    expect(await migrateQualifiedMechanics(genericItem)).toMatchObject({
+      ok: false,
+      reason: 'unsupported-capability',
+    });
+    expect(await migrateQualifiedMechanics({ ...genericItem, schemaVersion: 0 })).toMatchObject({
+      ok: false,
+      reason: 'unsupported-version',
+    });
+  });
+});
+
+describe('treasure derivation and notices', () => {
+  const item = { id: 'sword', name: 'Sword', description: 'A sword.', weight: 1.5 };
+
+  it('does not overwrite an existing target variant', async () => {
+    const result = await deriveTreasureItemMechanics(
+      IRONARACHNE_RULESET_REF,
+      item,
+      { variants: [genericItem] },
+      {},
+      new RNG('duplicate'),
+    );
+    expect(result).toMatchObject({ ok: false, reason: 'variant-conflict' });
+  });
+
+  it('reports an unsupported derivation capability', async () => {
+    const result = await deriveTreasureItemMechanics(
+      IRONARACHNE_RULESET_REF,
+      item,
+      { variants: [] },
+      {},
+      new RNG('unsupported'),
+    );
+    expect(result).toMatchObject({ ok: false, reason: 'unsupported-capability' });
+  });
+
+  it('deduplicates source notices in ruleset order', () => {
+    const result = rulesetNotices([IRONARACHNE_RULESET_REF, IRONARACHNE_RULESET_REF]);
+    expect(result).toEqual({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          id: 'ironarachne.normalized-mechanics.v1',
+          redistributable: true,
+        }),
+      ],
+    });
+  });
+
+  it('refuses to omit notices for an unknown release', () => {
+    expect(rulesetNotices([{ id: 'ironarachne', release: '2' }])).toMatchObject({
+      ok: false,
+      reason: 'unknown-release',
+    });
+  });
+});
+
+describe('result helpers', () => {
+  it('construct successful and failed results', () => {
+    expect(acceptedRuleset(3)).toEqual({ ok: true, value: 3 });
+    expect(rejectedRuleset('migration-failed', 'no path')).toEqual({
+      ok: false,
+      reason: 'migration-failed',
+      message: 'no path',
+    });
+  });
+});

--- a/src/lib/rulesets/rulesets.ts
+++ b/src/lib/rulesets/rulesets.ts
@@ -1,0 +1,266 @@
+import type { RNG } from '@ironarachne/rng';
+
+import {
+  findRulesDataSource,
+  findRulesetDescriptor,
+  findRulesetLoader,
+  sameRulesetRef,
+} from './ruleset_catalog';
+import { acceptedRuleset, rejectedRuleset } from './ruleset_results';
+import {
+  MECHANICS_ORIGINS,
+  MECHANICS_SUBJECTS,
+  RULESET_IDS,
+  type MechanicsOrigin,
+  type MechanicsSet,
+  type MechanicsSubject,
+  type QualifiedMechanics,
+  type RulesDataSource,
+  type RulesNeutralItem,
+  type RulesetDefinition,
+  type RulesetId,
+  type RulesetRef,
+  type RulesetResult,
+} from './ruleset_types';
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
+function isRulesetId(value: unknown): value is RulesetId {
+  return typeof value === 'string' && (RULESET_IDS as readonly string[]).includes(value);
+}
+
+function isMechanicsSubject(value: unknown): value is MechanicsSubject {
+  return typeof value === 'string' && (MECHANICS_SUBJECTS as readonly string[]).includes(value);
+}
+
+function isMechanicsOrigin(value: unknown): value is MechanicsOrigin {
+  return typeof value === 'string' && (MECHANICS_ORIGINS as readonly string[]).includes(value);
+}
+
+function readRulesetRef(value: unknown): RulesetResult<RulesetRef> {
+  const record = asRecord(value);
+  if (record === undefined || !isRulesetId(record.id)) {
+    return rejectedRuleset('unknown-ruleset', 'mechanics names no supported ruleset id');
+  }
+  if (typeof record.release !== 'string' || record.release.trim() === '') {
+    return rejectedRuleset('unknown-release', 'mechanics names no ruleset release');
+  }
+
+  const ref = { id: record.id, release: record.release };
+  if (findRulesetDescriptor(ref) === undefined) {
+    return rejectedRuleset(
+      'unknown-release',
+      `no ruleset release registered as "${ref.id}@${ref.release}"`,
+    );
+  }
+  return acceptedRuleset(ref);
+}
+
+export async function getRuleset(ref: RulesetRef): Promise<RulesetResult<RulesetDefinition>> {
+  const checked = readRulesetRef(ref);
+  if (!checked.ok) {
+    return checked;
+  }
+
+  const load = findRulesetLoader(checked.value);
+  if (load === undefined) {
+    return rejectedRuleset(
+      'unknown-release',
+      `no ruleset release registered as "${ref.id}@${ref.release}"`,
+    );
+  }
+
+  let definition: RulesetDefinition;
+  try {
+    definition = await load();
+  } catch (error) {
+    const detail = error instanceof Error ? `: ${error.message}` : '';
+    return rejectedRuleset(
+      'ruleset-load-failed',
+      `could not load ruleset "${ref.id}@${ref.release}"${detail}`,
+    );
+  }
+  if (!sameRulesetRef(definition.descriptor.ref, checked.value)) {
+    return rejectedRuleset(
+      'invalid-mechanics',
+      `ruleset loader for "${ref.id}@${ref.release}" returned a different release`,
+    );
+  }
+  return acceptedRuleset(definition);
+}
+
+export function validateQualifiedMechanics(value: unknown): RulesetResult<QualifiedMechanics> {
+  const record = asRecord(value);
+  if (record === undefined) {
+    return rejectedRuleset('invalid-mechanics', 'qualified mechanics is not an object');
+  }
+
+  const ruleset = readRulesetRef(record.ruleset);
+  if (!ruleset.ok) {
+    return ruleset;
+  }
+  if (!isMechanicsSubject(record.subject)) {
+    return rejectedRuleset('invalid-mechanics', 'qualified mechanics has no known subject');
+  }
+  if (!Number.isInteger(record.schemaVersion) || (record.schemaVersion as number) < 1) {
+    return rejectedRuleset(
+      'unsupported-version',
+      'mechanics schema version must be a positive integer',
+    );
+  }
+  if (!isMechanicsOrigin(record.origin)) {
+    return rejectedRuleset('invalid-mechanics', 'qualified mechanics has no known origin');
+  }
+  if (!isStringArray(record.sourceIds)) {
+    return rejectedRuleset('invalid-mechanics', 'qualified mechanics source ids are not strings');
+  }
+  const unknownSource = record.sourceIds.find((id) => findRulesDataSource(id) === undefined);
+  if (unknownSource !== undefined) {
+    return rejectedRuleset(
+      'unknown-source',
+      `no rules data source registered as "${unknownSource}"`,
+    );
+  }
+  if (!Object.hasOwn(record, 'payload')) {
+    return rejectedRuleset('invalid-mechanics', 'qualified mechanics has no payload');
+  }
+
+  return acceptedRuleset({
+    ruleset: ruleset.value,
+    subject: record.subject,
+    schemaVersion: record.schemaVersion as number,
+    origin: record.origin,
+    sourceIds: [...record.sourceIds],
+    payload: record.payload,
+  });
+}
+
+export function addMechanicsVariant(
+  set: Readonly<MechanicsSet>,
+  variant: QualifiedMechanics,
+): RulesetResult<MechanicsSet> {
+  const checked = validateQualifiedMechanics(variant);
+  if (!checked.ok) {
+    return checked;
+  }
+  if (set.variants.some((current) => sameRulesetRef(current.ruleset, checked.value.ruleset))) {
+    return rejectedRuleset(
+      'variant-conflict',
+      `mechanics already contains "${variant.ruleset.id}@${variant.ruleset.release}"`,
+    );
+  }
+  return acceptedRuleset({ variants: [...set.variants, checked.value] });
+}
+
+export function mechanicsFor(
+  set: Readonly<MechanicsSet>,
+  ref: RulesetRef,
+): QualifiedMechanics | undefined {
+  return set.variants.find((variant) => sameRulesetRef(variant.ruleset, ref));
+}
+
+export async function migrateQualifiedMechanics(
+  value: QualifiedMechanics,
+): Promise<RulesetResult<QualifiedMechanics>> {
+  const checked = validateQualifiedMechanics(value);
+  if (!checked.ok) {
+    return checked;
+  }
+  const resolved = await getRuleset(checked.value.ruleset);
+  if (!resolved.ok) {
+    return resolved;
+  }
+  const codec = resolved.value.mechanics;
+  if (codec === undefined) {
+    return rejectedRuleset(
+      'unsupported-capability',
+      `ruleset "${value.ruleset.id}@${value.ruleset.release}" has no mechanics codec`,
+    );
+  }
+
+  const current = codec.schemaVersion(checked.value.subject);
+  if (current === undefined) {
+    return rejectedRuleset(
+      'unsupported-capability',
+      `ruleset does not support ${checked.value.subject} mechanics`,
+    );
+  }
+  if (checked.value.schemaVersion > current) {
+    return rejectedRuleset(
+      'unsupported-version',
+      `mechanics schema version ${checked.value.schemaVersion} is newer than ${current}`,
+    );
+  }
+
+  const payload =
+    checked.value.schemaVersion === current
+      ? codec.validate(checked.value.subject, checked.value.payload, current)
+      : codec.migrate(checked.value.subject, checked.value.payload, checked.value.schemaVersion);
+  if (!payload.ok) {
+    return payload;
+  }
+
+  return acceptedRuleset({ ...checked.value, schemaVersion: current, payload: payload.value });
+}
+
+export async function deriveTreasureItemMechanics<TContext>(
+  target: RulesetRef,
+  item: Readonly<RulesNeutralItem>,
+  existing: Readonly<MechanicsSet>,
+  context: TContext,
+  rng: RNG,
+): Promise<RulesetResult<QualifiedMechanics>> {
+  if (mechanicsFor(existing, target) !== undefined) {
+    return rejectedRuleset(
+      'variant-conflict',
+      `mechanics already contains "${target.id}@${target.release}"`,
+    );
+  }
+  const resolved = await getRuleset(target);
+  if (!resolved.ok) {
+    return resolved;
+  }
+  if (resolved.value.treasureItems === undefined) {
+    return rejectedRuleset(
+      'unsupported-capability',
+      `ruleset "${target.id}@${target.release}" cannot derive treasure item mechanics`,
+    );
+  }
+  return resolved.value.treasureItems.derive(item, existing, context, rng);
+}
+
+export function rulesetNotices(refs: readonly RulesetRef[]): RulesetResult<RulesDataSource[]> {
+  const sourceIds: string[] = [];
+  for (const ref of refs) {
+    const descriptor = findRulesetDescriptor(ref);
+    if (descriptor === undefined) {
+      return rejectedRuleset(
+        'unknown-release',
+        `no ruleset release registered as "${ref.id}@${ref.release}"`,
+      );
+    }
+    for (const sourceId of descriptor.sourceIds) {
+      if (!sourceIds.includes(sourceId)) {
+        sourceIds.push(sourceId);
+      }
+    }
+  }
+
+  const sources: RulesDataSource[] = [];
+  for (const sourceId of sourceIds) {
+    const source = findRulesDataSource(sourceId);
+    if (source === undefined) {
+      return rejectedRuleset('unknown-source', `no rules data source registered as "${sourceId}"`);
+    }
+    sources.push({ ...source, grant: { ...source.grant } });
+  }
+  return acceptedRuleset(sources);
+}


### PR DESCRIPTION
## Summary
- add stable versioned ruleset identity and typed ruleset failures
- add qualified mechanics envelopes with additive conflict protection
- add lazy ruleset loading and an honest capability-definition gate
- add exact production source manifests and deduplicated notice resolution
- register the capability-free Iron Arachne compatibility descriptor for #210

## Verification
- npm run verify
- 459 test files and 6,205 tests passed
- 101 of 101 library coverage gates passed with no new baseline debt

Closes #206