### PR TITLE
Record and enforce the DCC licensing gate

### DIFF
--- a/docs/dcc-source-audit.md
+++ b/docs/dcc-source-audit.md
@@ -1,0 +1,62 @@
+# Dungeon Crawl Classics rules-data source audit
+
+**Status:** Production mechanics blocked pending an accepted Goodman Games agreement, reviewed
+2026-09-05
+
+## Decision
+
+Iron Arachne does not currently have a redistribution grant that admits Dungeon Crawl Classics
+core data into the ruleset registry. The repository therefore registers only the stable
+`dcc@legacy` identity used by existing character snapshots. That descriptor has zero capabilities
+and zero source ids. It makes old data readable without presenting the pre-audit tables as an
+approved production rules package.
+
+Goodman Games describes DCC support as a formal, free third-party publishing programme. Its
+[publisher hub](https://goodman-games.com/third-party-publisher-hub/) requires a publisher to seek
+the licence and obtain approval; the public descriptions say product quality is a condition. No
+accepted Iron Arachne agreement, versioned terms, approval, or permitted-content schedule is
+present in this repository. The programme's existence is not itself the grant required by
+`docs/rules-system.md`.
+
+The official
+[DCC RPG Quick Start Rules](https://goodman-games.com/wp-content/uploads/2020/03/DCC_QSR_Free.pdf)
+do include OGL 1.0a, but their designation is deliberately narrow. DCC-specific terms, spell names,
+proper nouns, capitalized and italicized terms, artwork, maps, symbols, and illustrations are
+Product Identity. Only SRD-derived portions of creature statistics are designated Open Game
+Content. That does not authorize copying the occupation, lucky-sign, currency, equipment, or
+treasure tables needed by this package.
+
+The machine-readable result is `src/lib/rulesets/dcc/source_manifest.ts`. It is intentionally not a
+`RulesDataSource` and is absent from the production source catalog: that type admits only material
+already approved for redistribution.
+
+## Existing data inventory
+
+The pre-registry `src/lib/dcc` library contains a zero-level character generator, occupation and
+lucky-sign tables, languages, starting currency and equipment, and derived character statistics.
+Those rows predate source-level provenance. The code comments identify the core rulebook, but that
+is not evidence of an applicable grant or of the particular printing from which each row came.
+
+Consequently:
+
+- existing `character.dcc` snapshots remain `dcc@legacy` and gain no source ids;
+- none of the old tables is imported, wrapped, or re-exported by the ruleset package;
+- the candidate actor, item, currency, equipment, and treasure-item TypeScript shapes contain no
+  copied table data and are not advertised as capabilities; and
+- currency conversion, codecs, equipment services, and treasure derivation remain disabled.
+
+## Enablement gate
+
+A later production DCC release needs all of the following before registration:
+
+1. The exact agreement accepted by Goodman Games and Iron Arachne, including its version or date.
+2. Its permitted content scope, required attribution and notices, logo/compatibility conditions,
+   approval process, and any distribution restrictions.
+3. A row-by-row and algorithm-by-algorithm audit of the proposed release against that grant.
+4. A redistributable `RulesDataSource` manifest and source ids on every admitted row and generated
+   payload.
+5. Codec round-trip, attribution, unsupported-capability, and fixed-seed derivation tests.
+
+Until then, requests for DCC treasure derivation return `unsupported-capability`, notices are empty,
+and no unapproved source can pass `defineRulesDataSource`. This is an engineering source policy,
+not legal advice.

--- a/src/lib/dcc/README.md
+++ b/src/lib/dcc/README.md
@@ -10,9 +10,11 @@ are defined.
 
 ## Which edition, and what is deliberately absent
 
-This is **Dungeon Crawl Classics as published in the core rulebook**, and only the part of it a
-zero-level character needs: the six attributes, the birth augur (lucky sign), the occupation tables
-for the four ancestries, starting equipment and coin, languages, and the four saves.
+This legacy library represents **Dungeon Crawl Classics core-rulebook material**, and only the part
+of it a zero-level character needs: the six attributes, the birth augur (lucky sign), the occupation
+tables for the four ancestries, starting equipment and coin, languages, and the four saves. Its rows
+predate source-level provenance and are not admitted into the production ruleset package; see
+[`docs/dcc-source-audit.md`](../../../docs/dcc-source-audit.md).
 
 What is **not** here, and is out of scope rather than missing:
 

--- a/src/lib/dcc/dcc_character_snapshot.ts
+++ b/src/lib/dcc/dcc_character_snapshot.ts
@@ -34,7 +34,7 @@
  */
 
 import type { RNG } from '@ironarachne/rng';
-import type { RulesetRef } from '$lib/rulesets';
+import { DCC_LEGACY_RULESET_REF, type RulesetRef } from '$lib/rulesets';
 
 import type { DCCCharacter, DCCLuckyRoll, DCCOccupation } from './dcc_types.js';
 import * as DwarfOccupations from './dwarf_occupations.js';
@@ -51,10 +51,7 @@ export type StoredDccLuckyRoll = Omit<DCCLuckyRoll, 'apply'>;
 
 /** A DCC character as it is stored. */
 /** Stable identity for the pre-audit tables; it asserts no source or licence provenance. */
-export const DCC_CHARACTER_RULESET_REF = {
-  id: 'dcc',
-  release: 'legacy',
-} as const satisfies RulesetRef;
+export const DCC_CHARACTER_RULESET_REF = DCC_LEGACY_RULESET_REF;
 
 export type DccCharacterSnapshot = Omit<DCCCharacter, 'occupation' | 'luckyRoll'> & {
   ruleset: RulesetRef;

--- a/src/lib/rulesets/README.md
+++ b/src/lib/rulesets/README.md
@@ -41,5 +41,17 @@ The pre-existing `$lib/adnd` generator tables remain `adnd-2e@legacy`: they pred
 provenance and are not silently relabelled. The detailed source inventory and boundary are recorded
 in [`docs/adnd-2e-source-audit.md`](../../../docs/adnd-2e-source-audit.md).
 
+## Dungeon Crawl Classics package
+
+`$lib/rulesets/dcc` registers the existing `dcc@legacy` snapshot identity with zero capabilities
+and zero sources. Goodman Games' public third-party programme requires a formal licence and
+approval, while the Quick Start Rules' OGL designation does not open the core tables the first
+consumers need. The package therefore exposes candidate payload types but no production codec,
+currency, equipment, or treasure service.
+
+The pre-existing `$lib/dcc` generator remains readable as legacy data and gains no invented source
+history. The evidence, existing-data inventory, and enablement gate are recorded in
+[`docs/dcc-source-audit.md`](../../../docs/dcc-source-audit.md).
+
 The full contract, dependency rules, and migration plan are in
 [`docs/rules-system.md`](../../../docs/rules-system.md).

--- a/src/lib/rulesets/dcc/dcc.test.ts
+++ b/src/lib/rulesets/dcc/dcc.test.ts
@@ -1,0 +1,61 @@
+import { RNG } from '@ironarachne/rng';
+import { describe, expect, it } from 'vitest';
+
+import { DCC_CHARACTER_RULESET_REF } from '$lib/dcc';
+import {
+  allRulesDataSources,
+  deriveTreasureItemMechanics,
+  getRuleset,
+  rulesetNotices,
+} from '../index.js';
+import { DCC_LEGACY_RULESET_REF, DCC_SOURCE_REVIEW } from './index.js';
+
+describe('DCC source review', () => {
+  it('keeps production data disabled without an accepted Goodman Games agreement', () => {
+    expect(DCC_SOURCE_REVIEW).toMatchObject({
+      publisher: 'Goodman Games',
+      reviewedAt: '2026-09-05',
+      status: 'blocked-pending-written-permission',
+      redistributable: false,
+    });
+    expect(DCC_SOURCE_REVIEW.findings).toContain(
+      'The Quick Start Rules designate only SRD-derived portions of creature statistics as Open Game Content.',
+    );
+    expect(allRulesDataSources().map(({ id }) => id)).not.toContain(DCC_SOURCE_REVIEW.id);
+  });
+
+  it('does not invent source history for existing DCC characters', () => {
+    expect(DCC_LEGACY_RULESET_REF).toEqual({ id: 'dcc', release: 'legacy' });
+    expect(DCC_CHARACTER_RULESET_REF).toEqual(DCC_LEGACY_RULESET_REF);
+    expect(DCC_LEGACY_RULESET_REF).not.toHaveProperty('sourceIds');
+  });
+});
+
+describe('disabled DCC ruleset package', () => {
+  it('registers only the capability-free legacy identity', async () => {
+    expect(await getRuleset(DCC_LEGACY_RULESET_REF)).toMatchObject({
+      ok: true,
+      value: {
+        descriptor: {
+          capabilities: [],
+          sourceIds: [],
+        },
+      },
+    });
+    expect(rulesetNotices([DCC_LEGACY_RULESET_REF])).toEqual({ ok: true, value: [] });
+  });
+
+  it('rejects treasure derivation before using the supplied fixed-seed RNG', async () => {
+    const rng = new RNG('disabled-dcc-treasure');
+
+    expect(
+      await deriveTreasureItemMechanics(
+        DCC_LEGACY_RULESET_REF,
+        { id: 'gem', name: 'Gem', description: 'A test fixture.', weight: 0 },
+        { variants: [] },
+        { kind: 'valuable', minimumValue: 1, maximumValue: 6, denomination: 'gp' },
+        rng,
+      ),
+    ).toMatchObject({ ok: false, reason: 'unsupported-capability' });
+  });
+});

--- a/src/lib/rulesets/dcc/definition.ts
+++ b/src/lib/rulesets/dcc/definition.ts
@@ -1,0 +1,5 @@
+import { defineRuleset } from '../ruleset_definitions';
+import { DCC_LEGACY_RULESET_DESCRIPTOR } from './descriptor';
+
+/** No mechanics services are enabled while the DCC source review is blocked. */
+export const dccLegacyRuleset = defineRuleset({ descriptor: DCC_LEGACY_RULESET_DESCRIPTOR });

--- a/src/lib/rulesets/dcc/descriptor.ts
+++ b/src/lib/rulesets/dcc/descriptor.ts
@@ -1,0 +1,21 @@
+import type { RulesetDescriptor, RulesetRef } from '../ruleset_types';
+
+/** Stable identity for existing pre-audit DCC snapshots; it asserts no source provenance. */
+export const DCC_LEGACY_RULESET_REF = {
+  id: 'dcc',
+  release: 'legacy',
+} as const satisfies RulesetRef;
+
+/**
+ * A readable catalog identity, not an enabled production mechanics package.
+ *
+ * Zero capabilities and zero sources are intentional until the Goodman Games agreement is
+ * obtained, recorded, and approved.
+ */
+export const DCC_LEGACY_RULESET_DESCRIPTOR: RulesetDescriptor = {
+  ref: DCC_LEGACY_RULESET_REF,
+  displayName: 'Dungeon Crawl Classics (legacy)',
+  gameSystem: 'dcc',
+  capabilities: [],
+  sourceIds: [],
+};

--- a/src/lib/rulesets/dcc/index.ts
+++ b/src/lib/rulesets/dcc/index.ts
@@ -1,0 +1,4 @@
+export * from './definition.js';
+export * from './descriptor.js';
+export * from './mechanics_types.js';
+export * from './source_manifest.js';

--- a/src/lib/rulesets/dcc/mechanics_types.ts
+++ b/src/lib/rulesets/dcc/mechanics_types.ts
@@ -1,0 +1,53 @@
+/**
+ * Candidate DCC payload shapes for the first ruleset consumers.
+ *
+ * These are schemas only. They contain no core tables or rulebook prose, and the disabled legacy
+ * descriptor advertises none of them as a supported production capability.
+ */
+export type DccSavingThrows = {
+  fortitude: number;
+  reflex: number;
+  willpower: number;
+};
+
+export type DccActorMechanics = {
+  armorClass: number;
+  hitPoints: number;
+  attackModifier: number;
+  saves: DccSavingThrows;
+};
+
+export type DccCurrencyId = 'cp' | 'sp' | 'gp';
+
+export type DccCurrencyAmounts = Record<DccCurrencyId, number>;
+
+export type DccWeaponMechanics = {
+  kind: 'weapon';
+  value: number;
+  denomination: DccCurrencyId;
+  damage: string;
+  range: string;
+};
+
+export type DccArmorMechanics = {
+  kind: 'armor';
+  value: number;
+  denomination: DccCurrencyId;
+  armorClass: number;
+};
+
+export type DccValuableMechanics = {
+  kind: 'valuable';
+  value: number;
+  denomination: DccCurrencyId;
+  magical: boolean;
+};
+
+export type DccItemMechanics = DccWeaponMechanics | DccArmorMechanics | DccValuableMechanics;
+
+export type DccTreasureItemContext = {
+  kind: DccItemMechanics['kind'];
+  minimumValue: number;
+  maximumValue: number;
+  denomination: DccCurrencyId;
+};

--- a/src/lib/rulesets/dcc/source_manifest.ts
+++ b/src/lib/rulesets/dcc/source_manifest.ts
@@ -1,0 +1,29 @@
+/**
+ * The result of the DCC source review, deliberately not a production `RulesDataSource`.
+ *
+ * Goodman Games advertises a free third-party programme, but the public material directs a
+ * publisher to apply for a formal licence. Iron Arachne has no accepted agreement to record, and
+ * the Quick Start Rules open only SRD-derived creature-stat portions. Keeping this object outside
+ * `defineRulesDataSource` makes that absence impossible to mistake for redistribution approval.
+ */
+export const DCC_SOURCE_REVIEW = {
+  id: 'goodman-games.dcc-third-party-programme',
+  title: 'Dungeon Crawl Classics third-party publishing programme',
+  publisher: 'Goodman Games',
+  reviewedAt: '2026-09-05',
+  status: 'blocked-pending-written-permission',
+  redistributable: false,
+  publicProgrammeUrl: 'https://goodman-games.com/third-party-publisher-hub/',
+  quickStartUrl: 'https://goodman-games.com/wp-content/uploads/2020/03/DCC_QSR_Free.pdf',
+  findings: [
+    'The programme requires a publisher to obtain a formal Goodman Games licence and approval.',
+    'No accepted Iron Arachne agreement or versioned licence text is present in the repository.',
+    'The Quick Start Rules reserve DCC-specific terms and tables as Product Identity.',
+    'The Quick Start Rules designate only SRD-derived portions of creature statistics as Open Game Content.',
+  ],
+  enablementRequirements: [
+    'Record the exact accepted Goodman Games agreement and its version.',
+    'Record its permitted content scope, attribution, logo, and approval conditions.',
+    'Audit every admitted production row and algorithm against that grant.',
+  ],
+} as const;

--- a/src/lib/rulesets/ruleset_catalog.ts
+++ b/src/lib/rulesets/ruleset_catalog.ts
@@ -1,5 +1,6 @@
 import { ADND_2E_RULESET_DESCRIPTOR, ADND_2E_RULESET_REF } from './adnd_2e/descriptor';
 import { ADND_2E_OPEN_RULES_SOURCE } from './adnd_2e/source_manifest';
+import { DCC_LEGACY_RULESET_DESCRIPTOR, DCC_LEGACY_RULESET_REF } from './dcc/descriptor';
 import { IRONARACHNE_RULESET_DESCRIPTOR, IRONARACHNE_RULESET_REF } from './ironarachne/descriptor';
 import { IRONARACHNE_ORIGINAL_SOURCE } from './ironarachne/source_manifest';
 import type {
@@ -27,6 +28,13 @@ const RULESET_CATALOG: RulesetCatalogEntry[] = [
     load: async () => {
       const { adnd2eRuleset } = await import('./adnd_2e/definition.js');
       return adnd2eRuleset;
+    },
+  },
+  {
+    descriptor: DCC_LEGACY_RULESET_DESCRIPTOR,
+    load: async () => {
+      const { dccLegacyRuleset } = await import('./dcc/definition.js');
+      return dccLegacyRuleset;
     },
   },
 ];
@@ -68,4 +76,4 @@ export function findRulesDataSource(id: string): RulesDataSource | undefined {
   return RULES_DATA_SOURCES.find((source) => source.id === id);
 }
 
-export { ADND_2E_RULESET_REF, IRONARACHNE_RULESET_REF };
+export { ADND_2E_RULESET_REF, DCC_LEGACY_RULESET_REF, IRONARACHNE_RULESET_REF };

--- a/src/lib/rulesets/rulesets.test.ts
+++ b/src/lib/rulesets/rulesets.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   IRONARACHNE_RULESET_REF,
   ADND_2E_RULESET_REF,
+  DCC_LEGACY_RULESET_REF,
   RULESET_IDS,
   acceptedRuleset,
   addMechanicsVariant,
@@ -52,6 +53,13 @@ describe('ruleset catalog', () => {
         gameSystem: 'adnd-2e',
         capabilities: ['actor', 'item', 'currency', 'equipment', 'treasure-items'],
       }),
+      expect.objectContaining({
+        ref: DCC_LEGACY_RULESET_REF,
+        displayName: 'Dungeon Crawl Classics (legacy)',
+        gameSystem: 'dcc',
+        capabilities: [],
+        sourceIds: [],
+      }),
     ]);
   });
 
@@ -99,7 +107,7 @@ describe('ruleset catalog', () => {
       release: '1',
     } as unknown as RulesetRef);
     const unknownRelease = await getRuleset({ id: 'ironarachne', release: 'newer' });
-    const unregisteredKnownId = await getRuleset({ id: 'dcc', release: '1' });
+    const unregisteredKnownId = await getRuleset({ id: 'dcc', release: 'not-registered' });
     const emptyRelease = await getRuleset({ id: 'ironarachne', release: '' });
     const blankRelease = await getRuleset({ id: 'ironarachne', release: '   ' });
 


### PR DESCRIPTION
Partial progress on #211.

This records the DCC source audit and enforces its fail-closed result. Goodman Games publicly describes a formal third-party publishing programme that requires publisher approval, while the official Quick Start Rules designate only SRD-derived creature-stat portions as Open Game Content and reserve DCC-specific terms and tables. No accepted Iron Arachne agreement is present, so this change does not admit a production DCC source or mechanics data.

It registers the stable dcc@legacy snapshot identity with zero capabilities and zero source IDs, adds candidate typed payload shapes without services or table data, preserves legacy character provenance, and verifies that treasure derivation remains unsupported. The audit lists the exact evidence and the agreement details required before production enablement.

This intentionally does not close #211; the production codec, currency, equipment, attribution, and deterministic treasure derivation remain blocked on the accepted Goodman Games agreement.

Verification:
- npm run verify:all
- 6,286 unit tests passed
- coverage gate: 101 libraries checked, all at or above 80 percent
- 632 Playwright tests passed, 5 expected skips