### PR TITLE
Add artifact quick roll to result vault

### DIFF
--- a/e2e/vault.spec.ts
+++ b/e2e/vault.spec.ts
@@ -106,6 +106,31 @@ test.describe('the result vault', () => {
 
     await vault(page).getByLabel('Search').fill('nothing matches this');
     await expect(vault(page).getByText('Nothing matches that.')).toBeVisible();
+    await expect(vault(page).getByRole('button', { name: 'Roll from these' })).toBeDisabled();
+    await expect(vault(page).getByText('0 results')).toBeVisible();
+  });
+
+  test('rolls among the filtered results without repeating the selection', async ({ page }) => {
+    await createProject(page, 'Ashfall');
+    await saveACulture(page, 'The Emberfolk');
+    await saveACulture(page, 'The Cinderborn');
+    await createProject(page, 'Dolmenwood');
+    await saveACulture(page, 'The Drune');
+
+    await visitRoute(page, '/vault', { title: 'Result Vault | Iron Arachne' });
+    await vault(page).getByLabel('Project').selectOption({ label: 'Ashfall' });
+
+    const roll = vault(page).getByRole('button', { name: 'Roll from these' });
+    await expect(vault(page).getByText('2 results')).toBeVisible();
+    await roll.click();
+
+    const firstName = await inspector(page).getByRole('heading').first().textContent();
+    expect(['The Emberfolk', 'The Cinderborn']).toContain(firstName);
+    await roll.click();
+
+    const secondName = await inspector(page).getByRole('heading').first().textContent();
+    expect(['The Emberfolk', 'The Cinderborn']).toContain(secondName);
+    expect(secondName).not.toBe(firstName);
   });
 
   test('inspects a selection without offering a way to edit its contents', async ({ page }) => {

--- a/src/components/layout/VaultPage.svelte
+++ b/src/components/layout/VaultPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { RNG } from '@ironarachne/rng';
   import { onMount } from 'svelte';
 
   import {
@@ -9,6 +10,7 @@
     hydrateArtifacts,
     listAllArtifacts,
     onArtifactsChanged,
+    pickRandomVaultEntry,
     searchArtifacts,
     toVaultEntries,
     vaultProjectNames,
@@ -32,6 +34,7 @@
 
   /** Registry order, so kinds group the way they are declared rather than alphabetically. */
   const kindOrder = registeredArtifactKinds().map((entry) => entry.kind);
+  const rng = new RNG(Date.now().toString());
 
   let entries: VaultEntry[] = $state([]);
   let query = $state('');
@@ -112,6 +115,10 @@
       : [...selectedTags, tag];
   }
 
+  function rollFromVisible(): void {
+    selectedId = pickRandomVaultEntry(visible, rng, selectedId)?.artifact.id;
+  }
+
   async function remove(summary: ArtifactSummary): Promise<void> {
     const confirmed = await showConfirmModal({
       title: 'Delete artifact',
@@ -174,6 +181,12 @@
               <option value={kind}>{kindLabel(kind)}</option>
             {/each}
           </select>
+        </div>
+        <div class="vault__roll">
+          <BaseButton variant="primary" onclick={rollFromVisible} disabled={visible.length === 0}>
+            Roll from these
+          </BaseButton>
+          <span>{visible.length} {visible.length === 1 ? 'result' : 'results'}</span>
         </div>
       </div>
 
@@ -295,6 +308,17 @@
   .vault__filters select {
     flex: 1 1 8rem;
     min-width: 0;
+  }
+
+  .vault__roll {
+    align-items: center;
+    display: flex;
+    gap: var(--s4);
+  }
+
+  .vault__roll span {
+    font-size: var(--t-small-size);
+    opacity: 0.8;
   }
 
   /* An inset, and the fieldset's own layout on top of it. */

--- a/src/lib/artifacts/vault_entries.test.ts
+++ b/src/lib/artifacts/vault_entries.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import { RNG } from '@ironarachne/rng';
 
 import type { ArtifactSummary } from './artifact_types';
 import {
   ORPHANED_PROJECT_NAME,
   filterVaultEntriesByProject,
+  pickRandomVaultEntry,
   toVaultEntries,
   vaultProjectNames,
 } from './vault_entries';
@@ -86,5 +88,28 @@ describe('filterVaultEntriesByProject', () => {
 
   it('returns nothing for a project that is not present', () => {
     expect(filterVaultEntriesByProject(entries, 'Nowhere')).toEqual([]);
+  });
+});
+
+describe('pickRandomVaultEntry', () => {
+  const entries = toVaultEntries(
+    [summary('a', 'p1'), summary('b', 'p1'), summary('c', 'p2')],
+    names,
+  );
+
+  it('picks an entry from the listing', () => {
+    expect(entries).toContain(pickRandomVaultEntry(entries, new RNG('vault-roll')));
+  });
+
+  it('does not repeat the current selection when another entry exists', () => {
+    expect(pickRandomVaultEntry(entries, new RNG('vault-roll'), 'a')?.artifact.id).not.toBe('a');
+  });
+
+  it('keeps the only entry available even when it is selected', () => {
+    expect(pickRandomVaultEntry([entries[0]], new RNG('vault-roll'), 'a')).toBe(entries[0]);
+  });
+
+  it('returns nothing for an empty listing', () => {
+    expect(pickRandomVaultEntry([], new RNG('vault-roll'))).toBeUndefined();
   });
 });

--- a/src/lib/artifacts/vault_entries.ts
+++ b/src/lib/artifacts/vault_entries.ts
@@ -1,3 +1,5 @@
+import type { RNG } from '@ironarachne/rng';
+
 import type { ArtifactSummary } from './artifact_types';
 
 /**
@@ -58,4 +60,27 @@ export function filterVaultEntriesByProject(
   return projectName === undefined || projectName === ''
     ? entries
     : entries.filter((entry) => entry.projectName === projectName);
+}
+
+/**
+ * Picks one entry from the current vault listing.
+ *
+ * A current selection is left out when another choice exists so rolling always has a visible
+ * effect. A one-entry listing remains rollable: that single artifact is still the honest result.
+ */
+export function pickRandomVaultEntry(
+  entries: VaultEntry[],
+  rng: RNG,
+  excludeId?: string,
+): VaultEntry | undefined {
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  const alternatives =
+    entries.length > 1 && excludeId !== undefined
+      ? entries.filter((entry) => entry.artifact.id !== excludeId)
+      : entries;
+
+  return rng.item(alternatives.length > 0 ? alternatives : entries);
 }


### PR DESCRIPTION
Adds a quick-roll control to the Result Vault that selects from the current filtered results, shows the pool size, avoids immediate repeats when alternatives exist, and disables itself for an empty pool. Adds unit coverage for the selection helper and browser coverage for filtering, selection, repeat avoidance, and the empty state. Verification: Svelte check, ESLint, changed-file Prettier, 6,387 unit tests with the per-library coverage gate, and the full Playwright suite (642 passed, 5 skipped). The repository-wide Prettier invocation remains blocked by the pre-existing untracked Claude outputs/issue-228-triage-comment.md, which this PR does not include. Closes #228.