### PR TITLE
Make backup and restore easier to find

### DIFF
--- a/e2e/shell.spec.ts
+++ b/e2e/shell.spec.ts
@@ -57,6 +57,23 @@ test.describe('the application shell', () => {
     expect(Number(await tools.innerText())).toBeGreaterThan(0);
   });
 
+  test('links the browser-only storage explanation to backup and restore', async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await visitRoute(page, '/');
+
+    const storageLink = page
+      .locator('.home__lede')
+      .getByRole('link', { name: 'Back up or restore your work' });
+    await expect(storageLink).toBeVisible();
+    await expect(storageLink).toHaveAttribute('href', '/projects#storage');
+
+    await storageLink.click();
+    await expect(page).toHaveURL(/\/projects\/#storage$/);
+    await expect(
+      page.locator('section.storage').getByRole('heading', { name: 'Storage' }),
+    ).toBeInViewport();
+  });
+
   test('reports what the vault holds on a page it did not save anything on', async ({ page }) => {
     // The regression this exists for: the bar reads indexes that are empty until someone reads the
     // database, and hydration publishes no event. A bar that only read at mount said "0 artifacts,

--- a/src/components/layout/HomePage.svelte
+++ b/src/components/layout/HomePage.svelte
@@ -8,6 +8,7 @@
   import Icon from '$components/common/Icon.svelte';
 
   const featured = featuredTools();
+  const storagePanelHref = `${resolve('/projects')}#storage`;
 </script>
 
 <svelte:head>
@@ -27,6 +28,8 @@
       a culture, a religion, a settlement, or a star system, keep what you like in a project, edit
       it until it is yours, and build the next piece out of the last. Everything you make stays in
       your browser — there is no account to create and nothing is sent anywhere.
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+      <a href={storagePanelHref}>Back up or restore your work</a>.
     </p>
     <p class="home__cta">
       <a href={resolve('/workshop')}>Open the workshop</a>


### PR DESCRIPTION
Closes #226

## Summary
- add a home-page link beside the browser-only storage explanation
- send visitors directly to the existing Storage section on Projects
- verify the link text, href, navigation, and anchored destination in Playwright

## Verification
- svelte-check: 0 errors and 0 warnings
- ESLint: passed
- unit tests: 6,355 passed
- coverage gate: 99 libraries passed
- Playwright: 641 passed, 5 skipped
- changed-file Prettier check: passed

The combined verify:all command stops at Prettier because of the unrelated untracked Claude outputs/issue-228-triage-comment.md file, which this branch leaves untouched. Its remaining gates were run independently and passed.