### PR TITLE
Migrate stored mechanics to ruleset-qualified payloads

### DIFF
--- a/src/lib/adnd/adnd_character_artifact_kind.test.ts
+++ b/src/lib/adnd/adnd_character_artifact_kind.test.ts
@@ -8,7 +8,7 @@ import {
   migrateAdndCharacterSnapshot,
   validateAdndCharacterSnapshot,
 } from './adnd_character_artifact_kind.js';
-import { toAdndCharacterSnapshot } from './adnd_character_snapshot.js';
+import { ADND_CHARACTER_RULESET_REF, toAdndCharacterSnapshot } from './adnd_character_snapshot.js';
 import type { AdndCharacterSnapshot } from './adnd_character_snapshot.js';
 import { generateCharacter } from './adndcharactergenerator.js';
 import { getDefaultConfig } from './adndcharactergeneratorconfig.js';
@@ -31,9 +31,9 @@ describe('the AD&D character kind', () => {
     expect(ADND_CHARACTER_ARTIFACT_KIND).toBe('character.adnd-2e');
   });
 
-  it('starts at payload version 1', () => {
-    expect(ADND_CHARACTER_PAYLOAD_VERSION).toBe(1);
-    expect(adndCharacterArtifactKind.payloadVersion).toBe(1);
+  it('pins system identity at payload version 2', () => {
+    expect(ADND_CHARACTER_PAYLOAD_VERSION).toBe(2);
+    expect(adndCharacterArtifactKind.payloadVersion).toBe(2);
   });
 
   it('names an artifact after the character', () => {
@@ -152,7 +152,18 @@ describe('validateAdndCharacterSnapshot', () => {
 });
 
 describe('migrateAdndCharacterSnapshot', () => {
-  it('rejects, because version 1 is the only shape there has been', () => {
+  it('pins the legacy ruleset ref without inventing source provenance', () => {
+    const { ruleset: _ruleset, ...legacy } = aSnapshot();
+    const result = migrateAdndCharacterSnapshot(legacy, 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({ ...legacy, ruleset: ADND_CHARACTER_RULESET_REF });
+      expect(result.value).not.toHaveProperty('sourceIds');
+    }
+  });
+
+  it('rejects an unsupported version', () => {
     const result = migrateAdndCharacterSnapshot({}, 0);
 
     expect(result.ok).toBe(false);

--- a/src/lib/adnd/adnd_character_artifact_kind.ts
+++ b/src/lib/adnd/adnd_character_artifact_kind.ts
@@ -10,7 +10,7 @@ import {
 } from '$lib/artifact_kinds';
 
 import type ADNDCharacter from './adndcharacter.js';
-import type { AdndCharacterSnapshot } from './adnd_character_snapshot';
+import { ADND_CHARACTER_RULESET_REF, type AdndCharacterSnapshot } from './adnd_character_snapshot';
 
 /**
  * Stable artifact kind id.
@@ -27,8 +27,17 @@ import type { AdndCharacterSnapshot } from './adnd_character_snapshot';
  */
 export const ADND_CHARACTER_ARTIFACT_KIND = 'character.adnd-2e' as const;
 
-/** Version 1. The first shape an AD&D 2E character has been stored in. */
-export const ADND_CHARACTER_PAYLOAD_VERSION = 1 as const;
+/** Version 2 pins the ruleset identity without claiming unaudited source provenance. */
+export const ADND_CHARACTER_PAYLOAD_VERSION = 2 as const;
+
+function hasAdndRulesetRef(value: unknown): boolean {
+  const ref = asRecord(value);
+  return (
+    ref !== null &&
+    ref.id === ADND_CHARACTER_RULESET_REF.id &&
+    ref.release === ADND_CHARACTER_RULESET_REF.release
+  );
+}
 
 const CHARACTER_STRING_FIELDS = [
   'firstName',
@@ -169,6 +178,9 @@ export function validateAdndCharacterSnapshot(
       `AD&D character payload needs numeric ${CHARACTER_NUMBER_FIELDS.join(', ')}`,
     );
   }
+  if (!hasAdndRulesetRef(record.ruleset)) {
+    return rejectedPayload('invalid-payload', 'AD&D character has no supported ruleset ref');
+  }
 
   const checks: PayloadResult<unknown>[] = [
     validateNamedList(record.spells, 'spells'),
@@ -188,21 +200,21 @@ export function validateAdndCharacterSnapshot(
   return acceptedPayload(record as unknown as AdndCharacterSnapshot);
 }
 
-/**
- * There has only ever been version 1, so this rejects rather than pretending otherwise.
- *
- * It is here because the contract requires it, and it is where the first real step goes the day
- * the shape changes. A kind without one looks complete right up until it silently drops someone's
- * work — and local-only means there is no server-side migration to fall back on.
- */
+/** Adds only the pinned system identity; every existing system-owned field remains untouched. */
 export function migrateAdndCharacterSnapshot(
-  _payload: unknown,
+  payload: unknown,
   from: number,
 ): PayloadResult<AdndCharacterSnapshot> {
-  return rejectedPayload(
-    'unsupported-version',
-    `AD&D character has no migration from payload version ${from}; version ${ADND_CHARACTER_PAYLOAD_VERSION} is the only shape there has been`,
-  );
+  if (from !== 1) {
+    return rejectedPayload(
+      'unsupported-version',
+      `AD&D character has no migration from payload version ${from}; version 1 is the only older shape there has been`,
+    );
+  }
+  const record = asRecord(payload);
+  return record === null
+    ? rejectedPayload('invalid-payload', 'AD&D character payload is not an object')
+    : validateAdndCharacterSnapshot({ ...record, ruleset: ADND_CHARACTER_RULESET_REF });
 }
 
 /** What to call a character that was never named: its race and class, which it always has. */

--- a/src/lib/adnd/adnd_character_snapshot.ts
+++ b/src/lib/adnd/adnd_character_snapshot.ts
@@ -21,6 +21,7 @@
  */
 
 import type { RNG } from '@ironarachne/rng';
+import type { RulesetRef } from '$lib/rulesets';
 
 import type ADNDCharacter from './adndcharacter.js';
 import { createAdndCharacter } from './adndcharacter.js';
@@ -33,7 +34,14 @@ import * as races from './races/races.js';
  * A character as it is stored: everything `ADNDCharacter` holds, with its race and class written
  * as the names they are looked up by.
  */
+/** Stable identity for the pre-audit tables; it asserts no source or licence provenance. */
+export const ADND_CHARACTER_RULESET_REF = {
+  id: 'adnd-2e',
+  release: 'legacy',
+} as const satisfies RulesetRef;
+
 export type AdndCharacterSnapshot = Omit<ADNDCharacter, 'race' | 'class'> & {
+  ruleset: RulesetRef;
   raceName: string;
   className: string;
 };
@@ -130,6 +138,7 @@ export function toAdndCharacterSnapshot(character: ADNDCharacter): AdndCharacter
   const { race, class: characterClass, ...rest } = character;
   return {
     ...rest,
+    ruleset: ADND_CHARACTER_RULESET_REF,
     raceName: race?.name ?? '',
     className: characterClass?.name ?? '',
   };
@@ -144,7 +153,7 @@ export function toAdndCharacterSnapshot(character: ADNDCharacter): AdndCharacter
  * be regenerating over the user's edits — the one thing requirement 4.2 forbids.
  */
 export function adndCharacterFromSnapshot(snapshot: AdndCharacterSnapshot): ADNDCharacter {
-  const { raceName, className, ...rest } = snapshot;
+  const { ruleset: _ruleset, raceName, className, ...rest } = snapshot;
   const race = races.getAll().find((entry) => entry.name === raceName);
   const characterClass = classes.getAll().find((entry) => entry.name === className);
   const resolvedRace = race ?? unknownAdndRace(raceName);

--- a/src/lib/characters/character_artifact_kind.test.ts
+++ b/src/lib/characters/character_artifact_kind.test.ts
@@ -104,7 +104,26 @@ describe('validating a character payload', () => {
 });
 
 describe('migrating a character payload', () => {
-  it('rejects, because version 1 is the only shape there has been', () => {
+  it('copies actor mechanics and preserves user-edited prose exactly', () => {
+    const { mechanics: _mechanics, ...legacy } = snapshot();
+    legacy.description = 'A user-authored history that must survive.';
+    const result = migrateCharacterSnapshot(legacy, 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.description).toBe(legacy.description);
+      expect(result.value.mechanics.variants[0]).toMatchObject({
+        subject: 'actor',
+        origin: 'migrated',
+        payload: {
+          combatProfile: legacy.combatProfile,
+          actions: legacy.actions,
+        },
+      });
+    }
+  });
+
+  it('rejects an unsupported older version', () => {
     const result = migrateCharacterSnapshot(snapshot(), 0);
 
     expect(result.ok).toBe(false);

--- a/src/lib/characters/character_artifact_kind.ts
+++ b/src/lib/characters/character_artifact_kind.ts
@@ -8,6 +8,7 @@ import {
   rejectedPayload,
   type PayloadResult,
 } from '$lib/artifact_kinds';
+import { validateMechanicsSet, withLegacyActorMechanics } from '$lib/rulesets';
 
 import type { CharacterSnapshot } from './character_snapshot';
 import type { Character } from './character_types';
@@ -29,8 +30,8 @@ import type { Character } from './character_types';
  */
 export const CHARACTER_ARTIFACT_KIND = 'character' as const;
 
-/** Version 1. The first shape a fantasy character has been stored in. */
-export const CHARACTER_PAYLOAD_VERSION = 1 as const;
+/** Version 2 adds an Iron Arachne actor mechanics variant. */
+export const CHARACTER_PAYLOAD_VERSION = 2 as const;
 
 const CHARACTER_STRING_FIELDS = [
   'id',
@@ -191,6 +192,13 @@ export function validateCharacterSnapshot(payload: unknown): PayloadResult<Chara
   if (!isStringArray(record.tags)) {
     return rejectedPayload('invalid-payload', 'character tags is not an array of strings');
   }
+  const mechanics = validateMechanicsSet(record.mechanics, 'actor');
+  if (!mechanics.ok) {
+    return rejectedPayload(
+      'invalid-payload',
+      `character has invalid mechanics: ${mechanics.message}`,
+    );
+  }
 
   const checks: PayloadResult<unknown>[] = [
     validateNamedRecord(record.gender, 'gender'),
@@ -210,21 +218,21 @@ export function validateCharacterSnapshot(payload: unknown): PayloadResult<Chara
   return acceptedPayload(record as unknown as CharacterSnapshot);
 }
 
-/**
- * Characters have only ever been stored at version 1, so there is nothing older to bring forward
- * and this rejects rather than pretending. It is here because the contract requires it, and it is
- * where the step goes the day the shape changes — a kind without one looks complete right up until
- * it silently drops someone's work, and local-only means there is no server-side migration to fall
- * back on.
- */
+/** Copies version-1 actor mechanics into an Iron Arachne variant without recomputation. */
 export function migrateCharacterSnapshot(
-  _payload: unknown,
+  payload: unknown,
   from: number,
 ): PayloadResult<CharacterSnapshot> {
-  return rejectedPayload(
-    'unsupported-version',
-    `character has no migration from payload version ${from}; version ${CHARACTER_PAYLOAD_VERSION} is the only shape there has been`,
-  );
+  if (from !== 1) {
+    return rejectedPayload(
+      'unsupported-version',
+      `character has no migration from payload version ${from}; version 1 is the only older shape there has been`,
+    );
+  }
+  const record = asRecord(payload);
+  return record === null
+    ? rejectedPayload('invalid-payload', 'character payload is not an object')
+    : validateCharacterSnapshot(withLegacyActorMechanics(record, 'migrated'));
 }
 
 /** What to call a character that was saved without a name: what they are, which they always have. */

--- a/src/lib/characters/character_generation.ts
+++ b/src/lib/characters/character_generation.ts
@@ -16,6 +16,7 @@ import { generateHeraldry, getDefaultHeraldryGeneratorConfig } from '$lib/herald
 import { fantasyHintToNameSetName } from './character_name_generation';
 import { getStandardNobleTitles } from './titles';
 import { applyTagFilter } from '$lib/tags';
+import { withLegacyActorMechanics } from '$lib/rulesets';
 
 export function describe(character: Character, rng: RNG.RNG): string {
   let description = '';
@@ -201,7 +202,7 @@ export function generate(seed: string, config: CharacterGenerationConfig): Chara
 
   character.description = describe(character, rng);
 
-  return character;
+  return withLegacyActorMechanics(character, 'generated');
 }
 
 /**

--- a/src/lib/characters/character_snapshot.ts
+++ b/src/lib/characters/character_snapshot.ts
@@ -28,6 +28,7 @@
 import type { Archetype } from '$lib/archetypes';
 import { toStoredArms, type StoredArms } from '$lib/heraldry';
 import { stripFunctionValuesDeep } from '$lib/persistent_save';
+import { withLegacyActorMechanics, type MechanicsSet } from '$lib/rulesets';
 
 import type { Character } from './character_types.js';
 
@@ -45,8 +46,12 @@ export type StoredArchetype = Omit<Archetype, 'equipmentGenerationConfigs'>;
  * one name drifting apart the first time either changes. The move is what
  * `SETTLEMENT_PAYLOAD_VERSION` 2 migrates.
  */
-export type StoredCharacter = Omit<Character, 'species' | 'archetype' | 'heraldry'> & {
+export type StoredCharacter = Omit<
+  Character,
+  'species' | 'archetype' | 'heraldry' | 'mechanics'
+> & {
   speciesName: string;
+  mechanics: MechanicsSet;
   archetype?: StoredArchetype;
   /**
    * `undefined` for a character with no arms, a value for one carrying its own, and `null` for one
@@ -81,12 +86,15 @@ export function toStoredArchetype(archetype: Archetype): StoredArchetype {
  */
 export function toStoredCharacter(character: Character): StoredCharacter {
   const { species, archetype, heraldry, ...rest } = character;
-  return {
-    ...rest,
-    speciesName: species.name,
-    ...(archetype === undefined ? {} : { archetype: toStoredArchetype(archetype) }),
-    ...(heraldry === undefined ? {} : { heraldry: toStoredArms(heraldry) }),
-  };
+  return withLegacyActorMechanics(
+    {
+      ...rest,
+      speciesName: species.name,
+      ...(archetype === undefined ? {} : { archetype: toStoredArchetype(archetype) }),
+      ...(heraldry === undefined ? {} : { heraldry: toStoredArms(heraldry) }),
+    },
+    'generated',
+  ) as StoredCharacter;
 }
 
 /**

--- a/src/lib/creatures/creature_snapshot.ts
+++ b/src/lib/creatures/creature_snapshot.ts
@@ -23,12 +23,14 @@ import {
   rejectedPayload,
   type PayloadResult,
 } from '$lib/artifact_kinds';
+import { validateMechanicsSet, withLegacyActorMechanics, type MechanicsSet } from '$lib/rulesets';
 
 import type { Creature } from './creature_types.js';
 
 /** A creature with its species written as a name. */
-export type StoredCreature = Omit<Creature, 'species'> & {
+export type StoredCreature = Omit<Creature, 'species' | 'mechanics'> & {
   speciesName: string;
+  mechanics: MechanicsSet;
 };
 
 /**
@@ -39,7 +41,10 @@ export type StoredCreature = Omit<Creature, 'species'> & {
  */
 export function toStoredCreature(creature: Creature): StoredCreature {
   const { species, ...rest } = creature;
-  return { ...rest, speciesName: species.name };
+  return withLegacyActorMechanics(
+    { ...rest, speciesName: species.name },
+    'generated',
+  ) as StoredCreature;
 }
 
 const CREATURE_STRING_FIELDS = ['id', 'name', 'description', 'shortDescription', 'speciesName'];
@@ -104,6 +109,13 @@ export function validateStoredCreature(payload: unknown): PayloadResult<StoredCr
       return rejectedPayload('invalid-payload', `creature ${field} is not a list of named entries`);
     }
   }
+  const mechanics = validateMechanicsSet(record.mechanics, 'actor');
+  if (!mechanics.ok) {
+    return rejectedPayload(
+      'invalid-payload',
+      `creature has invalid mechanics: ${mechanics.message}`,
+    );
+  }
 
-  return acceptedPayload(record as unknown as StoredCreature);
+  return acceptedPayload({ ...record, mechanics: mechanics.value } as unknown as StoredCreature);
 }

--- a/src/lib/creatures/creatures.ts
+++ b/src/lib/creatures/creatures.ts
@@ -2,6 +2,7 @@ import * as RNG from '@ironarachne/rng';
 import { AgeCategories } from '$lib/age';
 import * as CombatSystem from '$lib/combat_system';
 import { CommonSpecies } from '$lib/species';
+import { withLegacyActorMechanics } from '$lib/rulesets';
 import { getSizeConfig } from '$lib/size';
 import type { Creature } from './creature_types';
 import type { CreatureGenerationConfig } from './creature_types';
@@ -61,7 +62,7 @@ export function generate(seed: string, config: CreatureGenerationConfig): Creatu
     creatureTypes: creatureSpecies.creatureTypes,
   };
 
-  return creature;
+  return withLegacyActorMechanics(creature, 'generated');
 }
 
 export function getDefaultCreatureGenerationConfig(): CreatureGenerationConfig {

--- a/src/lib/dcc/dcc_character_artifact_kind.test.ts
+++ b/src/lib/dcc/dcc_character_artifact_kind.test.ts
@@ -11,6 +11,7 @@ import {
 } from './dcc_character_artifact_kind.js';
 import { rollDccCharacter, rollDccCharacterSnapshot } from './dcc_character_roll.js';
 import type { DccCharacterSnapshot } from './dcc_character_snapshot.js';
+import { DCC_CHARACTER_RULESET_REF } from './dcc_character_snapshot.js';
 
 /** A stored payload, as anything reading one actually receives it. */
 function storedSnapshot(seed = 'kind-fixture'): Record<string, unknown> {
@@ -150,7 +151,18 @@ describe('validating a DCC character payload', () => {
 });
 
 describe('migrating a DCC character payload', () => {
-  it('rejects, because version 1 is the only shape there has been', () => {
+  it('pins the legacy ruleset ref without inventing source provenance', () => {
+    const { ruleset: _ruleset, ...legacy } = snapshot;
+    const result = migrateDccCharacterSnapshot(legacy, 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({ ...legacy, ruleset: DCC_CHARACTER_RULESET_REF });
+      expect(result.value).not.toHaveProperty('sourceIds');
+    }
+  });
+
+  it('rejects an unsupported version', () => {
     const result = migrateDccCharacterSnapshot(snapshot, 0);
 
     expect(result.ok).toBe(false);

--- a/src/lib/dcc/dcc_character_artifact_kind.ts
+++ b/src/lib/dcc/dcc_character_artifact_kind.ts
@@ -9,7 +9,7 @@ import {
   type PayloadResult,
 } from '$lib/artifact_kinds';
 
-import type { DccCharacterSnapshot } from './dcc_character_snapshot';
+import { DCC_CHARACTER_RULESET_REF, type DccCharacterSnapshot } from './dcc_character_snapshot';
 import type { DCCCharacter } from './dcc_types';
 
 /**
@@ -29,8 +29,17 @@ import type { DCCCharacter } from './dcc_types';
  */
 export const DCC_CHARACTER_ARTIFACT_KIND = 'character.dcc' as const;
 
-/** Version 1. The first shape a DCC character has been stored in. */
-export const DCC_CHARACTER_PAYLOAD_VERSION = 1 as const;
+/** Version 2 pins the ruleset identity without claiming unaudited source provenance. */
+export const DCC_CHARACTER_PAYLOAD_VERSION = 2 as const;
+
+function hasDccRulesetRef(value: unknown): boolean {
+  const ref = asRecord(value);
+  return (
+    ref !== null &&
+    ref.id === DCC_CHARACTER_RULESET_REF.id &&
+    ref.release === DCC_CHARACTER_RULESET_REF.release
+  );
+}
 
 const CHARACTER_STRING_FIELDS = ['firstName', 'lastName', 'gender', 'alignment'];
 
@@ -169,6 +178,9 @@ export function validateDccCharacterSnapshot(
       `DCC character payload needs numeric ${CHARACTER_NUMBER_FIELDS.join(', ')}`,
     );
   }
+  if (!hasDccRulesetRef(record.ruleset)) {
+    return rejectedPayload('invalid-payload', 'DCC character has no supported ruleset ref');
+  }
 
   const checks: PayloadResult<unknown>[] = [
     validateAttributes(record),
@@ -188,21 +200,21 @@ export function validateDccCharacterSnapshot(
   return acceptedPayload(record as unknown as DccCharacterSnapshot);
 }
 
-/**
- * There has only ever been version 1, so this rejects rather than pretending otherwise.
- *
- * It is here because the contract requires it, and it is where the first real step goes the day the
- * shape changes. A kind without one looks complete right up until it silently drops someone's work
- * — and local-only means there is no server-side migration to fall back on.
- */
+/** Adds only the pinned system identity; every existing system-owned field remains untouched. */
 export function migrateDccCharacterSnapshot(
-  _payload: unknown,
+  payload: unknown,
   from: number,
 ): PayloadResult<DccCharacterSnapshot> {
-  return rejectedPayload(
-    'unsupported-version',
-    `DCC character has no migration from payload version ${from}; version ${DCC_CHARACTER_PAYLOAD_VERSION} is the only shape there has been`,
-  );
+  if (from !== 1) {
+    return rejectedPayload(
+      'unsupported-version',
+      `DCC character has no migration from payload version ${from}; version 1 is the only older shape there has been`,
+    );
+  }
+  const record = asRecord(payload);
+  return record === null
+    ? rejectedPayload('invalid-payload', 'DCC character payload is not an object')
+    : validateDccCharacterSnapshot({ ...record, ruleset: DCC_CHARACTER_RULESET_REF });
 }
 
 /** What to call a character that was saved unnamed: their occupation, which they always have. */

--- a/src/lib/dcc/dcc_character_snapshot.ts
+++ b/src/lib/dcc/dcc_character_snapshot.ts
@@ -34,6 +34,7 @@
  */
 
 import type { RNG } from '@ironarachne/rng';
+import type { RulesetRef } from '$lib/rulesets';
 
 import type { DCCCharacter, DCCLuckyRoll, DCCOccupation } from './dcc_types.js';
 import * as DwarfOccupations from './dwarf_occupations.js';
@@ -49,7 +50,14 @@ export type StoredDccOccupation = Omit<DCCOccupation, 'apply'>;
 export type StoredDccLuckyRoll = Omit<DCCLuckyRoll, 'apply'>;
 
 /** A DCC character as it is stored. */
+/** Stable identity for the pre-audit tables; it asserts no source or licence provenance. */
+export const DCC_CHARACTER_RULESET_REF = {
+  id: 'dcc',
+  release: 'legacy',
+} as const satisfies RulesetRef;
+
 export type DccCharacterSnapshot = Omit<DCCCharacter, 'occupation' | 'luckyRoll'> & {
+  ruleset: RulesetRef;
   occupation: StoredDccOccupation;
   luckyRoll: StoredDccLuckyRoll;
 };
@@ -98,7 +106,12 @@ export function toDccCharacterSnapshot(character: DCCCharacter): DccCharacterSna
   const { occupation, luckyRoll, ...rest } = character;
   const { apply: _occupationApply, ...storedOccupation } = occupation;
   const { apply: _luckyApply, ...storedLuckyRoll } = luckyRoll;
-  return { ...rest, occupation: storedOccupation, luckyRoll: storedLuckyRoll };
+  return {
+    ...rest,
+    ruleset: DCC_CHARACTER_RULESET_REF,
+    occupation: storedOccupation,
+    luckyRoll: storedLuckyRoll,
+  };
 }
 
 /**
@@ -109,7 +122,7 @@ export function toDccCharacterSnapshot(character: DCCCharacter): DccCharacterSna
  * docs/workshop.md.
  */
 export function dccCharacterFromSnapshot(snapshot: DccCharacterSnapshot): DCCCharacter {
-  const { occupation, luckyRoll, ...rest } = snapshot;
+  const { ruleset: _ruleset, occupation, luckyRoll, ...rest } = snapshot;
   return {
     ...rest,
     occupation: { ...occupation, apply: occupationApplyFor(occupation.name) },

--- a/src/lib/dungeon/README.md
+++ b/src/lib/dungeon/README.md
@@ -65,7 +65,7 @@ face, where the seven subsystems above are how it works inside.
   never the drawing. The two halves are split because reading rebuilds every room's encounter and
   reaches the archetype tables and the charge art through it; writing, listing and validating reach
   none of that.
-- **`dungeon_artifact_kind.ts`**: kind `dungeon`, payload version 1, with the validator and the
+- **`dungeon_artifact_kind.ts`**: kind `dungeon`, payload version 2, with the validator and the
   migration stub. Metadata and validation only; the codec is a dynamic import.
 - **`dungeon_editing.ts`**: pure snapshot-to-snapshot field edits — the dungeon's name and
   blueprint, and per room the name, purpose, description, encounter, combatants, treasure and keys.

--- a/src/lib/dungeon/dungeon_artifact_kind.test.ts
+++ b/src/lib/dungeon/dungeon_artifact_kind.test.ts
@@ -128,9 +128,27 @@ describe('validating a stored dungeon', () => {
 });
 
 describe('migrating a stored dungeon (7.3)', () => {
-  it('rejects every version, because version 1 is the only shape there has been', () => {
-    // The whole of this kind's migration story today, asserted so that the day a version 2 lands
-    // this test is what has to change rather than something that silently drops a user's dungeon.
+  it('migrates every nested encounter actor without changing room prose', () => {
+    const legacy = JSON.parse(JSON.stringify(snapshot), (key, value) =>
+      key === 'mechanics' ? undefined : value,
+    ) as DungeonSnapshot;
+    const result = migrateDungeonSnapshot(legacy, 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.rooms.map((room) => room.description)).toEqual(
+        snapshot.rooms.map((room) => room.description),
+      );
+      const mob = result.value.rooms
+        .flatMap((room) => room.encounter?.groups ?? [])
+        .flatMap((group) => group.mobs)[0];
+      if (mob !== undefined) {
+        expect(mob.mechanics.variants[0]).toMatchObject({ origin: 'migrated' });
+      }
+    }
+  });
+
+  it('rejects an unsupported migration version', () => {
     const result = migrateDungeonSnapshot(snapshot as unknown as DungeonSnapshot, 0);
     expect(result).toMatchObject({ ok: false, reason: 'unsupported-version' });
     expect(result.ok ? '' : result.message).toContain('version 0');

--- a/src/lib/dungeon/dungeon_artifact_kind.ts
+++ b/src/lib/dungeon/dungeon_artifact_kind.ts
@@ -11,7 +11,10 @@ import {
 // reaches the encounter generator and from there the species and archetype tables. This module is
 // metadata and validation only, and the registry that imports it is loaded by any page that lists
 // what a project contains.
-import { validateEncounterSnapshot } from '$lib/encounters/encounter_artifact_kind';
+import {
+  migrateEncounterSnapshot,
+  validateEncounterSnapshot,
+} from '$lib/encounters/encounter_artifact_kind';
 
 import type { DungeonSnapshot } from './dungeon_snapshot.js';
 import type { EngineeredDungeon } from './generator/types.js';
@@ -22,8 +25,8 @@ import type { EngineeredDungeon } from './generator/types.js';
  */
 export const DUNGEON_ARTIFACT_KIND = 'dungeon' as const;
 
-/** Version 1. The first shape a dungeon has been stored in. */
-export const DUNGEON_PAYLOAD_VERSION = 1 as const;
+/** Version 2 composes the actor migration through every room encounter. */
+export const DUNGEON_PAYLOAD_VERSION = 2 as const;
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
@@ -244,21 +247,34 @@ export function validateDungeonSnapshot(payload: unknown): PayloadResult<Dungeon
   return acceptedPayload(record as unknown as DungeonSnapshot);
 }
 
-/**
- * There has only ever been version 1, so this rejects rather than pretending otherwise.
- *
- * It is here because the contract requires it, and it is where the first real step goes the day the
- * shape changes — a kind without one looks complete right up until it silently drops someone's
- * work, and local-only means there is no server-side migration to fall back on.
- */
+/** Composes the encounter migration through every populated room. */
 export function migrateDungeonSnapshot(
-  _payload: unknown,
+  payload: unknown,
   from: number,
 ): PayloadResult<DungeonSnapshot> {
-  return rejectedPayload(
-    'unsupported-version',
-    `Dungeons have no migration from payload version ${from}; version ${DUNGEON_PAYLOAD_VERSION} is the only shape there has been`,
-  );
+  if (from !== 1) {
+    return rejectedPayload(
+      'unsupported-version',
+      `Dungeons have no migration from payload version ${from}; version 1 is the only older shape there has been`,
+    );
+  }
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'dungeon payload is not an object');
+  }
+  return validateDungeonSnapshot({
+    ...record,
+    rooms: Array.isArray(record.rooms)
+      ? record.rooms.map((room) => {
+          const storedRoom = asRecord(room);
+          if (storedRoom === null || storedRoom.encounter === undefined) {
+            return room;
+          }
+          const migrated = migrateEncounterSnapshot(storedRoom.encounter, 1);
+          return { ...storedRoom, encounter: migrated.ok ? migrated.value : storedRoom.encounter };
+        })
+      : record.rooms,
+  });
 }
 
 /** What to call a saved dungeon: its name, or the kind when the name has been emptied. */

--- a/src/lib/encounters/encounter_artifact_kind.test.ts
+++ b/src/lib/encounters/encounter_artifact_kind.test.ts
@@ -22,6 +22,16 @@ const beasts = JSON.parse(
 
 const groups = people.groups as { mobs: Record<string, unknown>[] }[];
 
+function withoutMechanics(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutMechanics);
+  if (typeof value !== 'object' || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, entry]) =>
+      key === 'mechanics' ? [] : [[key, withoutMechanics(entry)]],
+    ),
+  );
+}
+
 describe('the encounter artifact kind', () => {
   it('is registered under its own unqualified name', () => {
     expect(ENCOUNTER_ARTIFACT_KIND).toBe('encounter');
@@ -109,7 +119,20 @@ describe('the encounter artifact kind', () => {
     ).toBe(false);
   });
 
-  it('has no migration to offer, and says so rather than guessing', () => {
+  it('migrates character and creature mobs through the shared actor helper', () => {
+    for (const legacy of [withoutMechanics(people), withoutMechanics(beasts)]) {
+      const result = migrateEncounterSnapshot(legacy, 1);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.groups[0].mobs[0].mechanics.variants[0]).toMatchObject({
+          subject: 'actor',
+          origin: 'migrated',
+        });
+      }
+    }
+  });
+
+  it('rejects an unsupported migration version', () => {
     const result = migrateEncounterSnapshot(people, 0);
 
     expect(result.ok).toBe(false);

--- a/src/lib/encounters/encounter_artifact_kind.ts
+++ b/src/lib/encounters/encounter_artifact_kind.ts
@@ -10,6 +10,7 @@ import {
 } from '$lib/artifact_kinds';
 import { validateCharacterSnapshot } from '$lib/characters/character_artifact_kind';
 import { validateStoredCreature } from '$lib/creatures/creature_snapshot';
+import { withLegacyActorMechanics } from '$lib/rulesets';
 
 import type { EncounterSnapshot } from './encounter_snapshot';
 import type { Encounter } from './encounter_types';
@@ -20,8 +21,8 @@ import type { Encounter } from './encounter_types';
  */
 export const ENCOUNTER_ARTIFACT_KIND = 'encounter' as const;
 
-/** Version 1. The first shape an encounter has been stored in. */
-export const ENCOUNTER_PAYLOAD_VERSION = 1 as const;
+/** Version 2 qualifies every character and creature mob's compatibility mechanics. */
+export const ENCOUNTER_PAYLOAD_VERSION = 2 as const;
 
 /**
  * One stored mob, checked by the validator of the vocabulary type it says it is.
@@ -96,21 +97,39 @@ export function validateEncounterSnapshot(payload: unknown): PayloadResult<Encou
   return acceptedPayload(record as unknown as EncounterSnapshot);
 }
 
-/**
- * There has only ever been version 1, so this rejects rather than pretending otherwise.
- *
- * It is here because the contract requires it, and it is where the first real step goes the day the
- * shape changes — a kind without one looks complete right up until it silently drops someone's
- * work, and local-only means there is no server-side migration to fall back on.
- */
+/** Qualifies every stored mob without changing encounter groups or prose. */
 export function migrateEncounterSnapshot(
-  _payload: unknown,
+  payload: unknown,
   from: number,
 ): PayloadResult<EncounterSnapshot> {
-  return rejectedPayload(
-    'unsupported-version',
-    `Encounters have no migration from payload version ${from}; version ${ENCOUNTER_PAYLOAD_VERSION} is the only shape there has been`,
-  );
+  if (from !== 1) {
+    return rejectedPayload(
+      'unsupported-version',
+      `Encounters have no migration from payload version ${from}; version 1 is the only older shape there has been`,
+    );
+  }
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'encounter payload is not an object');
+  }
+  return validateEncounterSnapshot({
+    ...record,
+    groups: Array.isArray(record.groups)
+      ? record.groups.map((group) => {
+          const storedGroup = asRecord(group);
+          if (storedGroup === null || !Array.isArray(storedGroup.mobs)) {
+            return group;
+          }
+          return {
+            ...storedGroup,
+            mobs: storedGroup.mobs.map((mob) => {
+              const storedMob = asRecord(mob);
+              return storedMob === null ? mob : withLegacyActorMechanics(storedMob, 'migrated');
+            }),
+          };
+        })
+      : record.groups,
+  });
 }
 
 /** What to call a saved encounter: its name, or the kind when the name has been emptied. */

--- a/src/lib/equipment/armor.ts
+++ b/src/lib/equipment/armor.ts
@@ -1,4 +1,5 @@
 import * as RNG from '@ironarachne/rng';
+import { withLegacyItemMechanics } from '$lib/rulesets';
 import type { Armor, ArmorType } from './equipment_types';
 import { applyMaterial, getRandomMaterialForItem } from './foundry';
 
@@ -133,7 +134,7 @@ export function generateArmor(seed: string): Armor {
   const material = getRandomMaterialForItem(baseArmor, rng);
   const foundryArmor = applyMaterial(baseArmor, material) as Armor;
 
-  return foundryArmor;
+  return withLegacyItemMechanics(foundryArmor, 'generated');
 }
 
 export function getValueOfArmorType(type: ArmorType): number {

--- a/src/lib/equipment/equipment_types.ts
+++ b/src/lib/equipment/equipment_types.ts
@@ -110,7 +110,7 @@ export type Item = {
   weight: number; // Weight in kg
   properties: string[];
   containerId?: string; // The ID of the container holding this item
-  /** Ruleset-qualified mechanics. Optional until the payload migrations in #209 land. */
+  /** Ruleset-qualified mechanics. Optional while remaining live consumers transition in #213. */
   mechanics?: MechanicsSet;
   /** @deprecated Compatibility field for Iron Arachne mechanics; see #210 and #213. */
   combatProfile?: CombatProfile;

--- a/src/lib/equipment/generation.ts
+++ b/src/lib/equipment/generation.ts
@@ -1,5 +1,6 @@
 import * as RNG from '@ironarachne/rng';
 import * as MUN from '@ironarachne/made-up-names';
+import { withLegacyItemMechanics } from '$lib/rulesets';
 import {
   type Item,
   type Weapon,
@@ -198,7 +199,7 @@ export function generateItem(seed: string, config: EquipmentGenerationConfig): I
   item.value = roundValue(item.value);
   item.description = generateDescription(item);
 
-  return item;
+  return withLegacyItemMechanics(item, 'generated');
 }
 
 export function getDefaultGenerationConfig(): EquipmentGenerationConfig {

--- a/src/lib/equipment/item_artifact_kind.test.ts
+++ b/src/lib/equipment/item_artifact_kind.test.ts
@@ -33,7 +33,7 @@ describe('itemArtifactKind', () => {
     expect(itemArtifactKind.kind).toBe(ITEM_ARTIFACT_KIND);
     expect(ITEM_ARTIFACT_KIND).toBe('item');
     expect(itemArtifactKind.payloadVersion).toBe(ITEM_PAYLOAD_VERSION);
-    expect(ITEM_PAYLOAD_VERSION).toBe(1);
+    expect(ITEM_PAYLOAD_VERSION).toBe(2);
   });
 
   it('loads a codec that round-trips', async () => {
@@ -102,12 +102,54 @@ describe('validateItemSnapshot', () => {
     expect(accepted({ ...ITEM, uniqueName: '' }).uniqueName).toBeUndefined();
     expect(accepted({ ...ITEM, itemMinorType: '' }).itemMinorType).toBeUndefined();
   });
+
+  it('rejects unknown ruleset data without changing the payload kept for quarantine', () => {
+    const payload = {
+      ...ITEM,
+      mechanics: {
+        variants: [
+          {
+            ruleset: { id: 'future-system', release: '9' },
+            subject: 'item',
+            schemaVersion: 4,
+            origin: 'user',
+            sourceIds: ['future.source'],
+            payload: { edited: 'keep this exactly' },
+          },
+        ],
+      },
+    };
+    const before = structuredClone(payload);
+
+    expect(validateItemSnapshot(payload)).toMatchObject({ ok: false, reason: 'invalid-payload' });
+    expect(payload).toEqual(before);
+  });
 });
 
 describe('migrateItemSnapshot', () => {
+  it('copies legacy mechanics and user-edited prose without recomputation', () => {
+    const { mechanics: _mechanics, ...legacy } = {
+      ...ITEM,
+      name: 'hand-edited sword',
+      description: 'Kept exactly as written.',
+      value: 317,
+    };
+    const result = migrateItemSnapshot(legacy, 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.name).toBe('hand-edited sword');
+      expect(result.value.description).toBe('Kept exactly as written.');
+      expect(result.value.value).toBe(317);
+      expect(result.value.mechanics.variants[0]).toMatchObject({
+        subject: 'item',
+        origin: 'migrated',
+        payload: { value: 317 },
+      });
+    }
+  });
+
   it('rejects rather than pretending there has been another shape', () => {
-    // Requirement 7.3 has one step to exercise and it is the absence of one: version 1 is the only
-    // shape there has been, and a migration that quietly accepted anything would be worse than none.
     const result = migrateItemSnapshot({ name: 'sword' }, 0);
 
     expect(result.ok).toBe(false);

--- a/src/lib/equipment/item_artifact_kind.ts
+++ b/src/lib/equipment/item_artifact_kind.ts
@@ -7,6 +7,7 @@ import {
   rejectedPayload,
   type PayloadResult,
 } from '$lib/artifact_kinds';
+import { validateMechanicsSet, withLegacyItemMechanics } from '$lib/rulesets';
 
 import {
   DEFAULT_ITEM_DENSITY,
@@ -29,8 +30,8 @@ import type { DensityCategory, Rarity } from './equipment_types';
  */
 export const ITEM_ARTIFACT_KIND = 'item' as const;
 
-/** Version 1. The first shape an item has been stored in. */
-export const ITEM_PAYLOAD_VERSION = 1 as const;
+/** Version 2 adds ruleset-qualified mechanics while retaining transitional compatibility fields. */
+export const ITEM_PAYLOAD_VERSION = 2 as const;
 
 function isRarity(value: unknown): value is Rarity {
   return typeof value === 'string' && (ITEM_RARITIES as string[]).includes(value);
@@ -93,6 +94,13 @@ export function validateItemSnapshot(payload: unknown): PayloadResult<ItemSnapsh
   const combatProfile = optionalRecord<ItemSnapshot['combatProfile']>(record.combatProfile);
   const uniqueName = optionalText(record.uniqueName);
   const itemMinorType = optionalText(record.itemMinorType);
+  const mechanics = validateMechanicsSet(record.mechanics, 'item');
+  if (!mechanics.ok) {
+    return rejectedPayload(
+      'invalid-payload',
+      `Item payload has invalid mechanics: ${mechanics.message}`,
+    );
+  }
 
   return acceptedPayload({
     id: record.id as string,
@@ -108,6 +116,7 @@ export function validateItemSnapshot(payload: unknown): PayloadResult<ItemSnapsh
       : DEFAULT_ITEM_DENSITY,
     weight: record.weight as number,
     properties: isStringArray(record.properties) ? record.properties : [],
+    mechanics: mechanics.value,
     ...(combatProfile.present ? { combatProfile: combatProfile.value } : {}),
     ...(Array.isArray(record.actions)
       ? { actions: record.actions as ItemSnapshot['actions'] }
@@ -119,18 +128,18 @@ export function validateItemSnapshot(payload: unknown): PayloadResult<ItemSnapsh
   } as ItemSnapshot);
 }
 
-/**
- * There has only ever been version 1, so this rejects rather than pretending otherwise.
- *
- * It is here because the contract requires it, and it is where the first real step goes the day
- * the shape changes — a kind without one looks complete right up until it silently drops someone's
- * work, and local-only means there is no server-side migration to fall back on.
- */
-export function migrateItemSnapshot(_payload: unknown, from: number): PayloadResult<ItemSnapshot> {
-  return rejectedPayload(
-    'unsupported-version',
-    `Items have no migration from payload version ${from}; version ${ITEM_PAYLOAD_VERSION} is the only shape there has been`,
-  );
+/** Copies the version-1 mechanical fields into an Iron Arachne item variant. */
+export function migrateItemSnapshot(payload: unknown, from: number): PayloadResult<ItemSnapshot> {
+  if (from !== 1) {
+    return rejectedPayload(
+      'unsupported-version',
+      `Items have no migration from payload version ${from}; version 1 is the only older shape there has been`,
+    );
+  }
+  const record = asRecord(payload);
+  return record === null
+    ? rejectedPayload('invalid-payload', 'Item payload is not an object')
+    : validateItemSnapshot(withLegacyItemMechanics(record, 'migrated'));
 }
 
 /**

--- a/src/lib/equipment/item_presentation.test.ts
+++ b/src/lib/equipment/item_presentation.test.ts
@@ -96,6 +96,7 @@ describe('itemToMarkdown', () => {
       densityCategory: 'standard',
       weight: 0,
       properties: [],
+      mechanics: { variants: [] },
     };
 
     expect(itemToMarkdown(bare)).toBe(

--- a/src/lib/equipment/item_snapshot.ts
+++ b/src/lib/equipment/item_snapshot.ts
@@ -30,6 +30,7 @@ import type {
   CombatProfile,
   DamageType as CombatDamageType,
 } from '$lib/combat_system';
+import { withLegacyItemMechanics, type MechanicsSet } from '$lib/rulesets';
 
 import type {
   DensityCategory,
@@ -68,6 +69,7 @@ export type ItemSnapshot = {
   densityCategory: DensityCategory;
   weight: number;
   properties: string[];
+  mechanics: MechanicsSet;
   combatProfile?: CombatProfile;
   /** A weapon's attacks. Absent on armour and on anything else. */
   actions?: CombatAction[];
@@ -90,25 +92,28 @@ export const DEFAULT_ITEM_RARITY: Rarity = 'common';
 export const DEFAULT_ITEM_DENSITY: DensityCategory = 'standard';
 
 export function toItemSnapshot(item: RolledItem): ItemSnapshot {
-  return {
-    id: item.id,
-    name: item.name,
-    ...(item.uniqueName === undefined ? {} : { uniqueName: item.uniqueName }),
-    itemMajorType: item.itemMajorType,
-    ...(item.itemMinorType === undefined ? {} : { itemMinorType: item.itemMinorType }),
-    description: item.description,
-    value: item.value,
-    rarity: item.rarity,
-    densityCategory: item.densityCategory,
-    weight: item.weight,
-    properties: [...item.properties],
-    ...(item.combatProfile === undefined ? {} : { combatProfile: { ...item.combatProfile } }),
-    ...(item.actions === undefined ? {} : { actions: item.actions.map(copyAction) }),
-    ...(item.material === undefined ? {} : { material: { ...item.material } }),
-    ...(item.refinement === undefined ? {} : { refinement: { ...item.refinement } }),
-    ...(item.enchantment === undefined ? {} : { enchantment: { ...item.enchantment } }),
-    ...(item.decoration === undefined ? {} : { decoration: { ...item.decoration } }),
-  };
+  return withLegacyItemMechanics(
+    {
+      id: item.id,
+      name: item.name,
+      ...(item.uniqueName === undefined ? {} : { uniqueName: item.uniqueName }),
+      itemMajorType: item.itemMajorType,
+      ...(item.itemMinorType === undefined ? {} : { itemMinorType: item.itemMinorType }),
+      description: item.description,
+      value: item.value,
+      rarity: item.rarity,
+      densityCategory: item.densityCategory,
+      weight: item.weight,
+      properties: [...item.properties],
+      ...(item.combatProfile === undefined ? {} : { combatProfile: { ...item.combatProfile } }),
+      ...(item.actions === undefined ? {} : { actions: item.actions.map(copyAction) }),
+      ...(item.material === undefined ? {} : { material: { ...item.material } }),
+      ...(item.refinement === undefined ? {} : { refinement: { ...item.refinement } }),
+      ...(item.enchantment === undefined ? {} : { enchantment: { ...item.enchantment } }),
+      ...(item.decoration === undefined ? {} : { decoration: { ...item.decoration } }),
+    },
+    'generated',
+  ) as ItemSnapshot;
 }
 
 function copyAction(action: CombatAction): CombatAction {

--- a/src/lib/equipment/weapons.ts
+++ b/src/lib/equipment/weapons.ts
@@ -1,4 +1,5 @@
 import * as RNG from '@ironarachne/rng';
+import { withLegacyItemMechanics } from '$lib/rulesets';
 import type { Weapon, WeaponType } from './equipment_types';
 import { applyMaterial, getRandomMaterialForItem } from './foundry';
 
@@ -295,5 +296,5 @@ export function generateWeapon(seed: string): Weapon {
   const material = getRandomMaterialForItem(baseWeapon, rng);
   const foundryWeapon = applyMaterial(baseWeapon, material) as Weapon;
 
-  return foundryWeapon;
+  return withLegacyItemMechanics(foundryWeapon, 'generated');
 }

--- a/src/lib/families/family_artifact_kind.test.ts
+++ b/src/lib/families/family_artifact_kind.test.ts
@@ -20,6 +20,16 @@ const snapshot = JSON.parse(
 const members = snapshot.members as Record<string, unknown>[];
 const relationships = snapshot.relationships as Record<string, unknown>[];
 
+function withoutMechanics(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutMechanics);
+  if (typeof value !== 'object' || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, entry]) =>
+      key === 'mechanics' ? [] : [[key, withoutMechanics(entry)]],
+    ),
+  );
+}
+
 describe('the family artifact kind', () => {
   it('is registered under its own unqualified name', () => {
     expect(FAMILY_ARTIFACT_KIND).toBe('family');
@@ -108,7 +118,17 @@ describe('the family artifact kind', () => {
     ).toBe(true);
   });
 
-  it('has no migration to offer, and says so rather than guessing', () => {
+  it('migrates every member through the shared actor helper', () => {
+    const result = migrateFamilySnapshot(withoutMechanics(snapshot), 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.name).toBe(snapshot.name);
+      expect(result.value.members[0].mechanics.variants[0]).toMatchObject({ origin: 'migrated' });
+    }
+  });
+
+  it('rejects an unsupported migration version', () => {
     const result = migrateFamilySnapshot(snapshot, 0);
 
     expect(result.ok).toBe(false);

--- a/src/lib/families/family_artifact_kind.ts
+++ b/src/lib/families/family_artifact_kind.ts
@@ -8,6 +8,7 @@ import {
   rejectedPayload,
   type PayloadResult,
 } from '$lib/artifact_kinds';
+import { withLegacyActorMechanics } from '$lib/rulesets';
 import { validateCharacterSnapshot } from '$lib/characters/character_artifact_kind';
 
 import type { FamilySnapshot } from './family_snapshot';
@@ -19,8 +20,8 @@ import type { Family } from './family_types';
  */
 export const FAMILY_ARTIFACT_KIND = 'family' as const;
 
-/** Version 1. The first shape a family has been stored in. */
-export const FAMILY_PAYLOAD_VERSION = 1 as const;
+/** Version 2 qualifies every family member's compatibility mechanics. */
+export const FAMILY_PAYLOAD_VERSION = 2 as const;
 
 /** A pattern source: a list of patterns, or patterns with combinations. */
 function isPatternSource(value: unknown): boolean {
@@ -104,21 +105,30 @@ export function validateFamilySnapshot(payload: unknown): PayloadResult<FamilySn
   return acceptedPayload(record as unknown as FamilySnapshot);
 }
 
-/**
- * There has only ever been version 1, so this rejects rather than pretending otherwise.
- *
- * It is here because the contract requires it, and it is where the first real step goes the day the
- * shape changes — a kind without one looks complete right up until it silently drops someone's
- * work, and local-only means there is no server-side migration to fall back on.
- */
+/** Qualifies every embedded member without changing the family graph or prose. */
 export function migrateFamilySnapshot(
-  _payload: unknown,
+  payload: unknown,
   from: number,
 ): PayloadResult<FamilySnapshot> {
-  return rejectedPayload(
-    'unsupported-version',
-    `Families have no migration from payload version ${from}; version ${FAMILY_PAYLOAD_VERSION} is the only shape there has been`,
-  );
+  if (from !== 1) {
+    return rejectedPayload(
+      'unsupported-version',
+      `Families have no migration from payload version ${from}; version 1 is the only older shape there has been`,
+    );
+  }
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'family payload is not an object');
+  }
+  return validateFamilySnapshot({
+    ...record,
+    members: Array.isArray(record.members)
+      ? record.members.map((member) => {
+          const person = asRecord(member);
+          return person === null ? member : withLegacyActorMechanics(person, 'migrated');
+        })
+      : record.members,
+  });
 }
 
 /** What to call a saved family: "the X family", as the page heads it. */

--- a/src/lib/organizations/organization_artifact_kind.test.ts
+++ b/src/lib/organizations/organization_artifact_kind.test.ts
@@ -27,6 +27,16 @@ const marked = JSON.parse(
 const identity = heraldic.visualIdentity as Record<string, unknown>;
 const profile = heraldic.profile as Record<string, unknown>;
 
+function withoutMechanics(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutMechanics);
+  if (typeof value !== 'object' || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, entry]) =>
+      key === 'mechanics' ? [] : [[key, withoutMechanics(entry)]],
+    ),
+  );
+}
+
 describe('the organization artifact kind', () => {
   it('is registered under its own unqualified name, apart from the organization kind registry', () => {
     expect(ORGANIZATION_ARTIFACT_KIND).toBe('organization');
@@ -136,7 +146,20 @@ describe('the organization artifact kind', () => {
     ).toBe(false);
   });
 
-  it('has no migration to offer, and says so rather than guessing', () => {
+  it('migrates every embedded person through the shared actor helper', () => {
+    const result = migrateOrganizationSnapshot(withoutMechanics(heraldic), 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.name).toBe(heraldic.name);
+      expect(result.value.leader.mechanics.variants[0]).toMatchObject({ origin: 'migrated' });
+      expect(result.value.notableMembers[0].mechanics.variants[0]).toMatchObject({
+        origin: 'migrated',
+      });
+    }
+  });
+
+  it('rejects an unsupported migration version', () => {
     const result = migrateOrganizationSnapshot(heraldic, 0);
 
     expect(result.ok).toBe(false);

--- a/src/lib/organizations/organization_artifact_kind.ts
+++ b/src/lib/organizations/organization_artifact_kind.ts
@@ -7,6 +7,7 @@ import {
   rejectedPayload,
   type PayloadResult,
 } from '$lib/artifact_kinds';
+import { withLegacyActorMechanics } from '$lib/rulesets';
 import { validateCharacterSnapshot } from '$lib/characters/character_artifact_kind';
 
 import type { OrganizationSnapshot } from './organization_snapshot';
@@ -21,8 +22,8 @@ import type { Organization } from './organization_types';
  */
 export const ORGANIZATION_ARTIFACT_KIND = 'organization' as const;
 
-/** Version 1. The first shape an organization has been stored on its own in. */
-export const ORGANIZATION_PAYLOAD_VERSION = 1 as const;
+/** Version 2 qualifies the leader and notable members' compatibility mechanics. */
+export const ORGANIZATION_PAYLOAD_VERSION = 2 as const;
 
 const EMBLEM_KINDS = ['none', 'heraldry', 'merchant_mark', 'pattern_lattice', 'disc_emblem'];
 const GENRES = ['fantasy', 'science_fiction'];
@@ -186,21 +187,32 @@ export function validateOrganizationSnapshot(
   return acceptedPayload(record as unknown as OrganizationSnapshot);
 }
 
-/**
- * There has only ever been version 1, so this rejects rather than pretending otherwise.
- *
- * It is here because the contract requires it, and it is where the first real step goes the day the
- * shape changes — a kind without one looks complete right up until it silently drops someone's
- * work, and local-only means there is no server-side migration to fall back on.
- */
+/** Qualifies the leader and every notable member without changing organization data. */
 export function migrateOrganizationSnapshot(
-  _payload: unknown,
+  payload: unknown,
   from: number,
 ): PayloadResult<OrganizationSnapshot> {
-  return rejectedPayload(
-    'unsupported-version',
-    `Organizations have no migration from payload version ${from}; version ${ORGANIZATION_PAYLOAD_VERSION} is the only shape there has been`,
-  );
+  if (from !== 1) {
+    return rejectedPayload(
+      'unsupported-version',
+      `Organizations have no migration from payload version ${from}; version 1 is the only older shape there has been`,
+    );
+  }
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'organization payload is not an object');
+  }
+  const leader = asRecord(record.leader);
+  return validateOrganizationSnapshot({
+    ...record,
+    leader: leader === null ? record.leader : withLegacyActorMechanics(leader, 'migrated'),
+    notableMembers: Array.isArray(record.notableMembers)
+      ? record.notableMembers.map((member) => {
+          const person = asRecord(member);
+          return person === null ? member : withLegacyActorMechanics(person, 'migrated');
+        })
+      : record.notableMembers,
+  });
 }
 
 /** What to call a saved organization: its name, or the kind when the name has been emptied. */

--- a/src/lib/potions/potion_artifact_kind.test.ts
+++ b/src/lib/potions/potion_artifact_kind.test.ts
@@ -25,7 +25,7 @@ describe('potionArtifactKind', () => {
     expect(potionArtifactKind.kind).toBe(POTION_ARTIFACT_KIND);
     expect(POTION_ARTIFACT_KIND).toBe('potion');
     expect(potionArtifactKind.payloadVersion).toBe(POTION_PAYLOAD_VERSION);
-    expect(POTION_PAYLOAD_VERSION).toBe(1);
+    expect(POTION_PAYLOAD_VERSION).toBe(2);
   });
 
   it('is its own kind rather than a share of `item`', () => {
@@ -111,8 +111,36 @@ describe('validatePotionSnapshot', () => {
 });
 
 describe('migratePotionSnapshot', () => {
+  it('copies potion and nested item mechanics while preserving edited prose', () => {
+    const {
+      mechanics: _mechanics,
+      container: { mechanics: _containerMechanics, ...container },
+      liquid: { mechanics: _liquidMechanics, ...liquid },
+      ...rest
+    } = POTION;
+    const legacy = {
+      ...rest,
+      displayName: 'The referee renamed this',
+      container,
+      liquid: { ...liquid, value: 733 },
+    };
+    const result = migratePotionSnapshot(legacy, 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.displayName).toBe('The referee renamed this');
+      expect(result.value.liquid.value).toBe(733);
+      expect(result.value.mechanics.variants[0]).toMatchObject({
+        subject: 'potion',
+        origin: 'migrated',
+        payload: { effect: legacy.effect, modifications: legacy.modifications, value: 733 },
+      });
+      expect(result.value.container.mechanics.variants[0]).toMatchObject({ subject: 'item' });
+      expect(result.value.liquid.mechanics.variants[0]).toMatchObject({ subject: 'item' });
+    }
+  });
+
   it('rejects rather than pretending there has been another shape', () => {
-    // Requirement 7.3 has one step to exercise and it is the absence of one.
     const result = migratePotionSnapshot({ displayName: 'x' }, 0);
 
     expect(result.ok).toBe(false);

--- a/src/lib/potions/potion_artifact_kind.ts
+++ b/src/lib/potions/potion_artifact_kind.ts
@@ -8,6 +8,7 @@ import {
   type PayloadResult,
 } from '$lib/artifact_kinds';
 import type { Container } from '$lib/equipment';
+import { validateMechanicsSet, withLegacyPotionMechanics } from '$lib/rulesets';
 
 import type { PotionSnapshot, StoredPotionLiquid } from './potion_snapshot';
 import type { PotionEffect, PotionModification, PotionSensoryProfile } from './potion_types';
@@ -25,8 +26,8 @@ import type { PotionEffect, PotionModification, PotionSensoryProfile } from './p
  */
 export const POTION_ARTIFACT_KIND = 'potion' as const;
 
-/** Version 1. The first shape a potion has been stored in. */
-export const POTION_PAYLOAD_VERSION = 1 as const;
+/** Version 2 adds ruleset-qualified mechanics while retaining transitional compatibility fields. */
+export const POTION_PAYLOAD_VERSION = 2 as const;
 
 function readNumber(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
@@ -110,10 +111,31 @@ export function validatePotionSnapshot(payload: unknown): PayloadResult<PotionSn
   if (liquid === null) {
     return rejectedPayload('invalid-payload', 'Potion payload has no usable liquid');
   }
+  const containerMechanics = validateMechanicsSet(container.mechanics, 'item');
+  if (!containerMechanics.ok) {
+    return rejectedPayload(
+      'invalid-payload',
+      `Potion container has invalid mechanics: ${containerMechanics.message}`,
+    );
+  }
+  const liquidMechanics = validateMechanicsSet(liquid.mechanics, 'item');
+  if (!liquidMechanics.ok) {
+    return rejectedPayload(
+      'invalid-payload',
+      `Potion liquid has invalid mechanics: ${liquidMechanics.message}`,
+    );
+  }
 
   const effect = readEffect(record.effect);
   if (effect === undefined) {
     return rejectedPayload('invalid-payload', 'Potion payload has no usable effect');
+  }
+  const mechanics = validateMechanicsSet(record.mechanics, 'potion');
+  if (!mechanics.ok) {
+    return rejectedPayload(
+      'invalid-payload',
+      `Potion payload has invalid mechanics: ${mechanics.message}`,
+    );
   }
 
   return acceptedPayload({
@@ -124,6 +146,7 @@ export function validatePotionSnapshot(payload: unknown): PayloadResult<PotionSn
       value: readNumber(container.value, 0),
       properties: isStringArray(container.properties) ? container.properties : [],
       contents: isStringArray(container.contents) ? container.contents : [],
+      mechanics: containerMechanics.value,
     },
     liquid: {
       ...(liquid as unknown as StoredPotionLiquid),
@@ -132,6 +155,7 @@ export function validatePotionSnapshot(payload: unknown): PayloadResult<PotionSn
       value: readNumber(liquid.value, 0),
       weight: readNumber(liquid.weight, 0),
       properties: isStringArray(liquid.properties) ? liquid.properties : [],
+      mechanics: liquidMechanics.value,
     },
     displayName: record.displayName,
     ...(typeof record.canonicalName === 'string' && record.canonicalName !== ''
@@ -144,24 +168,25 @@ export function validatePotionSnapshot(payload: unknown): PayloadResult<PotionSn
           .map(readModification)
           .filter((modification): modification is PotionModification => modification !== undefined)
       : [],
+    mechanics: mechanics.value,
   });
 }
 
-/**
- * There has only ever been version 1, so this rejects rather than pretending otherwise.
- *
- * It is here because the contract requires it, and it is where the first real step goes the day
- * the shape changes — a kind without one looks complete right up until it silently drops someone's
- * work, and local-only means there is no server-side migration to fall back on.
- */
+/** Copies potion mechanics and composes the item migration through its container and liquid. */
 export function migratePotionSnapshot(
-  _payload: unknown,
+  payload: unknown,
   from: number,
 ): PayloadResult<PotionSnapshot> {
-  return rejectedPayload(
-    'unsupported-version',
-    `Potions have no migration from payload version ${from}; version ${POTION_PAYLOAD_VERSION} is the only shape there has been`,
-  );
+  if (from !== 1) {
+    return rejectedPayload(
+      'unsupported-version',
+      `Potions have no migration from payload version ${from}; version 1 is the only older shape there has been`,
+    );
+  }
+  const record = asRecord(payload);
+  return record === null
+    ? rejectedPayload('invalid-payload', 'Potion payload is not an object')
+    : validatePotionSnapshot(withLegacyPotionMechanics(record, 'migrated'));
 }
 
 /** What to call a saved potion: its display name, which is what the bottle's label would say. */

--- a/src/lib/potions/potion_generation.ts
+++ b/src/lib/potions/potion_generation.ts
@@ -2,6 +2,7 @@ import { RNG } from '@ironarachne/rng';
 import { generateRandomContainer, DENSITY_MAP } from '$lib/equipment';
 import type { DensityCategory, Rarity } from '$lib/equipment';
 import type { Duration, Element, MagicIntent, MagicSphere } from '$lib/magic';
+import { withLegacyPotionMechanics } from '$lib/rulesets';
 import {
   filterCatalogEntries,
   getDefaultPotionConfig,
@@ -130,15 +131,18 @@ export function generatePotion(
   container.currentVolume = parseFloat((container.currentVolume + volume).toFixed(2));
   container.currentWeight = parseFloat((container.currentWeight + weight).toFixed(2));
 
-  return {
-    container,
-    liquid,
-    displayName,
-    canonicalName,
-    sensory,
-    effect,
-    modifications,
-  };
+  return withLegacyPotionMechanics(
+    {
+      container,
+      liquid,
+      displayName,
+      canonicalName,
+      sensory,
+      effect,
+      modifications,
+    },
+    'generated',
+  ) as Potion;
 }
 
 export { buildPotionDescription as describePotion };

--- a/src/lib/potions/potion_snapshot.ts
+++ b/src/lib/potions/potion_snapshot.ts
@@ -18,6 +18,7 @@
  */
 
 import type { Container } from '$lib/equipment';
+import { withLegacyPotionMechanics, type MechanicsSet } from '$lib/rulesets';
 
 import type {
   Potion,
@@ -32,17 +33,20 @@ import type {
  *
  * `name`, `effect` and `sensory` are rebuilt on read from `displayName`, `effect` and `sensory`.
  */
-export type StoredPotionLiquid = Omit<PotionLiquid, 'name' | 'effect' | 'sensory'>;
+export type StoredPotionLiquid = Omit<PotionLiquid, 'name' | 'effect' | 'sensory' | 'mechanics'> & {
+  mechanics: MechanicsSet;
+};
 
 /** A potion as it is stored. */
 export type PotionSnapshot = {
-  container: Container;
+  container: Container & { mechanics: MechanicsSet };
   liquid: StoredPotionLiquid;
   displayName: string;
   canonicalName?: string;
   sensory: PotionSensoryProfile;
   effect: PotionEffect;
   modifications: PotionModification[];
+  mechanics: MechanicsSet;
 };
 
 function copyEffect(effect: PotionEffect): PotionEffect {
@@ -74,15 +78,18 @@ function copyStoredLiquid(liquid: PotionLiquid | StoredPotionLiquid): StoredPoti
 }
 
 export function toPotionSnapshot(potion: Potion): PotionSnapshot {
-  return {
-    container: copyContainer(potion.container),
-    liquid: copyStoredLiquid(potion.liquid),
-    displayName: potion.displayName,
-    ...(potion.canonicalName === undefined ? {} : { canonicalName: potion.canonicalName }),
-    sensory: { ...potion.sensory },
-    effect: copyEffect(potion.effect),
-    modifications: potion.modifications.map((modification) => ({ ...modification })),
-  };
+  return withLegacyPotionMechanics(
+    {
+      container: copyContainer(potion.container),
+      liquid: copyStoredLiquid(potion.liquid),
+      displayName: potion.displayName,
+      ...(potion.canonicalName === undefined ? {} : { canonicalName: potion.canonicalName }),
+      sensory: { ...potion.sensory },
+      effect: copyEffect(potion.effect),
+      modifications: potion.modifications.map((modification) => ({ ...modification })),
+    },
+    'generated',
+  ) as PotionSnapshot;
 }
 
 /**
@@ -110,6 +117,7 @@ export function potionFromSnapshot(snapshot: PotionSnapshot): Potion {
     sensory,
     effect,
     modifications: snapshot.modifications.map((modification) => ({ ...modification })),
+    mechanics: { variants: [...snapshot.mechanics.variants] },
   };
 }
 

--- a/src/lib/potions/potion_types.ts
+++ b/src/lib/potions/potion_types.ts
@@ -107,7 +107,7 @@ export type Potion = {
   displayName: string;
   canonicalName?: string;
   sensory: PotionSensoryProfile;
-  /** Ruleset-qualified mechanics. Optional until the payload migrations in #209 land. */
+  /** Ruleset-qualified mechanics. Optional while remaining live consumers transition in #213. */
   mechanics?: MechanicsSet;
   /** @deprecated Compatibility field for Iron Arachne mechanics; see #210 and #213. */
   effect: PotionEffect;

--- a/src/lib/regions/README.md
+++ b/src/lib/regions/README.md
@@ -72,7 +72,7 @@ The modules the readiness pass gives every Release-ready tool
   charge art. Writing, listing and validating reach none of it. Almost no conversion work is here:
   every part of a region already had a stored form by the time this tool reached the front of the
   pass, which is the whole point of the ordering.
-- **`region_artifact_kind.ts`** — kind `region`, payload version 1. Its validator composes the
+- **`region_artifact_kind.ts`** — kind `region`, payload version 2. Its validator composes the
   culture, settlement, organization and character validators rather than reimplementing them.
 - **`region_editing.ts`** — pure snapshot-to-snapshot edits over the region's words, its seat, its
   realms, its settlements and its organizations.

--- a/src/lib/regions/region_artifact_kind.test.ts
+++ b/src/lib/regions/region_artifact_kind.test.ts
@@ -11,6 +11,16 @@ import { rollRegionSnapshot } from './region_roll';
 
 const snapshot = rollRegionSnapshot('kind-seed');
 
+function withoutMechanics(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutMechanics);
+  if (typeof value !== 'object' || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, entry]) =>
+      key === 'mechanics' ? [] : [[key, withoutMechanics(entry)]],
+    ),
+  );
+}
+
 /** A copy of the good payload with one part replaced, for the rejection cases. */
 function broken(changes: Record<string, unknown>): unknown {
   return { ...(snapshot as unknown as Record<string, unknown>), ...changes };
@@ -137,9 +147,23 @@ describe('validating a stored region', () => {
 });
 
 describe('migrating a stored region (7.3)', () => {
-  it('rejects every version, because version 1 is the only shape there has been', () => {
-    // The whole of this kind's migration story today, asserted so that the day a version 2 lands
-    // this test is what has to change rather than something that silently drops a user's work.
+  it('migrates direct and composed actors without changing region prose', () => {
+    const result = migrateRegionSnapshot(withoutMechanics(snapshot), 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.description).toBe(snapshot.description);
+      expect(result.value.authority.mechanics.variants[0]).toMatchObject({ origin: 'migrated' });
+      expect(result.value.realms[0].authority.mechanics.variants[0]).toMatchObject({
+        origin: 'migrated',
+      });
+      expect(result.value.organizations[0].leader.mechanics.variants[0]).toMatchObject({
+        origin: 'migrated',
+      });
+    }
+  });
+
+  it('rejects an unsupported migration version', () => {
     const result = migrateRegionSnapshot(snapshot, 0);
     expect(result).toMatchObject({ ok: false, reason: 'unsupported-version' });
     expect(result.ok ? '' : result.message).toContain('version 0');

--- a/src/lib/regions/region_artifact_kind.ts
+++ b/src/lib/regions/region_artifact_kind.ts
@@ -13,8 +13,15 @@ import {
 // lists what a project contains.
 import { validateCharacterSnapshot } from '$lib/characters/character_artifact_kind';
 import { validateCultureSnapshot } from '$lib/culture/culture_artifact_kind';
-import { validateOrganizationSnapshot } from '$lib/organizations/organization_artifact_kind';
-import { validateSettlementSnapshot } from '$lib/settlements/settlement_artifact_kind';
+import {
+  migrateOrganizationSnapshot,
+  validateOrganizationSnapshot,
+} from '$lib/organizations/organization_artifact_kind';
+import { withLegacyActorMechanics } from '$lib/rulesets';
+import {
+  migrateSettlementSnapshot,
+  validateSettlementSnapshot,
+} from '$lib/settlements/settlement_artifact_kind';
 
 import type Region from './region.js';
 import type { RegionSnapshot } from './region_snapshot.js';
@@ -25,8 +32,8 @@ import type { RegionSnapshot } from './region_snapshot.js';
  */
 export const REGION_ARTIFACT_KIND = 'region' as const;
 
-/** Version 1. The first shape a region has been stored in. */
-export const REGION_PAYLOAD_VERSION = 1 as const;
+/** Version 2 qualifies every direct and composed actor's compatibility mechanics. */
+export const REGION_PAYLOAD_VERSION = 2 as const;
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
@@ -146,21 +153,54 @@ export function validateRegionSnapshot(payload: unknown): PayloadResult<RegionSn
   return acceptedPayload(record as unknown as RegionSnapshot);
 }
 
-/**
- * There has only ever been version 1, so this rejects rather than pretending otherwise.
- *
- * It is here because the contract requires it, and it is where the first real step goes the day the
- * shape changes — a kind without one looks complete right up until it silently drops someone's
- * work, and local-only means there is no server-side migration to fall back on.
- */
+/** Qualifies direct actors and composes the settlement and organization migrations. */
 export function migrateRegionSnapshot(
-  _payload: unknown,
+  payload: unknown,
   from: number,
 ): PayloadResult<RegionSnapshot> {
-  return rejectedPayload(
-    'unsupported-version',
-    `Regions have no migration from payload version ${from}; version ${REGION_PAYLOAD_VERSION} is the only shape there has been`,
-  );
+  if (from !== 1) {
+    return rejectedPayload(
+      'unsupported-version',
+      `Regions have no migration from payload version ${from}; version 1 is the only older shape there has been`,
+    );
+  }
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'region payload is not an object');
+  }
+
+  const migrateActor = (value: unknown): unknown => {
+    const actor = asRecord(value);
+    return actor === null ? value : withLegacyActorMechanics(actor, 'migrated');
+  };
+  const settlements = Array.isArray(record.settlements)
+    ? record.settlements.map((settlement) => {
+        const migrated = migrateSettlementSnapshot(settlement, 2);
+        return migrated.ok ? migrated.value : settlement;
+      })
+    : record.settlements;
+  const organizations = Array.isArray(record.organizations)
+    ? record.organizations.map((organization) => {
+        const migrated = migrateOrganizationSnapshot(organization, 1);
+        return migrated.ok ? migrated.value : organization;
+      })
+    : record.organizations;
+  const realms = Array.isArray(record.realms)
+    ? record.realms.map((realm) => {
+        const storedRealm = asRecord(realm);
+        return storedRealm === null
+          ? realm
+          : { ...storedRealm, authority: migrateActor(storedRealm.authority) };
+      })
+    : record.realms;
+
+  return validateRegionSnapshot({
+    ...record,
+    authority: migrateActor(record.authority),
+    settlements,
+    organizations,
+    realms,
+  });
 }
 
 /** What to call a saved region: its name, or the kind when the name has been emptied. */

--- a/src/lib/rulesets/README.md
+++ b/src/lib/rulesets/README.md
@@ -21,8 +21,14 @@ existing currency helpers that previously lived in the common `combat_system`, `
 `currency` libraries. Those old libraries are compatibility facades until #213 removes them.
 
 The package also supplies version-1 actor, item, potion, spell, and hoard payload codecs. Shared
-live types may carry a `MechanicsSet`; their legacy fields remain during the persistence migration
-in #209 so current generators and saved data do not change shape in this step.
+live types may carry a `MechanicsSet`; their legacy fields remain while consumers transition in
+#213.
+
+`legacy_migrations.ts` is the one pure compatibility path used by standalone and composed artifact
+codecs. It copies saved values into `ironarachne@1` variants, marks old records as `migrated`, and
+never recomputes a rule value or changes prose. AD&D and DCC character snapshots instead gain a
+top-level `legacy` ruleset ref: their payloads were already system-owned, and the ref deliberately
+adds no source ids before each package's separate source/licence audit.
 
 The full contract, dependency rules, and migration plan are in
 [`docs/rules-system.md`](../../../docs/rules-system.md).

--- a/src/lib/rulesets/index.ts
+++ b/src/lib/rulesets/index.ts
@@ -1,3 +1,4 @@
+export * from './legacy_migrations.js';
 export * from './ruleset_catalog.js';
 export * from './ruleset_definitions.js';
 export * from './ruleset_results.js';

--- a/src/lib/rulesets/ironarachne/mechanics.ts
+++ b/src/lib/rulesets/ironarachne/mechanics.ts
@@ -17,6 +17,11 @@ export type IronArachneActorMechanics = {
   combatProfile: CombatProfile;
   actions: CombatAction[];
   casterProfile?: CasterProfile;
+  archetype?: {
+    basePowerModifier?: number;
+    actions?: CombatAction[];
+    casterProfile?: CasterProfile;
+  };
 };
 
 export type IronArachneItemMechanics = {
@@ -93,6 +98,16 @@ function isCasterProfile(value: unknown): value is CasterProfile {
   );
 }
 
+function isArchetype(value: unknown): boolean {
+  const record = asRecord(value);
+  return (
+    record !== undefined &&
+    (record.basePowerModifier === undefined || isFiniteNumber(record.basePowerModifier)) &&
+    (record.actions === undefined || isActions(record.actions)) &&
+    (record.casterProfile === undefined || isCasterProfile(record.casterProfile))
+  );
+}
+
 function isNamedDescription(value: unknown): value is { name: string; description: string } {
   const record = asRecord(value);
   return (
@@ -107,7 +122,8 @@ function validateActor(payload: unknown): RulesetResult<unknown> {
   return record !== undefined &&
     isCombatProfile(record.combatProfile) &&
     isActions(record.actions) &&
-    (record.casterProfile === undefined || isCasterProfile(record.casterProfile))
+    (record.casterProfile === undefined || isCasterProfile(record.casterProfile)) &&
+    (record.archetype === undefined || isArchetype(record.archetype))
     ? acceptedRuleset(payload)
     : rejectedRuleset('invalid-mechanics', 'Iron Arachne actor mechanics is invalid');
 }

--- a/src/lib/rulesets/legacy_migrations.test.ts
+++ b/src/lib/rulesets/legacy_migrations.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { IRONARACHNE_RULESET_REF } from './ironarachne/descriptor.js';
+import {
+  withLegacyActorMechanics,
+  withLegacyHoardMechanics,
+  withLegacyItemMechanics,
+  withLegacyPotionMechanics,
+} from './legacy_migrations.js';
+
+function variantOf(record: { mechanics: { variants: unknown[] } }) {
+  return record.mechanics.variants[record.mechanics.variants.length - 1];
+}
+
+describe('legacy mechanics copies', () => {
+  it('copies every item mechanics field without changing the common record', () => {
+    const old = {
+      id: 'blade',
+      name: 'Edited blade',
+      value: 321,
+      combatProfile: { attack: 42 },
+      actions: [{ name: 'Cut' }],
+      enchantment: { name: 'Bright' },
+    };
+    const migrated = withLegacyItemMechanics(old, 'migrated');
+
+    expect(migrated).toMatchObject(old);
+    expect(variantOf(migrated)).toEqual({
+      ruleset: IRONARACHNE_RULESET_REF,
+      subject: 'item',
+      schemaVersion: 1,
+      origin: 'migrated',
+      sourceIds: ['ironarachne.normalized-mechanics.v1'],
+      payload: {
+        value: 321,
+        combatProfile: old.combatProfile,
+        actions: old.actions,
+        enchantment: old.enchantment,
+      },
+    });
+  });
+
+  it('copies potion, actor, archetype, and hoard values without recomputation', () => {
+    const potion = withLegacyPotionMechanics(
+      {
+        effect: { name: 'Edited effect' },
+        modifications: [{ kind: 'double' }],
+        liquid: { value: 7 },
+      },
+      'migrated',
+    );
+    expect(variantOf(potion)).toMatchObject({
+      subject: 'potion',
+      payload: { effect: { name: 'Edited effect' }, modifications: [{ kind: 'double' }], value: 7 },
+    });
+
+    const actor = withLegacyActorMechanics(
+      {
+        name: 'Edited person',
+        combatProfile: { attack: 19 },
+        actions: [{ name: 'Wait' }],
+        archetype: {
+          basePowerModifier: 11,
+          actions: [{ name: 'Cast' }],
+          casterProfile: { maxMagnitude: 55 },
+        },
+      },
+      'migrated',
+    );
+    expect(variantOf(actor)).toMatchObject({
+      subject: 'actor',
+      payload: {
+        combatProfile: { attack: 19 },
+        actions: [{ name: 'Wait' }],
+        archetype: {
+          basePowerModifier: 11,
+          actions: [{ name: 'Cast' }],
+          casterProfile: { maxMagnitude: 55 },
+        },
+      },
+    });
+
+    expect(variantOf(withLegacyHoardMechanics({ targetValue: 1234 }, 'migrated'))).toMatchObject({
+      subject: 'hoard',
+      payload: { targetValue: 1234 },
+    });
+  });
+
+  it('preserves existing variants and never duplicates Iron Arachne mechanics', () => {
+    const existing = {
+      mechanics: {
+        variants: [
+          {
+            ruleset: IRONARACHNE_RULESET_REF,
+            subject: 'item' as const,
+            schemaVersion: 1,
+            origin: 'user' as const,
+            sourceIds: [],
+            payload: { value: 999 },
+          },
+        ],
+      },
+      value: 1,
+    };
+    expect(withLegacyItemMechanics(existing, 'generated').mechanics).toEqual(existing.mechanics);
+  });
+});

--- a/src/lib/rulesets/legacy_migrations.ts
+++ b/src/lib/rulesets/legacy_migrations.ts
@@ -1,0 +1,151 @@
+import { IRONARACHNE_RULESET_REF } from './ironarachne/descriptor.js';
+import { IRONARACHNE_ORIGINAL_SOURCE } from './ironarachne/source_manifest.js';
+import type {
+  MechanicsOrigin,
+  MechanicsSet,
+  MechanicsSubject,
+  QualifiedMechanics,
+} from './ruleset_types.js';
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : undefined;
+}
+
+function optionalFields(record: UnknownRecord, fields: readonly string[]): UnknownRecord {
+  return Object.fromEntries(
+    fields.filter((field) => record[field] !== undefined).map((field) => [field, record[field]]),
+  );
+}
+
+function existingVariants(record: UnknownRecord): unknown[] {
+  const mechanics = asRecord(record.mechanics);
+  return Array.isArray(mechanics?.variants) ? mechanics.variants : [];
+}
+
+function withVariant<T extends object>(
+  record: T,
+  subject: MechanicsSubject,
+  payload: unknown,
+  origin: MechanicsOrigin,
+): T & { mechanics: MechanicsSet } {
+  const source = record as UnknownRecord;
+  const variants = existingVariants(source);
+  const alreadyQualified = variants.some((variant) => {
+    const candidate = asRecord(variant);
+    const ref = asRecord(candidate?.ruleset);
+    return (
+      ref?.id === IRONARACHNE_RULESET_REF.id && ref.release === IRONARACHNE_RULESET_REF.release
+    );
+  });
+  const compatibility: QualifiedMechanics = {
+    ruleset: IRONARACHNE_RULESET_REF,
+    subject,
+    schemaVersion: 1,
+    origin,
+    sourceIds: [IRONARACHNE_ORIGINAL_SOURCE.id],
+    payload,
+  };
+
+  return {
+    ...record,
+    mechanics: {
+      variants: (alreadyQualified
+        ? [...variants]
+        : [...variants, compatibility]) as QualifiedMechanics[],
+    },
+  };
+}
+
+/** Copies an old common item's mechanics into an Iron Arachne variant without recomputing them. */
+export function withLegacyItemMechanics<T extends object>(
+  record: T,
+  origin: MechanicsOrigin,
+): T & { mechanics: MechanicsSet } {
+  const source = record as UnknownRecord;
+  return withVariant(
+    record,
+    'item',
+    {
+      value: source.value,
+      ...optionalFields(source, ['combatProfile', 'actions', 'enchantment']),
+    },
+    origin,
+  );
+}
+
+/** Copies an old common potion's effect, modifications, and liquid value without recomputation. */
+export function withLegacyPotionMechanics<T extends object>(
+  record: T,
+  origin: MechanicsOrigin,
+): T & { mechanics: MechanicsSet } {
+  const source = record as UnknownRecord;
+  const container = asRecord(source.container);
+  const liquid = asRecord(source.liquid);
+  const qualified = {
+    ...record,
+    ...(container === undefined ? {} : { container: withLegacyItemMechanics(container, origin) }),
+    ...(liquid === undefined ? {} : { liquid: withLegacyItemMechanics(liquid, origin) }),
+  };
+  return withVariant(
+    qualified,
+    'potion',
+    {
+      effect: source.effect,
+      modifications: source.modifications,
+      ...(liquid?.value === undefined ? {} : { value: liquid.value }),
+    },
+    origin,
+  );
+}
+
+/** Copies an old common actor and its embedded archetype mechanics without recomputation. */
+export function withLegacyActorMechanics<T extends object>(
+  record: T,
+  origin: MechanicsOrigin,
+): T & { mechanics: MechanicsSet } {
+  const source = record as UnknownRecord;
+  const archetype = asRecord(source.archetype);
+  const qualified = {
+    ...record,
+    ...(Array.isArray(source.carried)
+      ? {
+          carried: source.carried.map((item) => {
+            const storedItem = asRecord(item);
+            return storedItem === undefined ? item : withLegacyItemMechanics(storedItem, origin);
+          }),
+        }
+      : {}),
+  };
+  return withVariant(
+    qualified,
+    'actor',
+    {
+      combatProfile: source.combatProfile,
+      actions: source.actions,
+      ...(archetype?.casterProfile === undefined ? {} : { casterProfile: archetype.casterProfile }),
+      ...(archetype === undefined
+        ? {}
+        : {
+            archetype: optionalFields(archetype, ['basePowerModifier', 'actions', 'casterProfile']),
+          }),
+    },
+    origin,
+  );
+}
+
+/** Copies an old common hoard's target value without recomputation. */
+export function withLegacyHoardMechanics<T extends object>(
+  record: T,
+  origin: MechanicsOrigin,
+): T & { mechanics: MechanicsSet } {
+  return withVariant(
+    record,
+    'hoard',
+    { targetValue: (record as UnknownRecord).targetValue },
+    origin,
+  );
+}

--- a/src/lib/rulesets/rulesets.test.ts
+++ b/src/lib/rulesets/rulesets.test.ts
@@ -17,6 +17,7 @@ import {
   rejectedRuleset,
   rulesetNotices,
   sameRulesetRef,
+  validateMechanicsSet,
   validateQualifiedMechanics,
   type MechanicsCodec,
   type QualifiedMechanics,
@@ -284,6 +285,35 @@ describe('qualified mechanics', () => {
       ok: false,
       reason: 'unsupported-version',
     });
+  });
+});
+
+describe('mechanics sets', () => {
+  it('validates variants and rejects duplicate refs', () => {
+    expect(validateMechanicsSet({ variants: [genericItem] })).toEqual({
+      ok: true,
+      value: { variants: [genericItem] },
+    });
+    expect(validateMechanicsSet({ variants: [genericItem, genericItem] })).toMatchObject({
+      ok: false,
+      reason: 'variant-conflict',
+    });
+  });
+
+  it('rejects a valid variant attached to the wrong kind of entity', () => {
+    expect(validateMechanicsSet({ variants: [genericItem] }, 'actor')).toMatchObject({
+      ok: false,
+      reason: 'invalid-mechanics',
+    });
+  });
+
+  it('rejects malformed and unknown variants so their artifacts can be quarantined intact', () => {
+    expect(validateMechanicsSet(null)).toMatchObject({ ok: false, reason: 'invalid-mechanics' });
+    expect(
+      validateMechanicsSet({
+        variants: [{ ...genericItem, ruleset: { id: 'future-system', release: '1' } }],
+      }),
+    ).toMatchObject({ ok: false, reason: 'unknown-ruleset' });
   });
 });
 

--- a/src/lib/rulesets/rulesets.ts
+++ b/src/lib/rulesets/rulesets.ts
@@ -143,6 +143,40 @@ export function validateQualifiedMechanics(value: unknown): RulesetResult<Qualif
   });
 }
 
+/** Validates a mechanics collection without discarding unknown or malformed stored data. */
+export function validateMechanicsSet(
+  value: unknown,
+  subject?: MechanicsSubject,
+): RulesetResult<MechanicsSet> {
+  const record = asRecord(value);
+  if (record === undefined || !Array.isArray(record.variants)) {
+    return rejectedRuleset('invalid-mechanics', 'mechanics set has no variant list');
+  }
+
+  const variants: QualifiedMechanics[] = [];
+  for (const candidate of record.variants) {
+    const checked = validateQualifiedMechanics(candidate);
+    if (!checked.ok) {
+      return checked;
+    }
+    if (subject !== undefined && checked.value.subject !== subject) {
+      return rejectedRuleset(
+        'invalid-mechanics',
+        `${subject} mechanics contains a ${checked.value.subject} variant`,
+      );
+    }
+    if (variants.some((current) => sameRulesetRef(current.ruleset, checked.value.ruleset))) {
+      return rejectedRuleset(
+        'variant-conflict',
+        `mechanics contains more than one "${checked.value.ruleset.id}@${checked.value.ruleset.release}" variant`,
+      );
+    }
+    variants.push(checked.value);
+  }
+
+  return acceptedRuleset({ variants });
+}
+
 export function addMechanicsVariant(
   set: Readonly<MechanicsSet>,
   variant: QualifiedMechanics,

--- a/src/lib/settlements/settlement_artifact_kind.test.ts
+++ b/src/lib/settlements/settlement_artifact_kind.test.ts
@@ -20,6 +20,16 @@ function storedSnapshot(seed: string, config = {}): Record<string, unknown> {
   return JSON.parse(JSON.stringify(snapshot)) as Record<string, unknown>;
 }
 
+function withoutMechanics(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutMechanics);
+  if (typeof value !== 'object' || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, entry]) =>
+      key === 'mechanics' ? [] : [[key, withoutMechanics(entry)]],
+    ),
+  );
+}
+
 describe('validateSettlementSnapshot', () => {
   /**
    * The two shapes of the same kind. `enrich_settlement.ts` is opt-in four times over, so a
@@ -124,11 +134,13 @@ describe('validateSettlementSnapshot', () => {
  * the generator produces — instead of a hand-typed approximation that goes stale.
  */
 function version1Snapshot(seed: string): Record<string, unknown> {
-  const snapshot = storedSnapshot(seed, {
-    size: 'large',
-    includeOrganizations: true,
-    includeNotables: true,
-  });
+  const snapshot = withoutMechanics(
+    storedSnapshot(seed, {
+      size: 'large',
+      includeOrganizations: true,
+      includeNotables: true,
+    }),
+  ) as Record<string, unknown>;
 
   const embed = (value: unknown): unknown => {
     const character = value as Record<string, unknown>;
@@ -152,6 +164,29 @@ function version1Snapshot(seed: string): Record<string, unknown> {
 }
 
 describe('migrateSettlementSnapshot', () => {
+  it('brings a version 2 settlement forward with migrated actor mechanics', () => {
+    const legacy = withoutMechanics(
+      storedSnapshot('greyhaven', {
+        size: 'large',
+        includeOrganizations: true,
+        includeNotables: true,
+      }),
+    );
+    const result = migrateSettlementSnapshot(legacy, 2);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.importantPeople?.[0].character.mechanics.variants[0]).toMatchObject({
+        subject: 'actor',
+        origin: 'migrated',
+      });
+      expect(result.value.organizations?.[0].leader.mechanics.variants[0]).toMatchObject({
+        subject: 'actor',
+        origin: 'migrated',
+      });
+    }
+  });
+
   /**
    * Requirement 7.3, and the site's first real payload step. Every settlement saved before this
    * release keeps every notable it had.

--- a/src/lib/settlements/settlement_artifact_kind.ts
+++ b/src/lib/settlements/settlement_artifact_kind.ts
@@ -8,6 +8,7 @@ import {
   rejectedPayload,
   type PayloadResult,
 } from '$lib/artifact_kinds';
+import { withLegacyActorMechanics } from '$lib/rulesets';
 
 import type { SettlementSnapshot } from './settlement_snapshot';
 import type { Settlement } from './settlement_types';
@@ -19,18 +20,19 @@ import type { Settlement } from './settlement_types';
 export const SETTLEMENT_ARTIFACT_KIND = 'settlement' as const;
 
 /**
- * Version 2: a notable's character stores `speciesName` where version 1 embedded a whole `Species`.
+ * Version 3 qualifies every embedded actor's compatibility mechanics. Version 2 changed a
+ * notable's character to store `speciesName` where version 1 embedded a whole `Species`.
  *
  * The site's first real payload step, and it exists because `StoredCharacter` moved to
  * `$lib/characters` for #46 — one shape in the library that owns the concept, rather than two types
  * with one name drifting apart. The shape change is not free: a settlement written by an older
- * build carries the embedded record, and reading it as a version 2 payload would leave every
+ * build carries the embedded record, and reading it as a later payload would leave every
  * notable without a species. {@link migrateSettlementSnapshot} is what stops that.
  *
  * It also drops a whole `Species` record per notable, which was the bulk of what a stored notable
  * was.
  */
-export const SETTLEMENT_PAYLOAD_VERSION = 2 as const;
+export const SETTLEMENT_PAYLOAD_VERSION = 3 as const;
 
 const SETTLEMENT_STRING_FIELDS = ['name', 'description', 'economicRole'];
 
@@ -227,31 +229,37 @@ export function validateSettlementSnapshot(payload: unknown): PayloadResult<Sett
  * one has never seen, so anything it assumes beyond "an object, possibly with a species that has a
  * name" is an assumption that can be wrong on someone's real data.
  */
-function migratedCharacter(value: unknown): unknown {
+function migratedCharacter(value: unknown, convertSpecies: boolean): unknown {
   const character = asRecord(value);
   if (character === null) {
     return value;
   }
+  if (!convertSpecies) {
+    return withLegacyActorMechanics(character, 'migrated');
+  }
   const { species, ...rest } = character;
   const speciesRecord = asRecord(species);
-  return {
-    ...rest,
-    // The name off the embedded record, or an empty one. A version 1 settlement with a malformed
-    // species is still a settlement; `character_rehydrate.ts` turns an unresolvable name into an
-    // inert placeholder, and losing the whole town over one notable would be the worse trade.
-    speciesName: typeof speciesRecord?.name === 'string' ? speciesRecord.name : '',
-  };
+  return withLegacyActorMechanics(
+    {
+      ...rest,
+      // The name off the embedded record, or an empty one. A version 1 settlement with a malformed
+      // species is still a settlement; `character_rehydrate.ts` turns an unresolvable name into an
+      // inert placeholder, and losing the whole town over one notable would be the worse trade.
+      speciesName: typeof speciesRecord?.name === 'string' ? speciesRecord.name : '',
+    },
+    'migrated',
+  );
 }
 
-function migratedNotable(value: unknown): unknown {
+function migratedNotable(value: unknown, convertSpecies: boolean): unknown {
   const notable = asRecord(value);
   if (notable === null) {
     return value;
   }
-  return { ...notable, character: migratedCharacter(notable.character) };
+  return { ...notable, character: migratedCharacter(notable.character, convertSpecies) };
 }
 
-function migratedOrganization(value: unknown): unknown {
+function migratedOrganization(value: unknown, convertSpecies: boolean): unknown {
   const organization = asRecord(value);
   if (organization === null) {
     return value;
@@ -260,20 +268,23 @@ function migratedOrganization(value: unknown): unknown {
     ...organization,
     ...(organization.leader === undefined
       ? {}
-      : { leader: migratedCharacter(organization.leader) }),
+      : { leader: migratedCharacter(organization.leader, convertSpecies) }),
     ...(Array.isArray(organization.notableMembers)
-      ? { notableMembers: organization.notableMembers.map(migratedCharacter) }
+      ? {
+          notableMembers: organization.notableMembers.map((member) =>
+            migratedCharacter(member, convertSpecies),
+          ),
+        }
       : {}),
   };
 }
 
 /**
- * Bring a settlement written before {@link SETTLEMENT_PAYLOAD_VERSION} 2 forward.
+ * Bring a settlement written before the current payload version forward.
  *
- * Every notable and every organization member is rewritten so its embedded species becomes a
- * `speciesName`; nothing else about the settlement is touched. Enrichment is opt-in four times
- * over, so a settlement may have neither notables nor organizations, and one that has neither
- * migrates by having nothing to do rather than by being rejected.
+ * Every notable and organization member gains its Iron Arachne actor variant. Version 1 also has
+ * its embedded species rewritten as `speciesName`; version 2 already did that. Nothing else about
+ * the settlement is touched. Enrichment is opt-in, so an unenriched settlement migrates cleanly.
  *
  * The result goes back through `validateSettlementSnapshot` rather than being trusted: a migration
  * that produced something unreadable should say so here, where the reason reaches the user as a
@@ -283,12 +294,13 @@ export function migrateSettlementSnapshot(
   payload: unknown,
   from: number,
 ): PayloadResult<SettlementSnapshot> {
-  if (from !== 1) {
+  if (from !== 1 && from !== 2) {
     return rejectedPayload(
       'unsupported-version',
-      `settlement has no migration from payload version ${from}; version 1 is the only older shape there has been`,
+      `settlement has no migration from payload version ${from}; versions 1 and 2 are the older shapes`,
     );
   }
+  const convertSpecies = from === 1;
   const record = asRecord(payload);
   if (record === null) {
     return rejectedPayload('invalid-payload', 'settlement payload is not an object');
@@ -297,10 +309,18 @@ export function migrateSettlementSnapshot(
   return validateSettlementSnapshot({
     ...record,
     ...(Array.isArray(record.importantPeople)
-      ? { importantPeople: record.importantPeople.map(migratedNotable) }
+      ? {
+          importantPeople: record.importantPeople.map((notable) =>
+            migratedNotable(notable, convertSpecies),
+          ),
+        }
       : {}),
     ...(Array.isArray(record.organizations)
-      ? { organizations: record.organizations.map(migratedOrganization) }
+      ? {
+          organizations: record.organizations.map((organization) =>
+            migratedOrganization(organization, convertSpecies),
+          ),
+        }
       : {}),
   });
 }

--- a/src/lib/treasure/treasure_hoard_artifact_kind.test.ts
+++ b/src/lib/treasure/treasure_hoard_artifact_kind.test.ts
@@ -9,8 +9,20 @@ import {
   validateTreasureHoardSnapshot,
 } from './treasure_hoard_artifact_kind';
 import { defaultTreasureHoardConfigRecord, rollTreasureHoardSnapshot } from './treasure_hoard_roll';
+import { withLegacyHoardMechanics, withLegacyItemMechanics } from '$lib/rulesets';
 
 const HOARD = rollTreasureHoardSnapshot('kind-seed', defaultTreasureHoardConfigRecord());
+
+function current(payload: Record<string, unknown>): unknown {
+  const items = Array.isArray(payload.items)
+    ? payload.items.map((item) =>
+        typeof item === 'object' && item !== null
+          ? withLegacyItemMechanics(item, 'generated')
+          : item,
+      )
+    : payload.items;
+  return withLegacyHoardMechanics({ ...payload, items }, 'generated');
+}
 
 function accepted(payload: unknown) {
   const result = validateTreasureHoardSnapshot(payload);
@@ -25,7 +37,7 @@ describe('treasureHoardArtifactKind', () => {
     expect(treasureHoardArtifactKind.kind).toBe(TREASURE_HOARD_ARTIFACT_KIND);
     expect(TREASURE_HOARD_ARTIFACT_KIND).toBe('treasure-hoard');
     expect(treasureHoardArtifactKind.payloadVersion).toBe(TREASURE_HOARD_PAYLOAD_VERSION);
-    expect(TREASURE_HOARD_PAYLOAD_VERSION).toBe(1);
+    expect(TREASURE_HOARD_PAYLOAD_VERSION).toBe(2);
   });
 
   it('loads a codec that round-trips', async () => {
@@ -52,38 +64,44 @@ describe('validateTreasureHoardSnapshot', () => {
 
   it('accepts a hoard the party has carried off entirely', () => {
     // 3.3 asks for a well-defined empty result rather than a refusal.
-    expect(accepted({ targetValue: 100, items: [] }).items).toEqual([]);
+    expect(accepted(current({ targetValue: 100, items: [] })).items).toEqual([]);
   });
 
   it('drops an item with no id, which nothing could place', () => {
     // The id is what a container's `contents` points at, so an item that has lost it would show
     // twice: once in a chest it is no longer in, and once loose.
-    const mixed = accepted({
-      targetValue: 100,
-      items: [{ name: 'a nameless thing', value: 5 }, HOARD.items[0]],
-    });
+    const mixed = accepted(
+      current({
+        targetValue: 100,
+        items: [{ name: 'a nameless thing', value: 5 }, HOARD.items[0]],
+      }),
+    );
 
     expect(mixed.items).toEqual([HOARD.items[0]]);
   });
 
   it('reads a missing number as zero rather than refusing', () => {
-    const sparse = accepted({ targetValue: 100, items: [{ id: 'x', name: 'a thing' }] });
+    const sparse = accepted(current({ targetValue: 100, items: [{ id: 'x', name: 'a thing' }] }));
 
     expect(sparse.items[0]).toMatchObject({ id: 'x', name: 'a thing', value: 0, weight: 0 });
   });
 
   it('keeps an empty contents list, which is what says "this is an empty container"', () => {
     // Its absence says "this is not a container at all", which is a different thing.
-    const chest = accepted({ targetValue: 0, items: [{ id: 'c', name: 'a chest', contents: [] }] });
+    const chest = accepted(
+      current({ targetValue: 0, items: [{ id: 'c', name: 'a chest', contents: [] }] }),
+    );
 
     expect(chest.items[0].contents).toEqual([]);
   });
 
   it('drops an extra that is not the right type', () => {
-    const odd = accepted({
-      targetValue: 0,
-      items: [{ id: 'g', name: 'a gem', cut: 4, quantity: 'lots', isCut: 'yes' }],
-    });
+    const odd = accepted(
+      current({
+        targetValue: 0,
+        items: [{ id: 'g', name: 'a gem', cut: 4, quantity: 'lots', isCut: 'yes' }],
+      }),
+    );
 
     expect('cut' in odd.items[0]).toBe(false);
     expect('quantity' in odd.items[0]).toBe(false);
@@ -91,11 +109,32 @@ describe('validateTreasureHoardSnapshot', () => {
   });
 
   it('reads a missing target value as nothing rather than refusing', () => {
-    expect(accepted({ items: [] }).targetValue).toBe(0);
+    expect(accepted(current({ items: [] })).targetValue).toBe(0);
   });
 });
 
 describe('migrateTreasureHoardSnapshot', () => {
+  it('copies the hoard and every item mechanics field into migrated variants', () => {
+    const { mechanics: _hoardMechanics, ...legacy } = HOARD;
+    const legacyItems = legacy.items.map(({ mechanics: _itemMechanics, ...item }) => item);
+    const result = migrateTreasureHoardSnapshot({ ...legacy, items: legacyItems }, 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.targetValue).toBe(legacy.targetValue);
+      expect(result.value.mechanics.variants[0]).toMatchObject({
+        subject: 'hoard',
+        origin: 'migrated',
+        payload: { targetValue: legacy.targetValue },
+      });
+      expect(result.value.items[0].mechanics.variants[0]).toMatchObject({
+        subject: 'item',
+        origin: 'migrated',
+        payload: { value: legacyItems[0].value },
+      });
+    }
+  });
+
   it('rejects rather than pretending there has been another shape', () => {
     // Requirement 7.3 has one step to exercise and it is the absence of one.
     const result = migrateTreasureHoardSnapshot({ items: [] }, 0);
@@ -109,6 +148,8 @@ describe('migrateTreasureHoardSnapshot', () => {
 describe('treasureHoardName', () => {
   it('says how big it is, which is what a hoard has instead of a name', () => {
     expect(treasureHoardName(HOARD)).toBe(`Treasure Hoard (${HOARD.items.length} items)`);
-    expect(treasureHoardName({ targetValue: 0, items: [] })).toBe('Treasure Hoard');
+    expect(treasureHoardName({ targetValue: 0, items: [], mechanics: { variants: [] } })).toBe(
+      'Treasure Hoard',
+    );
   });
 });

--- a/src/lib/treasure/treasure_hoard_artifact_kind.ts
+++ b/src/lib/treasure/treasure_hoard_artifact_kind.ts
@@ -9,6 +9,11 @@ import {
 } from '$lib/artifact_kinds';
 import { DEFAULT_ITEM_DENSITY, DEFAULT_ITEM_RARITY } from '$lib/equipment';
 import type { DensityCategory, Rarity } from '$lib/equipment';
+import {
+  validateMechanicsSet,
+  withLegacyHoardMechanics,
+  withLegacyItemMechanics,
+} from '$lib/rulesets';
 
 import type { HoardItemSnapshot, TreasureHoardSnapshot } from './treasure_hoard_snapshot';
 
@@ -21,8 +26,8 @@ import type { HoardItemSnapshot, TreasureHoardSnapshot } from './treasure_hoard_
  */
 export const TREASURE_HOARD_ARTIFACT_KIND = 'treasure-hoard' as const;
 
-/** Version 1. The first shape a hoard has been stored in. */
-export const TREASURE_HOARD_PAYLOAD_VERSION = 1 as const;
+/** Version 2 qualifies the hoard and every embedded item's compatibility mechanics. */
+export const TREASURE_HOARD_PAYLOAD_VERSION = 2 as const;
 
 function readNumber(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
@@ -75,6 +80,11 @@ function readHoardItem(value: unknown): HoardItemSnapshot | undefined {
     weight: readNumber(record.weight, 0),
     properties: isStringArray(record.properties) ? record.properties : [],
   };
+  const mechanics = validateMechanicsSet(record.mechanics, 'item');
+  if (!mechanics.ok) {
+    return undefined;
+  }
+  item.mechanics = mechanics.value;
 
   copyOptional(record, item, ['uniqueName', 'itemMinorType'], isText);
   copyOptional(record, item, ['containerId', 'cut', 'size', 'artist', 'denomination'], isText);
@@ -121,30 +131,53 @@ export function validateTreasureHoardSnapshot(
   if (!Array.isArray(record.items)) {
     return rejectedPayload('invalid-payload', 'Treasure hoard payload has no usable item list');
   }
+  const mechanics = validateMechanicsSet(record.mechanics, 'hoard');
+  if (!mechanics.ok) {
+    return rejectedPayload(
+      'invalid-payload',
+      `Treasure hoard payload has invalid mechanics: ${mechanics.message}`,
+    );
+  }
+
+  const invalidItemMechanics = record.items.find((item) => {
+    const itemRecord = asRecord(item);
+    return itemRecord !== null && !validateMechanicsSet(itemRecord.mechanics, 'item').ok;
+  });
+  if (invalidItemMechanics !== undefined) {
+    return rejectedPayload('invalid-payload', 'Treasure hoard item has invalid mechanics');
+  }
 
   return acceptedPayload({
     targetValue: readNumber(record.targetValue, 0),
     items: record.items
       .map(readHoardItem)
       .filter((item): item is HoardItemSnapshot => item !== undefined),
+    mechanics: mechanics.value,
   });
 }
 
-/**
- * There has only ever been version 1, so this rejects rather than pretending otherwise.
- *
- * It is here because the contract requires it, and it is where the first real step goes the day
- * the shape changes — a kind without one looks complete right up until it silently drops someone's
- * work, and local-only means there is no server-side migration to fall back on.
- */
+/** Qualifies the hoard and composes the item migration through every embedded item. */
 export function migrateTreasureHoardSnapshot(
-  _payload: unknown,
+  payload: unknown,
   from: number,
 ): PayloadResult<TreasureHoardSnapshot> {
-  return rejectedPayload(
-    'unsupported-version',
-    `Treasure hoards have no migration from payload version ${from}; version ${TREASURE_HOARD_PAYLOAD_VERSION} is the only shape there has been`,
-  );
+  if (from !== 1) {
+    return rejectedPayload(
+      'unsupported-version',
+      `Treasure hoards have no migration from payload version ${from}; version 1 is the only older shape there has been`,
+    );
+  }
+  const record = asRecord(payload);
+  if (record === null) {
+    return rejectedPayload('invalid-payload', 'Treasure hoard payload is not an object');
+  }
+  const items = Array.isArray(record.items)
+    ? record.items.map((item) => {
+        const itemRecord = asRecord(item);
+        return itemRecord === null ? item : withLegacyItemMechanics(itemRecord, 'migrated');
+      })
+    : record.items;
+  return validateTreasureHoardSnapshot(withLegacyHoardMechanics({ ...record, items }, 'migrated'));
 }
 
 /**

--- a/src/lib/treasure/treasure_hoard_presentation.test.ts
+++ b/src/lib/treasure/treasure_hoard_presentation.test.ts
@@ -34,10 +34,11 @@ function gems(count: number, name = 'emerald'): HoardItemSnapshot[] {
     densityCategory: 'standard',
     weight: 0.1,
     properties: [],
+    mechanics: { variants: [] },
   })) as HoardItemSnapshot[];
 }
 
-const EMPTY: TreasureHoardSnapshot = { targetValue: 0, items: [] };
+const EMPTY: TreasureHoardSnapshot = { targetValue: 0, items: [], mechanics: { variants: [] } };
 
 describe('tallyGems', () => {
   it('lists them one by one below the list limit', () => {
@@ -89,6 +90,7 @@ describe('hoardLines', () => {
         densityCategory: 'standard',
         weight: 1,
         properties: [],
+        mechanics: { variants: [] },
         denomination: 'gold',
         quantity: 5,
       } as HoardItemSnapshot,
@@ -110,6 +112,7 @@ describe('hoardLines', () => {
         densityCategory: 'standard',
         weight: 1,
         properties: [],
+        mechanics: { variants: [] },
       } as HoardItemSnapshot,
     ]);
 
@@ -179,6 +182,7 @@ describe('hoardToMarkdown', () => {
     // 6.4 with teeth.
     const emptyChest: TreasureHoardSnapshot = {
       targetValue: 0,
+      mechanics: { variants: [] },
       items: [
         {
           id: 'c',
@@ -190,6 +194,7 @@ describe('hoardToMarkdown', () => {
           densityCategory: 'standard',
           weight: 5,
           properties: [],
+          mechanics: { variants: [] },
           contents: [],
         } as HoardItemSnapshot,
       ],

--- a/src/lib/treasure/treasure_hoard_snapshot.ts
+++ b/src/lib/treasure/treasure_hoard_snapshot.ts
@@ -26,6 +26,7 @@
 
 import { toItemSnapshot, type ItemSnapshot, type RolledItem } from '$lib/equipment';
 import type { Item } from '$lib/equipment';
+import { withLegacyHoardMechanics, type MechanicsSet } from '$lib/rulesets';
 
 /**
  * One item of a hoard, as it is stored.
@@ -63,6 +64,7 @@ export type TreasureHoardSnapshot = {
   /** What the hoard was rolled to be worth, in copper. */
   targetValue: number;
   items: HoardItemSnapshot[];
+  mechanics: MechanicsSet;
 };
 
 /** The optional numbers a hoard item may carry, and the key each is stored under. */
@@ -108,7 +110,10 @@ export function toHoardItemSnapshot(item: Item): HoardItemSnapshot {
 }
 
 export function toTreasureHoardSnapshot(items: Item[], targetValue: number): TreasureHoardSnapshot {
-  return { targetValue, items: items.map(toHoardItemSnapshot) };
+  return withLegacyHoardMechanics(
+    { targetValue, items: items.map(toHoardItemSnapshot) },
+    'generated',
+  ) as TreasureHoardSnapshot;
 }
 
 /**
@@ -122,6 +127,7 @@ export function treasureHoardFromSnapshot(snapshot: TreasureHoardSnapshot): Trea
   return {
     targetValue: snapshot.targetValue,
     items: snapshot.items.map((item) => toHoardItemSnapshot(item as unknown as Item)),
+    mechanics: { variants: [...snapshot.mechanics.variants] },
   };
 }
 


### PR DESCRIPTION
## Summary

- add shared, lossless migration helpers for legacy item, potion, actor, and hoard mechanics
- version generic and composite artifact snapshots so embedded mechanics receive Iron Arachne ruleset variants
- pin legacy AD&D 2E and DCC snapshots to stable ruleset references without asserting source provenance
- validate ruleset-qualified payloads while preserving rejected raw data for quarantine and export
- version dungeon snapshots because they persist encounter snapshots migrated by this change

## Testing

- `npm run verify`
- 461 test files / 6,253 tests passed
- coverage gate: 101 libraries at or above 80%

Closes #209