### PR TITLE
Add initial star system loading state

### DIFF
--- a/e2e/star_system_loading.spec.ts
+++ b/e2e/star_system_loading.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { visitRoute } from './helpers';
+
+const INITIAL_STATUS = 'Generating the initial star system…';
+
+type FrameGateWindow = Window & { releaseAnimationFramesForTest?: () => void };
+
+/** Hold the first paint boundary until the test has observed the pending state. */
+async function gateAnimationFrames(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const requestFrame = window.requestAnimationFrame.bind(window);
+    const cancelFrame = window.cancelAnimationFrame.bind(window);
+    const waiting = new Map<number, FrameRequestCallback>();
+    let nextId = 1;
+
+    window.requestAnimationFrame = (callback) => {
+      const id = nextId;
+      nextId += 1;
+      waiting.set(id, callback);
+      return id;
+    };
+    window.cancelAnimationFrame = (id) => {
+      waiting.delete(id);
+    };
+    (window as FrameGateWindow).releaseAnimationFramesForTest = () => {
+      window.requestAnimationFrame = requestFrame;
+      window.cancelAnimationFrame = cancelFrame;
+      for (const callback of waiting.values()) {
+        requestFrame(callback);
+      }
+      waiting.clear();
+    };
+  });
+}
+
+async function releaseAnimationFrames(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as FrameGateWindow).releaseAnimationFramesForTest?.();
+  });
+}
+
+function initialStatus(page: Page) {
+  return page.getByRole('status').filter({ hasText: INITIAL_STATUS });
+}
+
+test.describe('initial star system generation', () => {
+  test.beforeEach(async ({ page }) => {
+    await gateAnimationFrames(page);
+  });
+
+  test('announces pending work and replaces it with a system on the standalone route', async ({
+    page,
+  }) => {
+    await page.goto('/star-system', { waitUntil: 'domcontentloaded' });
+
+    await expect(initialStatus(page)).toBeVisible();
+    await releaseAnimationFrames(page);
+    await expect(page.locator('article.media-banner').first()).toBeVisible({ timeout: 30_000 });
+    await expect(initialStatus(page)).toHaveCount(0);
+  });
+
+  test('announces pending work and replaces it with a system in the workshop panel', async ({
+    page,
+  }) => {
+    await visitRoute(page, '/workshop', { title: 'Workshop | Iron Arachne' });
+    await page
+      .locator('section.tool-browser')
+      .getByRole('button', { name: /^Star System/ })
+      .click();
+
+    const panel = page.locator('section.workshop-panel');
+    await expect(panel.getByRole('status').filter({ hasText: INITIAL_STATUS })).toBeVisible();
+    await releaseAnimationFrames(page);
+    await expect(panel.locator('article.media-banner').first()).toBeVisible({ timeout: 30_000 });
+    await expect(panel.getByRole('status').filter({ hasText: INITIAL_STATUS })).toHaveCount(0);
+  });
+});

--- a/src/components/locations/StarSystemGenerator.svelte
+++ b/src/components/locations/StarSystemGenerator.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import { RNG } from '@ironarachne/rng';
   import { browser } from '$app/environment';
   import Stat from '$components/common/Stat.svelte';
@@ -70,6 +70,9 @@
 
   let starImageSrcs = $state<string[]>([]);
   let planetImageSrcs = $state<string[]>([]);
+
+  /** The first roll waits for its status line to paint before doing synchronous preview work. */
+  let initialGenerationState = $state<'pending' | 'ready' | 'failed'>('pending');
 
   const planetCountOptions = [
     { value: Bodies.STAR_SYSTEM_ANY, label: 'Random' },
@@ -183,6 +186,32 @@
     rebuildSystemPreviewImages();
   }
 
+  /**
+   * Let Svelte write the pending state and the browser paint it before generating previews.
+   *
+   * The initial roll can render a composite and a figure for every body. Starting that work in
+   * the same task as hydration leaves the standalone route looking empty until it is all done;
+   * the workshop's module-loading message happened to hide that gap, but only there.
+   */
+  async function generateInitially(): Promise<void> {
+    await tick();
+    if (typeof requestAnimationFrame === 'function') {
+      await new Promise<void>((done) => requestAnimationFrame(() => done()));
+    }
+
+    try {
+      generate();
+      initialGenerationState = 'ready';
+    } catch {
+      initialGenerationState = 'failed';
+    }
+  }
+
+  function generateFromControls(): void {
+    generate();
+    initialGenerationState = 'ready';
+  }
+
   function exportMarkdown() {
     if (snapshot === null) {
       return;
@@ -233,7 +262,7 @@
   }
 
   onMount(() => {
-    generate();
+    void generateInitially();
   });
 </script>
 
@@ -244,6 +273,14 @@
       what this machine can do; every number below is written out regardless.
     </p>
   {/snippet}
+
+  {#if initialGenerationState === 'pending'}
+    <p class="initial-generation-status" role="status">Generating the initial star system…</p>
+  {:else if initialGenerationState === 'failed'}
+    <p class="initial-generation-status" role="status">
+      The initial star system could not be generated. Change the settings and try Generate again.
+    </p>
+  {/if}
 
   <RendererOverrideControls onchange={rebuildSystemPreviewImages} />
 
@@ -269,7 +306,7 @@
   />
 
   <div class="actions">
-    <BaseButton onclick={generate}>Generate</BaseButton>
+    <BaseButton onclick={generateFromControls}>Generate</BaseButton>
     <BaseButton onclick={exportMarkdown} disabled={!system}>Download Markdown</BaseButton>
     <BaseButton onclick={exportPdf} disabled={!system}>Download PDF</BaseButton>
     <BaseButton onclick={exportSvg} disabled={!system}>Download SVG</BaseButton>
@@ -369,6 +406,11 @@
     font: var(--t-small);
     color: var(--ink-muted);
     margin: var(--s3) 0 0;
+  }
+
+  .initial-generation-status {
+    font-style: italic;
+    color: var(--ink-muted);
   }
 
   article.media-banner {


### PR DESCRIPTION
## Summary

- show an accessible pending state before initial star-system generation
- yield a browser paint before starting synchronous preview work
- replace the pending state with generated output or an actionable failure message
- cover both the standalone route and Workshop panel flows

Closes #227

## Verification

- svelte-check: 0 errors and 0 warnings
- ESLint: passed
- Vitest: 6,383 passed
- coverage gate: 99 libraries passed
- focused Playwright tests: 2 passed
- full Playwright suite: 643 passed, 5 skipped
- manual Firefox load completed without a long-running-script warning

The aggregate npm run verify command is currently obstructed by an unrelated untracked, unformatted file at Claude outputs/issue-228-triage-comment.md; that file is not part of this branch or PR.