### PR TITLE
Make lone workshop tools fill the bench

### DIFF
--- a/e2e/workshop.spec.ts
+++ b/e2e/workshop.spec.ts
@@ -199,6 +199,29 @@ test.describe('the workshop bench', () => {
     expect(surfaces.artifact.field).not.toBe('rgba(0, 0, 0, 0)');
   });
 
+  test('lets a lone tool use the full bench width', async ({ page }) => {
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await mountTool(page, /^Culture/);
+
+    const bench = await page.locator('.workshop__bench').boundingBox();
+    const tool = await page.locator('.workshop-panel--tool').boundingBox();
+    expect(bench).not.toBeNull();
+    expect(tool).not.toBeNull();
+    expect(Math.abs(tool!.width - bench!.width)).toBeLessThan(1);
+  });
+
+  test('continues to let a lone artifact use the full bench width', async ({ page }) => {
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await benchWithToolAndArtifact(page, 'The Emberfolk');
+    await page.getByRole('button', { name: /^Close Culture/ }).click();
+
+    const bench = await page.locator('.workshop__bench').boundingBox();
+    const artifact = await page.locator('.workshop-panel--artifact').boundingBox();
+    expect(bench).not.toBeNull();
+    expect(artifact).not.toBeNull();
+    expect(Math.abs(artifact!.width - bench!.width)).toBeLessThan(1);
+  });
+
   /**
    * The width the cap exists for. A tool panel with `flex-grow` and no maximum takes the whole
    * bench, and the artifact opened beside it wraps underneath — reference below the fold, which

--- a/src/components/common/WorkshopPanel.svelte
+++ b/src/components/common/WorkshopPanel.svelte
@@ -24,6 +24,8 @@
      * is not the work.
      */
     holds: 'tool' | 'artifact';
+    /** Whether this tool has saved reference material open beside it on the bench. */
+    hasArtifactSibling: boolean;
     onClose: () => void;
     onMoveLeft: () => void;
     onMoveRight: () => void;
@@ -36,6 +38,7 @@
     position,
     total,
     holds,
+    hasArtifactSibling,
     onClose,
     onMoveLeft,
     onMoveRight,
@@ -46,6 +49,15 @@
   // alongside it to be operable at all, and two buttons are that equivalent without the drag.
   const canMoveLeft = $derived(position > 1);
   const canMoveRight = $derived(position < total);
+  const panelClass = $derived(
+    [
+      'workshop-panel',
+      `workshop-panel--${holds}`,
+      holds === 'tool' && hasArtifactSibling ? 'workshop-panel--tool-with-artifact' : '',
+    ]
+      .filter(Boolean)
+      .join(' '),
+  );
 
   // `$state`, because these are bound through the button component's `element` prop rather than by
   // `bind:this` on an element: a component binding writes back through the reactive graph, and a
@@ -89,14 +101,7 @@
      because a tool must behave identically in a panel and on its own route — the cost of that is
      an inverted heading level, and the alternative is a tool that is a different component in
      each place. -->
-<Panel
-  {title}
-  {subtitle}
-  bare={holds === 'tool'}
-  focal
-  class="workshop-panel workshop-panel--{holds}"
-  label="{title} panel"
->
+<Panel {title} {subtitle} bare={holds === 'tool'} focal class={panelClass} label="{title} panel">
   {#snippet actions()}
     <MoveLeftButton
       bind:element={moveLeftButton}
@@ -130,13 +135,13 @@
     flex: 1 1 32rem;
   }
 
-  /* The cap is what makes a third column possible. Without it the tool takes the whole bench and
-     an artifact opened beside it wraps underneath — which is the one arrangement the bench should
-     never produce, because the artifact is *reference* for the work and reference below the fold
-     is reference nobody reads. 32rem is measured rather than chosen: at 1920 the bench is a little
-     over 52rem once the rail stops growing, and 32 + a 1rem gap + the artifact's 18rem basis is
-     what fits inside that with room to spare. */
-  :global(.workshop-panel--tool) {
+  /* The cap is only for a tool with reference material beside it. Without it the tool takes the
+     whole bench and an artifact wraps underneath — which is the one arrangement the bench should
+     never produce, because reference below the fold is reference nobody reads. A lone tool has no
+     reference column to reserve and grows across the available bench instead. 32rem is measured
+     rather than chosen: at 1920 the bench is a little over 52rem once the rail stops growing, and
+     32 + a 1rem gap + the artifact's 18rem basis fits inside that with room to spare. */
+  :global(.workshop-panel--tool-with-artifact) {
     max-width: 32rem;
   }
 

--- a/src/components/layout/WorkshopPage.svelte
+++ b/src/components/layout/WorkshopPage.svelte
@@ -383,6 +383,7 @@
           title={panelTitle(panel)}
           subtitle={panel.toolPath === undefined ? 'Artifact' : 'Tool'}
           holds={panel.toolPath === undefined ? 'artifact' : 'tool'}
+          hasArtifactSibling={openArtifactIds.length > 0}
           position={panel.order + 1}
           total={bench.panels.length}
           onClose={() => void closePanel(panel)}


### PR DESCRIPTION
Closes #225

## Summary
- let a lone tool panel use the full available workshop bench width
- retain the 32rem tool cap when an artifact is open beside it
- cover lone-tool, lone-artifact, and side-by-side behavior in Playwright

## Verification
- npm run check
- npx eslint .
- npx prettier --check src/components/common/WorkshopPanel.svelte src/components/layout/WorkshopPage.svelte e2e/workshop.spec.ts
- npm run coverage:check (tests passed; coverage gate rerun directly after sandbox IPC restriction)
- npx tsx scripts/check_library_coverage.ts
- npm run test:e2e (640 passed, 5 skipped)

The combined npm run verify:all wrapper also sees an unrelated untracked Claude outputs/issue-228-triage-comment.md file that fails its repository-wide Prettier check; that user-owned file was left untouched.