### PR TITLE
Add project ruleset defaults and D&D 5E catalog selection

### DIFF
--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -187,6 +187,41 @@ test.describe('the projects page', () => {
     await expect(projectCard(page, 'Ashfall')).toContainText('Cyberpunk');
   });
 
+  test('sets and clears a ruleset default, confirming an incompatible system change', async ({
+    page,
+  }) => {
+    await projectsPage(page).getByLabel('New project').fill('Ashfall');
+    await projectsPage(page).getByLabel('Ruleset').selectOption('ironarachne@1');
+    await projectsPage(page).getByRole('button', { name: 'Create project' }).click();
+
+    let card = projectCard(page, 'Ashfall');
+    await expect(card).toContainText('Ruleset: Iron Arachne 1');
+
+    await card.getByRole('button', { name: 'Rename' }).click();
+    await editingCard(page).getByLabel('Ruleset').selectOption('');
+    await editingCard(page).getByRole('button', { name: 'Save' }).click();
+    await expect(projectCard(page, 'Ashfall')).not.toContainText('Ruleset:');
+
+    await projectCard(page, 'Ashfall').getByRole('button', { name: 'Rename' }).click();
+    await editingCard(page).getByLabel('Ruleset').selectOption('ironarachne@1');
+    await editingCard(page).getByLabel('System').selectOption('dnd-5e');
+    await editingCard(page).getByRole('button', { name: 'Save' }).click();
+
+    const dialog = page.locator('dialog.panel');
+    await expect(dialog).toContainText('Existing artifacts will not be changed');
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(editingCard(page)).toBeVisible();
+
+    await editingCard(page).getByRole('button', { name: 'Save' }).click();
+    await dialog.getByRole('button', { name: 'Change and clear' }).click();
+    card = projectCard(page, 'Ashfall');
+    await expect(card).toContainText('D&D 5E');
+    await expect(card).not.toContainText('Ruleset:');
+
+    await page.reload({ waitUntil: 'load' });
+    await expect(projectCard(page, 'Ashfall')).toContainText('D&D 5E');
+  });
+
   test('leaves a project set in nothing when nothing is chosen', async ({ page }) => {
     await create(page, 'A box of tools');
 

--- a/src/components/layout/ProjectsPage.svelte
+++ b/src/components/layout/ProjectsPage.svelte
@@ -17,6 +17,12 @@
     type ProjectDraft,
   } from '$lib/projects';
   import {
+    allRulesets,
+    findRulesetDescriptor,
+    type RulesetDescriptor,
+    type RulesetRef,
+  } from '$lib/rulesets';
+  import {
     hasSeenStorageDisclosure,
     recordStorageDisclosureShown,
     requestPersistenceIfWarranted,
@@ -57,12 +63,39 @@
     { value: '', label: 'Any system' },
     ...SYSTEMS.map((system) => ({ value: system, label: systemDisplayName(system) })),
   ];
+  const RULESETS = allRulesets();
+  const RULESET_OPTIONS = [
+    { value: '', label: 'No ruleset default' },
+    ...RULESETS.map((descriptor) => ({
+      value: rulesetValue(descriptor.ref),
+      label: `${descriptor.displayName} (${descriptor.ref.release})`,
+    })),
+  ];
+
+  function rulesetValue(ref: RulesetRef): string {
+    return `${ref.id}@${ref.release}`;
+  }
+
+  function selectedRuleset(value: string): RulesetDescriptor | undefined {
+    return RULESETS.find((descriptor) => rulesetValue(descriptor.ref) === value);
+  }
+
+  function rulesetSummary(project: Project): string | undefined {
+    if (project.ruleset === undefined) {
+      return undefined;
+    }
+    const descriptor = findRulesetDescriptor(project.ruleset);
+    return descriptor === undefined
+      ? undefined
+      : `Ruleset: ${descriptor.displayName} ${descriptor.ref.release}`;
+  }
 
   /** The genre and system of a project, as the card's fact line says them. Empty when it has none. */
   function settingSummary(project: Project): string {
     return [
       project.genre === undefined ? undefined : genreDisplayName(project.genre),
       project.system === undefined ? undefined : systemDisplayName(project.system),
+      rulesetSummary(project),
     ]
       .filter((name) => name !== undefined)
       .join(' · ');
@@ -78,6 +111,7 @@
   let newName = $state('');
   let newGenre = $state('');
   let newSystem = $state('');
+  let newRuleset = $state('');
   let storageError: string | null = $state(null);
   /** The project whose name and description are being edited, if any. */
   let editingId: string | undefined = $state(undefined);
@@ -85,6 +119,7 @@
   let editDescription = $state('');
   let editGenre = $state('');
   let editSystem = $state('');
+  let editRuleset = $state('');
   /** The local-only disclosure, shown once ever and dismissible. See docs/storage-disclosure.md. */
   let showDisclosure = $state(false);
 
@@ -179,6 +214,10 @@
     if (newSystem !== '') {
       draft.system = newSystem as GameSystem;
     }
+    const ruleset = selectedRuleset(newRuleset);
+    if (ruleset !== undefined) {
+      draft.ruleset = ruleset.ref;
+    }
     const created = await createProject(draft);
     report(created);
     if (created.ok) {
@@ -195,6 +234,9 @@
       }
       if (newSystem === (draft.system ?? '')) {
         newSystem = '';
+      }
+      if (newRuleset === (draft.ruleset === undefined ? '' : rulesetValue(draft.ruleset))) {
+        newRuleset = '';
       }
     }
     refresh();
@@ -214,6 +256,7 @@
     editDescription = project.description ?? '';
     editGenre = project.genre ?? '';
     editSystem = project.system ?? '';
+    editRuleset = project.ruleset === undefined ? '' : rulesetValue(project.ruleset);
   }
 
   function cancelEditing(): void {
@@ -226,16 +269,45 @@
     // action. An empty description clears it, which is what the field's placeholder promises.
     // `null` clears rather than an empty string, which is what "Any genre" has to mean: the field
     // is an enum and there is no empty member of one to stand in for absent.
+    const descriptor = selectedRuleset(editRuleset);
+    let ruleset: RulesetRef | null = descriptor?.ref ?? null;
+    const desiredSystem = editSystem === '' ? undefined : (editSystem as GameSystem);
+    if (descriptor !== undefined && descriptor.gameSystem !== desiredSystem) {
+      const confirmed = await showConfirmModal({
+        title: 'Change system and clear ruleset?',
+        message: `The selected system is not compatible with ${descriptor.displayName} ${descriptor.ref.release}. Change the system and clear the ruleset default? Existing artifacts will not be changed.`,
+        okLabel: 'Change and clear',
+      });
+      if (!confirmed) {
+        return;
+      }
+      ruleset = null;
+    }
     report(
       await updateProject(id, {
         name: editName,
         description: editDescription.trim(),
         genre: editGenre === '' ? null : (editGenre as Genre),
         system: editSystem === '' ? null : (editSystem as GameSystem),
+        ruleset,
       }),
     );
     editingId = undefined;
     refresh();
+  }
+
+  function chooseNewRuleset(): void {
+    const descriptor = selectedRuleset(newRuleset);
+    if (descriptor !== undefined) {
+      newSystem = descriptor.gameSystem ?? '';
+    }
+  }
+
+  function chooseEditRuleset(): void {
+    const descriptor = selectedRuleset(editRuleset);
+    if (descriptor !== undefined) {
+      editSystem = descriptor.gameSystem ?? '';
+    }
   }
 
   async function remove(row: Row): Promise<void> {
@@ -304,6 +376,13 @@
       bind:value={newSystem}
       options={SYSTEM_OPTIONS}
     />
+    <SelectField
+      id="{uid}-new-ruleset"
+      label="Ruleset"
+      bind:value={newRuleset}
+      options={RULESET_OPTIONS}
+      onchange={chooseNewRuleset}
+    />
     <!-- The page's one primary action. Primary is a claim about the page rather than about the
          button: everything else here — rename, delete, export — acts on something that already
          exists, and this is the thing a visitor with no projects came to do. -->
@@ -362,6 +441,13 @@
                   label="System"
                   bind:value={editSystem}
                   options={SYSTEM_OPTIONS}
+                />
+                <SelectField
+                  id="{uid}-ruleset-{row.project.id}"
+                  label="Ruleset"
+                  bind:value={editRuleset}
+                  options={RULESET_OPTIONS}
+                  onchange={chooseEditRuleset}
                 />
                 <div class="project-card__actions">
                   <BaseButton onclick={() => saveEdits(row.project.id)}>Save</BaseButton>

--- a/src/lib/artifacts/README.md
+++ b/src/lib/artifacts/README.md
@@ -27,6 +27,10 @@ rename a deity, the seed in `provenance` no longer reproduces what is on their s
 is recorded so a user can see where a thing came from and deliberately re-roll it, and re-rolling
 replaces the payload destructively, on purpose, when asked.
 
+Provenance may also carry the pinned ruleset default the generating tool actually consumed. It is
+optional history, not an instruction to reinterpret the payload; legacy artifacts retain their
+existing provenance with no inferred ruleset.
+
 There is no code path in this library that regenerates a payload from provenance, and there must
 never be one.
 

--- a/src/lib/artifacts/artifact_index.test.ts
+++ b/src/lib/artifacts/artifact_index.test.ts
@@ -2,6 +2,7 @@ import { IDBFactory } from 'fake-indexeddb';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { closeVault, writeArtifactSummaryRecord } from '$lib/vault_db';
+import { IRONARACHNE_RULESET_REF } from '$lib/rulesets';
 
 import {
   artifactsHydrated,
@@ -52,6 +53,26 @@ describe('toArtifactSummary', () => {
     expect(toArtifactSummary(aSummary({ provenance }))?.provenance).toEqual(provenance);
     expect(
       toArtifactSummary({ ...aSummary(), provenance: { toolPath: '/culture' } }),
+    ).toBeUndefined();
+  });
+
+  it('keeps a known provenance ruleset and rejects an unknown future one', () => {
+    const provenance: ArtifactProvenance = {
+      toolPath: '/culture',
+      seed: 'seed-1',
+      config: {},
+      ruleset: IRONARACHNE_RULESET_REF,
+    };
+    expect(toArtifactSummary(aSummary({ provenance }))?.provenance).toEqual(provenance);
+
+    expect(
+      toArtifactSummary({
+        ...aSummary(),
+        provenance: {
+          ...provenance,
+          ruleset: { id: 'dcc', release: 'from-a-later-build' },
+        },
+      }),
     ).toBeUndefined();
   });
 

--- a/src/lib/artifacts/artifact_index.ts
+++ b/src/lib/artifacts/artifact_index.ts
@@ -1,4 +1,5 @@
 import { readAllArtifactRecords, type VaultResult } from '$lib/vault_db';
+import { validateRulesetRef } from '$lib/rulesets';
 
 import type { ArtifactProvenance, ArtifactReference, ArtifactSummary } from './artifact_types';
 
@@ -31,16 +32,31 @@ function isArtifactReference(value: unknown): value is ArtifactReference {
  * Provenance is present or absent, never partial. A record missing its seed cannot answer the one
  * question provenance exists to answer, and half of an origin is worse than an honest none.
  */
-function isArtifactProvenance(value: unknown): value is ArtifactProvenance {
+function readArtifactProvenance(value: unknown): ArtifactProvenance | undefined {
   const record = asRecord(value);
   if (record === null) {
-    return false;
+    return undefined;
   }
-  return (
-    typeof record.toolPath === 'string' &&
-    typeof record.seed === 'string' &&
-    asRecord(record.config) !== null
-  );
+  if (
+    typeof record.toolPath !== 'string' ||
+    typeof record.seed !== 'string' ||
+    asRecord(record.config) === null
+  ) {
+    return undefined;
+  }
+  const provenance: ArtifactProvenance = {
+    toolPath: record.toolPath as ArtifactProvenance['toolPath'],
+    seed: record.seed,
+    config: record.config as Record<string, unknown>,
+  };
+  if (record.ruleset !== undefined) {
+    const ruleset = validateRulesetRef(record.ruleset);
+    if (!ruleset.ok) {
+      return undefined;
+    }
+    provenance.ruleset = ruleset.value;
+  }
+  return provenance;
 }
 
 function isFiniteNumber(value: unknown): value is number {
@@ -89,9 +105,9 @@ export function toArtifactSummary(value: unknown): ArtifactSummary | undefined {
   if (!Array.isArray(record.references) || !record.references.every(isArtifactReference)) {
     return undefined;
   }
-  if (record.provenance !== undefined && !isArtifactProvenance(record.provenance)) {
-    return undefined;
-  }
+  const provenance =
+    record.provenance === undefined ? undefined : readArtifactProvenance(record.provenance);
+  if (record.provenance !== undefined && provenance === undefined) return undefined;
   if (!isFiniteNumber(record.createdAt) || !isFiniteNumber(record.updatedAt)) {
     return undefined;
   }
@@ -108,8 +124,8 @@ export function toArtifactSummary(value: unknown): ArtifactSummary | undefined {
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
   };
-  if (record.provenance !== undefined) {
-    summary.provenance = record.provenance;
+  if (provenance !== undefined) {
+    summary.provenance = provenance;
   }
   return summary;
 }

--- a/src/lib/artifacts/artifact_types.ts
+++ b/src/lib/artifacts/artifact_types.ts
@@ -1,5 +1,6 @@
 import type { RouteId } from '$app/types';
 import type { ArtifactKind, QuarantineReason } from '$lib/artifact_kinds';
+import type { RulesetRef } from '$lib/rulesets';
 import type { TaggedItem } from '$lib/tags';
 import type { VaultFailureReason } from '$lib/vault_db';
 
@@ -17,6 +18,8 @@ export type ArtifactProvenance = {
   seed: string;
   /** Generator settings as the tool understood them. `{}` when the tool has none. */
   config: Record<string, unknown>;
+  /** The project default used for this generation, when the generating tool consumed one. */
+  ruleset?: RulesetRef;
 };
 
 /**

--- a/src/lib/artifacts/artifacts.test.ts
+++ b/src/lib/artifacts/artifacts.test.ts
@@ -291,6 +291,16 @@ describe('createArtifact', () => {
     });
   });
 
+  it('copies an optional ruleset into provenance', async () => {
+    const ruleset = { id: 'ironarachne', release: '1' } as const;
+    const artifact = await create({
+      provenance: { toolPath: '/culture', seed: 'seed-1', config: {}, ruleset },
+    });
+
+    expect(artifact.provenance?.ruleset).toEqual(ruleset);
+    expect(artifact.provenance?.ruleset).not.toBe(ruleset);
+  });
+
   it('leaves provenance absent rather than inventing one', async () => {
     expect(await create()).not.toHaveProperty('provenance');
   });

--- a/src/lib/artifacts/artifacts.ts
+++ b/src/lib/artifacts/artifacts.ts
@@ -91,6 +91,7 @@ function normalizeProvenance(
     toolPath: provenance.toolPath,
     seed: provenance.seed,
     config: provenance.config ?? {},
+    ...(provenance.ruleset === undefined ? {} : { ruleset: { ...provenance.ruleset } }),
   };
 }
 

--- a/src/lib/projects/README.md
+++ b/src/lib/projects/README.md
@@ -14,15 +14,16 @@ the project set — never reaches back. Both persist to
 
 ## The type
 
-| Field                     | Notes                                                          |
-| ------------------------- | -------------------------------------------------------------- |
-| `id`                      | Stable, never reused — including after a delete.               |
-| `name`                    | User-facing and editable. **Not** required to be unique.       |
-| `description`             | Optional, and absent rather than empty when there is not one.  |
-| `genre`                   | Optional. What the project is set in; see below.               |
-| `system`                  | Optional. What it is played with; see below.                   |
-| `tags`                    | Free-form. A `Project` is a [`TaggedItem`](../tags/README.md). |
-| `createdAt` / `updatedAt` | Epoch milliseconds, per decision 2 in the design document.     |
+| Field                     | Notes                                                               |
+| ------------------------- | ------------------------------------------------------------------- |
+| `id`                      | Stable, never reused — including after a delete.                    |
+| `name`                    | User-facing and editable. **Not** required to be unique.            |
+| `description`             | Optional, and absent rather than empty when there is not one.       |
+| `genre`                   | Optional. What the project is set in; see below.                    |
+| `system`                  | Optional tool-catalog filter. What it is played with; see below.    |
+| `ruleset`                 | Optional default rules release for future generation; see below.    |
+| `tags`                    | Free-form. A `Project` is a [`TaggedItem`](../tags/README.md).      |
+| `createdAt` / `updatedAt` | Epoch milliseconds, per decision 2 in the workshop design document. |
 
 ## Usage
 
@@ -79,8 +80,11 @@ and writing it back unaltered cannot reorder the list.
 `genre` and `system` are the tool catalog's own vocabularies — imported from
 [`$lib/tools`](../tools/README.md), never restated here, and the reason this library knows about
 that one while it must never learn about this one. They narrow the workshop's tool list and nothing
-else: no artifact records the genre of the project it was saved into, so **both may be changed as
-often as the user likes**, which is decision 7 in the design document.
+else. `ruleset` is different: it is a pinned `$lib/rulesets` release used as the default for future
+generator actions. Changing it never rewrites an artifact. When a ruleset has a `gameSystem`, its
+value and `system` must agree; selecting the ruleset sets that filter. Clearing the ruleset leaves
+the filter in place. Changing to an incompatible filter requires an explicit `ruleset: null`,
+which is how the UI proves it obtained confirmation first.
 
 Because a field is the only shape that gives every reader one answer, the matching `genre:` and
 `system:` tags are **derived** — `deriveSettingTags` rebuilds them from the fields on every read and
@@ -91,9 +95,10 @@ an import carrying a contradictory tag, unable to produce a project whose tag an
 await createProject({ name: 'Ashfall', genre: 'fantasy', system: 'adnd-2e' });
 await updateProject(id, { genre: 'cyberpunk' }); // a value sets
 await updateProject(id, { system: null }); // null clears — an enum has no empty member
+await updateProject(id, { ruleset: null, system: 'dcc' }); // confirmed incompatible change
 ```
 
-A stored genre or system this build does not recognise **drops the field and keeps the project**.
+A stored genre, system, or ruleset this build does not recognise **drops the field and keeps the project**.
 Rejecting the record would lose a project's name, description, tags and id — and spill its
 artifacts into the recovered-artifacts bucket — over a field that only decides which tools appear
 in a list.

--- a/src/lib/projects/project_index.test.ts
+++ b/src/lib/projects/project_index.test.ts
@@ -2,6 +2,7 @@ import { IDBFactory } from 'fake-indexeddb';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { closeVault, writeProjectRecord } from '$lib/vault_db';
+import { IRONARACHNE_RULESET_REF } from '$lib/rulesets';
 
 import {
   forgetProject,
@@ -71,6 +72,26 @@ describe('toProject', () => {
     expect(read?.genre).toBe('horror');
     expect(read?.system).toBe('dcc');
     expect(read?.tags).toEqual(['homebrew', 'genre:horror', 'system:dcc']);
+  });
+
+  it('reads a registered ruleset only when its game-system filter agrees', () => {
+    expect(toProject({ ...aProject(), ruleset: IRONARACHNE_RULESET_REF })?.ruleset).toEqual(
+      IRONARACHNE_RULESET_REF,
+    );
+    expect(
+      toProject({ ...aProject(), system: 'dcc', ruleset: IRONARACHNE_RULESET_REF }),
+    ).not.toHaveProperty('ruleset');
+  });
+
+  it('drops an unknown ruleset and keeps the project without inventing a replacement', () => {
+    const read = toProject({
+      ...aProject(),
+      system: 'dcc',
+      ruleset: { id: 'dcc', release: 'from-a-later-build' },
+    });
+
+    expect(read?.system).toBe('dcc');
+    expect(read).not.toHaveProperty('ruleset');
   });
 
   it.each<[string, unknown, string]>([

--- a/src/lib/projects/project_index.ts
+++ b/src/lib/projects/project_index.ts
@@ -1,4 +1,5 @@
 import { isGameSystem, isGenre } from '$lib/tools';
+import { findRulesetDescriptor, validateRulesetRef } from '$lib/rulesets';
 import { readAllProjectRecords, type VaultResult } from '$lib/vault_db';
 
 import { deriveSettingTags } from './project_setting';
@@ -69,6 +70,12 @@ export function toProject(value: unknown): Project | undefined {
   }
   if (isGameSystem(record.system)) {
     project.system = record.system;
+  }
+  if (record.ruleset !== undefined) {
+    const ruleset = validateRulesetRef(record.ruleset);
+    if (ruleset.ok && findRulesetDescriptor(ruleset.value)?.gameSystem === project.system) {
+      project.ruleset = ruleset.value;
+    }
   }
   // Derived on the way in as well as on the way out: a file may carry a `genre:` tag that disagrees
   // with the field, or one this build could not read, and neither may survive the read.

--- a/src/lib/projects/project_types.ts
+++ b/src/lib/projects/project_types.ts
@@ -1,5 +1,6 @@
 import type { TaggedItem } from '$lib/tags';
 import type { GameSystem, Genre } from '$lib/tools';
+import type { RulesetRef } from '$lib/rulesets';
 
 /**
  * The top-level container in the workshop: one campaign, one setting, one world. Deliberately
@@ -17,13 +18,16 @@ export interface Project extends TaggedItem {
    * What the project is set in, and what it is played with. Both optional — a project that is a
    * box of tools is neither — and both changeable, per decision 7 in docs/workshop.md.
    *
-   * They narrow the workshop's tool list and nothing else: no artifact records the genre of the
-   * project it was saved into, so changing one invalidates nothing. `Genre` and `GameSystem` are
-   * the tool catalog's own vocabularies rather than a second pair, which is why this library knows
-   * about `$lib/tools` and `$lib/tools` must never learn about this one.
+   * They narrow the workshop's tool list. No artifact records the genre or system of the project
+   * it was saved into, so changing one invalidates nothing. `system` must, however, agree with a
+   * ruleset default while one is selected. `Genre` and `GameSystem` are the tool catalog's own
+   * vocabularies rather than a second pair, which is why this library knows about `$lib/tools` and
+   * `$lib/tools` must never learn about this one.
    */
   genre?: Genre;
   system?: GameSystem;
+  /** The rules release future generator actions use by default; never reinterprets saved work. */
+  ruleset?: RulesetRef;
   /** Epoch milliseconds, per decision 2 in docs/workshop.md. */
   createdAt: number;
   /** Epoch milliseconds, per decision 2 in docs/workshop.md. */
@@ -36,6 +40,7 @@ export type ProjectDraft = {
   description?: string;
   genre?: Genre;
   system?: GameSystem;
+  ruleset?: RulesetRef;
   tags?: string[];
 };
 
@@ -53,6 +58,7 @@ export type ProjectChanges = {
    */
   genre?: Genre | null;
   system?: GameSystem | null;
+  ruleset?: RulesetRef | null;
   tags?: string[];
 };
 

--- a/src/lib/projects/projects.test.ts
+++ b/src/lib/projects/projects.test.ts
@@ -17,6 +17,7 @@ import {
   type Artifact,
 } from '$lib/artifacts';
 import { closeVault, type VaultResult } from '$lib/vault_db';
+import { IRONARACHNE_RULESET_REF } from '$lib/rulesets';
 
 import { readActiveProjectPayload, writeActiveProjectPayload } from './active_project_state';
 import { onProjectsChanged, resetProjectChangeListeners } from './project_events';
@@ -398,6 +399,65 @@ describe("a project's genre and system", () => {
     );
     expect(updated.genre).toBe('fantasy');
     expect(updated.tags).toEqual(['homebrew', 'genre:fantasy']);
+  });
+});
+
+describe("a project's ruleset default", () => {
+  it('stores a registered default and derives its game-system filter', async () => {
+    const created = await make(
+      { name: 'Ashfall', ruleset: IRONARACHNE_RULESET_REF },
+      { id: 'p1', now: 1000 },
+    );
+
+    expect(created.ruleset).toEqual(IRONARACHNE_RULESET_REF);
+    expect(created).not.toHaveProperty('system');
+    expect(created.tags).toEqual([]);
+  });
+
+  it('refuses a draft whose explicit system contradicts its ruleset', async () => {
+    await expect(
+      make({ name: 'Ashfall', system: 'dcc', ruleset: IRONARACHNE_RULESET_REF }, { id: 'p1' }),
+    ).rejects.toThrow(/must describe the same game system/);
+  });
+
+  it('clears a default while retaining the newly selected system filter', async () => {
+    await make({ name: 'Ashfall', ruleset: IRONARACHNE_RULESET_REF }, { id: 'p1', now: 1000 });
+
+    const updated = stored(
+      await updateProject('p1', { ruleset: null, system: 'dnd-5e' }, { now: 2000 }),
+    );
+
+    expect(updated).not.toHaveProperty('ruleset');
+    expect(updated.system).toBe('dnd-5e');
+    expect(updated.tags).toEqual(['system:dnd-5e']);
+  });
+
+  it('requires an incompatible filter change to explicitly clear the default', async () => {
+    await make({ name: 'Ashfall', ruleset: IRONARACHNE_RULESET_REF }, { id: 'p1', now: 1000 });
+
+    await expect(updateProject('p1', { system: 'dnd-5e' })).rejects.toThrow(
+      /explicitly clear the project ruleset/,
+    );
+    expect(getProject('p1')?.ruleset).toEqual(IRONARACHNE_RULESET_REF);
+  });
+
+  it('changes only the project and leaves its existing artifacts untouched', async () => {
+    await make({ name: 'Ashfall', ruleset: IRONARACHNE_RULESET_REF }, { id: 'p1', now: 1000 });
+    const artifact = await addNote('p1', 'a1');
+
+    await updateProject('p1', { ruleset: null, system: 'dnd-5e' }, { now: 2000 });
+
+    expect(listArtifacts('p1')).toEqual([
+      expect.objectContaining({ id: artifact.id, updatedAt: artifact.updatedAt }),
+    ]);
+    const read = await readArtifact(NOTE_KINDS, 'p1', artifact.id);
+    expect(read?.ok && read.artifact.payload).toEqual(note);
+  });
+
+  it('refuses to author an unregistered release', async () => {
+    await expect(
+      make({ name: 'Ashfall', ruleset: { id: 'dcc', release: 'unregistered' } }, { id: 'p1' }),
+    ).rejects.toThrow(/is not registered/);
   });
 });
 

--- a/src/lib/projects/projects.ts
+++ b/src/lib/projects/projects.ts
@@ -1,4 +1,5 @@
 import { forgetProjectArtifacts, hydrateArtifacts } from '$lib/artifacts';
+import { findRulesetDescriptor, sameRulesetRef, type RulesetRef } from '$lib/rulesets';
 import { deleteProjectCascade, writeProjectRecord, type VaultResult } from '$lib/vault_db';
 
 import { readActiveProjectPayload, writeActiveProjectPayload } from './active_project_state';
@@ -43,6 +44,24 @@ function normalizeTags(tags: string[] | undefined): string[] {
     }
   }
   return [...seen];
+}
+
+/**
+ * Apply a known ruleset default and keep the catalog filter beside it consistent. A ruleset such
+ * as Iron Arachne has no game-system filter; selecting it therefore clears `system` rather than
+ * manufacturing one.
+ */
+function setRulesetDefault(project: Project, ruleset: RulesetRef): void {
+  const descriptor = findRulesetDescriptor(ruleset);
+  if (descriptor === undefined) {
+    throw new Error(`ruleset "${ruleset.id}@${ruleset.release}" is not registered`);
+  }
+  project.ruleset = { ...descriptor.ref };
+  if (descriptor.gameSystem === undefined) {
+    delete project.system;
+  } else {
+    project.system = descriptor.gameSystem;
+  }
 }
 
 /**
@@ -107,6 +126,13 @@ export function toProjectRecord(
   if (draft.system !== undefined) {
     project.system = draft.system;
   }
+  if (draft.ruleset !== undefined) {
+    const descriptor = findRulesetDescriptor(draft.ruleset);
+    if (draft.system !== undefined && descriptor?.gameSystem !== draft.system) {
+      throw new Error('a project ruleset and system must describe the same game system');
+    }
+    setRulesetDefault(project, draft.ruleset);
+  }
   project.tags = deriveSettingTags(project.tags, project);
   return project;
 }
@@ -144,6 +170,10 @@ function sameProject(a: Project, b: Project): boolean {
     a.description === b.description &&
     a.genre === b.genre &&
     a.system === b.system &&
+    ((a.ruleset === undefined && b.ruleset === undefined) ||
+      (a.ruleset !== undefined &&
+        b.ruleset !== undefined &&
+        sameRulesetRef(a.ruleset, b.ruleset))) &&
     a.tags.length === b.tags.length &&
     a.tags.every((tag, index) => tag === b.tags[index])
   );
@@ -182,9 +212,9 @@ export async function updateProject(
       next.description = description;
     }
   }
-  // `null` clears and a value sets, per `ProjectChanges`. Both may be changed as often as the user
-  // likes: nothing keys off either field but which tools the workshop lists, so a change here
-  // invalidates no artifact and breaks no reference (docs/workshop.md, decision 7).
+  // `null` clears and a value sets, per `ProjectChanges`. Genre is independent. System also acts
+  // as the ruleset compatibility filter, so an incompatible change must name `ruleset: null` —
+  // the UI obtains confirmation before making that explicit request.
   if (changes.genre !== undefined) {
     if (changes.genre === null) {
       delete next.genre;
@@ -193,10 +223,34 @@ export async function updateProject(
     }
   }
   if (changes.system !== undefined) {
+    const desiredSystem = changes.system === null ? undefined : changes.system;
+    const rulesetSystem =
+      next.ruleset === undefined ? undefined : findRulesetDescriptor(next.ruleset)?.gameSystem;
+    if (
+      next.ruleset !== undefined &&
+      changes.ruleset === undefined &&
+      desiredSystem !== rulesetSystem
+    ) {
+      throw new Error('an incompatible system change must explicitly clear the project ruleset');
+    }
     if (changes.system === null) {
       delete next.system;
     } else {
       next.system = changes.system;
+    }
+  }
+  if (changes.ruleset !== undefined) {
+    if (changes.ruleset === null) {
+      delete next.ruleset;
+    } else {
+      if (changes.system !== undefined) {
+        const descriptor = findRulesetDescriptor(changes.ruleset);
+        const desiredSystem = changes.system === null ? undefined : changes.system;
+        if (descriptor === undefined || descriptor.gameSystem !== desiredSystem) {
+          throw new Error('a project ruleset and system must describe the same game system');
+        }
+      }
+      setRulesetDefault(next, changes.ruleset);
     }
   }
   // Last, and unconditionally: the setting tags are derived from the fields as they now stand, so a

--- a/src/lib/rulesets/rulesets.test.ts
+++ b/src/lib/rulesets/rulesets.test.ts
@@ -19,6 +19,7 @@ import {
   sameRulesetRef,
   validateMechanicsSet,
   validateQualifiedMechanics,
+  validateRulesetRef,
   type MechanicsCodec,
   type QualifiedMechanics,
   type RulesDataSource,
@@ -100,6 +101,18 @@ describe('ruleset catalog', () => {
     expect(unregisteredKnownId).toMatchObject({ ok: false, reason: 'unknown-release' });
     expect(emptyRelease).toMatchObject({ ok: false, reason: 'unknown-release' });
     expect(blankRelease).toMatchObject({ ok: false, reason: 'unknown-release' });
+  });
+
+  it('validates a registered durable ref without returning its input object', () => {
+    const ref = { ...IRONARACHNE_RULESET_REF };
+    const result = validateRulesetRef(ref);
+
+    expect(result).toEqual({ ok: true, value: IRONARACHNE_RULESET_REF });
+    expect(result.ok && result.value).not.toBe(ref);
+    expect(validateRulesetRef({ id: 'dcc', release: 'unregistered' })).toMatchObject({
+      ok: false,
+      reason: 'unknown-release',
+    });
   });
 });
 

--- a/src/lib/rulesets/rulesets.ts
+++ b/src/lib/rulesets/rulesets.ts
@@ -45,7 +45,8 @@ function isMechanicsOrigin(value: unknown): value is MechanicsOrigin {
   return typeof value === 'string' && (MECHANICS_ORIGINS as readonly string[]).includes(value);
 }
 
-function readRulesetRef(value: unknown): RulesetResult<RulesetRef> {
+/** A durable ref this build has registered, copied across the runtime boundary. */
+export function validateRulesetRef(value: unknown): RulesetResult<RulesetRef> {
   const record = asRecord(value);
   if (record === undefined || !isRulesetId(record.id)) {
     return rejectedRuleset('unknown-ruleset', 'mechanics names no supported ruleset id');
@@ -65,7 +66,7 @@ function readRulesetRef(value: unknown): RulesetResult<RulesetRef> {
 }
 
 export async function getRuleset(ref: RulesetRef): Promise<RulesetResult<RulesetDefinition>> {
-  const checked = readRulesetRef(ref);
+  const checked = validateRulesetRef(ref);
   if (!checked.ok) {
     return checked;
   }
@@ -103,7 +104,7 @@ export function validateQualifiedMechanics(value: unknown): RulesetResult<Qualif
     return rejectedRuleset('invalid-mechanics', 'qualified mechanics is not an object');
   }
 
-  const ruleset = readRulesetRef(record.ruleset);
+  const ruleset = validateRulesetRef(record.ruleset);
   if (!ruleset.ok) {
     return ruleset;
   }

--- a/src/lib/tools/README.md
+++ b/src/lib/tools/README.md
@@ -14,12 +14,12 @@ the `domain` it is listed under, and its `maturity`. Beyond that it is a `Tagged
 
 **Genre** and **game system** are both optional and are stored as namespaced tags:
 
-| Tag           | Meaning                                     |
-| ------------- | ------------------------------------------- |
-| `genre:*`     | `fantasy`, `scifi`, `cyberpunk`, `horror`   |
-| `system:*`    | `adnd-2e`, `dcc`, `swn`, `uncharted-worlds` |
-| `maturity:*`  | `experimental`, `beta`, `release-ready`     |
-| anything else | free-form, e.g. `character`, `map`, `magic` |
+| Tag           | Meaning                                               |
+| ------------- | ----------------------------------------------------- |
+| `genre:*`     | `fantasy`, `scifi`, `cyberpunk`, `horror`             |
+| `system:*`    | `adnd-2e`, `dcc`, `dnd-5e`, `swn`, `uncharted-worlds` |
+| `maturity:*`  | `experimental`, `beta`, `release-ready`               |
+| anything else | free-form, e.g. `character`, `map`, `magic`           |
 
 Storing them as tags rather than as fields means `applyTagFilter` works on tools unchanged, so
 a genre filter, a system filter, and a free-form tag filter are all the same operation and

--- a/src/lib/tools/tool_types.ts
+++ b/src/lib/tools/tool_types.ts
@@ -16,7 +16,7 @@ export type Genre = (typeof GENRES)[number];
  * Every game system the site knows about, in display order. Tools that produce system-agnostic
  * content carry no system at all rather than a placeholder value.
  */
-export const SYSTEMS = ['adnd-2e', 'dcc', 'swn', 'uncharted-worlds'] as const;
+export const SYSTEMS = ['adnd-2e', 'dcc', 'dnd-5e', 'swn', 'uncharted-worlds'] as const;
 
 export type GameSystem = (typeof SYSTEMS)[number];
 

--- a/src/lib/tools/tools.test.ts
+++ b/src/lib/tools/tools.test.ts
@@ -75,6 +75,14 @@ describe('featured', () => {
 describe('systemTag', () => {
   it('namespaces the system', () => {
     expect(systemTag('adnd-2e')).toBe('system:adnd-2e');
+    expect(systemTag('dnd-5e')).toBe('system:dnd-5e');
+  });
+
+  it('filters D&D 5E through the same system metadata as every other game', () => {
+    const dnd = defineTool({ ...environment, systems: ['dnd-5e'] });
+
+    expect(toolSystems(dnd)).toEqual(['dnd-5e']);
+    expect(hasSystem(dnd, 'dnd-5e')).toBe(true);
   });
 });
 
@@ -242,6 +250,7 @@ describe('genreDisplayName', () => {
 describe('systemDisplayName', () => {
   it('returns prose for a system', () => {
     expect(systemDisplayName('adnd-2e')).toBe('AD&D 2E');
+    expect(systemDisplayName('dnd-5e')).toBe('D&D 5E');
   });
 });
 

--- a/src/lib/tools/tools.ts
+++ b/src/lib/tools/tools.ts
@@ -119,6 +119,7 @@ const GENRE_NAMES: Record<ToolTypes.Genre, string> = {
 const SYSTEM_NAMES: Record<ToolTypes.GameSystem, string> = {
   'adnd-2e': 'AD&D 2E',
   dcc: 'Dungeon Crawl Classics',
+  'dnd-5e': 'D&D 5E',
   swn: 'Stars Without Number',
   'uncharted-worlds': 'Uncharted Worlds',
 };

--- a/src/lib/vault_file/vault_file_export.test.ts
+++ b/src/lib/vault_file/vault_file_export.test.ts
@@ -11,6 +11,7 @@ import {
 } from '$lib/artifact_kinds';
 import { createArtifact, listArtifacts, resetArtifactIndex } from '$lib/artifacts';
 import { createProject, resetProjectIndex } from '$lib/projects';
+import { IRONARACHNE_RULESET_REF } from '$lib/rulesets';
 import { closeVault, writeArtifactSummaryRecord } from '$lib/vault_db';
 import { writeProjectWorkspace } from '$lib/workspaces';
 
@@ -147,6 +148,39 @@ describe('buildProjectExportFile', () => {
       'First',
       'Second',
     ]);
+  });
+
+  it('preserves project and artifact-generation ruleset history', async () => {
+    const project = await createProject({
+      name: 'Aldia',
+      ruleset: IRONARACHNE_RULESET_REF,
+    });
+    if (!project.ok) {
+      expect.unreachable('the test project should be created');
+      return;
+    }
+    const artifact = await createArtifact(testKinds(), {
+      projectId: project.value.id,
+      kind: anythingKind.kind,
+      payload: { text: 'a' },
+      provenance: {
+        toolPath: '/culture',
+        seed: 'seed-1',
+        config: {},
+        ruleset: IRONARACHNE_RULESET_REF,
+      },
+    });
+    expect(artifact.ok).toBe(true);
+
+    const built = await buildProjectExportFile(project.value.id, { now: EXPORTED_AT });
+    if (!built.ok || built.value.envelope.scope !== 'project') {
+      expect.unreachable('the project should export');
+      return;
+    }
+    expect(built.value.envelope.body.project.ruleset).toEqual(IRONARACHNE_RULESET_REF);
+    expect(built.value.envelope.body.artifacts[0].provenance?.ruleset).toEqual(
+      IRONARACHNE_RULESET_REF,
+    );
   });
 
   it('sorts artifacts by id, so two exports of unchanged content are byte-identical', async () => {

--- a/src/lib/vault_file/vault_file_import.test.ts
+++ b/src/lib/vault_file/vault_file_import.test.ts
@@ -24,6 +24,7 @@ import {
   toCultureSnapshot,
 } from '$lib/culture';
 import { createProject, getProject, listProjects, resetProjectIndex } from '$lib/projects';
+import { IRONARACHNE_RULESET_REF } from '$lib/rulesets';
 import { closeVault, deleteProjectCascade, readVaultId } from '$lib/vault_db';
 import { ARTIFACT_KINDS } from '$lib/workshop';
 import { readProjectWorkspace, writeProjectWorkspace } from '$lib/workspaces';
@@ -533,6 +534,28 @@ describe('importExportFile: what a project is set in', () => {
     expect(restored.genre).toBe('horror');
     expect(restored.system).toBe('dcc');
     expect(restored.tags).toEqual(['genre:horror', 'system:dcc']);
+  });
+
+  it('round trips optional project and provenance ruleset refs', async () => {
+    const file = handBuiltFile('project', {
+      project: { ...handBuiltProject, ruleset: IRONARACHNE_RULESET_REF },
+      artifacts: [
+        exportedArtifact({
+          provenance: {
+            toolPath: '/culture',
+            seed: 'seed-1',
+            config: {},
+            ruleset: IRONARACHNE_RULESET_REF,
+          },
+        }),
+      ],
+    });
+
+    const result = await importExportFile(testKinds(), file);
+    expect(result.ok).toBe(true);
+    const [restored] = listProjects();
+    expect(restored.ruleset).toEqual(IRONARACHNE_RULESET_REF);
+    expect(listArtifacts(restored.id)[0].provenance?.ruleset).toEqual(IRONARACHNE_RULESET_REF);
   });
 
   it('keeps a project whose genre this build has never heard of', async () => {

--- a/src/lib/vault_file/vault_file_import.ts
+++ b/src/lib/vault_file/vault_file_import.ts
@@ -451,6 +451,7 @@ function stageProjectRecord(staging: Staging, project: Project, id: string): voi
       ...(project.description === undefined ? {} : { description: project.description }),
       ...(project.genre === undefined ? {} : { genre: project.genre }),
       ...(project.system === undefined ? {} : { system: project.system }),
+      ...(project.ruleset === undefined ? {} : { ruleset: project.ruleset }),
       tags: project.tags,
     },
     { id, now: project.updatedAt, createdAt: project.createdAt },

--- a/src/lib/workshop/artifact_saving.test.ts
+++ b/src/lib/workshop/artifact_saving.test.ts
@@ -8,6 +8,7 @@ import {
   type Artifact,
 } from '$lib/artifacts';
 import { closeVault } from '$lib/vault_db';
+import { IRONARACHNE_RULESET_REF } from '$lib/rulesets';
 
 import { ARTIFACT_KINDS } from './artifact_kind_catalog';
 import { saveToolArtifact } from './artifact_saving';
@@ -92,6 +93,18 @@ describe('saveToolArtifact', () => {
       seed: 'abc123',
       config: { nameSet: 'human' },
     });
+  });
+
+  it('records a ruleset only when the generating tool supplies one', async () => {
+    const result = await saveToolArtifact('p1', {
+      kind: 'culture',
+      payload: cultureSnapshot(),
+      toolPath: '/culture',
+      seed: 'abc123',
+      ruleset: IRONARACHNE_RULESET_REF,
+    });
+
+    expect(result.ok && result.value.provenance?.ruleset).toEqual(IRONARACHNE_RULESET_REF);
   });
 
   it('records no provenance at all rather than an invented seed', async () => {

--- a/src/lib/workshop/artifact_saving.ts
+++ b/src/lib/workshop/artifact_saving.ts
@@ -38,6 +38,7 @@ export function saveToolArtifact(
             toolPath: draft.toolPath,
             seed: draft.seed,
             config: draft.config ?? {},
+            ...(draft.ruleset === undefined ? {} : { ruleset: draft.ruleset }),
           },
         }),
   });

--- a/src/lib/workshop/workshop_types.ts
+++ b/src/lib/workshop/workshop_types.ts
@@ -8,6 +8,7 @@ import type {
   ArtifactReference,
   ArtifactSummary,
 } from '$lib/artifacts';
+import type { RulesetRef } from '$lib/rulesets';
 
 /**
  * A request to a tool that is already mounted: roll this seed, with these settings.
@@ -88,6 +89,8 @@ export type ToolArtifactDraft = {
   seed?: string;
   /** Generator settings as the tool understood them. */
   config?: Record<string, unknown>;
+  /** The pinned project default this generation consumed, when it consumed one. */
+  ruleset?: RulesetRef;
   /** What to call it. The kind's `nameOf` decides when this is blank. */
   name?: string;
   tags?: string[];


### PR DESCRIPTION
## Summary

- add `dnd-5e` to the shared game-system vocabulary, display names, tags, and filters
- add an optional pinned ruleset default to projects and enforce agreement with the project system filter
- let project creation and editing set or clear the default, requiring confirmation before an incompatible system change clears it
- add optional ruleset history to artifact-generation provenance without inferring it for existing artifacts
- preserve project and provenance refs through project and vault import/export
- keep existing artifacts byte-stable when project defaults change

The registered Iron Arachne compatibility release is selectable now. Published-system choices will appear from the same registry-backed UI when their audited packages land.

## Testing

- `npm run verify:all`
- 461 unit test files / 6,268 tests passed
- coverage gate: 101 libraries at or above 80%
- 631 Playwright tests passed across desktop and 320/360/375/390/430 px viewports; 5 platform-specific goldens skipped
- final focused pass: 681 unit tests and 15 Projects browser tests

Closes #212