### PR TITLE
Align river outlets with mapped water bodies

### DIFF
--- a/src/components/locations/RegionGenerator.svelte
+++ b/src/components/locations/RegionGenerator.svelte
@@ -458,7 +458,13 @@
     display: grid;
     column-gap: 1rem;
     margin-bottom: 1rem;
-    grid-template-columns: 210px auto;
+    grid-template-columns: 210px minmax(0, 1fr);
+  }
+
+  @media (max-width: 480px) {
+    div.ruler {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
 
   button.heraldry-inline-target {

--- a/src/lib/map/README.md
+++ b/src/lib/map/README.md
@@ -18,19 +18,30 @@ The map is a Voronoi diagram over Poisson-disk points, built with
   computed on corners, because water flows along edges rather than through cell middles.
 - **`MapEdge`** — the border between two cells, and the segment between two corners.
 
+Corners within 0.1 map units are interned by distance, including across spatial-hash bucket
+boundaries. Collapsed edges are removed from the cell ring, and polygons use the canonical corner
+positions so their geometry agrees with the graph.
+
 ## Pipeline
 
-| Stage                                 | What it does                                  |
-| ------------------------------------- | --------------------------------------------- |
-| `buildBaseMapGraph`                   | Points, triangulation, Voronoi, empty graph   |
-| `assignElevation`                     | Raises land and marks water, ocean, and coast |
-| `simulateWater`                       | Flows water downhill into rivers and lakes    |
-| `assignTemperature`, `assignMoisture` | Climate from latitude, elevation, and water   |
-| `assignBiomes`                        | A biome per cell from its climate             |
-| `generateRoads`                       | Routes roads over the finished terrain        |
+| Stage                                 | What it does                                           |
+| ------------------------------------- | ------------------------------------------------------ |
+| `buildBaseMapGraph`                   | Points, triangulation, Voronoi, empty graph            |
+| `assignElevation`                     | Raises land and averages corner elevations per cell    |
+| `simulateWater`                       | Classifies water and flows rivers into ocean and lakes |
+| `assignTemperature`, `assignMoisture` | Climate from latitude, elevation, and water            |
+| `assignBiomes`                        | A biome per cell from its climate                      |
+| `generateRoads`                       | Routes roads over the finished terrain                 |
 
 ## Features
 
+- **Water simulation** — a cell is submerged when its elevation is below sea level or at least
+  half its corners are below sea level. The builder's boundary-site cells seed the ocean; a flood
+  fill reaches submerged neighbors, while disconnected submerged cells are lakes. Corner water
+  flags follow their touching cells, and rivers stop at mapped ocean or lake shores. A river
+  reaching an unmapped local minimum makes its touching cells lake water. Thus a low corner alone
+  cannot masquerade as an ocean outlet in dry country. This changes seeded geography, including
+  downstream settlement placement, from the pre-#244 simulation.
 - **Types** — `RegionMap`, `MapNode`, `MapCorner`, `MapEdge`, `MapBuilderConfig`, and one config per
   stage (`ElevationConfig`, `WaterConfig`, `TemperatureConfig`, `MoistureConfig`,
   `BiomeAssignmentConfig`, `RoadConfig`).

--- a/src/lib/map/builder.test.ts
+++ b/src/lib/map/builder.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RNG } from '@ironarachne/rng';
+import * as Geometry from '$lib/geometry';
+import { buildBaseMapGraph } from './builder';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('corner interning', () => {
+  it('merges across bucket boundaries without collapsing distant vertices in the same bucket', () => {
+    const vertices = [
+      { x: 26.21, y: 33.54 },
+      { x: 26.22, y: 33.56 },
+      { x: 27.09, y: 34.09 },
+      { x: 27.11, y: 34.11 },
+      { x: -0.01, y: -0.01 },
+      { x: 0.01, y: 0.01 },
+      { x: 1.051, y: 1.051 },
+      { x: 1.149, y: 1.149 },
+    ];
+    vi.spyOn(Geometry, 'computeVoronoi').mockReturnValue({
+      cells: [{ site: { x: 20, y: 20 }, polygon: { vertices, edges: [] }, neighbors: [] }],
+      edges: [],
+    });
+    const map = buildBaseMapGraph({
+      width: 60,
+      height: 35,
+      seed: 'intern',
+      pointSpacing: 10,
+      rng: new RNG('intern'),
+    });
+    expect(map.corners.map((c) => c.point)).toEqual([
+      vertices[0],
+      vertices[2],
+      vertices[4],
+      vertices[6],
+      vertices[7],
+    ]);
+    expect(map.edges).toHaveLength(5);
+    expect(map.edges.every((e) => e.v0 !== e.v1)).toBe(true);
+    expect(map.nodes[0].polygon.vertices).toEqual(map.corners.map((c) => c.point));
+    expect(map.nodes[0].polygon.edges).toHaveLength(5);
+    expect(map.nodes[0].neighbors).toEqual([]);
+  });
+
+  it.each(['charlie', 'alpha', 'golf'])(
+    'keeps the generated %s graph canonical and connected',
+    (seed) => {
+      const map = buildBaseMapGraph({
+        width: 60,
+        height: 35,
+        seed,
+        pointSpacing: 2,
+        rng: new RNG(seed),
+      });
+      let nearest = Infinity;
+      for (const [i, a] of map.corners.entries()) {
+        for (const b of map.corners.slice(i + 1)) {
+          nearest = Math.min(nearest, Math.hypot(a.point.x - b.point.x, a.point.y - b.point.y));
+        }
+        expect(a.adjacent).not.toContain(a.id);
+        for (const id of a.touches) expect(map.nodes[id].corners).toContain(a.id);
+      }
+      expect(nearest).toBeGreaterThan(0.1);
+      for (const node of map.nodes) {
+        expect(new Set(node.corners).size).toBe(node.corners.length);
+        expect(node.polygon.vertices).toEqual(node.corners.map((id) => map.corners[id].point));
+        expect(node.neighbors).not.toContain(node.id);
+        for (const id of node.neighbors) expect(map.nodes[id].neighbors).toContain(node.id);
+      }
+      for (const edge of map.edges) {
+        expect(edge.v0).not.toBe(edge.v1);
+        expect(map.nodes[edge.d0].edges).toContain(edge.id);
+        if (edge.d1 !== undefined) expect(map.nodes[edge.d1].edges).toContain(edge.id);
+      }
+    },
+  );
+});

--- a/src/lib/map/builder.ts
+++ b/src/lib/map/builder.ts
@@ -1,10 +1,13 @@
 import type { RNG } from '@ironarachne/rng';
-import { generatePoissonDisk } from '../geometry/poisson.js';
-import { triangulate } from '../geometry/delaunay.js';
-import { computeVoronoi, type VoronoiCell } from '../geometry/voronoi.js';
+import {
+  generatePoissonDisk,
+  triangulate,
+  computeVoronoi,
+  getMidpoint,
+  type VoronoiCell,
+  type Vertex,
+} from '$lib/geometry';
 import type { RegionMap, MapNode, MapEdge, MapCorner } from './map_graph.js';
-import type Vertex from '../geometry/vertex.js';
-import { getMidpoint } from '../geometry/geometry.js';
 
 export interface MapBuilderConfig {
   width: number;
@@ -57,17 +60,25 @@ type GraphAccumulator = {
 };
 
 function createGraphAccumulator(regionMap: RegionMap): GraphAccumulator {
-  const cornerMap = new Map<string, MapCorner>();
+  const cornerMap = new Map<string, MapCorner[]>();
   const edgeMap = new Map<string, MapEdge>();
 
-  // A fuzzy coordinate hash to merge floating point corners safely
-  const coordHash = (v: Vertex) => `${v.x.toFixed(1)},${v.y.toFixed(1)}`;
+  // A distance tolerance, not coordinate rounding: close vertices may straddle a bucket edge.
+  const tolerance = 0.1;
 
   const getOrCreateCorner = (v: Vertex): MapCorner => {
-    const hash = coordHash(v);
-    if (cornerMap.has(hash)) {
-      return cornerMap.get(hash) as MapCorner;
+    const x = Math.floor(v.x / tolerance);
+    const y = Math.floor(v.y / tolerance);
+    for (let dx = -1; dx <= 1; dx++) {
+      for (let dy = -1; dy <= 1; dy++) {
+        for (const corner of cornerMap.get(`${x + dx},${y + dy}`) ?? []) {
+          if (Math.hypot(corner.point.x - v.x, corner.point.y - v.y) <= tolerance) {
+            return corner;
+          }
+        }
+      }
     }
+    const hash = `${x},${y}`;
     const newCorner: MapCorner = {
       id: regionMap.corners.length,
       point: v,
@@ -82,7 +93,9 @@ function createGraphAccumulator(regionMap: RegionMap): GraphAccumulator {
       isCoast: false,
       river: 0,
     };
-    cornerMap.set(hash, newCorner);
+    const bucket = cornerMap.get(hash) ?? [];
+    bucket.push(newCorner);
+    cornerMap.set(hash, bucket);
     regionMap.corners.push(newCorner);
     return newCorner;
   };
@@ -142,7 +155,10 @@ function addNodeForCell(
   nodeId: number,
   config: MapBuilderConfig,
 ): void {
-  const nodeCorners = cell.polygon.vertices.map((v) => accumulator.getOrCreateCorner(v));
+  // Merging a short Voronoi edge must not leave a self-loop or duplicate polygon vertex.
+  const nodeCorners = [
+    ...new Set(cell.polygon.vertices.map((v) => accumulator.getOrCreateCorner(v))),
+  ];
   const nodeEdges: MapEdge[] = [];
 
   // Link node back to corners
@@ -155,12 +171,13 @@ function addNodeForCell(
   // Build edges sequentially connecting corners
   for (let j = 0; j < nodeCorners.length; j++) {
     const nextIdx = (j + 1) % nodeCorners.length;
+    if (nodeCorners[j] === nodeCorners[nextIdx]) continue;
     const edge = accumulator.getOrCreateEdge(nodeCorners[j], nodeCorners[nextIdx]);
 
     // Link the node to the edge, edge to the node
     if (edge.d0 === -1) {
       edge.d0 = nodeId;
-    } else if (edge.d1 === undefined) {
+    } else if (edge.d1 === undefined && edge.d0 !== nodeId) {
       edge.d1 = nodeId;
     }
 
@@ -170,7 +187,13 @@ function addNodeForCell(
   const mapNode: MapNode = {
     id: nodeId,
     center: cell.site,
-    polygon: cell.polygon,
+    polygon: {
+      vertices: nodeCorners.map((c) => c.point),
+      edges: nodeCorners.map((c, i) => ({
+        a: c.point,
+        b: nodeCorners[(i + 1) % nodeCorners.length].point,
+      })),
+    },
     neighbors: [], // Populate after graph is formed
     edges: nodeEdges.map((e) => e.id),
     corners: nodeCorners.map((c) => c.id),

--- a/src/lib/map/region_routes.test.ts
+++ b/src/lib/map/region_routes.test.ts
@@ -22,7 +22,8 @@ for (const seed of ['alpha', 'bravo', 'charlie']) {
       };
       const svg = buildRegionMapSvgString(map, options);
       const drawn = [...svg.matchAll(/data-river-edge="(\d+)" data-flow="([\d.]+)"/g)];
-      expect(drawn.length).toBeGreaterThan(100);
+      // Rivers now stop at lake shores; their segment count is not a rendering contract.
+      expect(drawn.length).toBeGreaterThan(0);
       for (const match of drawn) {
         const edge = map.edges[Number(match[1])];
         expect(Number(match[2])).toBe(edge.river);
@@ -47,18 +48,9 @@ for (const seed of ['alpha', 'bravo', 'charlie']) {
           corner = next;
         }
       }
-      if (seed === 'charlie') {
-        // #244: a terminal ocean corner surrounded entirely by dry cells is not mapped water.
-        for (const id of [75, 85]) {
-          expect(map.corners[id].isOcean).toBe(true);
-          expect(map.corners[id].touches.every((node) => !map.nodes[node].isWater)).toBe(true);
-          expect(
-            drawn.some((match) => {
-              const edge = map.edges[Number(match[1])];
-              return edge.v0 === id || edge.v1 === id;
-            }),
-          ).toBe(false);
-        }
+      // #244: ocean outlets must belong to mapped water, regardless of corner renumbering.
+      for (const corner of map.corners.filter((c) => c.isOcean)) {
+        expect(corner.touches.some((id) => map.nodes[id].isWater)).toBe(true);
       }
       const lastGlyph = Math.max(
         svg.lastIndexOf('<use href="#tree-'),

--- a/src/lib/map/water.test.ts
+++ b/src/lib/map/water.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RNG } from '@ironarachne/rng';
+import { generate, getDefaultConfig } from '$lib/regions';
+import type { RegionMap } from './map_graph';
+import { simulateWater } from './water';
+
+/** A strip of square cells; all elevations start above sea level, with no ocean seed. */
+function stripMap(count: number): RegionMap {
+  const map: RegionMap = { width: count + 2, height: 3, nodes: [], corners: [], edges: [] };
+  for (let i = 0; i < (count + 1) * 2; i++) {
+    map.corners.push({
+      id: i,
+      point: { x: 1 + Math.floor(i / 2), y: 1 + (i % 2) },
+      touches: [],
+      protrudes: [],
+      adjacent: [],
+      elevation: 0.5,
+      moisture: 0,
+      temperature: 0,
+      isWater: false,
+      isOcean: false,
+      isCoast: false,
+      river: 0,
+    });
+  }
+  for (let i = 0; i < count; i++) {
+    const corners = [i * 2, i * 2 + 2, i * 2 + 3, i * 2 + 1];
+    const edges: number[] = [];
+    for (const [j, id] of corners.entries()) {
+      const next = corners[(j + 1) % corners.length];
+      let edge = map.edges.find(
+        (e) => (e.v0 === id && e.v1 === next) || (e.v1 === id && e.v0 === next),
+      );
+      if (edge) edge.d1 = i;
+      else {
+        const a = map.corners[id],
+          b = map.corners[next];
+        edge = {
+          id: map.edges.length,
+          d0: i,
+          v0: id,
+          v1: next,
+          river: 0,
+          midpoint: { x: (a.point.x + b.point.x) / 2, y: (a.point.y + b.point.y) / 2 },
+        };
+        map.edges.push(edge);
+        a.adjacent.push(next);
+        b.adjacent.push(id);
+        a.protrudes.push(edge.id);
+        b.protrudes.push(edge.id);
+      }
+      edges.push(edge.id);
+      map.corners[id].touches.push(i);
+    }
+    const vertices = corners.map((id) => map.corners[id].point);
+    map.nodes.push({
+      id: i,
+      center: { x: i + 1.5, y: 1.5 },
+      polygon: {
+        vertices,
+        edges: vertices.map((a, j) => ({ a, b: vertices[(j + 1) % vertices.length] })),
+      },
+      neighbors: [i - 1, i + 1].filter((id) => id >= 0 && id < count),
+      edges,
+      corners,
+      elevation: 0.5,
+      moisture: 0,
+      temperature: 0,
+      isOcean: false,
+      isWater: false,
+      isCoast: false,
+    });
+  }
+  return map;
+}
+
+describe('simulateWater', () => {
+  it('floods ocean through submerged cells from the rim, leaving disconnected water as lake', () => {
+    const map = stripMap(5);
+    map.nodes[0].isOcean = true; // Boundary-site marker supplied by the builder.
+    for (const id of [1, 2, 4]) map.nodes[id].elevation = -0.2;
+    const result = simulateWater(map, {
+      seaLevel: -0.1,
+      springCountPercentage: 0,
+      rng: new RNG('water'),
+    });
+    expect(result.nodes.map((n) => n.isOcean)).toEqual([true, true, true, false, false]);
+    expect(result.nodes.map((n) => n.isWater)).toEqual([true, true, true, false, true]);
+    expect(result.nodes.map((n) => n.isCoast)).toEqual([false, false, false, true, false]);
+    expect(result.corners[6]).toMatchObject({ isOcean: true, isWater: true, isCoast: true });
+    expect(result.corners[8]).toMatchObject({ isOcean: false, isWater: true, isCoast: false });
+    expect(result.corners[0].isCoast).toBe(false);
+  });
+
+  it('retains the submerged-corner cell rule and does not flood uphill through dry cells', () => {
+    const map = stripMap(3);
+    map.nodes[0].isOcean = true;
+    map.corners[2].elevation = -0.2;
+    map.corners[3].elevation = -0.2;
+    const result = simulateWater(map, {
+      seaLevel: -0.1,
+      springCountPercentage: 0,
+      rng: new RNG('water'),
+    });
+    expect(result.nodes.map((n) => n.isOcean)).toEqual([true, true, false]);
+    expect(result.nodes[2].isWater).toBe(false);
+  });
+
+  it('routes a river into a sub-sea-level pocket and creates mapped lake water there', () => {
+    const map = stripMap(1);
+    [1, 0.8, 0.4, -0.2].forEach((elevation, id) => {
+      map.corners[id].elevation = elevation;
+    });
+    const original = structuredClone(map);
+    const rng = new RNG('pocket');
+    const spring = vi.spyOn(rng, 'int').mockReturnValue(0);
+    const result = simulateWater(map, { seaLevel: -0.1, springCountPercentage: 0.25, rng });
+    expect(spring).toHaveBeenCalledTimes(1);
+    expect(result.edges.filter((e) => e.river > 0).map((e) => [e.v0, e.v1])).toEqual([
+      [0, 2],
+      [2, 3],
+    ]);
+    expect(result.corners[3]).toMatchObject({
+      isOcean: false,
+      isWater: true,
+      downslope: undefined,
+    });
+    expect(result.nodes[0]).toMatchObject({ isOcean: false, isWater: true });
+    expect(map).toEqual(original);
+  });
+
+  it('stops rivers on the shore of an existing inland lake', () => {
+    const map = stripMap(3);
+    map.nodes[2].elevation = -0.2;
+    [1, 2, 0.8, 2, 0.6, 2, 0.4, 2].forEach((elevation, id) => {
+      map.corners[id].elevation = elevation;
+    });
+    const rng = new RNG('lake');
+    vi.spyOn(rng, 'int').mockReturnValue(0);
+    const result = simulateWater(map, { seaLevel: -0.1, springCountPercentage: 0.25, rng });
+    expect(result.edges.filter((e) => e.river > 0).map((e) => [e.v0, e.v1])).toEqual([
+      [0, 2],
+      [2, 4],
+    ]);
+    expect(result.corners[4]).toMatchObject({ isOcean: false, isWater: true, downslope: 6 });
+  });
+});
+
+const seeds = [
+  'charlie',
+  'alpha',
+  'bravo',
+  'delta',
+  'echo',
+  'foxtrot',
+  'golf',
+  'hotel',
+  'india',
+  'juliet',
+];
+
+describe.each([
+  [60, 35],
+  [40, 30],
+])('water outlet regressions at %i × %i', (width, height) => {
+  it.each(seeds)('%s has mapped water at every river terminus and ocean corner', (seed) => {
+    const config = getDefaultConfig(new RNG(seed));
+    config.mapWidth = width;
+    config.mapHeight = height;
+    const map = generate(config).map;
+    const rimOcean = map.nodes.filter(
+      (node) =>
+        node.isOcean &&
+        (node.center.x <= 0.001 ||
+          node.center.x >= width - 0.001 ||
+          node.center.y <= 0.001 ||
+          node.center.y >= height - 0.001),
+    );
+    const connected = new Set(rimOcean.map((node) => node.id));
+    const queue = [...connected];
+    for (let i = 0; i < queue.length; i++) {
+      for (const id of map.nodes[queue[i]].neighbors) {
+        if (map.nodes[id].isOcean && !connected.has(id)) {
+          connected.add(id);
+          queue.push(id);
+        }
+      }
+    }
+    expect(connected).toEqual(
+      new Set(map.nodes.filter((node) => node.isOcean).map((node) => node.id)),
+    );
+    for (const corner of map.corners) {
+      if (corner.isOcean) expect(corner.touches.some((id) => map.nodes[id].isOcean)).toBe(true);
+      if (corner.isWater) expect(corner.touches.some((id) => map.nodes[id].isWater)).toBe(true);
+    }
+    const rivers = map.edges.filter((e) => e.river > 0);
+    expect(rivers.length).toBeGreaterThan(0);
+    for (const edge of rivers) {
+      expect(
+        map.corners[edge.v0].downslope === edge.v1 || map.corners[edge.v1].downslope === edge.v0,
+      ).toBe(true);
+      let corner = map.corners[map.corners[edge.v0].downslope === edge.v1 ? edge.v1 : edge.v0];
+      const visited = new Set<number>();
+      while (
+        corner.downslope !== undefined &&
+        corner.protrudes.some((id) => {
+          const next = map.edges[id];
+          return next.river > 0 && (next.v0 === corner.id ? next.v1 : next.v0) === corner.downslope;
+        })
+      ) {
+        expect(visited.has(corner.id)).toBe(false);
+        visited.add(corner.id);
+        corner = map.corners[corner.downslope];
+      }
+      expect(corner.isWater).toBe(true);
+      expect(corner.touches.some((id) => map.nodes[id].isWater)).toBe(true);
+    }
+  });
+});

--- a/src/lib/map/water.ts
+++ b/src/lib/map/water.ts
@@ -7,9 +7,56 @@ export interface WaterConfig {
   rng: RNG;
 }
 
+/** Water occupies cells; only water connected to a boundary-site cell is ocean. */
+function classifyWaterBodies(map: RegionMap, seaLevel: number): void {
+  const ocean = map.nodes.filter((node) => node.isOcean).map((node) => node.id);
+  for (const node of map.nodes) {
+    const submergedCorners = node.corners.filter(
+      (id) => map.corners[id].elevation < seaLevel,
+    ).length;
+    node.isWater =
+      node.isOcean ||
+      node.elevation < seaLevel ||
+      (node.corners.length > 0 && submergedCorners >= node.corners.length / 2);
+  }
+
+  for (let i = 0; i < ocean.length; i++) {
+    for (const id of map.nodes[ocean[i]].neighbors) {
+      const neighbor = map.nodes[id];
+      if (neighbor.isWater && !neighbor.isOcean) {
+        neighbor.isOcean = true;
+        ocean.push(id);
+      }
+    }
+  }
+}
+
+/** Corner outlets and coasts follow the polygons that will actually appear as water. */
+function updateWaterBoundaries(map: RegionMap): void {
+  for (const corner of map.corners) {
+    corner.isOcean = corner.touches.some((id) => map.nodes[id].isOcean);
+    corner.isWater = corner.touches.some((id) => map.nodes[id].isWater);
+    corner.isCoast = corner.isOcean && corner.touches.some((id) => !map.nodes[id].isWater);
+  }
+  for (const node of map.nodes) {
+    node.isCoast = !node.isWater && node.neighbors.some((id) => map.nodes[id].isOcean);
+  }
+}
+
+/** An unmapped local minimum becomes a lake when a river supplies it. */
+function fillLake(map: RegionMap, corner: MapCorner): void {
+  for (const id of corner.touches) {
+    const node = map.nodes[id];
+    node.isWater = true;
+    for (const cornerId of node.corners) {
+      map.corners[cornerId].isWater = true;
+    }
+  }
+}
+
 /**
  * Simulates downhill water flow from springs to calculate rivers and lakes.
- * Identifies oceans and coasts based on an elevation threshold.
+ * Identifies ocean by rim connectivity through submerged cells; inland water is lake.
  *
  * @param {RegionMap} map The input MapGraph with elevation already calculated.
  * @param {WaterConfig} config Algorithm parameters.
@@ -20,58 +67,9 @@ export function simulateWater(map: RegionMap, config: WaterConfig): RegionMap {
   const newMap: RegionMap = structuredClone(map);
   const { seaLevel, springCountPercentage, rng } = config;
 
-  // 1. Identify Ocean corners
-  for (const corner of newMap.corners) {
-    if (corner.elevation < seaLevel) {
-      corner.isOcean = true;
-      corner.isWater = true;
-    }
-  }
-
-  // Identify Ocean nodes
-  for (const node of newMap.nodes) {
-    let waterCorners = 0;
-    for (const cid of node.corners) {
-      if (newMap.corners[cid].isWater) waterCorners++;
-    }
-
-    // If the majority of corners are water, the node is water/ocean
-    if (node.elevation < seaLevel || waterCorners >= node.corners.length / 2) {
-      node.isOcean = true;
-      node.isWater = true;
-    }
-  }
-
-  // 2. Identify Coasts (Land nodes bordering Ocean nodes)
-  for (const node of newMap.nodes) {
-    if (node.isOcean) continue;
-
-    // Check neighbors
-    for (const neighborId of node.neighbors) {
-      const neighbor = newMap.nodes[neighborId];
-      if (neighbor.isOcean) {
-        node.isCoast = true;
-        break;
-      }
-    }
-  }
-
-  // Set coast for corners
-  for (const corner of newMap.corners) {
-    if (corner.isOcean) continue;
-    let touchesOcean = false;
-    let touchesLand = false;
-
-    for (const nodeId of corner.touches) {
-      const node = newMap.nodes[nodeId];
-      if (node.isOcean) touchesOcean = true;
-      else touchesLand = true;
-    }
-
-    if (touchesOcean && touchesLand) {
-      corner.isCoast = true;
-    }
-  }
+  // 1–2. Classify mapped water before deriving corner outlets and coasts.
+  classifyWaterBodies(newMap, seaLevel);
+  updateWaterBoundaries(newMap);
 
   // 3. Compute Downslopes
   for (const corner of newMap.corners) {
@@ -89,7 +87,7 @@ export function simulateWater(map: RegionMap, config: WaterConfig): RegionMap {
   }
 
   // 4. Generate Rivers using Downslopes
-  const landCorners = newMap.corners.filter((c) => !c.isOcean);
+  const landCorners = newMap.corners.filter((c) => !c.isWater);
   const riverCount = Math.floor(landCorners.length * springCountPercentage);
 
   if (landCorners.length > 0) {
@@ -102,20 +100,11 @@ export function simulateWater(map: RegionMap, config: WaterConfig): RegionMap {
       let current: number | undefined = spring.id;
       while (current !== undefined) {
         const currentCorner: MapCorner = newMap.corners[current as number];
-        if (currentCorner.isOcean) break; // River reached ocean
+        if (currentCorner.isWater) break; // River reached mapped ocean or lake
 
         const next: number | undefined = currentCorner.downslope;
         if (next === undefined) {
-          // Local minima: a lake forms
-          currentCorner.isWater = true;
-
-          // Mark surrounding polygon node as Lake (water, but not ocean)
-          for (const touchId of currentCorner.touches) {
-            const n = newMap.nodes[touchId];
-            if (!n.isOcean) {
-              n.isWater = true;
-            }
-          }
+          fillLake(newMap, currentCorner);
           break; // Stop river flow
         }
 
@@ -144,5 +133,6 @@ export function simulateWater(map: RegionMap, config: WaterConfig): RegionMap {
     }
   }
 
+  updateWaterBoundaries(newMap);
   return newMap;
 }

--- a/src/lib/regions/region_snapshot.test.ts
+++ b/src/lib/regions/region_snapshot.test.ts
@@ -79,11 +79,16 @@ describe('a region whose culture came from an artifact', () => {
 
 describe('a region with a referenced settlement', () => {
   it('leaves that settlement out of the payload', () => {
-    const first = region.settlements[0];
-    expect(first).toBeDefined();
-    const snapshot = toRegionSnapshot(region, { referencedSettlementName: first.name });
+    expect(region.settlements[0]).toBeDefined();
+    // Generated settlements can share a name; this fixture references exactly one settlement.
+    const first = { ...region.settlements[0], name: 'Unique referenced settlement' };
+    const fixture = { ...region, settlements: [first, ...region.settlements.slice(1)] };
+    const snapshot = toRegionSnapshot(fixture, { referencedSettlementName: first.name });
     expect(snapshot.settlements.map((s) => s.name)).not.toContain(first.name);
     expect(snapshot.settlements).toHaveLength(region.settlements.length - 1);
+    expect(snapshot.settlements.map((s) => s.name)).toEqual(
+      region.settlements.slice(1).map((s) => s.name),
+    );
   });
 });
 


### PR DESCRIPTION
Region rivers could terminate at sub-sea-level corners whose surrounding cells were all dry. The `charlie` reproduction also exposed near-coincident Voronoi corners split by coordinate-rounding buckets, creating a phantom downstream neighbor.

This change interns corners within 0.1 map units across neighboring buckets, removes collapsed cell edges, and aligns polygon geometry with the canonical graph. Water occupies cells: ocean is flood-filled from boundary sites through submerged neighbors, disconnected submerged cells become lakes, and corner water flags follow their touching cells. Rivers stop at mapped ocean or lake shores, or create mapped lake cells at a local minimum.

The regression tests cover corner interning, ocean connectivity, inland depressions, lake-shore termination, and river-outlet invariants over ten fixed seeds at both 60×35 and 40×30. Renderer tests now assert the corrected water invariant rather than the old broken corner IDs or a fixed river-segment minimum. The snapshot fixture uses an explicit unique reference name because generated settlements can share names. Changed seeded output also exposed a 320px ruler-layout overflow; that section now stacks on narrow screens.

Seeded geography and settlement placement intentionally change. A before/after audit of 50 seeds at each size (100 maps) reduced dry ocean corners from **258 to 0** and dry river termini from **121 to 0**, with no self-loop edges in the audited output. Settlement placement changed in every sampled map, and settlement counts changed in 66 of them. Rendered comparisons were reviewed for `alpha`, `bravo`, and `charlie`.

Validation: **`npm run verify:all` passed** with zero type-check errors or warnings, lint passing, **6,383 unit tests**, all **99 libraries** meeting the coverage gate, and **643 browser tests**. The region page also passed a targeted check at all five mobile widths.

Closes #244
